### PR TITLE
Unify door config fields and improve config editor UX

### DIFF
--- a/docs/sysop/configuration/configuration.md
+++ b/docs/sysop/configuration/configuration.md
@@ -160,9 +160,10 @@ Configures external door programs that can be launched from the BBS. The file co
 [
   {
     "name": "LORD",
-    "command": "",
-    "args": [],
-    "working_directory": "",
+    "commands": [
+      "START.BAT {NODE}"
+    ],
+    "working_directory": "C:\\DOORS\\LORD",
     "dropfile_type": "DOOR.SYS",
     "dropfile_location": "node",
     "io_mode": "",
@@ -174,12 +175,7 @@ Configures external door programs that can be launched from the BBS. The file co
     "cleanup_args": [],
     "environment_variables": {},
     "is_dos": true,
-    "dos_commands": [
-      "cd C:\\DOORS\\LORD",
-      "START.BAT {NODE}"
-    ],
     "drive_c_path": "drive_c",
-    "dropfile_dest": "C:\\DOORS\\LORD",
     "dos_emulator": "dosemu",
     "fossil_driver": "C:\\UTILS\\X00.EXE eliminate",
     "dosemu_config": ""
@@ -190,6 +186,8 @@ Configures external door programs that can be launched from the BBS. The file co
 ### Common Fields
 
 - `name` - Unique identifier used in `DOOR:NAME` menu commands
+- `commands` - Native: `[0]`=executable, `[1:]`=args. DOS: each entry is a batch command line
+- `working_directory` - Native: Linux directory to run the command in. DOS: DOS path to cd into before running commands
 - `dropfile_type` - Dropfile format: `DOOR.SYS`, `DOOR32.SYS`, `CHAIN.TXT`, `DORINFO1.DEF`, or blank
 - `dropfile_location` - Where to write dropfile: `startup` (working dir) or `node` (per-node temp dir)
 - `min_access_level` - Minimum user access level (0 = no restriction)
@@ -198,9 +196,6 @@ Configures external door programs that can be launched from the BBS. The file co
 
 ### Native Door Fields
 
-- `command` - Path to the executable
-- `args` - Command-line arguments (supports placeholders)
-- `working_directory` - Directory to run the command in
 - `io_mode` - I/O handling: `STDIO` (default) or `SOCKET`
 - `requires_raw_terminal` - Allocate a PTY for raw terminal I/O
 - `use_shell` - Wrap command in `/bin/sh -c`
@@ -209,9 +204,7 @@ Configures external door programs that can be launched from the BBS. The file co
 ### DOS Door Fields
 
 - `is_dos` - Set to `true` for DOS doors launched via dosemu2
-- `dos_commands` - DOS commands written to EXTERNAL.BAT (supports placeholders)
 - `drive_c_path` - Host path mounted as DOS C: drive (relative to BBS root, or absolute)
-- `dropfile_dest` - DOS path to auto-copy dropfile to (e.g., `C:\DOORS\LORD`)
 - `dos_emulator` - Emulator: `auto` (default) or `dosemu`
 - `fossil_driver` - FOSSIL driver command (e.g., `C:\UTILS\X00.EXE eliminate`)
 - `dosemu_config` - Custom `.dosemurc` config file path

--- a/docs/sysop/doors/doors.md
+++ b/docs/sysop/doors/doors.md
@@ -14,9 +14,10 @@ Door programs are stored in `configs/doors.json` as an array:
 [
   {
     "name": "LORD",
-    "command": "",
-    "args": [],
-    "working_directory": "",
+    "commands": [
+      "START.BAT {NODE}"
+    ],
+    "working_directory": "C:\\DOORS\\LORD",
     "dropfile_type": "DOOR.SYS",
     "dropfile_location": "node",
     "io_mode": "",
@@ -28,12 +29,7 @@ Door programs are stored in `configs/doors.json` as an array:
     "cleanup_args": [],
     "environment_variables": {},
     "is_dos": true,
-    "dos_commands": [
-      "cd C:\\DOORS\\LORD",
-      "START.BAT {NODE}"
-    ],
     "drive_c_path": "drive_c",
-    "dropfile_dest": "C:\\DOORS\\LORD",
     "dos_emulator": "dosemu",
     "fossil_driver": "C:\\UTILS\\X00.EXE eliminate",
     "dosemu_config": ""
@@ -50,12 +46,15 @@ These fields apply to both native and DOS doors:
 | Field | Type | Description |
 | --- | --- | --- |
 | `name` | string | Display name for the door (used in `DOOR:NAME` menu commands) |
+| `commands` | []string | Native: `[0]`=executable, `[1:]`=args. DOS: each entry is a batch command line |
+| `working_directory` | string | Native: Linux directory to run the command in. DOS: DOS path to `cd` into before running commands (e.g., `C:\DOORS\LORD`) |
 | `dropfile_type` | string | Dropfile format: `DOOR.SYS`, `DOOR32.SYS`, `CHAIN.TXT`, `DORINFO1.DEF`, or blank for none |
 | `dropfile_location` | string | Where to write dropfile: `startup` (working dir, default) or `node` (per-node temp dir) |
 | `min_access_level` | int | Minimum user access level required (0 = no restriction) |
 | `single_instance` | bool | Only allow one node to run this door at a time |
 | `cleanup_command` | string | Command to run after the door exits (optional) |
 | `cleanup_args` | []string | Arguments for cleanup command (supports placeholders) |
+| `environment_variables` | map | Additional environment variables to set (supports placeholders). Format: `{"KEY": "VALUE"}` |
 
 ### Native Door Fields
 
@@ -63,13 +62,9 @@ These fields are used when `is_dos` is `false` (the default):
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `command` | string | Path to the executable |
-| `args` | []string | Command-line arguments (supports placeholders) |
-| `working_directory` | string | Directory to run the command in |
 | `io_mode` | string | I/O handling: `STDIO` (default) or `SOCKET` |
 | `requires_raw_terminal` | bool | Allocate a PTY for raw terminal I/O |
 | `use_shell` | bool | Wrap command in `/bin/sh -c` (Linux) or `cmd /c` (Windows) |
-| `environment_variables` | map | Additional environment variables to set |
 
 ### DOS Door Fields
 
@@ -78,9 +73,7 @@ Set `is_dos: true` to run a 16-bit DOS door game via dosemu2.
 | Field | Type | Description |
 | --- | --- | --- |
 | `is_dos` | bool | `true` = DOS door launched via dosemu2 |
-| `dos_commands` | []string | DOS commands written to EXTERNAL.BAT (supports placeholders) |
 | `drive_c_path` | string | Host path mounted as DOS C: drive. Relative paths are resolved against the BBS root directory. Default: `~/.dosemu/drive_c` |
-| `dropfile_dest` | string | DOS path to auto-copy the dropfile before running (e.g., `C:\DOORS\LORD`). If set, a `COPY` command is automatically inserted into EXTERNAL.BAT |
 | `dos_emulator` | string | Emulator selection: `""` or `"auto"` (default), `"dosemu"` |
 | `fossil_driver` | string | DOS FOSSIL driver command to load before the door (e.g., `C:\UTILS\X00.EXE eliminate`). Loaded in EXTERNAL.BAT before `cls` and the door commands |
 | `dosemu_config` | string | Path to a custom `.dosemurc` config file. If blank, the user's `~/.dosemu/.dosemurc` is used as a base with per-node overrides appended |
@@ -95,7 +88,7 @@ The dosemu2 binary path is configured globally in `config.json` (System Configur
 
 ## Placeholders
 
-The following placeholders can be used in `args` (native doors), `dos_commands` (DOS doors), `cleanup_args`, and `environment_variables`. They are substituted at runtime:
+The following placeholders can be used in `commands`, `cleanup_args`, and `environment_variables`. They are substituted at runtime:
 
 | Placeholder | Value |
 | --- | --- |
@@ -127,7 +120,7 @@ Creates a Unix socketpair and passes one end to the door process as file descrip
 
 By default (`dropfile_location: "startup"` or blank), the dropfile is written to the door's `working_directory`. Set `dropfile_location: "node"` to write it to a per-node temporary directory (`/tmp/vision3_nodeN/`) instead. This is useful for multi-instance doors where multiple nodes may run simultaneously and need isolated dropfiles.
 
-For DOS doors, dropfiles are always written to the per-node temp directory inside `drive_c` (at `C:\NODES\TEMPn\`) regardless of this setting. Use `dropfile_dest` to automatically copy the dropfile to the door's game directory.
+For DOS doors, dropfiles are written to the per-node temp directory inside `drive_c` (at `C:\NODES\TEMPn\`). Configure the door game itself to read the dropfile from the node directory using the `{DOSNODEDIR}` placeholder, or set `dropfile_location: "startup"` to write it to the working directory instead.
 
 ## Access Control
 
@@ -180,7 +173,7 @@ DOS doors are supported on Linux x86/x86-64 via dosemu2. ViSiON/3 uses dosemu2's
 ### How It Works
 
 1. ViSiON/3 generates a per-node `dosemurc` config that maps `drive_c_path` as the DOS C: drive
-2. An `EXTERNAL.BAT` batch file is generated containing: FOSSIL driver loading (if configured), dropfile copy (if `dropfile_dest` is set), `cls`, and the user's `dos_commands`
+2. An `EXTERNAL.BAT` batch file is generated containing: FOSSIL driver loading (if configured), `cls`, `cd` to working directory (if set), and the user's `commands`
 3. dosemu2 boots DOS, executes EXTERNAL.BAT, and exits via `exitemu`
 4. The PTY output bridge gates on the `cls` clear screen sequence (`ESC[2J`), suppressing all DOS boot text from reaching the user
 5. After the door exits, the BBS session resumes
@@ -233,16 +226,15 @@ A complete LORD (Legend of the Red Dragon) configuration:
 ```json
 {
   "name": "LORD",
+  "working_directory": "C:\\DOORS\\LORD",
   "dropfile_type": "DOOR.SYS",
   "dropfile_location": "node",
   "single_instance": true,
   "is_dos": true,
-  "dos_commands": [
-    "cd C:\\DOORS\\LORD",
+  "commands": [
     "START.BAT {NODE}"
   ],
   "drive_c_path": "drive_c",
-  "dropfile_dest": "C:\\DOORS\\LORD",
   "fossil_driver": "C:\\UTILS\\X00.EXE eliminate",
   "dos_emulator": "dosemu"
 }
@@ -250,10 +242,10 @@ A complete LORD (Legend of the Red Dragon) configuration:
 
 This configuration:
 
+- Sets the DOS working directory to `C:\DOORS\LORD` (auto `cd` before commands)
 - Generates a `DOOR.SYS` dropfile in the per-node directory (`C:\NODES\TEMPn\`)
-- Automatically copies `DOOR.SYS` to `C:\DOORS\LORD\` (via `dropfile_dest`)
 - Loads the X00.EXE FOSSIL driver for COM1 serial I/O
-- Changes to the LORD directory and runs `START.BAT` with the node number
+- Runs `START.BAT` with the node number
 - Prevents multiple nodes from running LORD simultaneously (`single_instance`)
 
 ### dosemurc Template
@@ -293,4 +285,16 @@ The following environment variables are automatically set for all door processes
 | `DOOR_SOCKET_FD` | Socket FD (SOCKET mode only) |
 | `DOSEMU_QUIET` | `1` (DOS doors only, suppresses dosemu startup messages) |
 
-Additional variables can be configured per-door via the `environment_variables` field.
+Additional variables can be configured per-door via the `environment_variables` field. These are set in the OS environment before the door process (or DOS emulator) is launched. Placeholders are substituted at runtime.
+
+Example:
+
+```json
+{
+  "environment_variables": {
+    "TERM": "ansi",
+    "DSZLOG": "/tmp/node{NODE}_dsz.log",
+    "GAME_DATA": "/opt/bbs/doors/lord/data"
+  }
+}
+```

--- a/docs/sysop/reference/api-reference.md
+++ b/docs/sysop/reference/api-reference.md
@@ -208,8 +208,7 @@ type StringsConfig map[string]string
 type ThemeConfig map[string]interface{}
 type DoorConfig struct {
     Name                string
-    Command             string
-    Args                []string
+    Commands            []string
     WorkingDirectory    string
     DropfileType        string
     DropfileLocation    string
@@ -222,10 +221,8 @@ type DoorConfig struct {
     CleanupArgs         []string
     EnvironmentVars     map[string]string
     // DOS door fields
-    IsDOS        bool
-    DOSCommands  []string
-    DriveCPath   string
-    DropfileDest string
+    IsDOS       bool
+    DriveCPath  string
     DOSEmulator  string
     FossilDriver string
     DosemuConfig string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -588,9 +588,8 @@ func applyStringDefaults(c *StringsConfig) {
 // DoorConfig defines the configuration for a single external door program.
 type DoorConfig struct {
 	Name                string            `json:"name"`                            // Unique identifier used in DOOR:NAME commands
-	Command             string            `json:"command"`                         // Path to the executable
-	Args                []string          `json:"args"`                            // Command-line arguments (can include placeholders)
 	WorkingDirectory    string            `json:"working_directory,omitempty"`     // Directory to run the command in (optional)
+	Commands            []string          `json:"commands,omitempty"`              // Commands to execute (native: [0]=executable, [1:]=args; DOS: batch lines)
 	DropfileType        string            `json:"dropfile_type,omitempty"`         // Type of dropfile ("DOOR.SYS", "CHAIN.TXT", "NONE") (optional, defaults to NONE)
 	DropfileLocation    string            `json:"dropfile_location,omitempty"`     // Where to write dropfile: "startup" (working dir, default) or "node" (per-node temp dir)
 	IOMode              string            `json:"io_mode,omitempty"`               // I/O handling ("STDIO", "SOCKET") (optional, defaults to STDIO)
@@ -602,11 +601,9 @@ type DoorConfig struct {
 	CleanupArgs         []string          `json:"cleanup_args,omitempty"`          // Arguments for cleanup command (supports placeholders)
 	EnvironmentVars     map[string]string `json:"environment_variables,omitempty"` // Additional environment variables (optional)
 	// DOS door fields
-	IsDOS        bool     `json:"is_dos,omitempty"`        // true = DOS door launched via a DOS emulator
-	DOSCommands  []string `json:"dos_commands,omitempty"`  // DOS commands to run (e.g. ["cd c:\\doors\\lord\\", "lord /n{NODE}"])
-	DriveCPath   string   `json:"drive_c_path,omitempty"`  // Path to drive_c directory (default: ~/.dosemu/drive_c)
-	DropfileDest string   `json:"dropfile_dest,omitempty"` // DOS path to auto-copy dropfile before running (e.g. "C:\\DOORS\\LORD")
-	DOSEmulator  string   `json:"dos_emulator,omitempty"`  // Emulator to use: "auto" (default) or "dosemu"
+	IsDOS       bool   `json:"is_dos,omitempty"`       // true = DOS door launched via a DOS emulator
+	DriveCPath  string `json:"drive_c_path,omitempty"` // Path to drive_c directory (default: ~/.dosemu/drive_c)
+	DOSEmulator string   `json:"dos_emulator,omitempty"`  // Emulator to use: "auto" (default) or "dosemu"
 	FossilDriver string   `json:"fossil_driver,omitempty"` // DOS FOSSIL driver command (e.g. "C:\\UTILS\\X00.EXE eliminate")
 	// dosemu2-specific fields (Linux x86 only)
 	DosemuConfig string `json:"dosemu_config,omitempty"` // Path to custom .dosemurc (optional)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -211,7 +211,7 @@ type StringsConfig struct {
 	FileAreaNotFound       string `json:"fileAreaNotFound"`
 	SaveUserError          string `json:"saveUserError"`
 
-	QuotePrefix            string `json:"QuotePrefix"`
+	QuotePrefix string `json:"QuotePrefix"`
 
 	// Chat strings (V3-specific)
 	ChatHeader        string `json:"chatHeader"`
@@ -282,7 +282,7 @@ type StringsConfig struct {
 	CfgViewScreenWidth     string `json:"cfgViewScreenWidth"`
 	CfgViewScreenHeight    string `json:"cfgViewScreenHeight"`
 	CfgViewTermType        string `json:"cfgViewTermType"`
-CfgViewHotKeys         string `json:"cfgViewHotKeys"`
+	CfgViewHotKeys         string `json:"cfgViewHotKeys"`
 	CfgViewMorePrompts     string `json:"cfgViewMorePrompts"`
 	CfgViewMsgHeader       string `json:"cfgViewMsgHeader"`
 	CfgViewCustomPrompt    string `json:"cfgViewCustomPrompt"`
@@ -371,11 +371,11 @@ CfgViewHotKeys         string `json:"cfgViewHotKeys"`
 	FileOpenError      string `json:"fileOpenError"`
 
 	// File search strings
-	SearchFilesPrompt   string `json:"searchFilesPrompt"`
-	SearchFilesMinChars string `json:"searchFilesMinChars"`
-	SearchNoResults     string `json:"searchNoResults"`
-	SearchResultsHeader string `json:"searchResultsHeader"`
-	SearchResultFormat  string `json:"searchResultFormat"`
+	SearchFilesPrompt    string `json:"searchFilesPrompt"`
+	SearchFilesMinChars  string `json:"searchFilesMinChars"`
+	SearchNoResults      string `json:"searchNoResults"`
+	SearchResultsHeader  string `json:"searchResultsHeader"`
+	SearchResultFormat   string `json:"searchResultFormat"`
 	SearchResultsSummary string `json:"searchResultsSummary"`
 
 	// File info strings
@@ -601,10 +601,10 @@ type DoorConfig struct {
 	CleanupArgs         []string          `json:"cleanup_args,omitempty"`          // Arguments for cleanup command (supports placeholders)
 	EnvironmentVars     map[string]string `json:"environment_variables,omitempty"` // Additional environment variables (optional)
 	// DOS door fields
-	IsDOS       bool   `json:"is_dos,omitempty"`       // true = DOS door launched via a DOS emulator
-	DriveCPath  string `json:"drive_c_path,omitempty"` // Path to drive_c directory (default: ~/.dosemu/drive_c)
-	DOSEmulator string   `json:"dos_emulator,omitempty"`  // Emulator to use: "auto" (default) or "dosemu"
-	FossilDriver string   `json:"fossil_driver,omitempty"` // DOS FOSSIL driver command (e.g. "C:\\UTILS\\X00.EXE eliminate")
+	IsDOS        bool   `json:"is_dos,omitempty"`        // true = DOS door launched via a DOS emulator
+	DriveCPath   string `json:"drive_c_path,omitempty"`  // Path to drive_c directory (default: ~/.dosemu/drive_c)
+	DOSEmulator  string `json:"dos_emulator,omitempty"`  // Emulator to use: "auto" (default) or "dosemu"
+	FossilDriver string `json:"fossil_driver,omitempty"` // DOS FOSSIL driver command (e.g. "C:\\UTILS\\X00.EXE eliminate")
 	// dosemu2-specific fields (Linux x86 only)
 	DosemuConfig string `json:"dosemu_config,omitempty"` // Path to custom .dosemurc (optional)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,8 +10,8 @@ import (
 func TestLoadDoors_ValidFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	doors := []DoorConfig{
-		{Name: "LORD", Command: "/usr/bin/lord", Args: []string{"-n", "{NODE}"}},
-		{Name: "BRE", Command: "/usr/bin/bre"},
+		{Name: "LORD", Commands: []string{"/usr/bin/lord", "-n", "{NODE}"}},
+		{Name: "BRE", Commands: []string{"/usr/bin/bre"}},
 	}
 	data, _ := json.Marshal(doors)
 	os.WriteFile(filepath.Join(tmpDir, "doors.json"), data, 0644)
@@ -23,8 +23,8 @@ func TestLoadDoors_ValidFile(t *testing.T) {
 	if len(result) != 2 {
 		t.Fatalf("expected 2 doors, got %d", len(result))
 	}
-	if result["LORD"].Command != "/usr/bin/lord" {
-		t.Errorf("expected LORD command /usr/bin/lord, got %s", result["LORD"].Command)
+	if len(result["LORD"].Commands) == 0 || result["LORD"].Commands[0] != "/usr/bin/lord" {
+		t.Errorf("expected LORD command /usr/bin/lord, got %v", result["LORD"].Commands)
 	}
 }
 
@@ -41,8 +41,8 @@ func TestLoadDoors_MissingFile(t *testing.T) {
 func TestLoadDoors_DuplicateNames(t *testing.T) {
 	tmpDir := t.TempDir()
 	doors := []DoorConfig{
-		{Name: "LORD", Command: "/usr/bin/lord"},
-		{Name: "LORD", Command: "/usr/bin/lord2"},
+		{Name: "LORD", Commands: []string{"/usr/bin/lord"}},
+		{Name: "LORD", Commands: []string{"/usr/bin/lord2"}},
 	}
 	data, _ := json.Marshal(doors)
 	os.WriteFile(filepath.Join(tmpDir, "doors.json"), data, 0644)

--- a/internal/configeditor/fields_areas.go
+++ b/internal/configeditor/fields_areas.go
@@ -93,7 +93,7 @@ func (m *Model) fieldsMsgArea() []fieldDef {
 			Set: func(val string) error { a.BasePath = val; return nil },
 		},
 		{
-			Label: "Conference", Help: "Press Enter to select a conference", Type: ftLookup, Col: 3, Row: 9, Width: 40,
+			Label: "Conference", Help: "Select a conference", Type: ftLookup, Col: 3, Row: 9, Width: 40,
 			Get: func() string { return m.conferenceName(a.ConferenceID) },
 			Set: func(val string) error {
 				n, err := strconv.Atoi(val)
@@ -224,7 +224,7 @@ func (m *Model) fieldsFileArea() []fieldDef {
 			Set: func(val string) error { a.ACSDownload = val; return nil },
 		},
 		{
-			Label: "Conference", Help: "Press Enter to select a conference", Type: ftLookup, Col: 3, Row: 8, Width: 40,
+			Label: "Conference", Help: "Select a conference", Type: ftLookup, Col: 3, Row: 8, Width: 40,
 			Get: func() string {
 				return m.conferenceName(a.ConferenceID)
 			},

--- a/internal/configeditor/fields_doors.go
+++ b/internal/configeditor/fields_doors.go
@@ -35,45 +35,84 @@ func csvToSlice(s string) []string {
 }
 
 // doorCommandsGet returns the command string for display.
-// Native doors: "command arg1, arg2, ..."
-// DOS doors: "cmd1, cmd2, ..." from DOSCommands
+// Native doors: "command arg1, arg2, ..." (Commands[0] + Commands[1:])
+// DOS doors: "cmd1, cmd2, ..." (each Commands entry is a batch line)
 func doorCommandsGet(d *doorEditProxy) string {
-	if d.IsDOS {
-		return sliceToCSV(d.DOSCommands)
-	}
-	if d.Command == "" {
+	if len(d.Commands) == 0 {
 		return ""
 	}
-	if len(d.Args) == 0 {
-		return d.Command
+	if d.IsDOS {
+		return sliceToCSV(d.Commands)
 	}
-	return d.Command + " " + sliceToCSV(d.Args)
+	// Native: first entry is command, rest are args
+	if len(d.Commands) == 1 {
+		return d.Commands[0]
+	}
+	return d.Commands[0] + " " + sliceToCSV(d.Commands[1:])
 }
 
-// doorCommandsSet parses the command string back into the appropriate fields.
+// doorCommandsSet parses the command string back into the Commands field.
 // Native doors: first token is command, rest are comma-separated args.
-// DOS doors: comma-separated list goes into DOSCommands.
+// DOS doors: comma-separated list of batch commands.
 func doorCommandsSet(d *doorEditProxy, val string) {
 	if d.IsDOS {
-		d.DOSCommands = csvToSlice(val)
-		d.Command = ""
-		d.Args = nil
+		d.Commands = csvToSlice(val)
 		return
 	}
 	val = strings.TrimSpace(val)
 	if val == "" {
-		d.Command = ""
-		d.Args = nil
+		d.Commands = nil
 		return
 	}
 	// Split first space-separated token as the command
 	parts := strings.SplitN(val, " ", 2)
-	d.Command = parts[0]
+	d.Commands = []string{parts[0]}
 	if len(parts) > 1 {
-		d.Args = csvToSlice(parts[1])
-	} else {
-		d.Args = nil
+		d.Commands = append(d.Commands, csvToSlice(parts[1])...)
 	}
+}
+
+// envMapToCSV serializes a map[string]string as "KEY=VALUE, KEY2=VALUE2" for display.
+func envMapToCSV(m map[string]string) string {
+	if len(m) == 0 {
+		return ""
+	}
+	pairs := make([]string, 0, len(m))
+	for k, v := range m {
+		pairs = append(pairs, k+"="+v)
+	}
+	return strings.Join(pairs, ", ")
+}
+
+// csvToEnvMap parses "KEY=VALUE, KEY2=VALUE2" into a map[string]string.
+// Returns nil for empty input.
+func csvToEnvMap(s string) (map[string]string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	parts := strings.Split(s, ",")
+	result := make(map[string]string, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		kv := strings.SplitN(p, "=", 2)
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("invalid entry %q: expected KEY=VALUE", p)
+		}
+		key := strings.TrimSpace(kv[0])
+		val := strings.TrimSpace(kv[1])
+		if key == "" {
+			return nil, fmt.Errorf("empty key in %q", p)
+		}
+		result[key] = val
+	}
+	if len(result) == 0 {
+		return nil, nil
+	}
+	return result, nil
 }
 
 // doorEditProxy wraps DoorConfig fields for in-place editing via closures.
@@ -113,6 +152,17 @@ func (m *Model) fieldsDoor() []fieldDef {
 	})
 
 	row++
+	workDirHelp := "Directory to run the command in"
+	if dPtr.IsDOS {
+		workDirHelp = "DOS directory to cd into before running commands (e.g. C:\\DOORS\\LORD)"
+	}
+	fields = append(fields, fieldDef{
+		Label: "Working Dir", Help: workDirHelp, Type: ftString, Col: 3, Row: row, Width: 45,
+		Get: func() string { return dPtr.WorkingDirectory },
+		Set: func(val string) error { dPtr.WorkingDirectory = val; save(); return nil },
+	})
+
+	row++
 	fields = append(fields, fieldDef{
 		Label: "Commands", Help: "Native: command args / DOS: comma-separated DOS commands", Type: ftString, Col: 3, Row: row, Width: 45,
 		Get: func() string { return doorCommandsGet(dPtr) },
@@ -121,24 +171,29 @@ func (m *Model) fieldsDoor() []fieldDef {
 
 	row++
 	fields = append(fields, fieldDef{
-		Label: "Dropfile Type", Help: "DOOR.SYS, DOOR32.SYS, CHAIN.TXT, DORINFO1.DEF, or NONE", Type: ftString, Col: 3, Row: row, Width: 15,
+		Label: "Dropfile Type", Help: "Dropfile format", Type: ftLookup, Col: 3, Row: row, Width: 15,
 		Get: func() string { return dPtr.DropfileType },
 		Set: func(val string) error { dPtr.DropfileType = val; save(); return nil },
+		LookupItems: func() []LookupItem {
+			return []LookupItem{
+				{Value: "", Display: "(none)"},
+				{Value: "DOOR.SYS", Display: "DOOR.SYS"},
+				{Value: "DOOR32.SYS", Display: "DOOR32.SYS"},
+				{Value: "CHAIN.TXT", Display: "CHAIN.TXT"},
+				{Value: "DORINFO1.DEF", Display: "DORINFO1.DEF"},
+			}
+		},
 	})
 
 	row++
 	fields = append(fields, fieldDef{
-		Label: "Dropfile Location", Help: "Where to write dropfile: startup (working dir) or node (per-node temp dir)", Type: ftString, Col: 3, Row: row, Width: 10,
+		Label: "Dropfile Location", Help: "Where to write dropfile", Type: ftLookup, Col: 3, Row: row, Width: 10,
 		Get: func() string { return dPtr.DropfileLocation },
-		Set: func(val string) error {
-			val = strings.ToLower(strings.TrimSpace(val))
-			switch val {
-			case "", "startup", "node":
-				dPtr.DropfileLocation = val
-				save()
-				return nil
-			default:
-				return fmt.Errorf("invalid location %q: must be blank, startup, or node", val)
+		Set: func(val string) error { dPtr.DropfileLocation = val; save(); return nil },
+		LookupItems: func() []LookupItem {
+			return []LookupItem{
+				{Value: "startup", Display: "startup - Working directory (or '.')"},
+				{Value: "node", Display: "node - Per-node temp directory"},
 			}
 		},
 	})
@@ -146,11 +201,11 @@ func (m *Model) fieldsDoor() []fieldDef {
 	// Common fields for all door types
 	row++
 	fields = append(fields, fieldDef{
-		Label: "Min Access Level", Help: "Minimum user access level (0=no restriction)", Type: ftString, Col: 3, Row: row, Width: 5,
+		Label: "Min Access Level", Help: "Minimum user access level (0=no restriction)", Type: ftInteger, Col: 3, Row: row, Width: 5, Min: 0, Max: 255,
 		Get: func() string { return strconv.Itoa(dPtr.MinAccessLevel) },
 		Set: func(val string) error {
 			v, err := strconv.Atoi(strings.TrimSpace(val))
-			if err != nil || v < 0 || v > 255 {
+			if err != nil {
 				return fmt.Errorf("access level must be 0-255")
 			}
 			dPtr.MinAccessLevel = v
@@ -198,6 +253,21 @@ func (m *Model) fieldsDoor() []fieldDef {
 		},
 	})
 
+	row++
+	fields = append(fields, fieldDef{
+		Label: "Env Vars", Help: "Environment variables: KEY=VALUE, KEY2=VALUE2", Type: ftString, Col: 3, Row: row, Width: 45,
+		Get: func() string { return envMapToCSV(dPtr.EnvironmentVars) },
+		Set: func(val string) error {
+			m, err := csvToEnvMap(val)
+			if err != nil {
+				return err
+			}
+			dPtr.EnvironmentVars = m
+			save()
+			return nil
+		},
+	})
+
 	if dPtr.IsDOS {
 		// DOS-specific fields
 		row++
@@ -208,25 +278,15 @@ func (m *Model) fieldsDoor() []fieldDef {
 		})
 		row++
 		fields = append(fields, fieldDef{
-			Label: "DOS Emulator", Help: "Emulator: blank=auto, dosemu=dosemu2 (Linux x86 only)", Type: ftString, Col: 3, Row: row, Width: 10,
+			Label: "DOS Emulator", Help: "DOS emulator to use", Type: ftLookup, Col: 3, Row: row, Width: 10,
 			Get: func() string { return dPtr.DOSEmulator },
-			Set: func(val string) error {
-				val = strings.ToLower(strings.TrimSpace(val))
-				switch val {
-				case "", "auto", "dosemu":
-					dPtr.DOSEmulator = val
-					save()
-					return nil
-				default:
-					return fmt.Errorf("invalid emulator %q: must be blank, auto, or dosemu", val)
+			Set: func(val string) error { dPtr.DOSEmulator = val; save(); return nil },
+			LookupItems: func() []LookupItem {
+				return []LookupItem{
+					{Value: "auto", Display: "auto - Detect available emulator"},
+					{Value: "dosemu", Display: "dosemu - dosemu2 (Linux only)"},
 				}
 			},
-		})
-		row++
-		fields = append(fields, fieldDef{
-			Label: "Dropfile Dest", Help: "DOS path to auto-copy dropfile before running (e.g. C:\\DOORS\\LORD)", Type: ftString, Col: 3, Row: row, Width: 45,
-			Get: func() string { return dPtr.DropfileDest },
-			Set: func(val string) error { dPtr.DropfileDest = val; save(); return nil },
 		})
 		row++
 		fields = append(fields, fieldDef{
@@ -244,23 +304,13 @@ func (m *Model) fieldsDoor() []fieldDef {
 		// Native-specific fields
 		row++
 		fields = append(fields, fieldDef{
-			Label: "Working Dir", Help: "Directory to run the command in", Type: ftString, Col: 3, Row: row, Width: 45,
-			Get: func() string { return dPtr.WorkingDirectory },
-			Set: func(val string) error { dPtr.WorkingDirectory = val; save(); return nil },
-		})
-		row++
-		fields = append(fields, fieldDef{
-			Label: "I/O Mode", Help: "I/O handling: STDIO or SOCKET (pass FD to door)", Type: ftString, Col: 3, Row: row, Width: 15,
+			Label: "I/O Mode", Help: "I/O handling mode", Type: ftLookup, Col: 3, Row: row, Width: 15,
 			Get: func() string { return dPtr.IOMode },
-			Set: func(val string) error {
-				v := strings.ToUpper(strings.TrimSpace(val))
-				switch v {
-				case "", "STDIO", "SOCKET":
-					dPtr.IOMode = v
-					save()
-					return nil
-				default:
-					return fmt.Errorf("invalid I/O mode %q: must be blank, STDIO, or SOCKET", val)
+			Set: func(val string) error { dPtr.IOMode = val; save(); return nil },
+			LookupItems: func() []LookupItem {
+				return []LookupItem{
+					{Value: "STDIO", Display: "STDIO - Standard I/O redirection"},
+					{Value: "SOCKET", Display: "SOCKET - Pass socket FD to door"},
 				}
 			},
 		})

--- a/internal/configeditor/fields_doors.go
+++ b/internal/configeditor/fields_doors.go
@@ -2,6 +2,7 @@ package configeditor
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -73,13 +74,19 @@ func doorCommandsSet(d *doorEditProxy, val string) {
 }
 
 // envMapToCSV serializes a map[string]string as "KEY=VALUE, KEY2=VALUE2" for display.
+// Keys are sorted for stable output.
 func envMapToCSV(m map[string]string) string {
 	if len(m) == 0 {
 		return ""
 	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
 	pairs := make([]string, 0, len(m))
-	for k, v := range m {
-		pairs = append(pairs, k+"="+v)
+	for _, k := range keys {
+		pairs = append(pairs, k+"="+m[k])
 	}
 	return strings.Join(pairs, ", ")
 }

--- a/internal/configeditor/fields_events.go
+++ b/internal/configeditor/fields_events.go
@@ -109,7 +109,7 @@ func (m *Model) fieldsEvent() []fieldDef {
 			Set: func(val string) error { e.RunAtStartup = ynToBool(val); return nil },
 		},
 		{
-			Label: "Run After", Help: "Run after this event completes (press Enter to select)", Type: ftLookup, Col: 3, Row: 8, Width: 20,
+			Label: "Run After", Help: "Run after this event completes", Type: ftLookup, Col: 3, Row: 8, Width: 20,
 			Get: func() string {
 				if e.RunAfter == "" {
 					return "(none)"

--- a/internal/configeditor/fields_system.go
+++ b/internal/configeditor/fields_system.go
@@ -112,7 +112,7 @@ func sysFieldsRegistration(cfg *config.ServerConfig) []fieldDef {
 			Set: func(val string) error { cfg.SysOpName = val; return nil },
 		},
 		{
-			Label: "Timezone", Help: "IANA timezone (press Enter to select)", Type: ftLookup, Col: 3, Row: 3, Width: 30,
+			Label: "Timezone", Help: "IANA timezone", Type: ftLookup, Col: 3, Row: 3, Width: 30,
 			Get: func() string { return cfg.Timezone },
 			Set: func(val string) error { cfg.Timezone = val; return nil },
 			LookupItems: func() []LookupItem {
@@ -373,7 +373,7 @@ func sysFieldsDefaults(cfg *config.ServerConfig) []fieldDef {
 			Set: func(val string) error { cfg.AllowNewUsers = ynToBool(val); return nil },
 		},
 		{
-			Label: "File List Mode", Help: "File listing style (press Enter to select)", Type: ftLookup, Col: 3, Row: 2, Width: 15,
+			Label: "File List Mode", Help: "File listing style", Type: ftLookup, Col: 3, Row: 2, Width: 15,
 			Get: func() string { return cfg.FileListingMode },
 			Set: func(val string) error { cfg.FileListingMode = val; return nil },
 			LookupItems: func() []LookupItem {

--- a/internal/configeditor/view_record.go
+++ b/internal/configeditor/view_record.go
@@ -327,9 +327,12 @@ func (m Model) renderFieldHelpLine(fields []fieldDef, padL, padR, boxW int) stri
 	}
 	if m.editField >= 0 && m.editField < len(fields) && fields[m.editField].Help != "" {
 		helpText := fields[m.editField].Help
-		// Add toggle hint for Y/N fields
-		if fields[m.editField].Type == ftYesNo {
+		// Add interaction hints
+		switch fields[m.editField].Type {
+		case ftYesNo:
 			helpText += " (Space toggles)"
+		case ftLookup:
+			helpText += " (Enter to select)"
 		}
 		return bgFillStyle.Render(strings.Repeat("░", padL)) +
 			editInfoLabelStyle.Render(centerText(helpText, boxW+1)) +

--- a/internal/menu/door_handler.go
+++ b/internal/menu/door_handler.go
@@ -61,7 +61,11 @@ func writeBatchFile(ctx *DoorCtx, batchPath string) error {
 
 	// Auto-cd to the door's working directory if configured
 	if ctx.Config.WorkingDirectory != "" {
-		b.WriteString("cd " + ctx.Config.WorkingDirectory + crlf)
+		// Switch drive letter first (e.g. "D:"), then cd with quotes for spaces
+		if len(ctx.Config.WorkingDirectory) >= 2 && ctx.Config.WorkingDirectory[1] == ':' {
+			b.WriteString(ctx.Config.WorkingDirectory[:2] + crlf)
+		}
+		b.WriteString(fmt.Sprintf("cd \"%s\"", ctx.Config.WorkingDirectory) + crlf)
 	}
 
 	for _, cmd := range ctx.Config.Commands {
@@ -376,14 +380,16 @@ func executeNativeDoor(ctx *DoorCtx) error {
 	ctx.Subs["{NODEDIR}"] = dropfileDir
 
 	// Extract command and args from Commands slice (native: [0]=executable, [1:]=args)
-	doorCommand := ""
-	var doorArgs []string
-	if len(doorConfig.Commands) > 0 {
-		doorCommand = doorConfig.Commands[0]
-		doorArgs = doorConfig.Commands[1:]
+	if len(doorConfig.Commands) == 0 || doorConfig.Commands[0] == "" {
+		return fmt.Errorf("door %q has no command configured", ctx.DoorName)
 	}
+	doorCommand := doorConfig.Commands[0]
+	doorArgs := doorConfig.Commands[1:]
 
-	// Substitute in Arguments (after dropfile generation so {DROPFILE} etc. are available)
+	// Substitute placeholders in command and arguments
+	for key, val := range ctx.Subs {
+		doorCommand = strings.ReplaceAll(doorCommand, key, val)
+	}
 	substitutedArgs := make([]string, len(doorArgs))
 	for i, arg := range doorArgs {
 		newArg := arg

--- a/internal/menu/door_handler.go
+++ b/internal/menu/door_handler.go
@@ -55,19 +55,16 @@ func writeBatchFile(ctx *DoorCtx, batchPath string) error {
 		b.WriteString(ctx.Config.FossilDriver + crlf)
 	}
 
-	// Auto-copy dropfile to the door's directory if dropfile_dest is set
-	if ctx.Config.DropfileDest != "" {
-		dropfileName := dosDropfileName(ctx.Config.DropfileType)
-		src := ctx.Subs["{DOSNODEDIR}"] + "\\" + dropfileName
-		dest := ctx.Config.DropfileDest + "\\" + dropfileName
-		b.WriteString(fmt.Sprintf("COPY \"%s\" \"%s\" >NUL", src, dest) + crlf)
-	}
-
 	// Clear screen — the PTY bridge detects this ESC[2J sequence to know
 	// boot is done, discarding all prior DOS boot text.
 	b.WriteString("cls" + crlf)
 
-	for _, cmd := range ctx.Config.DOSCommands {
+	// Auto-cd to the door's working directory if configured
+	if ctx.Config.WorkingDirectory != "" {
+		b.WriteString("cd " + ctx.Config.WorkingDirectory + crlf)
+	}
+
+	for _, cmd := range ctx.Config.Commands {
 		processed := strings.ReplaceAll(cmd, "{NODE}", ctx.NodeNumStr)
 		for key, val := range ctx.Subs {
 			processed = strings.ReplaceAll(processed, key, val)
@@ -378,9 +375,17 @@ func executeNativeDoor(ctx *DoorCtx) error {
 	ctx.Subs["{DROPFILE}"] = dropfilePath
 	ctx.Subs["{NODEDIR}"] = dropfileDir
 
+	// Extract command and args from Commands slice (native: [0]=executable, [1:]=args)
+	doorCommand := ""
+	var doorArgs []string
+	if len(doorConfig.Commands) > 0 {
+		doorCommand = doorConfig.Commands[0]
+		doorArgs = doorConfig.Commands[1:]
+	}
+
 	// Substitute in Arguments (after dropfile generation so {DROPFILE} etc. are available)
-	substitutedArgs := make([]string, len(doorConfig.Args))
-	for i, arg := range doorConfig.Args {
+	substitutedArgs := make([]string, len(doorArgs))
+	for i, arg := range doorArgs {
 		newArg := arg
 		for key, val := range ctx.Subs {
 			newArg = strings.ReplaceAll(newArg, key, val)
@@ -404,11 +409,11 @@ func executeNativeDoor(ctx *DoorCtx) error {
 	var cmd *exec.Cmd
 	if doorConfig.UseShell {
 		// Use exec "$0" "$@" to preserve argument boundaries and prevent injection
-		shellArgs := append([]string{"-c", `exec "$0" "$@"`, doorConfig.Command}, substitutedArgs...)
+		shellArgs := append([]string{"-c", `exec "$0" "$@"`, doorCommand}, substitutedArgs...)
 		cmd = exec.Command("/bin/sh", shellArgs...)
-		log.Printf("DEBUG: Node %d: Using shell execution for %q with %d arg(s)", ctx.NodeNumber, doorConfig.Command, len(substitutedArgs))
+		log.Printf("DEBUG: Node %d: Using shell execution for %q with %d arg(s)", ctx.NodeNumber, doorCommand, len(substitutedArgs))
 	} else {
-		cmd = exec.Command(doorConfig.Command, substitutedArgs...)
+		cmd = exec.Command(doorCommand, substitutedArgs...)
 	}
 
 	if doorConfig.WorkingDirectory != "" {
@@ -1014,8 +1019,8 @@ func runDoorInfo(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, userMa
 		}
 
 		info := fmt.Sprintf("|15Door: |07%s\r\n|15Type: |07%s\r\n", upperInput, doorType)
-		if doorConfig.Command != "" {
-			info += fmt.Sprintf("|15Command: |07%s\r\n", doorConfig.Command)
+		if len(doorConfig.Commands) > 0 {
+			info += fmt.Sprintf("|15Commands: |07%s\r\n", strings.Join(doorConfig.Commands, ", "))
 		}
 		if doorConfig.WorkingDirectory != "" {
 			info += fmt.Sprintf("|15Directory: |07%s\r\n", doorConfig.WorkingDirectory)
@@ -1029,9 +1034,6 @@ func runDoorInfo(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, userMa
 		}
 		if doorConfig.IOMode != "" {
 			info += fmt.Sprintf("|15I/O Mode: |07%s\r\n", doorConfig.IOMode)
-		}
-		if doorConfig.IsDOS && len(doorConfig.DOSCommands) > 0 {
-			info += fmt.Sprintf("|15DOS Commands: |07%s\r\n", strings.Join(doorConfig.DOSCommands, " && "))
 		}
 		if doorConfig.MinAccessLevel > 0 {
 			info += fmt.Sprintf("|15Min Access: |07%d\r\n", doorConfig.MinAccessLevel)

--- a/internal/menu/door_handler_windows.go
+++ b/internal/menu/door_handler_windows.go
@@ -92,9 +92,17 @@ func executeNativeDoorWindows(ctx *DoorCtx) error {
 	ctx.Subs["{DROPFILE}"] = dropfilePath
 	ctx.Subs["{NODEDIR}"] = dropfileDir
 
+	// Extract command and args from Commands slice (native: [0]=executable, [1:]=args)
+	doorCommand := ""
+	var doorArgs []string
+	if len(doorConfig.Commands) > 0 {
+		doorCommand = doorConfig.Commands[0]
+		doorArgs = doorConfig.Commands[1:]
+	}
+
 	// Substitute in Arguments
-	substitutedArgs := make([]string, len(doorConfig.Args))
-	for i, arg := range doorConfig.Args {
+	substitutedArgs := make([]string, len(doorArgs))
+	for i, arg := range doorArgs {
 		newArg := arg
 		for key, val := range ctx.Subs {
 			newArg = strings.ReplaceAll(newArg, key, val)
@@ -121,14 +129,14 @@ func executeNativeDoorWindows(ctx *DoorCtx) error {
 	var cmd *exec.Cmd
 	if doorConfig.UseShell {
 		cmd = exec.Command("cmd")
-		cmdLine := "cmd /c " + syscall.EscapeArg(doorConfig.Command)
+		cmdLine := "cmd /c " + syscall.EscapeArg(doorCommand)
 		for _, arg := range substitutedArgs {
 			cmdLine += " " + syscall.EscapeArg(arg)
 		}
 		cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: cmdLine}
-		log.Printf("DEBUG: Node %d: Using shell execution for %q with %d arg(s)", ctx.NodeNumber, doorConfig.Command, len(substitutedArgs))
+		log.Printf("DEBUG: Node %d: Using shell execution for %q with %d arg(s)", ctx.NodeNumber, doorCommand, len(substitutedArgs))
 	} else {
-		cmd = exec.Command(doorConfig.Command, substitutedArgs...)
+		cmd = exec.Command(doorCommand, substitutedArgs...)
 	}
 
 	if doorConfig.WorkingDirectory != "" {
@@ -523,8 +531,8 @@ func runDoorInfo(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, userMa
 		}
 
 		info := fmt.Sprintf("|15Door: |07%s\r\n|15Type: |07%s\r\n", upperInput, doorType)
-		if doorConfig.Command != "" {
-			info += fmt.Sprintf("|15Command: |07%s\r\n", doorConfig.Command)
+		if len(doorConfig.Commands) > 0 {
+			info += fmt.Sprintf("|15Commands: |07%s\r\n", strings.Join(doorConfig.Commands, ", "))
 		}
 		if doorConfig.WorkingDirectory != "" {
 			info += fmt.Sprintf("|15Directory: |07%s\r\n", doorConfig.WorkingDirectory)

--- a/internal/menu/door_handler_windows.go
+++ b/internal/menu/door_handler_windows.go
@@ -93,14 +93,16 @@ func executeNativeDoorWindows(ctx *DoorCtx) error {
 	ctx.Subs["{NODEDIR}"] = dropfileDir
 
 	// Extract command and args from Commands slice (native: [0]=executable, [1:]=args)
-	doorCommand := ""
-	var doorArgs []string
-	if len(doorConfig.Commands) > 0 {
-		doorCommand = doorConfig.Commands[0]
-		doorArgs = doorConfig.Commands[1:]
+	if len(doorConfig.Commands) == 0 || doorConfig.Commands[0] == "" {
+		return fmt.Errorf("door %q has no command configured", ctx.DoorName)
 	}
+	doorCommand := doorConfig.Commands[0]
+	doorArgs := doorConfig.Commands[1:]
 
-	// Substitute in Arguments
+	// Substitute placeholders in command and arguments
+	for key, val := range ctx.Subs {
+		doorCommand = strings.ReplaceAll(doorCommand, key, val)
+	}
 	substitutedArgs := make([]string, len(doorArgs))
 	for i, arg := range doorArgs {
 		newArg := arg

--- a/templates/configs/doors.json
+++ b/templates/configs/doors.json
@@ -1,9 +1,10 @@
 [
     {
         "name": "LORD",
-        "command": "",
-        "args": [],
-        "working_directory": "",
+        "working_directory": "C:\\DOORS\\LORD",
+        "commands": [
+            "START.BAT {NODE}"
+        ],
         "dropfile_type": "DOOR.SYS",
         "dropfile_location": "node",
         "io_mode": "",
@@ -15,12 +16,7 @@
         "cleanup_args": [],
         "environment_variables": {},
         "is_dos": true,
-        "dos_commands": [
-            "cd C:\\DOORS\\LORD",
-            "START.BAT {NODE}"
-        ],
         "drive_c_path": "drive_c",
-        "dropfile_dest": "C:\\DOORS\\LORD",
         "dos_emulator": "dosemu",
         "fossil_driver": "C:\\UTILS\\X00.EXE eliminate",
         "dosemu_config": ""


### PR DESCRIPTION
## Summary
- Consolidate `command`, `args`, and `dos_commands` into a single unified `Commands` field — native doors use `[0]` as executable and `[1:]` as args; DOS doors use each entry as a batch command line
- Remove `dropfile_dest` field in favor of using `working_directory` for both native and DOS doors (DOS doors auto-`cd` to working directory in EXTERNAL.BAT)
- Replace free-text config editor inputs with lookup selectors for dropfile type, dropfile location, I/O mode, and DOS emulator
- Add environment variables editor field and move "Working Dir" to common fields section
- Update all documentation and tests to match the new schema

## Test plan
- [ ] Verify `go test ./internal/config/...` passes with updated door config tests
- [ ] Verify `go test ./internal/configeditor/...` passes
- [ ] Test config editor: door fields render correctly, lookup selectors work for dropfile type/location/IO mode/DOS emulator
- [ ] Test native door execution with the new `Commands` field format
- [ ] Test DOS door execution: confirm `working_directory` produces correct `cd` in EXTERNAL.BAT
- [ ] Verify existing `doors.json` configs migrate cleanly (field rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)