### PR TITLE
feat(v3net): area-level message access control

### DIFF
--- a/cmd/vision3/main.go
+++ b/cmd/vision3/main.go
@@ -1821,23 +1821,25 @@ func main() {
 			v3netAreaMap := make(map[int]v3netAreaInfo) // area ID → network info
 			nodeID := svc.NodeID()
 			for _, lcfg := range v3netConfig.Leaves {
-				area, ok := messageMgr.GetAreaByTag(lcfg.Board)
-				if !ok {
-					log.Printf("WARN: V3Net leaf %q: message area %q not found, skipping", lcfg.Network, lcfg.Board)
-					continue
-				}
-				writer := v3net.NewJAMAdapter(messageMgr, area.ID)
-				if err := v3netService.AddLeaf(lcfg, writer, nil); err != nil {
-					log.Printf("ERROR: V3Net leaf %q: %v", lcfg.Network, err)
-					continue
-				}
-				// Default origin to BBS name if not configured.
+				router := v3net.NewJAMRouter()
 				origin := lcfg.Origin
 				if origin == "" {
 					origin = serverConfig.BoardName
 				}
-				v3netAreaMap[area.ID] = v3netAreaInfo{Network: lcfg.Network, Origin: origin}
-				svc.RegisterArea(area.ID, lcfg.Network)
+				for _, tag := range lcfg.Boards {
+					area, ok := messageMgr.GetAreaByTag(tag)
+					if !ok {
+						log.Printf("WARN: V3Net leaf %q: message area %q not found, skipping", lcfg.Network, tag)
+						continue
+					}
+					router.Add(tag, v3net.NewJAMAdapter(messageMgr, area.ID))
+					v3netAreaMap[area.ID] = v3netAreaInfo{Network: lcfg.Network, Origin: origin}
+					svc.RegisterArea(area.ID, lcfg.Network)
+				}
+				if err := v3netService.AddLeaf(lcfg, router, nil); err != nil {
+					log.Printf("ERROR: V3Net leaf %q: %v", lcfg.Network, err)
+					continue
+				}
 			}
 
 			// Append tearline/origin to local JAM copy for V3Net areas so
@@ -1866,7 +1868,7 @@ func main() {
 				if strings.HasPrefix(body, "\x01V3NETUUID: ") {
 					return
 				}
-				msg := v3net.BuildWireMessage(info.Network, svc.NodeID(), serverConfig.BoardName, from, to, subject, body, info.Origin)
+				msg := v3net.BuildWireMessage(info.Network, area.Tag, svc.NodeID(), serverConfig.BoardName, from, to, subject, body, info.Origin)
 				if err := svc.SendMessage(info.Network, msg); err != nil {
 					log.Printf("ERROR: V3Net: failed to send message to %s: %v", info.Network, err)
 					return

--- a/cmd/vision3/main.go
+++ b/cmd/vision3/main.go
@@ -1826,6 +1826,7 @@ func main() {
 				if origin == "" {
 					origin = serverConfig.BoardName
 				}
+				var resolvedBoards []string
 				for _, tag := range lcfg.Boards {
 					area, ok := messageMgr.GetAreaByTag(tag)
 					if !ok {
@@ -1833,10 +1834,17 @@ func main() {
 						continue
 					}
 					router.Add(tag, v3net.NewJAMAdapter(messageMgr, area.ID))
+					resolvedBoards = append(resolvedBoards, tag)
 					v3netAreaMap[area.ID] = v3netAreaInfo{Network: lcfg.Network, Origin: origin}
 					svc.RegisterArea(area.ID, lcfg.Network)
 				}
-				if err := v3netService.AddLeaf(lcfg, router, nil); err != nil {
+				if len(resolvedBoards) == 0 {
+					log.Printf("WARN: V3Net leaf %q: no resolvable boards, skipping", lcfg.Network)
+					continue
+				}
+				leafCfg := lcfg
+				leafCfg.Boards = resolvedBoards
+				if err := v3netService.AddLeaf(leafCfg, router, nil); err != nil {
 					log.Printf("ERROR: V3Net leaf %q: %v", lcfg.Network, err)
 					continue
 				}

--- a/docs/plans/2026-03-19-v3net-area-level-message-access-design.md
+++ b/docs/plans/2026-03-19-v3net-area-level-message-access-design.md
@@ -1,0 +1,290 @@
+# V3Net Area-Level Message Access Control
+
+**Date:** 2026-03-19
+**Status:** Design
+**Scope:** Add `area_tag` to the message wire format and enforce area-level access control on both POST and GET message endpoints.
+
+---
+
+## Problem
+
+Messages in V3Net are currently stored and served at the network level with no area awareness. The NAL defines areas with access modes (open, approval, closed) and allow/deny lists, and `area_subscriptions` tracks per-node per-area subscription status — but neither is consulted during message POST or GET.
+
+This means a node that hasn't been approved for a restricted area can still post messages to it, and all nodes receive all messages regardless of their area subscriptions. The AGENTS.v3net.md spec (line 963) states: "Message distribution filters on `area_subscriptions` where `status = 'active'`."
+
+## Design Decisions
+
+- **`area_tag` is a new required field** on `protocol.Message`, alongside the existing `origin_board` (which remains for display/provenance).
+- **Enforcement on both POST and GET** — nodes cannot post to areas they aren't subscribed to, and GET results are filtered to only include messages for areas where the node has active subscriptions.
+- **Per-network cursor preserved** — the leaf continues to use a single `since=UUID` cursor per network. The hub silently skips messages for areas the requesting node isn't subscribed to. No per-area polling required.
+- **No backward compatibility concerns** — this is experimental software with no production deployments. Schema changes are drop-and-recreate.
+
+---
+
+## Wire Format Change
+
+Add `area_tag` to `protocol.Message`:
+
+```go
+type Message struct {
+    // ... existing fields ...
+    AreaTag     string         `json:"area_tag"`
+    OriginBoard string         `json:"origin_board"`
+    // ... remaining fields ...
+}
+```
+
+`area_tag` is the network-wide area identifier (e.g., `fel.general`) used for routing and access control. `origin_board` is the human-readable local board name at the originating BBS (e.g., "General Discussion") used for display.
+
+### Validation
+
+`Message.Validate()` rejects messages with a missing or invalid `area_tag` using the existing `protocol.AreaTagRegexp` (defined in `protocol/nal.go`): `^[a-z0-9]{1,8}\.[a-z0-9-]{1,24}$`.
+
+The hub performs additional validation on POST: the `area_tag` must exist in the network's NAL. This check lives in the handler, not in `Validate()`, because the wire-level validator has no NAL context.
+
+---
+
+## Hub POST /messages Enforcement
+
+After existing validation in `handlePostMessage`, two new checks are added:
+
+1. **NAL must exist** — load the NAL via `h.nalStore.Get(network)`. If `nil` (no NAL published yet), return HTTP 422 with `"no NAL published for this network"`. This forces operators to set up the NAL before messages can flow.
+2. **Area exists in NAL** — call `currentNAL.FindArea(msg.AreaTag)`. If the area doesn't exist, return HTTP 422 (`unknown area_tag`).
+3. **Node has active subscription** — read `nodeID` from `r.Header.Get(headerNodeID)` (set by auth middleware). Call `h.areaSubscriptions.IsActive(nodeID, network, msg.AreaTag)`. If not active, return HTTP 403 (`area access denied`).
+
+Check order: wire validation → network match → NAL exists → area exists in NAL → node authorized for area → dedup → store.
+
+Note: the `h.messages.Store` call signature changes to include `areaTag`, so the call in `handlePostMessage` must be updated accordingly.
+
+---
+
+## Hub GET /messages Filtering
+
+### Schema Change
+
+The `messages` table gains an `area_tag` column and a composite index. Since this is experimental software with no production data, the migration strategy is: `NewMessageStore` attempts to add the column via `ALTER TABLE messages ADD COLUMN area_tag TEXT NOT NULL DEFAULT ''`. If this fails (column already exists), it's a no-op. The `CREATE TABLE IF NOT EXISTS` statement is updated for fresh databases. Note: `CREATE TABLE IF NOT EXISTS` does not alter existing tables — it only applies to new databases.
+
+```sql
+CREATE TABLE IF NOT EXISTS messages (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    msg_uuid    TEXT UNIQUE NOT NULL,
+    network     TEXT NOT NULL,
+    area_tag    TEXT NOT NULL,
+    data        TEXT NOT NULL,
+    received_at DATETIME DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_messages_network ON messages(network, id);
+CREATE INDEX IF NOT EXISTS idx_messages_area ON messages(network, area_tag, id);
+```
+
+### Store Method
+
+`MessageStore.Store` gains an `areaTag` parameter:
+
+```go
+func (ms *MessageStore) Store(msgUUID, network, areaTag, data string) (bool, error)
+```
+
+The INSERT statement adds the `area_tag` column.
+
+### Fetch Method
+
+`MessageStore.Fetch` gains a `[]string` parameter for allowed area tags:
+
+```go
+func (ms *MessageStore) Fetch(network, sinceUUID string, limit int, areaTags []string) ([]string, bool, error)
+```
+
+**Empty areaTags short-circuit:** If `areaTags` is empty, return `(nil, false, nil)` immediately without querying the database. Building an `IN ()` clause with zero parameters produces invalid SQL.
+
+When `areaTags` is non-empty, the query adds an `area_tag IN (...)` filter. Both query branches (with and without `sinceUUID` cursor) must include this filter:
+
+```sql
+-- Without cursor (sinceUUID is empty):
+SELECT data FROM messages
+WHERE network = ? AND area_tag IN (?, ?, ...)
+ORDER BY id ASC LIMIT ?
+
+-- With cursor:
+SELECT data FROM messages
+WHERE network = ? AND area_tag IN (?, ?, ...)
+AND id > (SELECT COALESCE((SELECT id FROM messages WHERE msg_uuid = ?), 0))
+ORDER BY id ASC LIMIT ?
+```
+
+### Handler Changes
+
+`handleGetMessages` reads `nodeID` from `r.Header.Get(headerNodeID)` (currently this function does not use node ID — this is a new addition). It calls `areaSubscriptions.ListForNode(nodeID, network)`, filters to entries with `status = "active"`, extracts the tag list, and passes it to `Fetch`. If a node has no active subscriptions, the empty-slice short-circuit returns an empty array.
+
+### Pagination
+
+The existing cursor model is unchanged from the leaf's perspective. The leaf passes `since=<last_uuid>&limit=100` and gets back the next batch of messages it's allowed to see. The hub silently skips messages for areas the node isn't subscribed to. Gaps in the sequential ID space are invisible to the client.
+
+The composite index on `(network, area_tag, id)` keeps filtered queries efficient.
+
+---
+
+## Leaf-Side Changes
+
+### Config Change
+
+`V3NetLeafConfig` currently has a single `Board string` field — one area per leaf config. This changes to support multiple areas per network subscription:
+
+```go
+type V3NetLeafConfig struct {
+    HubURL       string   `json:"hubUrl"`
+    Network      string   `json:"network"`
+    Boards       []string `json:"boards"`           // V3Net area tags (e.g., ["fel.general", "fel.phreaking"])
+    PollInterval string   `json:"pollInterval"`
+    Origin       string   `json:"origin,omitempty"`
+}
+```
+
+The old `Board string` field is replaced by `Boards []string`. Each entry is a V3Net area tag that also serves as the local message area tag (consistent with how `SyncAreas` already works — it uses the area tag as both the V3Net identifier and the local `MessageArea.Tag`).
+
+### Wire Message Construction
+
+`BuildWireMessage` in `wire.go` (not "NewMessage" — that was a naming error) gains an `areaTag` parameter. When a BBS user posts a message to a V3Net area, the outbound path looks up the area tag from the local message area's config and sets it on the wire message.
+
+### JAM Router
+
+The `JAMWriter` interface is unchanged:
+
+```go
+type JAMWriter interface {
+    WriteMessage(msg protocol.Message) (int64, error)
+}
+```
+
+A new `JAMRouter` in `jam_router.go` implements `leaf.JAMWriter` and dispatches by area tag:
+
+```go
+type JAMRouter struct {
+    adapters map[string]*JAMAdapter // area_tag → adapter
+}
+
+func (r *JAMRouter) WriteMessage(msg protocol.Message) (int64, error) {
+    adapter, ok := r.adapters[msg.AreaTag]
+    if !ok {
+        slog.Warn("v3net: no local area for tag, skipping", "area_tag", msg.AreaTag)
+        return 0, nil
+    }
+    return adapter.WriteMessage(msg)
+}
+```
+
+Each `JAMAdapter` still holds a single `areaID` and writes to one JAM message base. The router dispatches based on `msg.AreaTag`.
+
+### Service Integration
+
+`Service.AddLeaf` receives the router (which satisfies `JAMWriter`). The router is built during startup by iterating the leaf config's `Boards` slice:
+
+```go
+for _, tag := range lcfg.Boards {
+    area, ok := mgr.GetAreaByTag(tag)
+    if !ok {
+        // SyncAreas should have created it; skip if missing
+        continue
+    }
+    router.adapters[tag] = NewJAMAdapter(mgr, area.ID)
+}
+```
+
+`SyncAreas` signature is unchanged — it still accepts `[]config.V3NetLeafConfig`. The internal loop changes to iterate `lcfg.Boards` instead of reading the old `lcfg.Board` field. Its return type remains `int` (count of areas created) — the router builds its own mapping separately using `mgr.GetAreaByTag`.
+
+The startup code that calls `service.RegisterArea(areaID, network)` must also be updated to loop over all boards in each leaf config, calling `RegisterArea` for each one. This ensures `NetworkForArea` returns the correct network for outbound message routing.
+
+### Subscribe with Area Tags
+
+The leaf's subscribe request already supports `area_tags` via `protocol.SubscribeRequest.AreaTags`. Currently the leaf sends no area tags. With this change:
+
+1. `leaf.Config` gains an `AreaTags []string` field (populated from `V3NetLeafConfig.Boards`).
+2. `leaf.subscribe()` in `leaf/sender.go` sets `req.AreaTags = l.cfg.AreaTags` before marshalling.
+3. `service.AddLeaf` passes `lcfg.Boards` through to `leaf.Config.AreaTags`.
+
+This ensures the hub creates `area_subscriptions` entries at subscribe time, which enables both POST authorization and GET filtering.
+
+---
+
+## Edge Cases
+
+### No NAL published yet
+
+If `nalStore.Get(network)` returns `(nil, nil)`, POST /messages returns HTTP 422: `"no NAL published for this network"`. GET /messages returns an empty array (since the node can have no active area subscriptions without a NAL). This forces the operator to publish a NAL before message flow begins.
+
+### Area removed from NAL after subscription
+
+If an area is removed from the NAL while nodes have active subscriptions: POST is rejected (area not in NAL). GET continues to serve stored messages for that area (the subscription is still active). This is acceptable — the area manager should revoke subscriptions when removing an area, or the hub can garbage-collect orphaned subscriptions in a future cleanup pass.
+
+---
+
+## Testing Strategy
+
+### Hub Tests (`hub/hub_area_msg_test.go` — new file)
+
+- POST message without `area_tag` → 422 (wire validation)
+- POST message with `area_tag` not in NAL → 422
+- POST message when no NAL exists → 422
+- POST message to area node isn't subscribed to → 403
+- POST message to area with active subscription → 200
+- GET messages only returns messages for node's active area subscriptions
+- GET messages with no active subscriptions → empty array
+
+### Protocol Tests (`protocol/message_test.go`)
+
+- `Message.Validate()` rejects missing `area_tag`
+- `Message.Validate()` rejects invalid `area_tag` format
+
+### Integration Tests (`integration_test.go`)
+
+- End-to-end: leaf posts message with `area_tag`, hub stores, other leaf polls and receives only messages for its subscribed areas
+
+### JAM Router Tests (`v3net/jam_router_test.go` — new file)
+
+- Router dispatches to correct adapter by `area_tag`
+- Router skips messages for unknown `area_tag` (returns 0, nil)
+
+### Existing Test Updates
+
+All existing tests that construct `protocol.Message` (both as Go structs and raw JSON strings) must add `AreaTag`/`"area_tag"` to avoid validation failures. This includes raw JSON literals in `hub_test.go`, `hub_nal_test.go`, `leaf_test.go`, and `integration_test.go`.
+
+---
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `internal/v3net/protocol/message.go` | Add `AreaTag` field, update `Validate()` |
+| `internal/v3net/hub/messages.go` | Add `area_tag` column to schema, update `Store`/`Fetch` signatures and queries |
+| `internal/v3net/hub/handlers.go` | Add NAL existence + area existence + subscription checks on POST; add node ID lookup and area filtering on GET; update `Store` call to pass `areaTag` |
+| `internal/v3net/wire.go` | Add `areaTag` parameter to `BuildWireMessage` |
+| `internal/v3net/jam_adapter.go` | No structural change (individual adapters unchanged) |
+| `internal/v3net/service.go` | Build `JAMRouter` from config boards, pass to `AddLeaf`; update `RegisterArea` loop |
+| `internal/v3net/area_sync.go` | Iterate `lcfg.Boards` instead of `lcfg.Board` |
+| `internal/config/config.go` | Change `V3NetLeafConfig.Board` to `Boards []string` |
+| `internal/v3net/leaf/config.go` | Add `AreaTags []string` field to `leaf.Config` |
+| `internal/v3net/leaf/sender.go` | Set `req.AreaTags` from config in `subscribe()` |
+| `internal/v3net/leaf/jam.go` | No change (interface unchanged) |
+
+## Files Added
+
+| File | Purpose |
+|------|---------|
+| `internal/v3net/jam_router.go` | `JAMRouter` struct implementing `leaf.JAMWriter` with area_tag dispatch |
+
+## Test Files Modified
+
+| File | Change |
+|------|--------|
+| `internal/v3net/hub/hub_test.go` | Add `AreaTag`/`"area_tag"` to all test messages (structs and raw JSON) |
+| `internal/v3net/hub/hub_nal_test.go` | Add `"area_tag"` to pagination test raw JSON messages |
+| `internal/v3net/protocol/message_test.go` | Add `area_tag` validation tests |
+| `internal/v3net/leaf/leaf_test.go` | Add `AreaTag` to test messages |
+| `internal/v3net/integration_test.go` | Add `AreaTag` to test messages, update `JAMWriter` for router, add area-filtered polling test |
+
+## Test Files Added
+
+| File | Purpose |
+|------|---------|
+| `internal/v3net/hub/hub_area_msg_test.go` | Hub area-level POST/GET enforcement tests |
+| `internal/v3net/jam_router_test.go` | JAM router dispatch and skip tests |

--- a/docs/plans/2026-03-19-v3net-area-level-message-access.md
+++ b/docs/plans/2026-03-19-v3net-area-level-message-access.md
@@ -1,0 +1,1406 @@
+# V3Net Area-Level Message Access Control — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `area_tag` to the message wire format and enforce area-level access control on hub POST and GET message endpoints.
+
+**Architecture:** Messages gain a required `area_tag` field validated against the NAL. The hub enforces area subscriptions on POST (reject unauthorized) and GET (filter to subscribed areas). The leaf sends area tags at subscribe time and routes inbound messages to per-area JAM adapters via a new JAMRouter.
+
+**Tech Stack:** Go stdlib, SQLite (modernc.org/sqlite), ed25519 auth, existing hub/leaf/protocol packages.
+
+**Spec:** `docs/plans/2026-03-19-v3net-area-level-message-access-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `internal/v3net/protocol/message.go` | Modify | Add `AreaTag` field, update `Validate()` |
+| `internal/v3net/protocol/message_test.go` | Modify | Add `AreaTag` to `validMessage()`, add area_tag validation tests |
+| `internal/v3net/hub/messages.go` | Modify | Add `area_tag` column, update `Store`/`Fetch` signatures |
+| `internal/v3net/hub/handlers.go` | Modify | POST: NAL+area+subscription checks; GET: area filtering; update `Store`/`Fetch` calls |
+| `internal/v3net/wire.go` | Modify | Add `areaTag` parameter to `BuildWireMessage` |
+| `internal/v3net/wire_test.go` | Modify | Update 3 `BuildWireMessage` call sites |
+| `internal/config/config.go` | Modify | `Board string` → `Boards []string` |
+| `internal/v3net/leaf/config.go` | Modify | Add `AreaTags []string` |
+| `internal/v3net/leaf/sender.go` | Modify | Set `req.AreaTags` in `subscribe()` |
+| `internal/v3net/jam_router.go` | **Create** | `JAMRouter` dispatches by `area_tag` |
+| `internal/v3net/service.go` | Modify | Pass `AreaTags` to leaf, build router |
+| `internal/v3net/area_sync.go` | Modify | Iterate `Boards` instead of `Board` |
+| `internal/v3net/area_sync_test.go` | Modify | Update `Board:` to `Boards:` in test fixtures |
+| `internal/menu/v3net_areas.go` | Modify | Update `.Board` references to work with `Boards` |
+| `internal/configeditor/fields_v3net.go` | Modify | Update Board field editor to Boards list |
+| `internal/configeditor/view_list.go` | Modify | Update v3netleaf list display |
+| `internal/configeditor/update_wizard_form.go` | Modify | `Board:` → `Boards: []string{...}` |
+| `internal/configeditor/update_v3net_wizard_hub.go` | Modify | `Board:` → `Boards: []string{...}` |
+| `cmd/vision3/main.go` | Modify | Iterate `lcfg.Boards`, build `JAMRouter`, update `BuildWireMessage` call |
+| `internal/v3net/hub/hub_test.go` | Modify | Add `AreaTag`, seed NAL, subscribe with areas in message tests |
+| `internal/v3net/hub/hub_nal_test.go` | Modify | Add `"area_tag"` to raw JSON messages, seed NAL, subscribe with areas |
+| `internal/v3net/leaf/leaf_test.go` | Modify | Add `AreaTag` to `testMessage()` |
+| `internal/v3net/integration_test.go` | Modify | Add `AreaTag`, seed NAL, subscribe with areas, add multi-area test |
+| `internal/v3net/hub/hub_area_msg_test.go` | **Create** | Area-level POST/GET enforcement tests |
+| `internal/v3net/jam_router_test.go` | **Create** | JAM router dispatch tests |
+
+---
+
+### Task 1: Add `AreaTag` to Wire Format, Validation, and All Test Fixtures
+
+This task adds the field, updates validation, and fixes **all** existing test fixtures in one atomic commit so no intermediate state breaks tests.
+
+**Files:**
+- Modify: `internal/v3net/protocol/message.go:19-36` (Message struct), `44-82` (Validate)
+- Modify: `internal/v3net/protocol/message_test.go:8-24` (validMessage + new tests)
+- Modify: `internal/v3net/hub/hub_test.go` (all message structs/JSON)
+- Modify: `internal/v3net/hub/hub_nal_test.go` (pagination test JSON)
+- Modify: `internal/v3net/leaf/leaf_test.go:128-143` (testMessage helper)
+- Modify: `internal/v3net/integration_test.go` (all message structs)
+
+- [ ] **Step 1: Add `AreaTag` field to Message struct**
+
+In `message.go`, add the field between `Network` and `MsgUUID`:
+
+```go
+type Message struct {
+    V3Net       string         `json:"v3net"`
+    Network     string         `json:"network"`
+    AreaTag     string         `json:"area_tag"`
+    MsgUUID     string         `json:"msg_uuid"`
+    // ... rest unchanged
+}
+```
+
+- [ ] **Step 2: Add area_tag validation to Validate()**
+
+In `Validate()`, add after the network check (after line 50):
+
+```go
+if !AreaTagRegexp.MatchString(m.AreaTag) {
+    return fmt.Errorf("invalid area_tag: %q", m.AreaTag)
+}
+```
+
+Note: `AreaTagRegexp` is already defined in `protocol/nal.go`.
+
+- [ ] **Step 3: Update protocol test fixtures and add area_tag tests**
+
+Update `validMessage()` in `message_test.go` to include `AreaTag: "fel.general"`.
+
+Add two test cases to the `TestValidate_InvalidFields` table:
+
+```go
+{
+    name:    "empty area_tag",
+    modify:  func(m *Message) { m.AreaTag = "" },
+    wantErr: "invalid area_tag",
+},
+{
+    name:    "invalid area_tag format",
+    modify:  func(m *Message) { m.AreaTag = "INVALID" },
+    wantErr: "invalid area_tag",
+},
+```
+
+- [ ] **Step 4: Update hub_test.go test fixtures**
+
+Add `AreaTag: "gen.general"` to the `protocol.Message` struct in `TestPostAndGetMessage` (line 163).
+
+Add `"area_tag":"gen.general"` to the raw JSON strings in:
+- `TestDuplicatePostReturns200` (line 227)
+- `TestSSEReceivesNewMessageEvent` (line 286)
+
+Add `"area_tag":"gen.general"` to each raw JSON message in `TestGetMessages_Pagination` in `hub_nal_test.go` (line 287).
+
+These fixture updates only add the field so `Validate()` passes. The tests still use the pre-enforcement POST path. POST enforcement and NAL seeding happen in Task 3.
+
+- [ ] **Step 5: Update leaf_test.go and integration_test.go fixtures**
+
+Add `AreaTag: "gen.general"` to `testMessage()` in `leaf/leaf_test.go`.
+
+Add `AreaTag: "gen.general"` to all `protocol.Message` structs in `integration_test.go`:
+- `TestIntegration_PostAndPoll` (line 138)
+- `TestIntegration_DedupPreventsDoubleWrite` (line 181)
+- `TestIntegration_SSEReceivesEvents` (line 244)
+
+- [ ] **Step 6: Run all tests to verify everything passes**
+
+Run: `go test ./internal/v3net/... -v -count=1`
+Expected: All PASS. The `area_tag` field is on the wire but no enforcement exists yet — existing tests pass because POST doesn't check areas yet.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/v3net/protocol/message.go internal/v3net/protocol/message_test.go \
+  internal/v3net/hub/hub_test.go internal/v3net/hub/hub_nal_test.go \
+  internal/v3net/leaf/leaf_test.go internal/v3net/integration_test.go
+git commit -m "feat(protocol): add area_tag field to Message with validation
+
+Update all test fixtures across hub, leaf, and integration tests to
+include area_tag so Validate() passes."
+```
+
+---
+
+### Task 2: Hub Message Store — Schema and Store Method
+
+This task only changes the `Store` method and schema. The `Fetch` method and `handleGetMessages` are unchanged here — those move to Task 3 together with test fixes to avoid breaking existing GET tests.
+
+**Files:**
+- Modify: `internal/v3net/hub/messages.go:8-17` (schema), `25-30` (NewMessageStore), `33-46` (Store)
+- Modify: `internal/v3net/hub/handlers.go:123` (Store call)
+- Create: `internal/v3net/hub/hub_area_msg_test.go` (Store test)
+
+- [ ] **Step 1: Write failing test for Store with areaTag**
+
+Create `internal/v3net/hub/hub_area_msg_test.go`:
+
+```go
+package hub
+
+import (
+    "testing"
+)
+
+func TestMessageStore_StoreWithAreaTag(t *testing.T) {
+    h, _ := setupTestHub(t)
+
+    ok, err := h.messages.Store("uuid-001", "testnet", "gen.general", `{"test":"data"}`)
+    if err != nil {
+        t.Fatalf("Store: %v", err)
+    }
+    if !ok {
+        t.Fatal("expected new message to be stored")
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/v3net/hub/ -run TestMessageStore_StoreWithAreaTag -v`
+Expected: Compilation error — `Store` takes 3 args, not 4.
+
+- [ ] **Step 3: Update schema, migration, and Store method**
+
+In `messages.go`, update the schema:
+
+```go
+const messagesSchema = `
+CREATE TABLE IF NOT EXISTS messages (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    msg_uuid    TEXT UNIQUE NOT NULL,
+    network     TEXT NOT NULL,
+    area_tag    TEXT NOT NULL,
+    data        TEXT NOT NULL,
+    received_at DATETIME DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_messages_network ON messages(network, id);
+CREATE INDEX IF NOT EXISTS idx_messages_area ON messages(network, area_tag, id);
+`
+```
+
+Add migration in `NewMessageStore`:
+
+```go
+func NewMessageStore(db *sql.DB) (*MessageStore, error) {
+    if _, err := db.Exec(messagesSchema); err != nil {
+        return nil, fmt.Errorf("hub: create messages table: %w", err)
+    }
+    // Migration: add area_tag column to existing databases.
+    db.Exec("ALTER TABLE messages ADD COLUMN area_tag TEXT NOT NULL DEFAULT ''")
+    // Migration: add composite index for area filtering.
+    db.Exec("CREATE INDEX IF NOT EXISTS idx_messages_area ON messages(network, area_tag, id)")
+    return &MessageStore{db: db}, nil
+}
+```
+
+Update `Store` signature and INSERT:
+
+```go
+func (ms *MessageStore) Store(msgUUID, network, areaTag, data string) (bool, error) {
+    res, err := ms.db.Exec(
+        "INSERT OR IGNORE INTO messages (msg_uuid, network, area_tag, data) VALUES (?, ?, ?, ?)",
+        msgUUID, network, areaTag, data,
+    )
+    // ... rest unchanged
+}
+```
+
+- [ ] **Step 4: Update Store call in handlePostMessage**
+
+In `handlers.go:123`:
+
+```go
+isNew, err := h.messages.Store(msg.MsgUUID, network, msg.AreaTag, string(data))
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test ./internal/v3net/hub/ -v -count=1`
+Expected: All PASS. `Fetch` and `handleGetMessages` are unchanged, so existing GET tests still work.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/v3net/hub/messages.go internal/v3net/hub/handlers.go \
+  internal/v3net/hub/hub_area_msg_test.go
+git commit -m "feat(hub): add area_tag column to messages table, update Store signature"
+```
+
+---
+
+### Task 3: Hub POST Enforcement + Fetch Filtering + Fix Existing Tests
+
+This task adds all enforcement (POST and GET) and simultaneously updates all existing tests that POST or GET messages. Everything changes in one atomic commit.
+
+**Files:**
+- Modify: `internal/v3net/hub/messages.go:51-97` (Fetch method)
+- Modify: `internal/v3net/hub/handlers.go:59-91` (handleGetMessages), `94-141` (handlePostMessage)
+- Modify: `internal/v3net/hub/hub_test.go` (tests that POST/GET messages)
+- Modify: `internal/v3net/hub/hub_nal_test.go` (pagination test)
+- Modify: `internal/v3net/integration_test.go` (setup + message tests)
+- Add to: `internal/v3net/hub/hub_area_msg_test.go` (enforcement + fetch filter tests)
+
+- [ ] **Step 1: Update Fetch method with area filtering**
+
+Add `"strings"` to the import block in `messages.go`. Replace the `Fetch` method:
+
+```go
+func (ms *MessageStore) Fetch(network, sinceUUID string, limit int, areaTags []string) ([]string, bool, error) {
+    if len(areaTags) == 0 {
+        return nil, false, nil
+    }
+    if limit <= 0 || limit > 500 {
+        limit = 100
+    }
+
+    placeholders := make([]string, len(areaTags))
+    args := make([]any, 0, len(areaTags)+3)
+    args = append(args, network)
+    for i, tag := range areaTags {
+        placeholders[i] = "?"
+        args = append(args, tag)
+    }
+    inClause := strings.Join(placeholders, ",")
+
+    fetchLimit := limit + 1
+
+    var query string
+    if sinceUUID == "" || sinceUUID == "0" {
+        query = fmt.Sprintf(
+            "SELECT data FROM messages WHERE network = ? AND area_tag IN (%s) ORDER BY id ASC LIMIT ?",
+            inClause,
+        )
+        args = append(args, fetchLimit)
+    } else {
+        query = fmt.Sprintf(
+            `SELECT data FROM messages
+             WHERE network = ? AND area_tag IN (%s)
+             AND id > (SELECT COALESCE((SELECT id FROM messages WHERE msg_uuid = ?), 0))
+             ORDER BY id ASC LIMIT ?`,
+            inClause,
+        )
+        args = append(args, sinceUUID, fetchLimit)
+    }
+
+    rows, err := ms.db.Query(query, args...)
+    if err != nil {
+        return nil, false, fmt.Errorf("hub: fetch messages: %w", err)
+    }
+    defer rows.Close()
+
+    var results []string
+    for rows.Next() {
+        var data string
+        if err := rows.Scan(&data); err != nil {
+            return nil, false, fmt.Errorf("hub: scan message: %w", err)
+        }
+        results = append(results, data)
+    }
+    if err := rows.Err(); err != nil {
+        return nil, false, fmt.Errorf("hub: iterate messages: %w", err)
+    }
+
+    hasMore := len(results) > limit
+    if hasMore {
+        results = results[:limit]
+    }
+    return results, hasMore, nil
+}
+```
+
+- [ ] **Step 2: Replace handleGetMessages to filter by area subscriptions**
+
+Replace `handleGetMessages` in `handlers.go`:
+
+```go
+func (h *Hub) handleGetMessages(w http.ResponseWriter, r *http.Request) {
+    network := extractNetwork(r.URL.Path)
+    nodeID := r.Header.Get(headerNodeID)
+    since := r.URL.Query().Get("since")
+    limit := 100
+    if l := r.URL.Query().Get("limit"); l != "" {
+        if n, err := strconv.Atoi(l); err == nil && n >= 1 && n <= 500 {
+            limit = n
+        }
+    }
+
+    subs, err := h.areaSubscriptions.ListForNode(nodeID, network)
+    if err != nil {
+        slog.Error("list area subscriptions", "error", err)
+        http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+        return
+    }
+    var areaTags []string
+    for _, s := range subs {
+        if s.Status == "active" {
+            areaTags = append(areaTags, s.Tag)
+        }
+    }
+
+    results, hasMore, err := h.messages.Fetch(network, since, limit, areaTags)
+    if err != nil {
+        slog.Error("fetch messages", "error", err)
+        http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+        return
+    }
+
+    if hasMore {
+        w.Header().Set("X-V3Net-Has-More", "true")
+    }
+
+    w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(http.StatusOK)
+    w.Write([]byte("["))
+    for i, data := range results {
+        if i > 0 {
+            w.Write([]byte(","))
+        }
+        w.Write([]byte(data))
+    }
+    w.Write([]byte("]"))
+}
+```
+
+- [ ] **Step 3: Add POST enforcement to handlePostMessage**
+
+In `handlers.go`, after the network mismatch check (line 111) and before `NeedsTruncation`, add:
+
+```go
+// Area-level access control.
+nodeID := r.Header.Get(headerNodeID)
+
+currentNAL, nalErr := h.nalStore.Get(network)
+if nalErr != nil || currentNAL == nil {
+    writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+        "error": "no NAL published for this network",
+    })
+    return
+}
+
+if currentNAL.FindArea(msg.AreaTag) == nil {
+    writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+        "error": "unknown area_tag: " + msg.AreaTag,
+    })
+    return
+}
+
+active, err := h.areaSubscriptions.IsActive(nodeID, network, msg.AreaTag)
+if err != nil {
+    slog.Error("check area subscription", "error", err)
+    http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+    return
+}
+if !active {
+    http.Error(w, `{"error":"area access denied"}`, http.StatusForbidden)
+    return
+}
+```
+
+- [ ] **Step 4: Write POST enforcement and GET filtering tests**
+
+Add to `hub_area_msg_test.go` (adding necessary imports at the top):
+
+```go
+import (
+    "encoding/json"
+    "fmt"
+    "net/http"
+    "net/http/httptest"
+    "path/filepath"
+    "strings"
+    "testing"
+
+    "github.com/ViSiON-3/vision-3-bbs/internal/v3net/keystore"
+    "github.com/ViSiON-3/vision-3-bbs/internal/v3net/nal"
+    "github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+)
+
+func seedAreaMsgNAL(t *testing.T, h *Hub, ks *keystore.Keystore) {
+    t.Helper()
+    testNAL := &protocol.NAL{
+        V3NetNAL: "1.0", Network: "testnet",
+        CoordNodeID: ks.NodeID(), CoordPubKeyB64: ks.PubKeyBase64(),
+        Areas: []protocol.Area{
+            {
+                Tag: "gen.general", Name: "General", Language: "en",
+                ManagerNodeID: ks.NodeID(), ManagerPubKeyB64: ks.PubKeyBase64(),
+                Access: protocol.AreaAccess{Mode: protocol.AccessModeOpen},
+                Policy: protocol.AreaPolicy{MaxBodyBytes: 65536, AllowANSI: true},
+            },
+            {
+                Tag: "gen.restricted", Name: "Restricted", Language: "en",
+                ManagerNodeID: ks.NodeID(), ManagerPubKeyB64: ks.PubKeyBase64(),
+                Access: protocol.AreaAccess{Mode: protocol.AccessModeApproval},
+                Policy: protocol.AreaPolicy{MaxBodyBytes: 65536, AllowANSI: true},
+            },
+        },
+    }
+    if err := nal.Sign(testNAL, ks); err != nil {
+        t.Fatalf("sign NAL: %v", err)
+    }
+    if err := h.nalStore.Put("testnet", testNAL); err != nil {
+        t.Fatalf("put NAL: %v", err)
+    }
+}
+
+func registerLeafWithAreas(t *testing.T, ts *httptest.Server, leafKS *keystore.Keystore, areaTags []string) {
+    t.Helper()
+    req := protocol.SubscribeRequest{
+        Network: "testnet", NodeID: leafKS.NodeID(),
+        PubKeyB64: leafKS.PubKeyBase64(),
+        BBSName: "Test BBS", BBSHost: "test.example.net",
+        AreaTags: areaTags,
+    }
+    body, _ := json.Marshal(req)
+    resp, err := http.Post(ts.URL+"/v3net/v1/subscribe", "application/json",
+        strings.NewReader(string(body)))
+    if err != nil {
+        t.Fatalf("subscribe: %v", err)
+    }
+    resp.Body.Close()
+    if resp.StatusCode != http.StatusOK {
+        t.Fatalf("subscribe status: %d", resp.StatusCode)
+    }
+}
+
+func testMsgJSON(areaTag, uuid string) string {
+    return fmt.Sprintf(`{
+        "v3net":"1.0","network":"testnet","area_tag":%q,
+        "msg_uuid":%q,"thread_uuid":%q,
+        "origin_node":"test.example.net","origin_board":"General",
+        "from":"Tester","to":"All","subject":"Test",
+        "date_utc":"2026-03-16T04:20:00Z","body":"Hello!","kludges":{}
+    }`, areaTag, uuid, uuid)
+}
+
+func TestPostMessage_NoNAL_Returns422(t *testing.T) {
+    h, _ := setupTestHub(t)
+    ts := httptest.NewServer(h.newMux())
+    defer ts.Close()
+
+    leafKS, _, _ := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+    registerLeaf(t, ts, leafKS)
+
+    body := testMsgJSON("gen.general", "550e8400-e29b-41d4-a716-446655440000")
+    req := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/messages", body)
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        t.Fatalf("POST: %v", err)
+    }
+    resp.Body.Close()
+    if resp.StatusCode != http.StatusUnprocessableEntity {
+        t.Errorf("expected 422, got %d", resp.StatusCode)
+    }
+}
+
+func TestPostMessage_UnknownArea_Returns422(t *testing.T) {
+    h, hubKS := setupTestHub(t)
+    ts := httptest.NewServer(h.newMux())
+    defer ts.Close()
+    seedAreaMsgNAL(t, h, hubKS)
+
+    leafKS, _, _ := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+    registerLeafWithAreas(t, ts, leafKS, []string{"gen.general"})
+
+    body := testMsgJSON("gen.nonexistent", "550e8400-e29b-41d4-a716-446655440000")
+    req := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/messages", body)
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        t.Fatalf("POST: %v", err)
+    }
+    resp.Body.Close()
+    if resp.StatusCode != http.StatusUnprocessableEntity {
+        t.Errorf("expected 422, got %d", resp.StatusCode)
+    }
+}
+
+func TestPostMessage_NotSubscribed_Returns403(t *testing.T) {
+    h, hubKS := setupTestHub(t)
+    ts := httptest.NewServer(h.newMux())
+    defer ts.Close()
+    seedAreaMsgNAL(t, h, hubKS)
+
+    leafKS, _, _ := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+    registerLeaf(t, ts, leafKS) // no area subscriptions
+
+    body := testMsgJSON("gen.general", "550e8400-e29b-41d4-a716-446655440000")
+    req := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/messages", body)
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        t.Fatalf("POST: %v", err)
+    }
+    resp.Body.Close()
+    if resp.StatusCode != http.StatusForbidden {
+        t.Errorf("expected 403, got %d", resp.StatusCode)
+    }
+}
+
+func TestPostMessage_ActiveSubscription_Returns200(t *testing.T) {
+    h, hubKS := setupTestHub(t)
+    ts := httptest.NewServer(h.newMux())
+    defer ts.Close()
+    seedAreaMsgNAL(t, h, hubKS)
+
+    leafKS, _, _ := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+    registerLeafWithAreas(t, ts, leafKS, []string{"gen.general"})
+
+    body := testMsgJSON("gen.general", "550e8400-e29b-41d4-a716-446655440000")
+    req := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/messages", body)
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        t.Fatalf("POST: %v", err)
+    }
+    resp.Body.Close()
+    if resp.StatusCode != http.StatusOK {
+        t.Errorf("expected 200, got %d", resp.StatusCode)
+    }
+}
+
+func TestGetMessages_FiltersToSubscribedAreas(t *testing.T) {
+    h, hubKS := setupTestHub(t)
+    ts := httptest.NewServer(h.newMux())
+    defer ts.Close()
+    seedAreaMsgNAL(t, h, hubKS)
+
+    leafKS, _, _ := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+    registerLeafWithAreas(t, ts, leafKS, []string{"gen.general"})
+
+    // Store messages in both areas directly.
+    h.messages.Store("uuid-a1", "testnet", "gen.general", testMsgJSON("gen.general", "uuid-a1"))
+    h.messages.Store("uuid-b1", "testnet", "gen.restricted", testMsgJSON("gen.restricted", "uuid-b1"))
+    h.messages.Store("uuid-a2", "testnet", "gen.general", testMsgJSON("gen.general", "uuid-a2"))
+
+    req := signedRequest(t, leafKS, "GET", ts.URL+"/v3net/v1/testnet/messages", "")
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        t.Fatalf("GET: %v", err)
+    }
+    defer resp.Body.Close()
+
+    var messages []json.RawMessage
+    json.NewDecoder(resp.Body).Decode(&messages)
+    if len(messages) != 2 {
+        t.Errorf("expected 2 messages (gen.general only), got %d", len(messages))
+    }
+}
+
+func TestGetMessages_NoSubscriptions_ReturnsEmpty(t *testing.T) {
+    h, hubKS := setupTestHub(t)
+    ts := httptest.NewServer(h.newMux())
+    defer ts.Close()
+    seedAreaMsgNAL(t, h, hubKS)
+
+    leafKS, _, _ := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+    registerLeaf(t, ts, leafKS) // no area subscriptions
+
+    h.messages.Store("uuid-001", "testnet", "gen.general", testMsgJSON("gen.general", "uuid-001"))
+
+    req := signedRequest(t, leafKS, "GET", ts.URL+"/v3net/v1/testnet/messages", "")
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        t.Fatalf("GET: %v", err)
+    }
+    defer resp.Body.Close()
+
+    var messages []json.RawMessage
+    json.NewDecoder(resp.Body).Decode(&messages)
+    if len(messages) != 0 {
+        t.Errorf("expected 0 messages for unsubscribed node, got %d", len(messages))
+    }
+}
+
+func TestMessageStore_FetchFiltersByAreaTags(t *testing.T) {
+    h, _ := setupTestHub(t)
+
+    h.messages.Store("uuid-a1", "testnet", "gen.general", `{"area_tag":"gen.general","msg_uuid":"uuid-a1"}`)
+    h.messages.Store("uuid-b1", "testnet", "gen.coding", `{"area_tag":"gen.coding","msg_uuid":"uuid-b1"}`)
+    h.messages.Store("uuid-a2", "testnet", "gen.general", `{"area_tag":"gen.general","msg_uuid":"uuid-a2"}`)
+
+    results, _, err := h.messages.Fetch("testnet", "", 100, []string{"gen.general"})
+    if err != nil {
+        t.Fatalf("Fetch: %v", err)
+    }
+    if len(results) != 2 {
+        t.Fatalf("expected 2 messages for gen.general, got %d", len(results))
+    }
+}
+
+func TestMessageStore_FetchEmptyAreaTagsReturnsNil(t *testing.T) {
+    h, _ := setupTestHub(t)
+
+    h.messages.Store("uuid-001", "testnet", "gen.general", `{"test":"data"}`)
+
+    results, hasMore, err := h.messages.Fetch("testnet", "", 100, []string{})
+    if err != nil {
+        t.Fatalf("Fetch: %v", err)
+    }
+    if results != nil {
+        t.Errorf("expected nil results for empty areaTags, got %v", results)
+    }
+    if hasMore {
+        t.Error("expected hasMore=false for empty areaTags")
+    }
+}
+```
+
+- [ ] **Step 5: Update existing hub tests that POST/GET messages**
+
+All tests that POST messages now need NAL seeded and area subscriptions. All tests that GET messages need area subscriptions for results to be returned.
+
+In `hub_test.go`, update each test:
+
+**`TestPostAndGetMessage`**: Add `seedTestNAL(t, h, hubKS)` after `setupTestHub`. Replace `registerLeaf(t, ts, leafKS)` with `registerLeafWithAreas(t, ts, leafKS, []string{"gen.general"})`.
+
+**`TestDuplicatePostReturns200`**: Same pattern — seed NAL, use `registerLeafWithAreas`.
+
+**`TestSSEReceivesNewMessageEvent`**: Same pattern — seed NAL, use `registerLeafWithAreas`.
+
+In `hub_nal_test.go`, update **`TestGetMessages_Pagination`**: Seed NAL via `seedTestNAL(t, h, hubKS)` (change `h, _ := setupTestHub(t)` to `h, hubKS := setupTestHub(t)`). Replace `registerLeaf(t, ts, leafKS)` with `registerLeafWithAreas(t, ts, leafKS, []string{"gen.general"})`.
+
+- [ ] **Step 6: Update integration_test.go**
+
+Update `setupIntegration` to: (a) return `hubKS` as an additional return value (add `hubKS *keystore.Keystore` to the return signature), (b) seed NAL, and (c) subscribe with area tags. After `h, err = hub.New(hubCfg)`:
+
+```go
+// Seed NAL for area-level access control.
+hubNAL := &protocol.NAL{
+    V3NetNAL: "1.0", Network: "testnet",
+    CoordNodeID: hubKS.NodeID(), CoordPubKeyB64: hubKS.PubKeyBase64(),
+    Areas: []protocol.Area{{
+        Tag: "gen.general", Name: "General", Language: "en",
+        ManagerNodeID: hubKS.NodeID(), ManagerPubKeyB64: hubKS.PubKeyBase64(),
+        Access: protocol.AreaAccess{Mode: protocol.AccessModeOpen},
+        Policy: protocol.AreaPolicy{MaxBodyBytes: 65536, AllowANSI: true},
+    }},
+}
+nal.Sign(hubNAL, hubKS)
+h.NALStore().Put("testnet", hubNAL)
+```
+
+Update the subscribe request to include area tags:
+
+```go
+registerBody, _ := json.Marshal(protocol.SubscribeRequest{
+    Network:   "testnet",
+    NodeID:    leafKS.NodeID(),
+    PubKeyB64: leafKS.PubKeyBase64(),
+    BBSName:   "Integration Test BBS",
+    BBSHost:   "test.example.net",
+    AreaTags:  []string{"gen.general"},
+})
+```
+
+Add import: `"github.com/ViSiON-3/vision-3-bbs/internal/v3net/nal"`.
+
+`h.NALStore()` already exists in `hub.go:157`. Update all existing callers of `setupIntegration` in this file to unpack the new `hubKS` return value (use `_` where not needed).
+
+- [ ] **Step 7: Run all tests**
+
+Run: `go test ./internal/v3net/... -v -count=1`
+Expected: All PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/v3net/hub/messages.go internal/v3net/hub/handlers.go \
+  internal/v3net/hub/hub_area_msg_test.go \
+  internal/v3net/hub/hub_test.go internal/v3net/hub/hub_nal_test.go \
+  internal/v3net/integration_test.go
+git commit -m "feat(hub): enforce area-level access control on POST/GET messages
+
+- POST rejects messages when: no NAL exists (422), area_tag not in NAL
+  (422), or node has no active area subscription (403).
+- GET filters results to only include messages for the node's actively
+  subscribed areas. Empty subscriptions returns empty array.
+- Update all existing hub, integration tests to seed NAL and subscribe
+  with area tags."
+```
+
+---
+
+### Task 4: JAM Router
+
+This task is independent of hub changes — it only depends on Task 1 (AreaTag field on Message).
+
+**Files:**
+- Create: `internal/v3net/jam_router.go`
+- Create: `internal/v3net/jam_router_test.go`
+
+- [ ] **Step 1: Write failing router tests**
+
+Create `internal/v3net/jam_router_test.go`:
+
+```go
+package v3net
+
+import (
+    "testing"
+
+    "github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+)
+
+type mockWriter struct {
+    messages []protocol.Message
+}
+
+func (m *mockWriter) WriteMessage(msg protocol.Message) (int64, error) {
+    m.messages = append(m.messages, msg)
+    return int64(len(m.messages)), nil
+}
+
+func TestJAMRouter_DispatchesToCorrectAdapter(t *testing.T) {
+    general := &mockWriter{}
+    coding := &mockWriter{}
+    router := NewJAMRouter()
+    router.Add("gen.general", general)
+    router.Add("gen.coding", coding)
+
+    msg := protocol.Message{AreaTag: "gen.general", MsgUUID: "uuid-1"}
+    if _, err := router.WriteMessage(msg); err != nil {
+        t.Fatalf("WriteMessage: %v", err)
+    }
+
+    if len(general.messages) != 1 {
+        t.Errorf("expected 1 message to general, got %d", len(general.messages))
+    }
+    if len(coding.messages) != 0 {
+        t.Errorf("expected 0 messages to coding, got %d", len(coding.messages))
+    }
+}
+
+func TestJAMRouter_UnknownAreaTagReturnsZero(t *testing.T) {
+    router := NewJAMRouter()
+
+    msg := protocol.Message{AreaTag: "gen.unknown", MsgUUID: "uuid-1"}
+    num, err := router.WriteMessage(msg)
+    if err != nil {
+        t.Fatalf("WriteMessage: %v", err)
+    }
+    if num != 0 {
+        t.Errorf("expected 0 for unknown area, got %d", num)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/v3net/ -run TestJAMRouter -v`
+Expected: Compilation error — `NewJAMRouter` undefined.
+
+- [ ] **Step 3: Implement JAMRouter**
+
+Create `internal/v3net/jam_router.go`:
+
+```go
+package v3net
+
+import (
+    "log/slog"
+
+    "github.com/ViSiON-3/vision-3-bbs/internal/v3net/leaf"
+    "github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+)
+
+// JAMRouter implements leaf.JAMWriter and dispatches messages to the
+// correct per-area JAMAdapter based on the message's AreaTag.
+type JAMRouter struct {
+    adapters map[string]leaf.JAMWriter // area_tag → writer
+}
+
+// NewJAMRouter creates an empty JAMRouter.
+func NewJAMRouter() *JAMRouter {
+    return &JAMRouter{
+        adapters: make(map[string]leaf.JAMWriter),
+    }
+}
+
+// Add registers a writer for the given area tag.
+func (r *JAMRouter) Add(areaTag string, writer leaf.JAMWriter) {
+    r.adapters[areaTag] = writer
+}
+
+// WriteMessage dispatches the message to the adapter matching msg.AreaTag.
+// Returns (0, nil) if no adapter exists for the tag.
+func (r *JAMRouter) WriteMessage(msg protocol.Message) (int64, error) {
+    adapter, ok := r.adapters[msg.AreaTag]
+    if !ok {
+        slog.Warn("v3net: no local area for tag, skipping", "area_tag", msg.AreaTag)
+        return 0, nil
+    }
+    return adapter.WriteMessage(msg)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/v3net/ -run TestJAMRouter -v`
+Expected: All PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/v3net/jam_router.go internal/v3net/jam_router_test.go
+git commit -m "feat(v3net): add JAMRouter for area-tag based message dispatch"
+```
+
+---
+
+### Task 5: Leaf Config and Subscribe with Area Tags
+
+**Files:**
+- Modify: `internal/v3net/leaf/config.go:14-24`
+- Modify: `internal/v3net/leaf/sender.go:19-26`
+
+- [ ] **Step 1: Add AreaTags to leaf Config**
+
+In `leaf/config.go`, add `AreaTags` after `Network`:
+
+```go
+type Config struct {
+    HubURL       string
+    Network      string
+    AreaTags     []string // V3Net area tags to subscribe to
+    PollInterval time.Duration
+    Keystore     *keystore.Keystore
+    DedupIndex   *dedup.Index
+    JAMWriter    JAMWriter
+    OnEvent      func(protocol.Event)
+    BBSName      string
+    BBSHost      string
+}
+```
+
+- [ ] **Step 2: Update subscribe() to send area tags**
+
+In `leaf/sender.go`, add `AreaTags: l.cfg.AreaTags` to the subscribe request:
+
+```go
+req := protocol.SubscribeRequest{
+    Network:   l.cfg.Network,
+    NodeID:    l.cfg.Keystore.NodeID(),
+    PubKeyB64: l.cfg.Keystore.PubKeyBase64(),
+    BBSName:   l.cfg.BBSName,
+    BBSHost:   l.cfg.BBSHost,
+    AreaTags:  l.cfg.AreaTags,
+}
+```
+
+- [ ] **Step 3: Run leaf tests**
+
+Run: `go test ./internal/v3net/leaf/ -v`
+Expected: All PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/v3net/leaf/config.go internal/v3net/leaf/sender.go
+git commit -m "feat(leaf): add AreaTags to config and send in subscribe request"
+```
+
+---
+
+### Task 6: Config Change + All Downstream Consumers
+
+This is an atomic commit that changes `Board` to `Boards` and updates **all** downstream consumers simultaneously. This prevents any intermediate broken state.
+
+**Files:**
+- Modify: `internal/config/config.go:929-935`
+- Modify: `internal/v3net/area_sync.go:16-50`
+- Modify: `internal/v3net/area_sync_test.go:35-38`
+- Modify: `internal/v3net/wire.go:16-35`
+- Modify: `internal/v3net/wire_test.go` (3 call sites)
+- Modify: `internal/v3net/service.go:195-216` (AddLeaf)
+- Modify: `internal/menu/v3net_areas.go:62,341,346-349,396`
+- Modify: `internal/configeditor/fields_v3net.go:74-76`
+- Modify: `internal/configeditor/view_list.go:281`
+- Modify: `internal/configeditor/update_wizard_form.go:247`
+- Modify: `internal/configeditor/update_v3net_wizard_hub.go:239`
+- Modify: `cmd/vision3/main.go:1823-1841,1869`
+
+- [ ] **Step 1: Update V3NetLeafConfig**
+
+In `config.go:929-935`, replace `Board string` with `Boards []string`:
+
+```go
+type V3NetLeafConfig struct {
+    HubURL       string   `json:"hubUrl"`
+    Network      string   `json:"network"`
+    Boards       []string `json:"boards"`             // V3Net area tags (e.g., ["fel.general", "fel.phreaking"])
+    PollInterval string   `json:"pollInterval"`       // Duration string (e.g., "5m")
+    Origin       string   `json:"origin,omitempty"`   // Origin line text
+}
+```
+
+- [ ] **Step 2: Update area_sync.go**
+
+Replace the loop body in `SyncAreas` to iterate `lcfg.Boards`:
+
+```go
+func SyncAreas(leaves []config.V3NetLeafConfig, mgr *message.MessageManager, confMgr *conference.ConferenceManager) int {
+    created := 0
+    for _, lcfg := range leaves {
+        for _, board := range lcfg.Boards {
+            if board == "" {
+                continue
+            }
+            if _, ok := mgr.GetAreaByTag(board); ok {
+                continue
+            }
+
+            area := message.MessageArea{
+                Tag:          board,
+                Name:         areaNameFromTag(board, lcfg.Network),
+                AreaType:     "v3net",
+                Network:      lcfg.Network,
+                EchoTag:      board,
+                ConferenceID: inferConferenceID(mgr, confMgr, lcfg.Network),
+                AutoJoin:     true,
+                ACSRead:      "s10",
+                ACSWrite:     "s20",
+            }
+
+            id, err := mgr.AddArea(area)
+            if err != nil {
+                slog.Error("v3net: auto-create area failed",
+                    "tag", board, "network", lcfg.Network, "error", err)
+                continue
+            }
+            slog.Info("v3net: auto-created message area",
+                "id", id, "tag", board, "network", lcfg.Network,
+                "conference_id", area.ConferenceID)
+            created++
+        }
+    }
+    return created
+}
+```
+
+- [ ] **Step 3: Update area_sync_test.go**
+
+Change `Board:` to `Boards: []string{...}` in the test fixtures:
+
+```go
+leaves := []config.V3NetLeafConfig{
+    {HubURL: "https://hub.example.com", Network: "felonynet", Boards: []string{"FELGEN"}},
+    {HubURL: "https://hub.example.com", Network: "felonynet", Boards: []string{"GENERAL"}}, // already exists
+    {HubURL: "https://hub.example.com", Network: "felonynet", Boards: []string{"FELTECH"}},
+}
+```
+
+- [ ] **Step 4: Update BuildWireMessage to accept areaTag**
+
+In `wire.go`, add `areaTag` as the second parameter:
+
+```go
+func BuildWireMessage(network, areaTag, originNode, originBoard, from, to, subject, body, origin string) protocol.Message {
+    uuid := newUUID()
+    return protocol.Message{
+        V3Net:       protocol.ProtocolVersion,
+        Network:     network,
+        AreaTag:     areaTag,
+        MsgUUID:     uuid,
+        ThreadUUID:  uuid,
+        // ... rest unchanged
+    }
+}
+```
+
+- [ ] **Step 5: Update wire_test.go call sites**
+
+Update all 3 calls to `BuildWireMessage` to pass `areaTag` as the second argument:
+
+```go
+// line 9:
+msg := BuildWireMessage("testnet", "gen.general", "abc123", "General", "Sysop", "All", "Hello", "body text", "My Cool BBS")
+
+// line 16:
+msg := BuildWireMessage("testnet", "gen.general", "abc123", "General", "Sysop", "All", "Hello", "body text", "My Cool BBS - bbs.example.com")
+
+// line 23:
+msg := BuildWireMessage("testnet", "gen.general", "abc123", "General", "Sysop", "All", "Hello", "body text", "")
+```
+
+- [ ] **Step 6: Update cmd/vision3/main.go — leaf setup**
+
+Replace the leaf setup loop (lines 1823-1841) to iterate boards and build a `JAMRouter`:
+
+```go
+for _, lcfg := range v3netConfig.Leaves {
+    router := v3net.NewJAMRouter()
+    origin := lcfg.Origin
+    if origin == "" {
+        origin = serverConfig.BoardName
+    }
+    for _, tag := range lcfg.Boards {
+        area, ok := messageMgr.GetAreaByTag(tag)
+        if !ok {
+            log.Printf("WARN: V3Net leaf %q: message area %q not found, skipping", lcfg.Network, tag)
+            continue
+        }
+        router.Add(tag, v3net.NewJAMAdapter(messageMgr, area.ID))
+        v3netAreaMap[area.ID] = v3netAreaInfo{Network: lcfg.Network, Origin: origin}
+        svc.RegisterArea(area.ID, lcfg.Network)
+    }
+    if err := v3netService.AddLeaf(lcfg, router, nil); err != nil {
+        log.Printf("ERROR: V3Net leaf %q: %v", lcfg.Network, err)
+        continue
+    }
+}
+```
+
+- [ ] **Step 7: Update cmd/vision3/main.go — BuildWireMessage call**
+
+Line 1869 calls `BuildWireMessage` with 8 args. Add `area.Tag` as the second argument. The area tag is available from `area *message.MessageArea` in the `OnMessagePosted` callback:
+
+```go
+msg := v3net.BuildWireMessage(info.Network, area.Tag, svc.NodeID(), serverConfig.BoardName, from, to, subject, body, info.Origin)
+```
+
+- [ ] **Step 8: Update service.go AddLeaf**
+
+Pass `lcfg.Boards` to `leaf.Config.AreaTags`:
+
+```go
+l := leaf.New(leaf.Config{
+    HubURL:       lcfg.HubURL,
+    Network:      lcfg.Network,
+    AreaTags:     lcfg.Boards,
+    PollInterval: interval,
+    // ... rest unchanged
+})
+```
+
+- [ ] **Step 9: Update menu/v3net_areas.go**
+
+Four changes:
+
+**Line 62** — build subscribed set:
+```go
+for _, lcfg := range v3cfg.Leaves {
+    for _, board := range lcfg.Boards {
+        subSet[lcfg.Network+":"+board] = true
+    }
+}
+```
+
+**Line 341** — check if already subscribed. Add helper and update check:
+```go
+func containsBoard(boards []string, tag string) bool {
+    for _, b := range boards {
+        if b == tag {
+            return true
+        }
+    }
+    return false
+}
+```
+Then replace: `l.Board == area.Tag` → `containsBoard(l.Boards, area.Tag)`
+
+**Lines 346-349** — add subscription. Append to existing leaf for same network, or create new:
+```go
+found := false
+for i, l := range cfg.Leaves {
+    if l.Network == network {
+        cfg.Leaves[i].Boards = append(cfg.Leaves[i].Boards, area.Tag)
+        found = true
+        break
+    }
+}
+if !found {
+    cfg.Leaves = append(cfg.Leaves, config.V3NetLeafConfig{
+        HubURL:       hubURL,
+        Network:      network,
+        Boards:       []string{area.Tag},
+        PollInterval: "5m",
+    })
+}
+```
+
+**Line 396** — unsubscribe. Remove the board from the Boards slice. If Boards becomes empty, remove the entire leaf config entry:
+```go
+for i, l := range cfg.Leaves {
+    if l.Network == network {
+        filtered := l.Boards[:0]
+        for _, b := range l.Boards {
+            if b != tag {
+                filtered = append(filtered, b)
+            }
+        }
+        if len(filtered) == 0 {
+            cfg.Leaves = append(cfg.Leaves[:i], cfg.Leaves[i+1:]...)
+        } else {
+            cfg.Leaves[i].Boards = filtered
+        }
+        break
+    }
+}
+```
+
+- [ ] **Step 10: Update configeditor/fields_v3net.go**
+
+Change the Board field to comma-separated Boards:
+
+```go
+{
+    Label: "Boards", Help: "V3Net area tags, comma-separated (e.g. fel.general,fel.coding)", Type: ftString, Col: 3, Row: 3, Width: 49,
+    Get: func() string { return strings.Join(l.Boards, ",") },
+    Set: func(val string) error {
+        if val == "" {
+            l.Boards = nil
+        } else {
+            l.Boards = strings.Split(val, ",")
+        }
+        return nil
+    },
+},
+```
+
+Add `"strings"` to the import block if not already present.
+
+- [ ] **Step 11: Update configeditor/view_list.go**
+
+Line 281 — update the list display:
+
+```go
+boards := ""
+if len(l.Boards) > 0 {
+    boards = l.Boards[0]
+    if len(l.Boards) > 1 {
+        boards += fmt.Sprintf(" (+%d)", len(l.Boards)-1)
+    }
+}
+content = fmt.Sprintf(" %3d  %-30s %-14s %s", idx+1, padRight(l.HubURL, 30), padRight(l.Network, 14), boards)
+```
+
+- [ ] **Step 12: Update configeditor/update_wizard_form.go**
+
+Line 247 — change `Board:` to `Boards:`:
+
+```go
+leaf := config.V3NetLeafConfig{
+    HubURL:       m.wizard.hubURL,
+    Network:      m.wizard.networkName,
+    Boards:       []string{m.wizard.boardTag},
+    PollInterval: m.wizard.pollInterval,
+    Origin:       m.wizard.origin,
+}
+```
+
+- [ ] **Step 13: Update configeditor/update_v3net_wizard_hub.go**
+
+Line 239 — change `Board:` to `Boards:`:
+
+```go
+m.configs.V3Net.Leaves = append(m.configs.V3Net.Leaves, config.V3NetLeafConfig{
+    HubURL:       hubURL,
+    Network:      network,
+    Boards:       []string{network},
+    PollInterval: "5m",
+})
+```
+
+- [ ] **Step 14: Verify full compilation**
+
+Run: `go build ./...`
+Expected: Clean build.
+
+- [ ] **Step 15: Run all tests**
+
+Run: `go test ./... -count=1`
+Expected: All PASS.
+
+- [ ] **Step 16: Commit**
+
+```bash
+git add internal/config/config.go internal/v3net/area_sync.go \
+  internal/v3net/area_sync_test.go \
+  internal/v3net/wire.go internal/v3net/wire_test.go \
+  internal/v3net/service.go internal/menu/v3net_areas.go \
+  internal/configeditor/fields_v3net.go internal/configeditor/view_list.go \
+  internal/configeditor/update_wizard_form.go \
+  internal/configeditor/update_v3net_wizard_hub.go \
+  cmd/vision3/main.go
+git commit -m "feat(config): change V3NetLeafConfig.Board to Boards []string
+
+Update all consumers: area_sync, BuildWireMessage, service AddLeaf,
+menu area subscribe/unsubscribe, config editor, wizard forms, and
+cmd/vision3/main.go startup."
+```
+
+---
+
+### Task 7: Integration Test — Multi-Area Filtered Polling
+
+Per the spec's testing strategy: "End-to-end: leaf posts message with area_tag, hub stores, other leaf polls and receives only messages for its subscribed areas."
+
+**Files:**
+- Modify: `internal/v3net/integration_test.go`
+
+- [ ] **Step 1: Write integration test for area-filtered polling**
+
+The integration test is in package `v3net_test` (external), so it cannot access `h.messages` directly. Instead, use the hub's HTTP API to store a message for a different area by registering a second leaf subscribed to a different area.
+
+Since `setupIntegration` was updated in Task 3 to return `hubKS`, update all existing callers to unpack the new return value. Then add the test:
+
+```go
+func TestIntegration_AreaFilteredPolling(t *testing.T) {
+    h, ts, l, leafKS, hubKS, _, writer := setupIntegration(t)
+    _ = leafKS
+
+    // The default leaf from setupIntegration is subscribed to gen.general.
+    // Post a message to gen.general — it should be received.
+    msg := protocol.Message{
+        V3Net: "1.0", Network: "testnet", AreaTag: "gen.general",
+        MsgUUID: "880e8400-e29b-41d4-a716-446655440010",
+        ThreadUUID: "880e8400-e29b-41d4-a716-446655440010",
+        OriginNode: "test.example.net", OriginBoard: "General",
+        From: "Tester", To: "All", Subject: "Area filtered test",
+        DateUTC: "2026-03-16T04:20:00Z", Body: "Should be received.",
+        Kludges: map[string]any{},
+    }
+    if err := l.SendMessage(msg); err != nil {
+        t.Fatalf("SendMessage gen.general: %v", err)
+    }
+
+    // Update NAL to include a second area (gen.coding).
+    updatedNAL := &protocol.NAL{
+        V3NetNAL: "1.0", Network: "testnet",
+        CoordNodeID: hubKS.NodeID(), CoordPubKeyB64: hubKS.PubKeyBase64(),
+        Areas: []protocol.Area{
+            {
+                Tag: "gen.general", Name: "General", Language: "en",
+                ManagerNodeID: hubKS.NodeID(), ManagerPubKeyB64: hubKS.PubKeyBase64(),
+                Access: protocol.AreaAccess{Mode: protocol.AccessModeOpen},
+                Policy: protocol.AreaPolicy{MaxBodyBytes: 65536, AllowANSI: true},
+            },
+            {
+                Tag: "gen.coding", Name: "Coding", Language: "en",
+                ManagerNodeID: hubKS.NodeID(), ManagerPubKeyB64: hubKS.PubKeyBase64(),
+                Access: protocol.AreaAccess{Mode: protocol.AccessModeOpen},
+                Policy: protocol.AreaPolicy{MaxBodyBytes: 65536, AllowANSI: true},
+            },
+        },
+    }
+    nal.Sign(updatedNAL, hubKS)
+    h.NALStore().Put("testnet", updatedNAL)
+
+    // Register a second leaf subscribed to gen.coding and use it to POST a message.
+    leaf2KS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf2.key"))
+    if err != nil {
+        t.Fatalf("load leaf2 keystore: %v", err)
+    }
+    registerBody2, _ := json.Marshal(protocol.SubscribeRequest{
+        Network: "testnet", NodeID: leaf2KS.NodeID(),
+        PubKeyB64: leaf2KS.PubKeyBase64(),
+        BBSName: "Leaf 2 BBS", BBSHost: "leaf2.example.net",
+        AreaTags: []string{"gen.coding"},
+    })
+    resp2, _ := ts.Client().Post(ts.URL+"/v3net/v1/subscribe", "application/json",
+        bytes.NewReader(registerBody2))
+    resp2.Body.Close()
+
+    // Create a second leaf instance to POST the gen.coding message through the hub API.
+    leaf2Writer := &testJAMWriter{}
+    leaf2Dedup, _ := dedup.Open(filepath.Join(t.TempDir(), "dedup2.sqlite"))
+    t.Cleanup(func() { leaf2Dedup.Close() })
+    l2 := leaf.New(leaf.Config{
+        HubURL:       ts.URL,
+        Network:      "testnet",
+        AreaTags:     []string{"gen.coding"},
+        PollInterval: 50 * time.Millisecond,
+        Keystore:     leaf2KS,
+        DedupIndex:   leaf2Dedup,
+        JAMWriter:    leaf2Writer,
+    })
+
+    codingMsg := protocol.Message{
+        V3Net: "1.0", Network: "testnet", AreaTag: "gen.coding",
+        MsgUUID: "990e8400-e29b-41d4-a716-446655440011",
+        ThreadUUID: "990e8400-e29b-41d4-a716-446655440011",
+        OriginNode: "leaf2.example.net", OriginBoard: "Coding",
+        From: "Leaf2 User", To: "All", Subject: "Coding msg",
+        DateUTC: "2026-03-16T04:20:00Z", Body: "Should NOT be received by leaf 1.",
+        Kludges: map[string]any{},
+    }
+    if err := l2.SendMessage(codingMsg); err != nil {
+        t.Fatalf("SendMessage gen.coding: %v", err)
+    }
+
+    // Poll with the original leaf (subscribed to gen.general only).
+    ctx := context.Background()
+    count, err := l.Poll(ctx)
+    if err != nil {
+        t.Fatalf("poll: %v", err)
+    }
+    if count != 1 {
+        t.Fatalf("expected 1 message from poll (gen.general only), got %d", count)
+    }
+    if writer.count() != 1 {
+        t.Fatalf("expected 1 JAM write, got %d", writer.count())
+    }
+    got := writer.get(0)
+    if got.AreaTag != "gen.general" {
+        t.Errorf("expected area_tag gen.general, got %q", got.AreaTag)
+    }
+}
+```
+
+All callers of `setupIntegration` in this file must be updated to unpack the additional `hubKS` return value (use `_` where not needed). Update the existing test functions: `h, ts, l, leafKS, _, writer := setupIntegration(t)` → `h, ts, l, leafKS, _, _, writer := setupIntegration(t)`.
+
+- [ ] **Step 2: Run the test**
+
+Run: `go test ./internal/v3net/ -run TestIntegration_AreaFilteredPolling -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/v3net/integration_test.go
+git commit -m "test(v3net): add integration test for area-filtered message polling"
+```
+
+---
+
+### Task 8: Full Test Suite Verification
+
+- [ ] **Step 1: Run all v3net tests**
+
+Run: `go test ./internal/v3net/... -v -count=1`
+Expected: All PASS.
+
+- [ ] **Step 2: Run full project test suite**
+
+Run: `go test ./... -count=1`
+Expected: All PASS.
+
+- [ ] **Step 3: Run linters**
+
+Run: `gofmt -l ./internal/ && go vet ./...`
+Expected: No output.
+
+- [ ] **Step 4: Final commit if any fixes needed**
+
+```bash
+git add -A
+git commit -m "fix: address remaining issues from area-level access control"
+```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -927,11 +927,11 @@ type V3NetHubArea struct {
 
 // V3NetLeafConfig configures a subscription to a V3Net network.
 type V3NetLeafConfig struct {
-	HubURL       string `json:"hubUrl"`
-	Network      string `json:"network"`
-	Board        string `json:"board"`            // Local message area tag to write received messages
-	PollInterval string `json:"pollInterval"`     // Duration string (e.g., "5m")
-	Origin       string `json:"origin,omitempty"` // Origin line text (e.g. "My Cool BBS - bbs.example.com")
+	HubURL       string   `json:"hubUrl"`
+	Network      string   `json:"network"`
+	Boards       []string `json:"boards"`           // Local message area tags to write received messages
+	PollInterval string   `json:"pollInterval"`     // Duration string (e.g., "5m")
+	Origin       string   `json:"origin,omitempty"` // Origin line text (e.g. "My Cool BBS - bbs.example.com")
 }
 
 // EventConfig defines a scheduled event configuration

--- a/internal/configeditor/fields_v3net.go
+++ b/internal/configeditor/fields_v3net.go
@@ -78,7 +78,13 @@ func (m *Model) fieldsV3NetLeaf() []fieldDef {
 				if val == "" {
 					l.Boards = nil
 				} else {
-					l.Boards = strings.Split(val, ",")
+					var boards []string
+				for _, part := range strings.Split(val, ",") {
+					if tag := strings.TrimSpace(part); tag != "" {
+						boards = append(boards, tag)
+					}
+				}
+				l.Boards = boards
 				}
 				return nil
 			},

--- a/internal/configeditor/fields_v3net.go
+++ b/internal/configeditor/fields_v3net.go
@@ -2,6 +2,7 @@ package configeditor
 
 import (
 	"fmt"
+	"strings"
 )
 
 // fieldsV3NetHubNetwork returns fields for editing a single hub network.
@@ -71,9 +72,16 @@ func (m *Model) fieldsV3NetLeaf() []fieldDef {
 			},
 		},
 		{
-			Label: "Board", Help: "Local message area tag to receive messages", Type: ftString, Col: 3, Row: 3, Width: 30,
-			Get: func() string { return l.Board },
-			Set: func(val string) error { l.Board = val; return nil },
+			Label: "Boards", Help: "Comma-separated local message area tags to receive messages (e.g. fel.general,fel.tech)", Type: ftString, Col: 3, Row: 3, Width: 49,
+			Get: func() string { return strings.Join(l.Boards, ",") },
+			Set: func(val string) error {
+				if val == "" {
+					l.Boards = nil
+				} else {
+					l.Boards = strings.Split(val, ",")
+				}
+				return nil
+			},
 		},
 		{
 			Label: "Poll Interval", Help: "How often to poll for new messages (e.g. 5m, 30s)", Type: ftString, Col: 3, Row: 4, Width: 10,

--- a/internal/configeditor/update_v3net_wizard_hub.go
+++ b/internal/configeditor/update_v3net_wizard_hub.go
@@ -236,7 +236,7 @@ func (m *Model) addSelfLeaf(network string, port int) {
 	m.configs.V3Net.Leaves = append(m.configs.V3Net.Leaves, config.V3NetLeafConfig{
 		HubURL:       hubURL,
 		Network:      network,
-		Board:        network,
+		Boards:       []string{network},
 		PollInterval: "5m",
 	})
 }

--- a/internal/configeditor/update_v3net_wizard_hub.go
+++ b/internal/configeditor/update_v3net_wizard_hub.go
@@ -233,10 +233,14 @@ func (m *Model) addSelfLeaf(network string, port int) {
 			return
 		}
 	}
+	boards := make([]string, 0, len(m.wizard.areas))
+	for _, a := range m.wizard.areas {
+		boards = append(boards, a.Tag)
+	}
 	m.configs.V3Net.Leaves = append(m.configs.V3Net.Leaves, config.V3NetLeafConfig{
 		HubURL:       hubURL,
 		Network:      network,
-		Boards:       []string{network},
+		Boards:       boards,
 		PollInterval: "5m",
 	})
 }

--- a/internal/configeditor/update_wizard_form.go
+++ b/internal/configeditor/update_wizard_form.go
@@ -244,7 +244,7 @@ func (m Model) confirmLeafWizard() (Model, tea.Cmd) {
 	leaf := config.V3NetLeafConfig{
 		HubURL:       m.wizard.hubURL,
 		Network:      m.wizard.networkName,
-		Board:        m.wizard.boardTag,
+		Boards:       []string{m.wizard.boardTag},
 		PollInterval: m.wizard.pollInterval,
 		Origin:       m.wizard.origin,
 	}

--- a/internal/configeditor/view_list.go
+++ b/internal/configeditor/view_list.go
@@ -278,7 +278,14 @@ func (m Model) renderRecordRow(idx, boxW int) string {
 	case "v3netleaf":
 		if idx < len(m.configs.V3Net.Leaves) {
 			l := m.configs.V3Net.Leaves[idx]
-			content = fmt.Sprintf(" %3d  %-30s %-14s %s", idx+1, padRight(l.HubURL, 30), padRight(l.Network, 14), l.Board)
+			boards := ""
+			if len(l.Boards) > 0 {
+				boards = l.Boards[0]
+				if len(l.Boards) > 1 {
+					boards += fmt.Sprintf(" (+%d)", len(l.Boards)-1)
+				}
+			}
+			content = fmt.Sprintf(" %3d  %-30s %-14s %s", idx+1, padRight(l.HubURL, 30), padRight(l.Network, 14), boards)
 		}
 	case "v3nethub":
 		if idx < len(m.configs.V3Net.Hub.Networks) {

--- a/internal/menu/v3net_areas.go
+++ b/internal/menu/v3net_areas.go
@@ -59,7 +59,9 @@ func runV3NetAreas(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, _ *u
 	// Build set of subscribed board tags per network.
 	subSet := make(map[string]bool) // "network:board" → true
 	for _, lcfg := range v3cfg.Leaves {
-		subSet[lcfg.Network+":"+lcfg.Board] = true
+		for _, board := range lcfg.Boards {
+			subSet[lcfg.Network+":"+board] = true
+		}
 	}
 
 	// Fetch NAL for each network and build entry list.
@@ -338,17 +340,28 @@ func v3netSubscribe(configPath string, mgr *message.MessageManager, network, hub
 
 	// Check if already subscribed.
 	for _, l := range cfg.Leaves {
-		if l.Network == network && l.Board == area.Tag {
+		if l.Network == network && containsBoard(l.Boards, area.Tag) {
 			return nil
 		}
 	}
 
-	cfg.Leaves = append(cfg.Leaves, config.V3NetLeafConfig{
-		HubURL:       hubURL,
-		Network:      network,
-		Board:        area.Tag,
-		PollInterval: "5m",
-	})
+	// Append to existing leaf for this network, or create a new one.
+	found := false
+	for i, l := range cfg.Leaves {
+		if l.Network == network {
+			cfg.Leaves[i].Boards = append(cfg.Leaves[i].Boards, area.Tag)
+			found = true
+			break
+		}
+	}
+	if !found {
+		cfg.Leaves = append(cfg.Leaves, config.V3NetLeafConfig{
+			HubURL:       hubURL,
+			Network:      network,
+			Boards:       []string{area.Tag},
+			PollInterval: "5m",
+		})
+	}
 
 	if err := config.SaveV3NetConfig(configPath, cfg); err != nil {
 		return fmt.Errorf("save v3net.json: %w", err)
@@ -384,23 +397,43 @@ func v3netSubscribe(configPath string, mgr *message.MessageManager, network, hub
 	return nil
 }
 
-// v3netUnsubscribe removes a leaf config entry. Does not delete the message area.
+// v3netUnsubscribe removes a board tag from the leaf config entry for the given
+// network. Removes the entire leaf entry if it has no remaining boards.
+// Does not delete the message area.
 func v3netUnsubscribe(configPath, network, tag string) error {
 	cfg, err := config.LoadV3NetConfig(configPath)
 	if err != nil {
 		return err
 	}
 
-	filtered := cfg.Leaves[:0]
-	for _, l := range cfg.Leaves {
-		if l.Network == network && l.Board == tag {
-			continue
+	for i, l := range cfg.Leaves {
+		if l.Network == network {
+			var filtered []string
+			for _, b := range l.Boards {
+				if b != tag {
+					filtered = append(filtered, b)
+				}
+			}
+			if len(filtered) == 0 {
+				cfg.Leaves = append(cfg.Leaves[:i], cfg.Leaves[i+1:]...)
+			} else {
+				cfg.Leaves[i].Boards = filtered
+			}
+			break
 		}
-		filtered = append(filtered, l)
 	}
-	cfg.Leaves = filtered
 
 	return config.SaveV3NetConfig(configPath, cfg)
+}
+
+// containsBoard reports whether boards contains the given tag.
+func containsBoard(boards []string, tag string) bool {
+	for _, b := range boards {
+		if b == tag {
+			return true
+		}
+	}
+	return false
 }
 
 // v3netAreasShowMessage displays a single message with a pause prompt.

--- a/internal/message/manager.go
+++ b/internal/message/manager.go
@@ -633,6 +633,59 @@ func (mm *MessageManager) AddMessage(areaID int, from, to, subject, body, replyT
 	return msgNum, err
 }
 
+// AddMessageWithDate is like AddMessage but uses the provided timestamp instead
+// of time.Now(). Used by V3Net to preserve the original authored date.
+func (mm *MessageManager) AddMessageWithDate(areaID int, from, to, subject, body, replyToMsgID string, dateTime time.Time) (int, error) {
+	b, area, err := mm.openBase(areaID)
+	if err != nil {
+		return 0, err
+	}
+
+	jamBody := body
+	if mm.BodyTransform != nil {
+		jamBody = mm.BodyTransform(areaID, body)
+	}
+
+	msg := jam.NewMessage()
+	msg.From = from
+	msg.To = to
+	msg.Subject = subject
+	msg.Text = jamBody
+	msg.DateTime = dateTime
+
+	if replyToMsgID != "" {
+		msg.ReplyID = replyToMsgID
+	}
+
+	msgType := jam.DetermineMessageType(area.AreaType, area.EchoTag)
+
+	if msgType.IsNetmail() {
+		name, addr := splitNetmailTo(to)
+		msg.To = name
+		if addr != "" {
+			msg.DestAddr = addr
+		}
+	}
+
+	var msgNum int
+	if msgType.IsEchomail() || msgType.IsNetmail() {
+		msg.OrigAddr = area.OriginAddr
+		msgNum, err = b.WriteMessageExt(msg, msgType, area.EchoTag, mm.boardName, mm.tearlineForNetwork(area.Network))
+	} else {
+		msgNum, err = b.WriteMessage(msg)
+	}
+
+	b.Close()
+
+	if err == nil {
+		mm.invalidateThreadIndex(areaID)
+		if mm.OnMessagePosted != nil {
+			mm.OnMessagePosted(area, msgNum, from, to, subject, body)
+		}
+	}
+	return msgNum, err
+}
+
 // AddPrivateMessage creates and writes a new private message to the specified area.
 // It sets the MSG_PRIVATE flag on the message to indicate it's private user-to-user mail.
 // For netmail areas, "user@zone:net/node" in the To field is automatically split

--- a/internal/v3net/area_sync.go
+++ b/internal/v3net/area_sync.go
@@ -16,35 +16,37 @@ import (
 func SyncAreas(leaves []config.V3NetLeafConfig, mgr *message.MessageManager, confMgr *conference.ConferenceManager) int {
 	created := 0
 	for _, lcfg := range leaves {
-		if lcfg.Board == "" {
-			continue
-		}
-		if _, ok := mgr.GetAreaByTag(lcfg.Board); ok {
-			continue
-		}
+		for _, board := range lcfg.Boards {
+			if board == "" {
+				continue
+			}
+			if _, ok := mgr.GetAreaByTag(board); ok {
+				continue
+			}
 
-		area := message.MessageArea{
-			Tag:          lcfg.Board,
-			Name:         areaNameFromTag(lcfg.Board, lcfg.Network),
-			AreaType:     "v3net",
-			Network:      lcfg.Network,
-			EchoTag:      lcfg.Board,
-			ConferenceID: inferConferenceID(mgr, confMgr, lcfg.Network),
-			AutoJoin:     true,
-			ACSRead:      "s10",
-			ACSWrite:     "s20",
-		}
+			area := message.MessageArea{
+				Tag:          board,
+				Name:         areaNameFromTag(board, lcfg.Network),
+				AreaType:     "v3net",
+				Network:      lcfg.Network,
+				EchoTag:      board,
+				ConferenceID: inferConferenceID(mgr, confMgr, lcfg.Network),
+				AutoJoin:     true,
+				ACSRead:      "s10",
+				ACSWrite:     "s20",
+			}
 
-		id, err := mgr.AddArea(area)
-		if err != nil {
-			slog.Error("v3net: auto-create area failed",
-				"tag", lcfg.Board, "network", lcfg.Network, "error", err)
-			continue
+			id, err := mgr.AddArea(area)
+			if err != nil {
+				slog.Error("v3net: auto-create area failed",
+					"tag", board, "network", lcfg.Network, "error", err)
+				continue
+			}
+			slog.Info("v3net: auto-created message area",
+				"id", id, "tag", board, "network", lcfg.Network,
+				"conference_id", area.ConferenceID)
+			created++
 		}
-		slog.Info("v3net: auto-created message area",
-			"id", id, "tag", lcfg.Board, "network", lcfg.Network,
-			"conference_id", area.ConferenceID)
-		created++
 	}
 	return created
 }

--- a/internal/v3net/area_sync_test.go
+++ b/internal/v3net/area_sync_test.go
@@ -33,9 +33,9 @@ func TestSyncAreasCreatesMissing(t *testing.T) {
 	defer mgr.Close()
 
 	leaves := []config.V3NetLeafConfig{
-		{HubURL: "https://hub.example.com", Network: "felonynet", Board: "FELGEN"},
-		{HubURL: "https://hub.example.com", Network: "felonynet", Board: "GENERAL"}, // already exists
-		{HubURL: "https://hub.example.com", Network: "felonynet", Board: "FELTECH"},
+		{HubURL: "https://hub.example.com", Network: "felonynet", Boards: []string{"FELGEN"}},
+		{HubURL: "https://hub.example.com", Network: "felonynet", Boards: []string{"GENERAL"}}, // already exists
+		{HubURL: "https://hub.example.com", Network: "felonynet", Boards: []string{"FELTECH"}},
 	}
 
 	created := SyncAreas(leaves, mgr, nil)

--- a/internal/v3net/dedup/dedup.go
+++ b/internal/v3net/dedup/dedup.go
@@ -28,6 +28,11 @@ func Open(path string) (*Index, error) {
 	if err != nil {
 		return nil, fmt.Errorf("dedup: open %s: %w", path, err)
 	}
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec("PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("dedup: configure pragmas: %w", err)
+	}
 	if _, err := db.Exec(schema); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("dedup: create schema: %w", err)
@@ -68,7 +73,7 @@ func (ix *Index) MarkSeen(msgUUID, network string, localMsgNum *int64) error {
 func (ix *Index) LastSeen(network string) (string, error) {
 	var uuid string
 	err := ix.db.QueryRow(
-		"SELECT msg_uuid FROM seen_messages WHERE network = ? ORDER BY seen_at DESC, rowid DESC LIMIT 1",
+		"SELECT msg_uuid FROM seen_messages WHERE network = ? ORDER BY rowid DESC LIMIT 1",
 		network,
 	).Scan(&uuid)
 	if err == sql.ErrNoRows {

--- a/internal/v3net/hub/coordinator_handler.go
+++ b/internal/v3net/hub/coordinator_handler.go
@@ -102,12 +102,12 @@ func (h *Hub) handleCoordAccept(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Look up the pending transfer.
-	var newNodeID, newPubKeyB64, storedToken string
+	// Look up the pending transfer. Tokens expire after 24 hours.
+	var newNodeID, newPubKeyB64, storedToken, createdAt string
 	err := h.db.QueryRow(
-		`SELECT new_node_id, new_pubkey_b64, token FROM coordinator_transfers WHERE network = ?`,
+		`SELECT new_node_id, new_pubkey_b64, token, created_at FROM coordinator_transfers WHERE network = ?`,
 		network,
-	).Scan(&newNodeID, &newPubKeyB64, &storedToken)
+	).Scan(&newNodeID, &newPubKeyB64, &storedToken, &createdAt)
 	if err == sql.ErrNoRows {
 		http.Error(w, `{"error":"no pending transfer"}`, http.StatusNotFound)
 		return
@@ -118,12 +118,19 @@ func (h *Hub) handleCoordAccept(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if nodeID != newNodeID {
-		http.Error(w, `{"error":"this transfer is not for your node"}`, http.StatusForbidden)
-		return
+	// Enforce 24-hour TTL on transfer tokens.
+	if t, parseErr := time.Parse("2006-01-02 15:04:05", createdAt); parseErr == nil {
+		if time.Since(t) > 24*time.Hour {
+			h.db.Exec("DELETE FROM coordinator_transfers WHERE network = ?", network)
+			http.Error(w, `{"error":"transfer token expired"}`, http.StatusGone)
+			return
+		}
 	}
-	if req.Token != storedToken {
-		http.Error(w, `{"error":"invalid transfer token"}`, http.StatusUnauthorized)
+
+	// Use the same error message for both mismatches to avoid leaking
+	// information about pending transfers and their targets.
+	if nodeID != newNodeID || req.Token != storedToken {
+		http.Error(w, `{"error":"invalid transfer credentials"}`, http.StatusForbidden)
 		return
 	}
 

--- a/internal/v3net/hub/events.go
+++ b/internal/v3net/hub/events.go
@@ -2,7 +2,6 @@ package hub
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -124,12 +123,7 @@ func (b *Broadcaster) ServeSSE(w http.ResponseWriter, r *http.Request, network s
 			if !ok {
 				return
 			}
-			data, err := json.Marshal(json.RawMessage(ev.Data))
-			if err != nil {
-				slog.Error("marshal SSE event data", "error", err)
-				continue
-			}
-			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.Type, data)
+			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.Type, ev.Data)
 			flusher.Flush()
 		}
 	}

--- a/internal/v3net/hub/handlers.go
+++ b/internal/v3net/hub/handlers.go
@@ -129,7 +129,12 @@ func (h *Hub) handlePostMessage(w http.ResponseWriter, r *http.Request) {
 
 	// Enforce NAL-based area access control.
 	currentNAL, nalErr := h.nalStore.Get(network)
-	if nalErr != nil || currentNAL == nil {
+	if nalErr != nil {
+		slog.Error("get NAL for post", "network", network, "error", nalErr)
+		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		return
+	}
+	if currentNAL == nil {
 		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": "no NAL published for this network"})
 		return
 	}
@@ -321,8 +326,13 @@ func (h *Hub) handleSubscribe(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(req.AreaTags) > 0 {
 		currentNAL, nalErr := h.nalStore.Get(req.Network)
-		if nalErr != nil || currentNAL == nil {
-			// No NAL available — return basic response without area status.
+		if nalErr != nil {
+			slog.Error("get NAL for subscribe", "network", req.Network, "error", nalErr)
+			http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+			return
+		}
+		if currentNAL == nil {
+			// No NAL published yet — return basic response without area status.
 			writeJSON(w, http.StatusOK, protocol.SubscribeResponse{OK: true, Status: actualStatus})
 			return
 		}

--- a/internal/v3net/hub/handlers.go
+++ b/internal/v3net/hub/handlers.go
@@ -56,8 +56,10 @@ func (h *Hub) handleNetworkInfo(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleGetMessages returns messages newer than a cursor (auth required).
+// Results are filtered to the node's actively subscribed areas.
 func (h *Hub) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 	network := extractNetwork(r.URL.Path)
+	nodeID := r.Header.Get(headerNodeID)
 	since := r.URL.Query().Get("since")
 	limit := 100
 	if l := r.URL.Query().Get("limit"); l != "" {
@@ -66,7 +68,21 @@ func (h *Hub) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	results, hasMore, err := h.messages.Fetch(network, since, limit)
+	// Collect the node's actively subscribed area tags.
+	allSubs, err := h.areaSubscriptions.ListForNode(nodeID, network)
+	if err != nil {
+		slog.Error("list area subscriptions", "error", err)
+		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		return
+	}
+	var areaTags []string
+	for _, s := range allSubs {
+		if s.Status == "active" {
+			areaTags = append(areaTags, s.Tag)
+		}
+	}
+
+	results, hasMore, err := h.messages.Fetch(network, since, limit, areaTags)
 	if err != nil {
 		slog.Error("fetch messages", "error", err)
 		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
@@ -93,6 +109,7 @@ func (h *Hub) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 // handlePostMessage accepts a new message from a leaf node (auth required).
 func (h *Hub) handlePostMessage(w http.ResponseWriter, r *http.Request) {
 	network := extractNetwork(r.URL.Path)
+	nodeID := r.Header.Get(headerNodeID)
 
 	var msg protocol.Message
 	if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
@@ -107,6 +124,30 @@ func (h *Hub) handlePostMessage(w http.ResponseWriter, r *http.Request) {
 
 	if msg.Network != network {
 		http.Error(w, `{"error":"network mismatch"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Enforce NAL-based area access control.
+	currentNAL, nalErr := h.nalStore.Get(network)
+	if nalErr != nil || currentNAL == nil {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": "no NAL published for this network"})
+		return
+	}
+
+	area := currentNAL.FindArea(msg.AreaTag)
+	if area == nil {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": "unknown area_tag: " + msg.AreaTag})
+		return
+	}
+
+	active, err := h.areaSubscriptions.IsActive(nodeID, network, msg.AreaTag)
+	if err != nil {
+		slog.Error("check area subscription", "error", err)
+		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		return
+	}
+	if !active {
+		http.Error(w, `{"error":"area access denied"}`, http.StatusForbidden)
 		return
 	}
 

--- a/internal/v3net/hub/handlers.go
+++ b/internal/v3net/hub/handlers.go
@@ -1,6 +1,9 @@
 package hub
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -235,6 +238,19 @@ func (h *Hub) handleSubscribe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate that node_id is the correct derivation of the submitted public key.
+	pubKeyBytes, err := base64.StdEncoding.DecodeString(req.PubKeyB64)
+	if err != nil || len(pubKeyBytes) != 32 {
+		http.Error(w, `{"error":"invalid pubkey_b64"}`, http.StatusUnprocessableEntity)
+		return
+	}
+	h256 := sha256.Sum256(pubKeyBytes)
+	expectedNodeID := hex.EncodeToString(h256[:8])
+	if req.NodeID != expectedNodeID {
+		http.Error(w, `{"error":"node_id does not match pubkey_b64"}`, http.StatusUnprocessableEntity)
+		return
+	}
+
 	status := "pending"
 	if h.cfg.AutoApprove {
 		status = "active"
@@ -257,6 +273,11 @@ func (h *Hub) handleSubscribe(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// If area_tags are provided, process area subscriptions.
+	// Only process area subscriptions for active network subscribers.
+	if len(req.AreaTags) > 0 && actualStatus != "active" {
+		writeJSON(w, http.StatusOK, protocol.SubscribeResponse{OK: true, Status: actualStatus})
+		return
+	}
 	if len(req.AreaTags) > 0 {
 		currentNAL, nalErr := h.nalStore.Get(req.Network)
 		if nalErr != nil || currentNAL == nil {

--- a/internal/v3net/hub/handlers.go
+++ b/internal/v3net/hub/handlers.go
@@ -120,7 +120,7 @@ func (h *Hub) handlePostMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	isNew, err := h.messages.Store(msg.MsgUUID, network, string(data))
+	isNew, err := h.messages.Store(msg.MsgUUID, network, msg.AreaTag, string(data))
 	if err != nil {
 		slog.Error("store message", "error", err)
 		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)

--- a/internal/v3net/hub/hub.go
+++ b/internal/v3net/hub/hub.go
@@ -37,6 +37,11 @@ func New(cfg Config) (*Hub, error) {
 	if err != nil {
 		return nil, fmt.Errorf("hub: open database: %w", err)
 	}
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec("PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("hub: configure pragmas: %w", err)
+	}
 
 	subscribers, err := NewSubscriberStore(db)
 	if err != nil {

--- a/internal/v3net/hub/hub_access_test.go
+++ b/internal/v3net/hub/hub_access_test.go
@@ -1,0 +1,497 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/keystore"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/nal"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+)
+
+func seedNALWithAreas(t *testing.T, h *Hub, ks *keystore.Keystore, areas []protocol.Area) {
+	t.Helper()
+	for i := range areas {
+		if areas[i].ManagerNodeID == "" {
+			areas[i].ManagerNodeID = ks.NodeID()
+			areas[i].ManagerPubKeyB64 = ks.PubKeyBase64()
+		}
+	}
+	testNAL := &protocol.NAL{
+		V3NetNAL:       "1.0",
+		Network:        "testnet",
+		CoordNodeID:    ks.NodeID(),
+		CoordPubKeyB64: ks.PubKeyBase64(),
+		Areas:          areas,
+	}
+	if err := nal.Sign(testNAL, ks); err != nil {
+		t.Fatalf("sign test NAL: %v", err)
+	}
+	if err := h.nalStore.Put("testnet", testNAL); err != nil {
+		t.Fatalf("put test NAL: %v", err)
+	}
+}
+
+func registerHubAsLeaf(t *testing.T, ts *httptest.Server, hubKS *keystore.Keystore) {
+	t.Helper()
+	body := fmt.Sprintf(`{"network":"testnet","node_id":%q,"pubkey_b64":%q,"bbs_name":"Hub BBS","bbs_host":"hub.example.net"}`,
+		hubKS.NodeID(), hubKS.PubKeyBase64())
+	resp, err := http.Post(ts.URL+"/v3net/v1/subscribe", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("register hub as leaf: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("register hub status: %d", resp.StatusCode)
+	}
+}
+
+func TestGetAccess_ManagerOnly(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+
+	registerHubAsLeaf(t, ts, hubKS)
+	registerLeaf(t, ts, leafKS)
+
+	seedNALWithAreas(t, h, hubKS, []protocol.Area{
+		{
+			Tag:         "gen.general",
+			Name:        "General",
+			Description: "General discussion",
+			Language:    "en",
+			Access:      protocol.AreaAccess{Mode: protocol.AccessModeOpen},
+		},
+	})
+
+	// (a) Leaf should get 403.
+	leafReq := signedRequest(t, leafKS, "GET", ts.URL+"/v3net/v1/testnet/areas/gen.general/access", "")
+	resp, err := http.DefaultClient.Do(leafReq)
+	if err != nil {
+		t.Fatalf("GET access as leaf: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 for non-manager, got %d", resp.StatusCode)
+	}
+
+	// (b) Hub (manager) should get 200.
+	hubReq := signedRequest(t, hubKS, "GET", ts.URL+"/v3net/v1/testnet/areas/gen.general/access", "")
+	resp2, err := http.DefaultClient.Do(hubReq)
+	if err != nil {
+		t.Fatalf("GET access as hub: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for manager, got %d", resp2.StatusCode)
+	}
+
+	var cfg protocol.AreaAccessConfig
+	if err := json.NewDecoder(resp2.Body).Decode(&cfg); err != nil {
+		t.Fatalf("decode access config: %v", err)
+	}
+	if cfg.Mode != protocol.AccessModeOpen {
+		t.Errorf("expected mode %q, got %q", protocol.AccessModeOpen, cfg.Mode)
+	}
+	if len(cfg.AllowList) != 0 {
+		t.Errorf("expected empty allow_list, got %v", cfg.AllowList)
+	}
+	if len(cfg.DenyList) != 0 {
+		t.Errorf("expected empty deny_list, got %v", cfg.DenyList)
+	}
+}
+
+func TestSetAccessMode(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	registerHubAsLeaf(t, ts, hubKS)
+
+	seedNALWithAreas(t, h, hubKS, []protocol.Area{
+		{
+			Tag:         "gen.general",
+			Name:        "General",
+			Description: "General discussion",
+			Language:    "en",
+			Access:      protocol.AreaAccess{Mode: protocol.AccessModeOpen},
+		},
+	})
+
+	// POST to change mode to approval.
+	modeBody := `{"mode":"approval"}`
+	req := signedRequest(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/areas/gen.general/access/mode", modeBody)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST access mode: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for set mode, got %d", resp.StatusCode)
+	}
+
+	// GET and verify mode changed.
+	getReq := signedRequest(t, hubKS, "GET", ts.URL+"/v3net/v1/testnet/areas/gen.general/access", "")
+	resp2, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatalf("GET access: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	var cfg protocol.AreaAccessConfig
+	if err := json.NewDecoder(resp2.Body).Decode(&cfg); err != nil {
+		t.Fatalf("decode access config: %v", err)
+	}
+	if cfg.Mode != protocol.AccessModeApproval {
+		t.Errorf("expected mode %q, got %q", protocol.AccessModeApproval, cfg.Mode)
+	}
+}
+
+func TestApproveAccess_AddsToAllowList(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+
+	registerHubAsLeaf(t, ts, hubKS)
+	registerLeaf(t, ts, leafKS)
+
+	seedNALWithAreas(t, h, hubKS, []protocol.Area{
+		{
+			Tag:         "gen.general",
+			Name:        "General",
+			Description: "General discussion",
+			Language:    "en",
+			Access:      protocol.AreaAccess{Mode: protocol.AccessModeApproval},
+		},
+	})
+
+	// Approve the leaf node.
+	approveBody := fmt.Sprintf(`{"node_ids":[%q]}`, leafKS.NodeID())
+	req := signedRequest(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/areas/gen.general/access/approve", approveBody)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST approve: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for approve, got %d", resp.StatusCode)
+	}
+
+	// GET access config and verify allow_list.
+	getReq := signedRequest(t, hubKS, "GET", ts.URL+"/v3net/v1/testnet/areas/gen.general/access", "")
+	resp2, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatalf("GET access: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	var cfg protocol.AreaAccessConfig
+	if err := json.NewDecoder(resp2.Body).Decode(&cfg); err != nil {
+		t.Fatalf("decode access config: %v", err)
+	}
+
+	found := false
+	for _, id := range cfg.AllowList {
+		if id == leafKS.NodeID() {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected leaf node_id %q in allow_list, got %v", leafKS.NodeID(), cfg.AllowList)
+	}
+}
+
+func TestDenyAccess_AddsToDenyList(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+
+	registerHubAsLeaf(t, ts, hubKS)
+	registerLeaf(t, ts, leafKS)
+
+	seedNALWithAreas(t, h, hubKS, []protocol.Area{
+		{
+			Tag:         "gen.general",
+			Name:        "General",
+			Description: "General discussion",
+			Language:    "en",
+			Access:      protocol.AreaAccess{Mode: protocol.AccessModeOpen},
+		},
+	})
+
+	// Deny the leaf node.
+	denyBody := fmt.Sprintf(`{"node_ids":[%q]}`, leafKS.NodeID())
+	req := signedRequest(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/areas/gen.general/access/deny", denyBody)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST deny: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for deny, got %d", resp.StatusCode)
+	}
+
+	// GET access config and verify deny_list.
+	getReq := signedRequest(t, hubKS, "GET", ts.URL+"/v3net/v1/testnet/areas/gen.general/access", "")
+	resp2, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatalf("GET access: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	var cfg protocol.AreaAccessConfig
+	if err := json.NewDecoder(resp2.Body).Decode(&cfg); err != nil {
+		t.Fatalf("decode access config: %v", err)
+	}
+
+	found := false
+	for _, id := range cfg.DenyList {
+		if id == leafKS.NodeID() {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected leaf node_id %q in deny_list, got %v", leafKS.NodeID(), cfg.DenyList)
+	}
+}
+
+func TestRemoveFromDenyList(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+
+	registerHubAsLeaf(t, ts, hubKS)
+	registerLeaf(t, ts, leafKS)
+
+	// Seed NAL with area that has the leaf in deny_list.
+	seedNALWithAreas(t, h, hubKS, []protocol.Area{
+		{
+			Tag:         "gen.general",
+			Name:        "General",
+			Description: "General discussion",
+			Language:    "en",
+			Access: protocol.AreaAccess{
+				Mode:     protocol.AccessModeOpen,
+				DenyList: []string{leafKS.NodeID()},
+			},
+		},
+	})
+
+	// Remove the leaf from deny_list.
+	removeBody := fmt.Sprintf(`{"node_ids":[%q]}`, leafKS.NodeID())
+	req := signedRequest(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/areas/gen.general/access/remove", removeBody)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST remove: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for remove, got %d", resp.StatusCode)
+	}
+
+	// GET access config and verify deny_list is empty.
+	getReq := signedRequest(t, hubKS, "GET", ts.URL+"/v3net/v1/testnet/areas/gen.general/access", "")
+	resp2, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatalf("GET access: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	var cfg protocol.AreaAccessConfig
+	if err := json.NewDecoder(resp2.Body).Decode(&cfg); err != nil {
+		t.Fatalf("decode access config: %v", err)
+	}
+	if len(cfg.DenyList) != 0 {
+		t.Errorf("expected empty deny_list after remove, got %v", cfg.DenyList)
+	}
+}
+
+func TestSubscribeWithAreaTags_OpenArea(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+
+	seedNALWithAreas(t, h, hubKS, []protocol.Area{
+		{
+			Tag:         "gen.general",
+			Name:        "General",
+			Description: "General discussion",
+			Language:    "en",
+			Access:      protocol.AreaAccess{Mode: protocol.AccessModeOpen},
+		},
+	})
+
+	body := fmt.Sprintf(`{"network":"testnet","node_id":%q,"pubkey_b64":%q,"bbs_name":"Test BBS","bbs_host":"test.example.net","area_tags":["gen.general"]}`,
+		leafKS.NodeID(), leafKS.PubKeyBase64())
+	resp, err := http.Post(ts.URL+"/v3net/v1/subscribe", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST subscribe: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result protocol.SubscribeWithAreasResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !result.OK {
+		t.Errorf("expected ok=true, got false")
+	}
+	if len(result.Areas) != 1 {
+		t.Fatalf("expected 1 area status, got %d", len(result.Areas))
+	}
+	if result.Areas[0].Tag != "gen.general" {
+		t.Errorf("expected tag gen.general, got %q", result.Areas[0].Tag)
+	}
+	if result.Areas[0].Status != "active" {
+		t.Errorf("expected status active, got %q", result.Areas[0].Status)
+	}
+}
+
+func TestSubscribeWithAreaTags_ApprovalArea(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+
+	seedNALWithAreas(t, h, hubKS, []protocol.Area{
+		{
+			Tag:         "gen.general",
+			Name:        "General",
+			Description: "General discussion",
+			Language:    "en",
+			Access:      protocol.AreaAccess{Mode: protocol.AccessModeApproval},
+		},
+	})
+
+	body := fmt.Sprintf(`{"network":"testnet","node_id":%q,"pubkey_b64":%q,"bbs_name":"Test BBS","bbs_host":"test.example.net","area_tags":["gen.general"]}`,
+		leafKS.NodeID(), leafKS.PubKeyBase64())
+	resp, err := http.Post(ts.URL+"/v3net/v1/subscribe", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST subscribe: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result protocol.SubscribeWithAreasResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(result.Areas) != 1 {
+		t.Fatalf("expected 1 area status, got %d", len(result.Areas))
+	}
+	if result.Areas[0].Status != "pending" {
+		t.Errorf("expected status pending, got %q", result.Areas[0].Status)
+	}
+}
+
+func TestSubscribeWithAreaTags_ClosedDenied(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+
+	seedNALWithAreas(t, h, hubKS, []protocol.Area{
+		{
+			Tag:         "gen.general",
+			Name:        "General",
+			Description: "General discussion",
+			Language:    "en",
+			Access:      protocol.AreaAccess{Mode: protocol.AccessModeClosed},
+		},
+	})
+
+	body := fmt.Sprintf(`{"network":"testnet","node_id":%q,"pubkey_b64":%q,"bbs_name":"Test BBS","bbs_host":"test.example.net","area_tags":["gen.general"]}`,
+		leafKS.NodeID(), leafKS.PubKeyBase64())
+	resp, err := http.Post(ts.URL+"/v3net/v1/subscribe", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST subscribe: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 for closed area, got %d", resp.StatusCode)
+	}
+}
+
+func TestSubscribeWithAreaTags_DenyList(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+
+	seedNALWithAreas(t, h, hubKS, []protocol.Area{
+		{
+			Tag:         "gen.general",
+			Name:        "General",
+			Description: "General discussion",
+			Language:    "en",
+			Access: protocol.AreaAccess{
+				Mode:     protocol.AccessModeOpen,
+				DenyList: []string{leafKS.NodeID()},
+			},
+		},
+	})
+
+	body := fmt.Sprintf(`{"network":"testnet","node_id":%q,"pubkey_b64":%q,"bbs_name":"Test BBS","bbs_host":"test.example.net","area_tags":["gen.general"]}`,
+		leafKS.NodeID(), leafKS.PubKeyBase64())
+	resp, err := http.Post(ts.URL+"/v3net/v1/subscribe", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST subscribe: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 for deny-listed node, got %d", resp.StatusCode)
+	}
+}

--- a/internal/v3net/hub/hub_area_msg_test.go
+++ b/internal/v3net/hub/hub_area_msg_test.go
@@ -1,0 +1,17 @@
+package hub
+
+import (
+	"testing"
+)
+
+func TestMessageStore_StoreWithAreaTag(t *testing.T) {
+	h, _ := setupTestHub(t)
+
+	ok, err := h.messages.Store("uuid-001", "testnet", "gen.general", `{"test":"data"}`)
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected new message to be stored")
+	}
+}

--- a/internal/v3net/hub/hub_area_msg_test.go
+++ b/internal/v3net/hub/hub_area_msg_test.go
@@ -1,8 +1,96 @@
 package hub
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/keystore"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/nal"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
 )
+
+// seedAreaMsgNAL seeds a NAL with two areas: gen.general (open) and gen.restricted (approval).
+func seedAreaMsgNAL(t *testing.T, h *Hub, ks *keystore.Keystore) {
+	t.Helper()
+	testNAL := &protocol.NAL{
+		V3NetNAL:       "1.0",
+		Network:        "testnet",
+		CoordNodeID:    ks.NodeID(),
+		CoordPubKeyB64: ks.PubKeyBase64(),
+		Areas: []protocol.Area{
+			{
+				Tag:              "gen.general",
+				Name:             "General",
+				Language:         "en",
+				ManagerNodeID:    ks.NodeID(),
+				ManagerPubKeyB64: ks.PubKeyBase64(),
+				Access:           protocol.AreaAccess{Mode: protocol.AccessModeOpen},
+				Policy:           protocol.AreaPolicy{MaxBodyBytes: 65536, AllowANSI: true},
+			},
+			{
+				Tag:              "gen.restricted",
+				Name:             "Restricted",
+				Language:         "en",
+				ManagerNodeID:    ks.NodeID(),
+				ManagerPubKeyB64: ks.PubKeyBase64(),
+				Access:           protocol.AreaAccess{Mode: protocol.AccessModeApproval},
+				Policy:           protocol.AreaPolicy{MaxBodyBytes: 65536, AllowANSI: true},
+			},
+		},
+	}
+	if err := nal.Sign(testNAL, ks); err != nil {
+		t.Fatalf("sign area msg NAL: %v", err)
+	}
+	if err := h.nalStore.Put("testnet", testNAL); err != nil {
+		t.Fatalf("put area msg NAL: %v", err)
+	}
+}
+
+// registerLeafWithAreas subscribes a leaf node and requests area subscriptions.
+func registerLeafWithAreas(t *testing.T, ts *httptest.Server, leafKS *keystore.Keystore, areaTags []string) {
+	t.Helper()
+	req := protocol.SubscribeRequest{
+		Network:   "testnet",
+		NodeID:    leafKS.NodeID(),
+		PubKeyB64: leafKS.PubKeyBase64(),
+		BBSName:   "Test BBS",
+		BBSHost:   "test.example.net",
+		AreaTags:  areaTags,
+	}
+	body, _ := json.Marshal(req)
+	resp, err := http.Post(ts.URL+"/v3net/v1/subscribe", "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatalf("subscribe with areas: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("subscribe with areas status: %d", resp.StatusCode)
+	}
+}
+
+// testMsgJSON returns a valid message JSON for the given area tag and UUID.
+func testMsgJSON(areaTag, uuid string) string {
+	return fmt.Sprintf(`{
+		"v3net": "1.0",
+		"network": "testnet",
+		"area_tag": %q,
+		"msg_uuid": %q,
+		"thread_uuid": %q,
+		"origin_node": "test.example.net",
+		"origin_board": "General",
+		"from": "Tester",
+		"to": "All",
+		"subject": "Test message",
+		"date_utc": "2026-03-16T04:20:00Z",
+		"body": "Hello V3Net!",
+		"kludges": {}
+	}`, areaTag, uuid, uuid)
+}
 
 func TestMessageStore_StoreWithAreaTag(t *testing.T) {
 	h, _ := setupTestHub(t)
@@ -13,5 +101,235 @@ func TestMessageStore_StoreWithAreaTag(t *testing.T) {
 	}
 	if !ok {
 		t.Fatal("expected new message to be stored")
+	}
+}
+
+func TestPostMessage_NoNAL_Returns422(t *testing.T) {
+	h, _ := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+	// Register leaf without area subscriptions (no NAL seeded).
+	registerLeaf(t, ts, leafKS)
+
+	msgJSON := testMsgJSON("gen.general", "aa0e8400-e29b-41d4-a716-446655440001")
+	req := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/messages", msgJSON)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d", resp.StatusCode)
+	}
+}
+
+func TestPostMessage_UnknownArea_Returns422(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+	seedAreaMsgNAL(t, h, hubKS)
+	registerLeafWithAreas(t, ts, leafKS, []string{"gen.general"})
+
+	// Post to an area that doesn't exist in the NAL.
+	msgJSON := testMsgJSON("gen.nonexistent", "ab0e8400-e29b-41d4-a716-446655440002")
+	req := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/messages", msgJSON)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d", resp.StatusCode)
+	}
+}
+
+func TestPostMessage_NotSubscribed_Returns403(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+	seedAreaMsgNAL(t, h, hubKS)
+	// Register without subscribing to gen.general.
+	registerLeaf(t, ts, leafKS)
+
+	msgJSON := testMsgJSON("gen.general", "ac0e8400-e29b-41d4-a716-446655440003")
+	req := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/messages", msgJSON)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestPostMessage_ActiveSubscription_Returns200(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+	seedAreaMsgNAL(t, h, hubKS)
+	registerLeafWithAreas(t, ts, leafKS, []string{"gen.general"})
+
+	msgJSON := testMsgJSON("gen.general", "ad0e8400-e29b-41d4-a716-446655440004")
+	req := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/messages", msgJSON)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestGetMessages_FiltersToSubscribedAreas(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+	seedAreaMsgNAL(t, h, hubKS)
+
+	// Directly store messages bypassing POST enforcement.
+	h.messages.Store("ae0e8400-e29b-41d4-a716-000000000001", "testnet", "gen.general", testMsgJSON("gen.general", "ae0e8400-e29b-41d4-a716-000000000001"))
+	h.messages.Store("ae0e8400-e29b-41d4-a716-000000000002", "testnet", "gen.general", testMsgJSON("gen.general", "ae0e8400-e29b-41d4-a716-000000000002"))
+	h.messages.Store("ae0e8400-e29b-41d4-a716-000000000003", "testnet", "gen.restricted", testMsgJSON("gen.restricted", "ae0e8400-e29b-41d4-a716-000000000003"))
+
+	// Register leaf only with gen.general subscription.
+	registerLeafWithAreas(t, ts, leafKS, []string{"gen.general"})
+
+	getReq := signedRequest(t, leafKS, "GET", ts.URL+"/v3net/v1/testnet/messages", "")
+	resp, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET status: %d", resp.StatusCode)
+	}
+
+	var messages []protocol.Message
+	if err := json.NewDecoder(resp.Body).Decode(&messages); err != nil {
+		t.Fatalf("decode messages: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Errorf("expected 2 messages (gen.general only), got %d", len(messages))
+	}
+	for _, m := range messages {
+		if m.AreaTag != "gen.general" {
+			t.Errorf("expected only gen.general messages, got area_tag %q", m.AreaTag)
+		}
+	}
+}
+
+func TestGetMessages_NoSubscriptions_ReturnsEmpty(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+	seedAreaMsgNAL(t, h, hubKS)
+
+	// Store a message directly.
+	h.messages.Store("af0e8400-e29b-41d4-a716-000000000001", "testnet", "gen.general", testMsgJSON("gen.general", "af0e8400-e29b-41d4-a716-000000000001"))
+
+	// Register leaf without any area subscriptions.
+	registerLeaf(t, ts, leafKS)
+
+	getReq := signedRequest(t, leafKS, "GET", ts.URL+"/v3net/v1/testnet/messages", "")
+	resp, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET status: %d", resp.StatusCode)
+	}
+
+	var messages []json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&messages); err != nil {
+		t.Fatalf("decode messages: %v", err)
+	}
+	if len(messages) != 0 {
+		t.Errorf("expected 0 messages for node with no subscriptions, got %d", len(messages))
+	}
+}
+
+func TestMessageStore_FetchFiltersByAreaTags(t *testing.T) {
+	h, _ := setupTestHub(t)
+
+	// Store messages in two areas.
+	h.messages.Store("b00e8400-0001", "testnet", "gen.general", `{"msg_uuid":"b00e8400-0001","area_tag":"gen.general"}`)
+	h.messages.Store("b00e8400-0002", "testnet", "gen.general", `{"msg_uuid":"b00e8400-0002","area_tag":"gen.general"}`)
+	h.messages.Store("b00e8400-0003", "testnet", "gen.restricted", `{"msg_uuid":"b00e8400-0003","area_tag":"gen.restricted"}`)
+
+	// Fetch only gen.general.
+	results, hasMore, err := h.messages.Fetch("testnet", "", 100, []string{"gen.general"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if hasMore {
+		t.Error("expected hasMore=false")
+	}
+	if len(results) != 2 {
+		t.Errorf("expected 2 results, got %d", len(results))
+	}
+
+	// Fetch both areas.
+	all, _, err := h.messages.Fetch("testnet", "", 100, []string{"gen.general", "gen.restricted"})
+	if err != nil {
+		t.Fatalf("Fetch all: %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("expected 3 results, got %d", len(all))
+	}
+}
+
+func TestMessageStore_FetchEmptyAreaTagsReturnsNil(t *testing.T) {
+	h, _ := setupTestHub(t)
+
+	h.messages.Store("b10e8400-0001", "testnet", "gen.general", `{"msg_uuid":"b10e8400-0001"}`)
+
+	results, hasMore, err := h.messages.Fetch("testnet", "", 100, []string{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if hasMore {
+		t.Error("expected hasMore=false")
+	}
+	if results != nil {
+		t.Errorf("expected nil results for empty areaTags, got %v", results)
 	}
 }

--- a/internal/v3net/hub/hub_coordinator_test.go
+++ b/internal/v3net/hub/hub_coordinator_test.go
@@ -1,0 +1,275 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/keystore"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/nal"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+)
+
+func seedCoordNAL(t *testing.T, h *Hub, ks *keystore.Keystore) {
+	t.Helper()
+	testNAL := &protocol.NAL{
+		V3NetNAL:       "1.0",
+		Network:        "testnet",
+		CoordNodeID:    ks.NodeID(),
+		CoordPubKeyB64: ks.PubKeyBase64(),
+		Areas:          []protocol.Area{},
+	}
+	if err := nal.Sign(testNAL, ks); err != nil {
+		t.Fatalf("sign test NAL: %v", err)
+	}
+	if err := h.nalStore.Put("testnet", testNAL); err != nil {
+		t.Fatalf("put test NAL: %v", err)
+	}
+}
+
+func registerAsLeaf(t *testing.T, ts *httptest.Server, ks *keystore.Keystore) {
+	t.Helper()
+	body := fmt.Sprintf(`{"network":"testnet","node_id":%q,"pubkey_b64":%q,"bbs_name":"Node","bbs_host":"node.example.net"}`, ks.NodeID(), ks.PubKeyBase64())
+	resp, err := http.Post(ts.URL+"/v3net/v1/subscribe", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("register status: %d", resp.StatusCode)
+	}
+}
+
+func TestCoordTransfer_FullFlow(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+
+	registerAsLeaf(t, ts, hubKS)
+	registerAsLeaf(t, ts, leafKS)
+	seedCoordNAL(t, h, hubKS)
+
+	// Initiate transfer as hub (coordinator) to leaf.
+	transferBody := fmt.Sprintf(`{"new_node_id":%q,"new_pubkey_b64":%q}`, leafKS.NodeID(), leafKS.PubKeyBase64())
+	req := signedRequest(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/coordinator/transfer", transferBody)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST transfer: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("transfer expected 200, got %d", resp.StatusCode)
+	}
+
+	var transferResp map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&transferResp); err != nil {
+		t.Fatalf("decode transfer response: %v", err)
+	}
+	token, ok := transferResp["token"].(string)
+	if !ok || token == "" {
+		t.Fatalf("expected non-empty token, got %v", transferResp["token"])
+	}
+
+	// Accept transfer as leaf (new coordinator).
+	acceptBody := fmt.Sprintf(`{"token":%q}`, token)
+	acceptReq := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/coordinator/accept", acceptBody)
+	acceptResp, err := http.DefaultClient.Do(acceptReq)
+	if err != nil {
+		t.Fatalf("POST accept: %v", err)
+	}
+	defer acceptResp.Body.Close()
+
+	if acceptResp.StatusCode != http.StatusOK {
+		t.Fatalf("accept expected 200, got %d", acceptResp.StatusCode)
+	}
+
+	// Verify NAL coordinator changed to leaf.
+	nalResp, err := http.Get(ts.URL + "/v3net/v1/testnet/nal")
+	if err != nil {
+		t.Fatalf("GET nal: %v", err)
+	}
+	defer nalResp.Body.Close()
+
+	if nalResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET nal expected 200, got %d", nalResp.StatusCode)
+	}
+
+	var updatedNAL protocol.NAL
+	if err := json.NewDecoder(nalResp.Body).Decode(&updatedNAL); err != nil {
+		t.Fatalf("decode NAL: %v", err)
+	}
+	if updatedNAL.CoordNodeID != leafKS.NodeID() {
+		t.Errorf("expected coordinator_node_id %q, got %q", leafKS.NodeID(), updatedNAL.CoordNodeID)
+	}
+	if updatedNAL.CoordPubKeyB64 != leafKS.PubKeyBase64() {
+		t.Errorf("expected coordinator_pubkey_b64 %q, got %q", leafKS.PubKeyBase64(), updatedNAL.CoordPubKeyB64)
+	}
+}
+
+func TestCoordTransfer_NonCoordinator(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+
+	registerAsLeaf(t, ts, hubKS)
+	registerAsLeaf(t, ts, leafKS)
+	seedCoordNAL(t, h, hubKS)
+
+	// Attempt transfer as leaf (non-coordinator).
+	transferBody := fmt.Sprintf(`{"new_node_id":%q,"new_pubkey_b64":%q}`, hubKS.NodeID(), hubKS.PubKeyBase64())
+	req := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/coordinator/transfer", transferBody)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST transfer: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 for non-coordinator transfer, got %d", resp.StatusCode)
+	}
+}
+
+func TestCoordAccept_WrongNode(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+	thirdKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "third.key"))
+	if err != nil {
+		t.Fatalf("load third keystore: %v", err)
+	}
+
+	registerAsLeaf(t, ts, hubKS)
+	registerAsLeaf(t, ts, leafKS)
+	registerAsLeaf(t, ts, thirdKS)
+	seedCoordNAL(t, h, hubKS)
+
+	// Initiate transfer to leaf.
+	transferBody := fmt.Sprintf(`{"new_node_id":%q,"new_pubkey_b64":%q}`, leafKS.NodeID(), leafKS.PubKeyBase64())
+	req := signedRequest(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/coordinator/transfer", transferBody)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST transfer: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var transferResp map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&transferResp); err != nil {
+		t.Fatalf("decode transfer response: %v", err)
+	}
+	token := transferResp["token"].(string)
+
+	// Attempt accept as third keystore (wrong node).
+	acceptBody := fmt.Sprintf(`{"token":%q}`, token)
+	acceptReq := signedRequest(t, thirdKS, "POST", ts.URL+"/v3net/v1/testnet/coordinator/accept", acceptBody)
+	acceptResp, err := http.DefaultClient.Do(acceptReq)
+	if err != nil {
+		t.Fatalf("POST accept: %v", err)
+	}
+	acceptResp.Body.Close()
+
+	if acceptResp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 for wrong node accept, got %d", acceptResp.StatusCode)
+	}
+}
+
+func TestCoordAccept_InvalidToken(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+
+	registerAsLeaf(t, ts, hubKS)
+	registerAsLeaf(t, ts, leafKS)
+	seedCoordNAL(t, h, hubKS)
+
+	// Initiate transfer to leaf.
+	transferBody := fmt.Sprintf(`{"new_node_id":%q,"new_pubkey_b64":%q}`, leafKS.NodeID(), leafKS.PubKeyBase64())
+	req := signedRequest(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/coordinator/transfer", transferBody)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST transfer: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("transfer expected 200, got %d", resp.StatusCode)
+	}
+
+	// Attempt accept with bogus token.
+	acceptBody := `{"token":"dGhpcyBpcyBub3QgYSB2YWxpZCB0b2tlbg=="}`
+	acceptReq := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/coordinator/accept", acceptBody)
+	acceptResp, err := http.DefaultClient.Do(acceptReq)
+	if err != nil {
+		t.Fatalf("POST accept: %v", err)
+	}
+	acceptResp.Body.Close()
+
+	if acceptResp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 for invalid token, got %d", acceptResp.StatusCode)
+	}
+}
+
+func TestCoordTransfer_SSEEvent(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+
+	registerAsLeaf(t, ts, hubKS)
+	registerAsLeaf(t, ts, leafKS)
+	seedCoordNAL(t, h, hubKS)
+
+	ch, cancel := h.broadcaster.Subscribe("testnet")
+	defer cancel()
+
+	// Initiate transfer.
+	transferBody := fmt.Sprintf(`{"new_node_id":%q,"new_pubkey_b64":%q}`, leafKS.NodeID(), leafKS.PubKeyBase64())
+	req := signedRequest(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/coordinator/transfer", transferBody)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST transfer: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("transfer expected 200, got %d", resp.StatusCode)
+	}
+
+	select {
+	case ev := <-ch:
+		if ev.Type != "coordinator_transfer_pending" {
+			t.Errorf("expected coordinator_transfer_pending event, got %q", ev.Type)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timed out waiting for coordinator_transfer_pending SSE event")
+	}
+}

--- a/internal/v3net/hub/hub_coordinator_test.go
+++ b/internal/v3net/hub/hub_coordinator_test.go
@@ -173,11 +173,19 @@ func TestCoordAccept_WrongNode(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	var transferResp map[string]any
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST transfer expected 200, got %d", resp.StatusCode)
+	}
+	var transferResp struct {
+		Token string `json:"token"`
+	}
 	if err := json.NewDecoder(resp.Body).Decode(&transferResp); err != nil {
 		t.Fatalf("decode transfer response: %v", err)
 	}
-	token := transferResp["token"].(string)
+	if transferResp.Token == "" {
+		t.Fatal("expected non-empty token")
+	}
+	token := transferResp.Token
 
 	// Attempt accept as third keystore (wrong node).
 	acceptBody := fmt.Sprintf(`{"token":%q}`, token)

--- a/internal/v3net/hub/hub_nal_test.go
+++ b/internal/v3net/hub/hub_nal_test.go
@@ -1,0 +1,364 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/keystore"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/nal"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+)
+
+func seedTestNAL(t *testing.T, h *Hub, ks *keystore.Keystore) {
+	t.Helper()
+	testNAL := &protocol.NAL{
+		V3NetNAL:       "1.0",
+		Network:        "testnet",
+		CoordNodeID:    ks.NodeID(),
+		CoordPubKeyB64: ks.PubKeyBase64(),
+		Areas: []protocol.Area{
+			{
+				Tag:              "gen.general",
+				Name:             "General",
+				Description:      "General discussion",
+				Language:         "en",
+				ManagerNodeID:    ks.NodeID(),
+				ManagerPubKeyB64: ks.PubKeyBase64(),
+				Access:           protocol.AreaAccess{Mode: protocol.AccessModeOpen},
+				Policy:           protocol.AreaPolicy{MaxBodyBytes: 65536, AllowANSI: true},
+			},
+		},
+	}
+	if err := nal.Sign(testNAL, ks); err != nil {
+		t.Fatalf("sign test NAL: %v", err)
+	}
+	if err := h.nalStore.Put("testnet", testNAL); err != nil {
+		t.Fatalf("put test NAL: %v", err)
+	}
+}
+
+func TestGetNAL_Public(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	seedTestNAL(t, h, hubKS)
+
+	resp, err := http.Get(ts.URL + "/v3net/v1/testnet/nal")
+	if err != nil {
+		t.Fatalf("GET /nal: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var got protocol.NAL
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode NAL: %v", err)
+	}
+	if got.Network != "testnet" {
+		t.Errorf("expected network testnet, got %q", got.Network)
+	}
+	if got.CoordNodeID != hubKS.NodeID() {
+		t.Errorf("expected coord node ID %q, got %q", hubKS.NodeID(), got.CoordNodeID)
+	}
+	if len(got.Areas) != 1 {
+		t.Errorf("expected 1 area, got %d", len(got.Areas))
+	}
+}
+
+func TestGetNAL_NotFound(t *testing.T) {
+	h, _ := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v3net/v1/testnet/nal")
+	if err != nil {
+		t.Fatalf("GET /nal: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestPostNAL_Coordinator(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	// Register the hub keystore as a subscriber so auth passes.
+	body := fmt.Sprintf(`{"network":"testnet","node_id":%q,"pubkey_b64":%q,"bbs_name":"Hub BBS","bbs_host":"hub.example.net"}`,
+		hubKS.NodeID(), hubKS.PubKeyBase64())
+	resp, err := http.Post(ts.URL+"/v3net/v1/subscribe", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("subscribe hub: %v", err)
+	}
+	resp.Body.Close()
+
+	seedTestNAL(t, h, hubKS)
+
+	// Build an updated NAL signed by the hub (coordinator).
+	updatedNAL := &protocol.NAL{
+		V3NetNAL:       "1.0",
+		Network:        "testnet",
+		CoordNodeID:    hubKS.NodeID(),
+		CoordPubKeyB64: hubKS.PubKeyBase64(),
+		Areas: []protocol.Area{
+			{
+				Tag:              "gen.general",
+				Name:             "General",
+				Description:      "General discussion updated",
+				Language:         "en",
+				ManagerNodeID:    hubKS.NodeID(),
+				ManagerPubKeyB64: hubKS.PubKeyBase64(),
+				Access:           protocol.AreaAccess{Mode: protocol.AccessModeOpen},
+				Policy:           protocol.AreaPolicy{MaxBodyBytes: 65536, AllowANSI: true},
+			},
+		},
+	}
+	if err := nal.Sign(updatedNAL, hubKS); err != nil {
+		t.Fatalf("sign updated NAL: %v", err)
+	}
+
+	nalJSON, _ := json.Marshal(updatedNAL)
+	req := signedRequest(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/nal", string(nalJSON))
+	postResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /nal: %v", err)
+	}
+	defer postResp.Body.Close()
+
+	if postResp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", postResp.StatusCode)
+	}
+}
+
+func TestPostNAL_NonCoordinator(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+	registerLeaf(t, ts, leafKS)
+
+	// Seed NAL with hub as coordinator.
+	seedTestNAL(t, h, hubKS)
+
+	// Leaf tries to POST a NAL — should be forbidden.
+	fakeNAL := &protocol.NAL{
+		V3NetNAL:       "1.0",
+		Network:        "testnet",
+		CoordNodeID:    leafKS.NodeID(),
+		CoordPubKeyB64: leafKS.PubKeyBase64(),
+		Areas: []protocol.Area{
+			{
+				Tag:              "gen.general",
+				Name:             "General",
+				Description:      "Hijacked",
+				Language:         "en",
+				ManagerNodeID:    leafKS.NodeID(),
+				ManagerPubKeyB64: leafKS.PubKeyBase64(),
+				Access:           protocol.AreaAccess{Mode: protocol.AccessModeOpen},
+				Policy:           protocol.AreaPolicy{MaxBodyBytes: 65536, AllowANSI: true},
+			},
+		},
+	}
+	if err := nal.Sign(fakeNAL, leafKS); err != nil {
+		t.Fatalf("sign fake NAL: %v", err)
+	}
+
+	nalJSON, _ := json.Marshal(fakeNAL)
+	req := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/nal", string(nalJSON))
+	postResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /nal: %v", err)
+	}
+	defer postResp.Body.Close()
+
+	if postResp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", postResp.StatusCode)
+	}
+}
+
+func TestPostNAL_InitialCreation_HubOnly(t *testing.T) {
+	h, _ := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+	registerLeaf(t, ts, leafKS)
+
+	// Leaf tries to create initial NAL — should be forbidden.
+	initialNAL := &protocol.NAL{
+		V3NetNAL:       "1.0",
+		Network:        "testnet",
+		CoordNodeID:    leafKS.NodeID(),
+		CoordPubKeyB64: leafKS.PubKeyBase64(),
+		Areas: []protocol.Area{
+			{
+				Tag:              "gen.general",
+				Name:             "General",
+				Description:      "Attempted initial creation",
+				Language:         "en",
+				ManagerNodeID:    leafKS.NodeID(),
+				ManagerPubKeyB64: leafKS.PubKeyBase64(),
+				Access:           protocol.AreaAccess{Mode: protocol.AccessModeOpen},
+				Policy:           protocol.AreaPolicy{MaxBodyBytes: 65536, AllowANSI: true},
+			},
+		},
+	}
+	if err := nal.Sign(initialNAL, leafKS); err != nil {
+		t.Fatalf("sign initial NAL: %v", err)
+	}
+
+	nalJSON, _ := json.Marshal(initialNAL)
+	req := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/nal", string(nalJSON))
+	postResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /nal: %v", err)
+	}
+	defer postResp.Body.Close()
+
+	if postResp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", postResp.StatusCode)
+	}
+}
+
+func TestAuthClockSkew_Rejected(t *testing.T) {
+	h, _ := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+	registerLeaf(t, ts, leafKS)
+
+	req := signedRequest(t, leafKS, "GET", ts.URL+"/v3net/v1/testnet/messages", "")
+	// Override date to 10 minutes ago — clock skew check happens before signature verification.
+	req.Header.Set("Date", time.Now().Add(-10*time.Minute).UTC().Format(http.TimeFormat))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /messages: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401 for clock skew, got %d", resp.StatusCode)
+	}
+}
+
+func TestGetMessages_Pagination(t *testing.T) {
+	h, _ := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+	registerLeaf(t, ts, leafKS)
+
+	// Post 3 messages with unique UUIDs.
+	uuids := []string{
+		"a50e8400-e29b-41d4-a716-446655440001",
+		"b50e8400-e29b-41d4-a716-446655440002",
+		"c50e8400-e29b-41d4-a716-446655440003",
+	}
+	for i, uuid := range uuids {
+		msgJSON := fmt.Sprintf(`{
+			"v3net":"1.0",
+			"network":"testnet",
+			"msg_uuid":%q,
+			"thread_uuid":%q,
+			"origin_node":"test.example.net",
+			"origin_board":"General",
+			"from":"Tester",
+			"to":"All",
+			"subject":"Message %d",
+			"date_utc":"2026-03-16T04:20:00Z",
+			"body":"Body %d",
+			"kludges":{}
+		}`, uuid, uuid, i+1, i+1)
+
+		req := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/messages", msgJSON)
+		resp, postErr := http.DefaultClient.Do(req)
+		if postErr != nil {
+			t.Fatalf("POST message %d: %v", i+1, postErr)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("POST message %d status: %d", i+1, resp.StatusCode)
+		}
+	}
+
+	// GET with limit=2 — should return 2 messages and X-V3Net-Has-More: true.
+	getReq := signedRequest(t, leafKS, "GET", ts.URL+"/v3net/v1/testnet/messages?limit=2", "")
+	resp, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatalf("GET messages limit=2: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET messages status: %d", resp.StatusCode)
+	}
+
+	hasMore := resp.Header.Get("X-V3Net-Has-More")
+	if hasMore != "true" {
+		t.Errorf("expected X-V3Net-Has-More: true, got %q", hasMore)
+	}
+
+	var batch1 []protocol.Message
+	if err := json.NewDecoder(resp.Body).Decode(&batch1); err != nil {
+		t.Fatalf("decode batch 1: %v", err)
+	}
+	if len(batch1) != 2 {
+		t.Fatalf("expected 2 messages in batch 1, got %d", len(batch1))
+	}
+
+	// GET with since=last UUID from first batch — should return remaining message(s).
+	sinceUUID := batch1[len(batch1)-1].MsgUUID
+	getReq2 := signedRequest(t, leafKS, "GET",
+		fmt.Sprintf("%s/v3net/v1/testnet/messages?since=%s&limit=10", ts.URL, sinceUUID), "")
+	resp2, err := http.DefaultClient.Do(getReq2)
+	if err != nil {
+		t.Fatalf("GET messages since: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("GET messages since status: %d", resp2.StatusCode)
+	}
+
+	var batch2 []protocol.Message
+	if err := json.NewDecoder(resp2.Body).Decode(&batch2); err != nil {
+		t.Fatalf("decode batch 2: %v", err)
+	}
+	if len(batch2) != 1 {
+		t.Errorf("expected 1 message in batch 2, got %d", len(batch2))
+	}
+
+	hasMore2 := resp2.Header.Get("X-V3Net-Has-More")
+	if hasMore2 == "true" {
+		t.Errorf("expected no X-V3Net-Has-More on final batch, got %q", hasMore2)
+	}
+}

--- a/internal/v3net/hub/hub_nal_test.go
+++ b/internal/v3net/hub/hub_nal_test.go
@@ -267,15 +267,17 @@ func TestAuthClockSkew_Rejected(t *testing.T) {
 }
 
 func TestGetMessages_Pagination(t *testing.T) {
-	h, _ := setupTestHub(t)
+	h, hubKS := setupTestHub(t)
 	ts := httptest.NewServer(h.newMux())
 	defer ts.Close()
+
+	seedTestNAL(t, h, hubKS)
 
 	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
 	if err != nil {
 		t.Fatalf("load leaf keystore: %v", err)
 	}
-	registerLeaf(t, ts, leafKS)
+	registerLeafWithAreas(t, ts, leafKS, []string{"gen.general"})
 
 	// Post 3 messages with unique UUIDs.
 	uuids := []string{

--- a/internal/v3net/hub/hub_nal_test.go
+++ b/internal/v3net/hub/hub_nal_test.go
@@ -287,6 +287,7 @@ func TestGetMessages_Pagination(t *testing.T) {
 		msgJSON := fmt.Sprintf(`{
 			"v3net":"1.0",
 			"network":"testnet",
+			"area_tag":"gen.general",
 			"msg_uuid":%q,
 			"thread_uuid":%q,
 			"origin_node":"test.example.net",

--- a/internal/v3net/hub/hub_proposal_test.go
+++ b/internal/v3net/hub/hub_proposal_test.go
@@ -1,0 +1,418 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/keystore"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/nal"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+)
+
+func setupTestHubManual(t *testing.T) (*Hub, *keystore.Keystore) {
+	t.Helper()
+	dir := t.TempDir()
+	ks, _, err := keystore.Load(filepath.Join(dir, "hub.key"))
+	if err != nil {
+		t.Fatalf("load hub keystore: %v", err)
+	}
+	cfg := Config{
+		ListenAddr:  ":0",
+		DataDir:     dir,
+		Keystore:    ks,
+		AutoApprove: false,
+		Networks:    []NetworkConfig{{Name: "testnet", Description: "Test network"}},
+	}
+	h, err := New(cfg)
+	if err != nil {
+		t.Fatalf("create hub: %v", err)
+	}
+	t.Cleanup(func() { h.Close() })
+	return h, ks
+}
+
+func seedTestNALForProposals(t *testing.T, h *Hub, ks *keystore.Keystore) {
+	t.Helper()
+	testNAL := &protocol.NAL{
+		V3NetNAL:       "1.0",
+		Network:        "testnet",
+		CoordNodeID:    ks.NodeID(),
+		CoordPubKeyB64: ks.PubKeyBase64(),
+		Areas:          []protocol.Area{},
+	}
+	if err := nal.Sign(testNAL, ks); err != nil {
+		t.Fatalf("sign test NAL: %v", err)
+	}
+	if err := h.nalStore.Put("testnet", testNAL); err != nil {
+		t.Fatalf("put test NAL: %v", err)
+	}
+}
+
+func activateSubscriber(t *testing.T, h *Hub, nodeID, network string) {
+	t.Helper()
+	h.subscribers.mu.Lock()
+	defer h.subscribers.mu.Unlock()
+	key := nodeID + ":" + network
+	if s, ok := h.subscribers.cache[key]; ok {
+		s.Status = "active"
+	}
+	if _, err := h.subscribers.db.Exec(
+		`UPDATE subscribers SET status = 'active' WHERE node_id = ? AND network = ?`,
+		nodeID, network,
+	); err != nil {
+		t.Fatalf("activate subscriber: %v", err)
+	}
+}
+
+func registerAndActivate(t *testing.T, ts *httptest.Server, h *Hub, ks *keystore.Keystore, bbsName, bbsHost string) {
+	t.Helper()
+	body := fmt.Sprintf(`{"network":"testnet","node_id":%q,"pubkey_b64":%q,"bbs_name":%q,"bbs_host":%q}`,
+		ks.NodeID(), ks.PubKeyBase64(), bbsName, bbsHost)
+	resp, err := http.Post(ts.URL+"/v3net/v1/subscribe", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("subscribe %s: %v", bbsName, err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("subscribe %s status: %d", bbsName, resp.StatusCode)
+	}
+	activateSubscriber(t, h, ks.NodeID(), "testnet")
+}
+
+const proposalBody = `{"tag":"gen.test","name":"Test Area","description":"A test","language":"en","access_mode":"open","allow_ansi":true}`
+
+func TestPropose_AutoApprove(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+	registerLeaf(t, ts, leafKS)
+	seedTestNALForProposals(t, h, hubKS)
+
+	req := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/areas/propose", proposalBody)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST propose: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result["status"] != "approved" {
+		t.Errorf("expected status approved, got %v", result["status"])
+	}
+	if result["proposal_id"] == nil || result["proposal_id"] == "" {
+		t.Errorf("expected non-empty proposal_id")
+	}
+
+	// Verify the area was added to the NAL.
+	nalResp, err := http.Get(ts.URL + "/v3net/v1/testnet/nal")
+	if err != nil {
+		t.Fatalf("GET nal: %v", err)
+	}
+	defer nalResp.Body.Close()
+
+	if nalResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET nal status: %d", nalResp.StatusCode)
+	}
+
+	var nalDoc protocol.NAL
+	if err := json.NewDecoder(nalResp.Body).Decode(&nalDoc); err != nil {
+		t.Fatalf("decode NAL: %v", err)
+	}
+	if nalDoc.FindArea("gen.test") == nil {
+		t.Errorf("expected area gen.test in NAL, got areas: %+v", nalDoc.Areas)
+	}
+}
+
+func TestPropose_ManualPending(t *testing.T) {
+	h, hubKS := setupTestHubManual(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+	registerAndActivate(t, ts, h, leafKS, "Test BBS", "test.example.net")
+	seedTestNALForProposals(t, h, hubKS)
+
+	ch, cancel := h.broadcaster.Subscribe("testnet")
+	defer cancel()
+
+	req := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/areas/propose", proposalBody)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST propose: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result["status"] != "pending" {
+		t.Errorf("expected status pending, got %v", result["status"])
+	}
+
+	select {
+	case ev := <-ch:
+		if ev.Type != "area_proposed" {
+			t.Errorf("expected area_proposed event, got %q", ev.Type)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timed out waiting for area_proposed event")
+	}
+}
+
+func TestListProposals_CoordinatorOnly(t *testing.T) {
+	h, hubKS := setupTestHubManual(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+	registerAndActivate(t, ts, h, leafKS, "Test BBS", "test.example.net")
+	seedTestNALForProposals(t, h, hubKS)
+
+	// Propose an area as the leaf.
+	propReq := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/areas/propose", proposalBody)
+	propResp, err := http.DefaultClient.Do(propReq)
+	if err != nil {
+		t.Fatalf("POST propose: %v", err)
+	}
+	propResp.Body.Close()
+
+	// (a) GET proposals as non-coordinator leaf -> 403.
+	listReq := signedRequest(t, leafKS, "GET", ts.URL+"/v3net/v1/testnet/areas/proposals", "")
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("GET proposals as leaf: %v", err)
+	}
+	listResp.Body.Close()
+	if listResp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 for non-coordinator, got %d", listResp.StatusCode)
+	}
+
+	// (b) Register hub keystore as subscriber, GET proposals as coordinator -> 200.
+	registerAndActivate(t, ts, h, hubKS, "Hub BBS", "hub.example.net")
+
+	listReq2 := signedRequest(t, hubKS, "GET", ts.URL+"/v3net/v1/testnet/areas/proposals", "")
+	listResp2, err := http.DefaultClient.Do(listReq2)
+	if err != nil {
+		t.Fatalf("GET proposals as coordinator: %v", err)
+	}
+	defer listResp2.Body.Close()
+
+	if listResp2.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", listResp2.StatusCode)
+	}
+
+	var proposals []protocol.AreaProposal
+	if err := json.NewDecoder(listResp2.Body).Decode(&proposals); err != nil {
+		t.Fatalf("decode proposals: %v", err)
+	}
+	if len(proposals) != 1 {
+		t.Fatalf("expected 1 proposal, got %d", len(proposals))
+	}
+	if proposals[0].Tag != "gen.test" {
+		t.Errorf("expected tag gen.test, got %q", proposals[0].Tag)
+	}
+	if proposals[0].Status != "pending" {
+		t.Errorf("expected status pending, got %q", proposals[0].Status)
+	}
+}
+
+func TestApproveProposal_AddsToNAL(t *testing.T) {
+	h, hubKS := setupTestHubManual(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+	registerAndActivate(t, ts, h, leafKS, "Test BBS", "test.example.net")
+	registerAndActivate(t, ts, h, hubKS, "Hub BBS", "hub.example.net")
+	seedTestNALForProposals(t, h, hubKS)
+
+	// Propose an area as the leaf.
+	propReq := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/areas/propose", proposalBody)
+	propResp, err := http.DefaultClient.Do(propReq)
+	if err != nil {
+		t.Fatalf("POST propose: %v", err)
+	}
+	propResp.Body.Close()
+
+	// Get the proposal ID from the list.
+	listReq := signedRequest(t, hubKS, "GET", ts.URL+"/v3net/v1/testnet/areas/proposals", "")
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("GET proposals: %v", err)
+	}
+	defer listResp.Body.Close()
+
+	var proposals []protocol.AreaProposal
+	if err := json.NewDecoder(listResp.Body).Decode(&proposals); err != nil {
+		t.Fatalf("decode proposals: %v", err)
+	}
+	if len(proposals) != 1 {
+		t.Fatalf("expected 1 proposal, got %d", len(proposals))
+	}
+	proposalID := proposals[0].ID
+
+	// Subscribe to broadcaster before approve to catch the nal_updated event.
+	ch, cancel := h.broadcaster.Subscribe("testnet")
+	defer cancel()
+
+	// Approve the proposal.
+	approveReq := signedRequest(t, hubKS, "POST",
+		ts.URL+"/v3net/v1/testnet/areas/proposals/"+proposalID+"/approve",
+		`{"access_mode":"open"}`)
+	approveResp, err := http.DefaultClient.Do(approveReq)
+	if err != nil {
+		t.Fatalf("POST approve: %v", err)
+	}
+	approveResp.Body.Close()
+	if approveResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", approveResp.StatusCode)
+	}
+
+	// Verify the area was added to the NAL.
+	nalResp, err := http.Get(ts.URL + "/v3net/v1/testnet/nal")
+	if err != nil {
+		t.Fatalf("GET nal: %v", err)
+	}
+	defer nalResp.Body.Close()
+
+	var nalDoc protocol.NAL
+	if err := json.NewDecoder(nalResp.Body).Decode(&nalDoc); err != nil {
+		t.Fatalf("decode NAL: %v", err)
+	}
+	if nalDoc.FindArea("gen.test") == nil {
+		t.Errorf("expected area gen.test in NAL after approve")
+	}
+
+	// Verify nal_updated event was broadcast.
+	select {
+	case ev := <-ch:
+		if ev.Type != "nal_updated" {
+			t.Errorf("expected nal_updated event, got %q", ev.Type)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timed out waiting for nal_updated event")
+	}
+}
+
+func TestRejectProposal_Event(t *testing.T) {
+	h, hubKS := setupTestHubManual(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+	registerAndActivate(t, ts, h, leafKS, "Test BBS", "test.example.net")
+	registerAndActivate(t, ts, h, hubKS, "Hub BBS", "hub.example.net")
+	seedTestNALForProposals(t, h, hubKS)
+
+	// Propose an area as the leaf.
+	propReq := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/areas/propose", proposalBody)
+	propResp, err := http.DefaultClient.Do(propReq)
+	if err != nil {
+		t.Fatalf("POST propose: %v", err)
+	}
+	propResp.Body.Close()
+
+	// Get the proposal ID from the list.
+	listReq := signedRequest(t, hubKS, "GET", ts.URL+"/v3net/v1/testnet/areas/proposals", "")
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("GET proposals: %v", err)
+	}
+	defer listResp.Body.Close()
+
+	var proposals []protocol.AreaProposal
+	if err := json.NewDecoder(listResp.Body).Decode(&proposals); err != nil {
+		t.Fatalf("decode proposals: %v", err)
+	}
+	if len(proposals) != 1 {
+		t.Fatalf("expected 1 proposal, got %d", len(proposals))
+	}
+	proposalID := proposals[0].ID
+
+	// Subscribe to broadcaster before reject to catch the event.
+	ch, cancel := h.broadcaster.Subscribe("testnet")
+	defer cancel()
+
+	// Reject the proposal.
+	rejectReq := signedRequest(t, hubKS, "POST",
+		ts.URL+"/v3net/v1/testnet/areas/proposals/"+proposalID+"/reject",
+		`{"reason":"not needed"}`)
+	rejectResp, err := http.DefaultClient.Do(rejectReq)
+	if err != nil {
+		t.Fatalf("POST reject: %v", err)
+	}
+	rejectResp.Body.Close()
+	if rejectResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rejectResp.StatusCode)
+	}
+
+	// Verify proposal_rejected event was broadcast.
+	select {
+	case ev := <-ch:
+		if ev.Type != "proposal_rejected" {
+			t.Errorf("expected proposal_rejected event, got %q", ev.Type)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timed out waiting for proposal_rejected event")
+	}
+}
+
+func TestPropose_InvalidTag(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+	registerLeaf(t, ts, leafKS)
+	seedTestNALForProposals(t, h, hubKS)
+
+	invalidBody := `{"tag":"INVALID","name":"Bad Area","description":"Invalid tag","language":"en","access_mode":"open","allow_ansi":false}`
+	req := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/areas/propose", invalidBody)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST propose: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422 for invalid tag, got %d", resp.StatusCode)
+	}
+}

--- a/internal/v3net/hub/hub_proposal_test.go
+++ b/internal/v3net/hub/hub_proposal_test.go
@@ -204,6 +204,9 @@ func TestListProposals_CoordinatorOnly(t *testing.T) {
 		t.Fatalf("POST propose: %v", err)
 	}
 	propResp.Body.Close()
+	if propResp.StatusCode != http.StatusOK {
+		t.Fatalf("POST propose expected 200, got %d", propResp.StatusCode)
+	}
 
 	// (a) GET proposals as non-coordinator leaf -> 403.
 	listReq := signedRequest(t, leafKS, "GET", ts.URL+"/v3net/v1/testnet/areas/proposals", "")

--- a/internal/v3net/hub/hub_test.go
+++ b/internal/v3net/hub/hub_test.go
@@ -163,6 +163,7 @@ func TestPostAndGetMessage(t *testing.T) {
 	msg := protocol.Message{
 		V3Net:       "1.0",
 		Network:     "testnet",
+		AreaTag:     "gen.general",
 		MsgUUID:     "550e8400-e29b-41d4-a716-446655440000",
 		ThreadUUID:  "550e8400-e29b-41d4-a716-446655440000",
 		OriginNode:  "test.example.net",
@@ -227,6 +228,7 @@ func TestDuplicatePostReturns200(t *testing.T) {
 	msgJSON := `{
 		"v3net": "1.0",
 		"network": "testnet",
+		"area_tag": "gen.general",
 		"msg_uuid": "550e8400-e29b-41d4-a716-446655440000",
 		"thread_uuid": "550e8400-e29b-41d4-a716-446655440000",
 		"origin_node": "test.example.net",
@@ -286,6 +288,7 @@ func TestSSEReceivesNewMessageEvent(t *testing.T) {
 	msgJSON := `{
 		"v3net": "1.0",
 		"network": "testnet",
+		"area_tag": "gen.general",
 		"msg_uuid": "660e8400-e29b-41d4-a716-446655440001",
 		"thread_uuid": "660e8400-e29b-41d4-a716-446655440001",
 		"origin_node": "test.example.net",

--- a/internal/v3net/hub/hub_test.go
+++ b/internal/v3net/hub/hub_test.go
@@ -148,16 +148,18 @@ func TestUnauthenticatedRequestReturns401(t *testing.T) {
 }
 
 func TestPostAndGetMessage(t *testing.T) {
-	h, _ := setupTestHub(t)
+	h, hubKS := setupTestHub(t)
 	ts := httptest.NewServer(h.newMux())
 	defer ts.Close()
+
+	seedTestNAL(t, h, hubKS)
 
 	// Register a leaf node.
 	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
 	if err != nil {
 		t.Fatalf("load leaf keystore: %v", err)
 	}
-	registerLeaf(t, ts, leafKS)
+	registerLeafWithAreas(t, ts, leafKS, []string{"gen.general"})
 
 	// POST a message.
 	msg := protocol.Message{
@@ -215,15 +217,17 @@ func TestPostAndGetMessage(t *testing.T) {
 }
 
 func TestDuplicatePostReturns200(t *testing.T) {
-	h, _ := setupTestHub(t)
+	h, hubKS := setupTestHub(t)
 	ts := httptest.NewServer(h.newMux())
 	defer ts.Close()
+
+	seedTestNAL(t, h, hubKS)
 
 	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
 	if err != nil {
 		t.Fatalf("load leaf keystore: %v", err)
 	}
-	registerLeaf(t, ts, leafKS)
+	registerLeafWithAreas(t, ts, leafKS, []string{"gen.general"})
 
 	msgJSON := `{
 		"v3net": "1.0",
@@ -270,15 +274,17 @@ func TestDuplicatePostReturns200(t *testing.T) {
 }
 
 func TestSSEReceivesNewMessageEvent(t *testing.T) {
-	h, _ := setupTestHub(t)
+	h, hubKS := setupTestHub(t)
 	ts := httptest.NewServer(h.newMux())
 	defer ts.Close()
+
+	seedTestNAL(t, h, hubKS)
 
 	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
 	if err != nil {
 		t.Fatalf("load leaf keystore: %v", err)
 	}
-	registerLeaf(t, ts, leafKS)
+	registerLeafWithAreas(t, ts, leafKS, []string{"gen.general"})
 
 	// Subscribe to the broadcaster directly to avoid HTTP SSE timing issues.
 	ch, cancel := h.broadcaster.Subscribe("testnet")

--- a/internal/v3net/hub/messages.go
+++ b/internal/v3net/hub/messages.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 )
 
 const messagesSchema = `
@@ -51,31 +52,57 @@ func (ms *MessageStore) Store(msgUUID, network, areaTag, data string) (bool, err
 	return rows > 0, nil
 }
 
-// Fetch returns messages for a network newer than the given cursor UUID.
+// Fetch returns messages for a network newer than the given cursor UUID,
+// filtered to only areas in areaTags. If areaTags is empty, returns nil immediately.
 // If sinceUUID is empty or "0", returns from the beginning.
 // Returns the raw JSON data strings ordered oldest first.
-func (ms *MessageStore) Fetch(network, sinceUUID string, limit int) ([]string, bool, error) {
+func (ms *MessageStore) Fetch(network, sinceUUID string, limit int, areaTags []string) ([]string, bool, error) {
+	if len(areaTags) == 0 {
+		return nil, false, nil
+	}
+
 	if limit <= 0 || limit > 500 {
 		limit = 100
 	}
 
-	var rows *sql.Rows
-	var err error
+	// Build IN (?,?,...) placeholder list.
+	placeholders := make([]string, len(areaTags))
+	for i := range areaTags {
+		placeholders[i] = "?"
+	}
+	inClause := strings.Join(placeholders, ",")
 
 	// Fetch limit+1 to detect if there are more pages.
 	fetchLimit := limit + 1
 
+	var rows *sql.Rows
+	var err error
+
 	if sinceUUID == "" || sinceUUID == "0" {
+		// Args: network, each areaTag, fetchLimit.
+		args := make([]any, 0, 1+len(areaTags)+1)
+		args = append(args, network)
+		for _, tag := range areaTags {
+			args = append(args, tag)
+		}
+		args = append(args, fetchLimit)
 		rows, err = ms.db.Query(
-			"SELECT data FROM messages WHERE network = ? ORDER BY id ASC LIMIT ?",
-			network, fetchLimit,
+			"SELECT data FROM messages WHERE network = ? AND area_tag IN ("+inClause+") ORDER BY id ASC LIMIT ?",
+			args...,
 		)
 	} else {
+		// Args: network, each areaTag, sinceUUID, fetchLimit.
+		args := make([]any, 0, 1+len(areaTags)+2)
+		args = append(args, network)
+		for _, tag := range areaTags {
+			args = append(args, tag)
+		}
+		args = append(args, sinceUUID, fetchLimit)
 		rows, err = ms.db.Query(
 			`SELECT data FROM messages
-			 WHERE network = ? AND id > (SELECT COALESCE((SELECT id FROM messages WHERE msg_uuid = ?), 0))
+			 WHERE network = ? AND area_tag IN (`+inClause+`) AND id > (SELECT COALESCE((SELECT id FROM messages WHERE msg_uuid = ?), 0))
 			 ORDER BY id ASC LIMIT ?`,
-			network, sinceUUID, fetchLimit,
+			args...,
 		)
 	}
 	if err != nil {

--- a/internal/v3net/hub/messages.go
+++ b/internal/v3net/hub/messages.go
@@ -30,9 +30,16 @@ func NewMessageStore(db *sql.DB) (*MessageStore, error) {
 		return nil, fmt.Errorf("hub: create messages table: %w", err)
 	}
 	// Migration: add area_tag column to existing databases.
-	db.Exec("ALTER TABLE messages ADD COLUMN area_tag TEXT NOT NULL DEFAULT ''")
+	if _, err := db.Exec("ALTER TABLE messages ADD COLUMN area_tag TEXT NOT NULL DEFAULT ''"); err != nil {
+		// Ignore "duplicate column" — migration already applied.
+		if !strings.Contains(err.Error(), "duplicate column") {
+			return nil, fmt.Errorf("hub: migrate add area_tag column: %w", err)
+		}
+	}
 	// Migration: add composite index for area filtering.
-	db.Exec("CREATE INDEX IF NOT EXISTS idx_messages_area ON messages(network, area_tag, id)")
+	if _, err := db.Exec("CREATE INDEX IF NOT EXISTS idx_messages_area ON messages(network, area_tag, id)"); err != nil {
+		return nil, fmt.Errorf("hub: migrate create area index: %w", err)
+	}
 	return &MessageStore{db: db}, nil
 }
 

--- a/internal/v3net/hub/messages.go
+++ b/internal/v3net/hub/messages.go
@@ -10,10 +10,12 @@ CREATE TABLE IF NOT EXISTS messages (
 	id          INTEGER PRIMARY KEY AUTOINCREMENT,
 	msg_uuid    TEXT UNIQUE NOT NULL,
 	network     TEXT NOT NULL,
+	area_tag    TEXT NOT NULL,
 	data        TEXT NOT NULL,
 	received_at DATETIME DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_messages_network ON messages(network, id);
+CREATE INDEX IF NOT EXISTS idx_messages_area ON messages(network, area_tag, id);
 `
 
 // MessageStore handles SQLite-backed message persistence for the hub.
@@ -26,14 +28,18 @@ func NewMessageStore(db *sql.DB) (*MessageStore, error) {
 	if _, err := db.Exec(messagesSchema); err != nil {
 		return nil, fmt.Errorf("hub: create messages table: %w", err)
 	}
+	// Migration: add area_tag column to existing databases.
+	db.Exec("ALTER TABLE messages ADD COLUMN area_tag TEXT NOT NULL DEFAULT ''")
+	// Migration: add composite index for area filtering.
+	db.Exec("CREATE INDEX IF NOT EXISTS idx_messages_area ON messages(network, area_tag, id)")
 	return &MessageStore{db: db}, nil
 }
 
 // Store inserts a message. Returns false if the msg_uuid already exists (dedup).
-func (ms *MessageStore) Store(msgUUID, network, data string) (bool, error) {
+func (ms *MessageStore) Store(msgUUID, network, areaTag, data string) (bool, error) {
 	res, err := ms.db.Exec(
-		"INSERT OR IGNORE INTO messages (msg_uuid, network, data) VALUES (?, ?, ?)",
-		msgUUID, network, data,
+		"INSERT OR IGNORE INTO messages (msg_uuid, network, area_tag, data) VALUES (?, ?, ?, ?)",
+		msgUUID, network, areaTag, data,
 	)
 	if err != nil {
 		return false, fmt.Errorf("hub: store message: %w", err)

--- a/internal/v3net/hub/nal_handler.go
+++ b/internal/v3net/hub/nal_handler.go
@@ -120,10 +120,18 @@ func (h *Hub) handlePostNAL(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"only the coordinator may update the NAL"}`, http.StatusForbidden)
 		return
 	}
-	// For initial NAL creation, verify the submitted CoordNodeID matches the sender.
-	if existing == nil && n.CoordNodeID != nodeID {
-		http.Error(w, `{"error":"coordinator node ID must match sender"}`, http.StatusBadRequest)
-		return
+	// For initial NAL creation, only the hub itself may bootstrap the coordinator role.
+	// This prevents any subscriber from claiming coordinator authority.
+	if existing == nil {
+		hubNodeID := h.cfg.Keystore.NodeID()
+		if nodeID != hubNodeID {
+			http.Error(w, `{"error":"only the hub operator may create the initial NAL"}`, http.StatusForbidden)
+			return
+		}
+		if n.CoordNodeID != nodeID {
+			http.Error(w, `{"error":"coordinator node ID must match sender for initial NAL"}`, http.StatusBadRequest)
+			return
+		}
 	}
 
 	if err := nal.Verify(&n); err != nil {

--- a/internal/v3net/hub/proposal_handler.go
+++ b/internal/v3net/hub/proposal_handler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -349,7 +350,7 @@ func (h *Hub) handleApproveProposal(w http.ResponseWriter, r *http.Request) {
 
 	// Parse optional overrides (empty body is fine — overrides are optional).
 	var overrides protocol.ProposalApproveRequest
-	if err := json.NewDecoder(r.Body).Decode(&overrides); err != nil && err.Error() != "EOF" {
+	if err := json.NewDecoder(r.Body).Decode(&overrides); err != nil && !errors.Is(err, io.EOF) {
 		http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
 		return
 	}
@@ -400,7 +401,7 @@ func (h *Hub) handleRejectProposal(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req protocol.ProposalRejectRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err.Error() != "EOF" {
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 		http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
 		return
 	}

--- a/internal/v3net/hub/server.go
+++ b/internal/v3net/hub/server.go
@@ -62,9 +62,9 @@ func (h *Hub) newMux() http.Handler {
 				h.handlePropose(w, r)
 			case strings.HasSuffix(path, "/areas/proposals") && r.Method == http.MethodGet:
 				h.handleListProposals(w, r)
-			case strings.HasSuffix(path, "/approve") && strings.Contains(path, "/proposals/") && r.Method == http.MethodPost:
+			case matchProposalActionPath(path, "approve") && r.Method == http.MethodPost:
 				h.handleApproveProposal(w, r)
-			case strings.HasSuffix(path, "/reject") && strings.Contains(path, "/proposals/") && r.Method == http.MethodPost:
+			case matchProposalActionPath(path, "reject") && r.Method == http.MethodPost:
 				h.handleRejectProposal(w, r)
 
 			// Area access management.
@@ -95,6 +95,24 @@ func (h *Hub) newMux() http.Handler {
 }
 
 // matchAreaAccessPath checks if a path matches /v3net/v1/{network}/areas/{tag}/{suffix}.
+// Requires the path segments to be exactly: v3net/v1/{network}/areas/{tag}/{suffix-segments...}
 func (h *Hub) matchAreaAccessPath(path, suffix string) bool {
-	return strings.Contains(path, "/areas/") && strings.HasSuffix(path, suffix)
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	// v3net/v1/{network}/areas/{tag}/access[/sub]
+	if len(parts) < 6 || parts[3] != "areas" {
+		return false
+	}
+	// Reconstruct the tail after the tag (parts[5:])
+	tail := "/" + strings.Join(parts[5:], "/")
+	return tail == suffix
+}
+
+// matchProposalActionPath checks if a path matches /v3net/v1/{network}/areas/proposals/{id}/{action}.
+func matchProposalActionPath(path, action string) bool {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	// v3net/v1/{network}/areas/proposals/{id}/{action}
+	if len(parts) != 7 {
+		return false
+	}
+	return parts[3] == "areas" && parts[4] == "proposals" && parts[6] == action
 }

--- a/internal/v3net/integration_test.go
+++ b/internal/v3net/integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/hub"
 	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/keystore"
 	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/leaf"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/nal"
 	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
 )
 
@@ -54,6 +55,7 @@ func setupIntegration(t *testing.T) (
 	ts *httptest.Server,
 	l *leaf.Leaf,
 	leafKS *keystore.Keystore,
+	hubKS *keystore.Keystore,
 	dedupIx *dedup.Index,
 	writer *testJAMWriter,
 ) {
@@ -85,7 +87,30 @@ func setupIntegration(t *testing.T) (
 	ts = httptest.NewServer(h.Mux())
 	t.Cleanup(ts.Close)
 
-	// Create leaf keystore and register with hub.
+	// Seed NAL so POST enforcement and GET filtering work.
+	hubNAL := &protocol.NAL{
+		V3NetNAL:       "1.0",
+		Network:        "testnet",
+		CoordNodeID:    hubKS.NodeID(),
+		CoordPubKeyB64: hubKS.PubKeyBase64(),
+		Areas: []protocol.Area{{
+			Tag:              "gen.general",
+			Name:             "General",
+			Language:         "en",
+			ManagerNodeID:    hubKS.NodeID(),
+			ManagerPubKeyB64: hubKS.PubKeyBase64(),
+			Access:           protocol.AreaAccess{Mode: protocol.AccessModeOpen},
+			Policy:           protocol.AreaPolicy{MaxBodyBytes: 65536, AllowANSI: true},
+		}},
+	}
+	if err := nal.Sign(hubNAL, hubKS); err != nil {
+		t.Fatalf("sign hub NAL: %v", err)
+	}
+	if err := h.NALStore().Put("testnet", hubNAL); err != nil {
+		t.Fatalf("seed hub NAL: %v", err)
+	}
+
+	// Create leaf keystore and register with hub (including area subscription).
 	leafKS, _, err = keystore.Load(filepath.Join(dir, "leaf.key"))
 	if err != nil {
 		t.Fatalf("load leaf keystore: %v", err)
@@ -97,6 +122,7 @@ func setupIntegration(t *testing.T) (
 		PubKeyB64: leafKS.PubKeyBase64(),
 		BBSName:   "Integration Test BBS",
 		BBSHost:   "test.example.net",
+		AreaTags:  []string{"gen.general"},
 	})
 	resp, err := ts.Client().Post(ts.URL+"/v3net/v1/subscribe", "application/json",
 		bytes.NewReader(registerBody))
@@ -131,7 +157,7 @@ func setupIntegration(t *testing.T) (
 }
 
 func TestIntegration_PostAndPoll(t *testing.T) {
-	_, _, l, _, _, writer := setupIntegration(t)
+	_, _, l, _, _, _, writer := setupIntegration(t)
 
 	// Leaf sends a message to the hub.
 	msg := protocol.Message{
@@ -177,7 +203,7 @@ func TestIntegration_PostAndPoll(t *testing.T) {
 }
 
 func TestIntegration_DedupPreventsDoubleWrite(t *testing.T) {
-	_, _, l, _, _, writer := setupIntegration(t)
+	_, _, l, _, _, _, writer := setupIntegration(t)
 
 	msg := protocol.Message{
 		V3Net:       "1.0",
@@ -226,7 +252,7 @@ func TestIntegration_DedupPreventsDoubleWrite(t *testing.T) {
 }
 
 func TestIntegration_SSEReceivesEvents(t *testing.T) {
-	_, _, l, _, _, _ := setupIntegration(t)
+	_, _, l, _, _, _, _ := setupIntegration(t)
 
 	events := make(chan protocol.Event, 10)
 	l.SetOnEvent(func(ev protocol.Event) {
@@ -274,7 +300,7 @@ func TestIntegration_SSEReceivesEvents(t *testing.T) {
 }
 
 func TestIntegration_ChatEvent(t *testing.T) {
-	_, _, l, _, _, _ := setupIntegration(t)
+	_, _, l, _, _, _, _ := setupIntegration(t)
 
 	events := make(chan protocol.Event, 10)
 	l.SetOnEvent(func(ev protocol.Event) {
@@ -302,7 +328,7 @@ func TestIntegration_ChatEvent(t *testing.T) {
 }
 
 func TestIntegration_PresenceEvents(t *testing.T) {
-	_, _, l, _, _, _ := setupIntegration(t)
+	_, _, l, _, _, _, _ := setupIntegration(t)
 
 	events := make(chan protocol.Event, 10)
 	l.SetOnEvent(func(ev protocol.Event) {

--- a/internal/v3net/integration_test.go
+++ b/internal/v3net/integration_test.go
@@ -137,6 +137,7 @@ func TestIntegration_PostAndPoll(t *testing.T) {
 	msg := protocol.Message{
 		V3Net:       "1.0",
 		Network:     "testnet",
+		AreaTag:     "gen.general",
 		MsgUUID:     "550e8400-e29b-41d4-a716-446655440000",
 		ThreadUUID:  "550e8400-e29b-41d4-a716-446655440000",
 		OriginNode:  "test.example.net",
@@ -181,6 +182,7 @@ func TestIntegration_DedupPreventsDoubleWrite(t *testing.T) {
 	msg := protocol.Message{
 		V3Net:       "1.0",
 		Network:     "testnet",
+		AreaTag:     "gen.general",
 		MsgUUID:     "660e8400-e29b-41d4-a716-446655440001",
 		ThreadUUID:  "660e8400-e29b-41d4-a716-446655440001",
 		OriginNode:  "test.example.net",
@@ -244,6 +246,7 @@ func TestIntegration_SSEReceivesEvents(t *testing.T) {
 	msg := protocol.Message{
 		V3Net:       "1.0",
 		Network:     "testnet",
+		AreaTag:     "gen.general",
 		MsgUUID:     "770e8400-e29b-41d4-a716-446655440002",
 		ThreadUUID:  "770e8400-e29b-41d4-a716-446655440002",
 		OriginNode:  "test.example.net",

--- a/internal/v3net/integration_test.go
+++ b/internal/v3net/integration_test.go
@@ -327,6 +327,109 @@ func TestIntegration_ChatEvent(t *testing.T) {
 	}
 }
 
+func TestIntegration_AreaFilteredPolling(t *testing.T) {
+	h, ts, l, _, hubKS, _, writer := setupIntegration(t)
+
+	// Post a message to gen.general via leaf 1.
+	msg := protocol.Message{
+		V3Net: "1.0", Network: "testnet", AreaTag: "gen.general",
+		MsgUUID:     "880e8400-e29b-41d4-a716-446655440010",
+		ThreadUUID:  "880e8400-e29b-41d4-a716-446655440010",
+		OriginNode:  "test.example.net", OriginBoard: "General",
+		From: "Tester", To: "All", Subject: "Area filtered test",
+		DateUTC: "2026-03-16T04:20:00Z", Body: "Should be received.",
+		Kludges: map[string]any{},
+	}
+	if err := l.SendMessage(msg); err != nil {
+		t.Fatalf("SendMessage gen.general: %v", err)
+	}
+
+	// Update NAL to include gen.coding.
+	updatedNAL := &protocol.NAL{
+		V3NetNAL: "1.0", Network: "testnet",
+		CoordNodeID: hubKS.NodeID(), CoordPubKeyB64: hubKS.PubKeyBase64(),
+		Areas: []protocol.Area{
+			{
+				Tag: "gen.general", Name: "General", Language: "en",
+				ManagerNodeID: hubKS.NodeID(), ManagerPubKeyB64: hubKS.PubKeyBase64(),
+				Access: protocol.AreaAccess{Mode: protocol.AccessModeOpen},
+				Policy: protocol.AreaPolicy{MaxBodyBytes: 65536, AllowANSI: true},
+			},
+			{
+				Tag: "gen.coding", Name: "Coding", Language: "en",
+				ManagerNodeID: hubKS.NodeID(), ManagerPubKeyB64: hubKS.PubKeyBase64(),
+				Access: protocol.AreaAccess{Mode: protocol.AccessModeOpen},
+				Policy: protocol.AreaPolicy{MaxBodyBytes: 65536, AllowANSI: true},
+			},
+		},
+	}
+	if err := nal.Sign(updatedNAL, hubKS); err != nil {
+		t.Fatalf("sign updated NAL: %v", err)
+	}
+	if err := h.NALStore().Put("testnet", updatedNAL); err != nil {
+		t.Fatalf("put updated NAL: %v", err)
+	}
+
+	// Register leaf 2 subscribed to gen.coding.
+	leaf2KS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf2.key"))
+	if err != nil {
+		t.Fatalf("load leaf2 keystore: %v", err)
+	}
+	registerBody2, _ := json.Marshal(protocol.SubscribeRequest{
+		Network: "testnet", NodeID: leaf2KS.NodeID(),
+		PubKeyB64: leaf2KS.PubKeyBase64(),
+		BBSName: "Leaf 2 BBS", BBSHost: "leaf2.example.net",
+		AreaTags: []string{"gen.coding"},
+	})
+	resp2, _ := ts.Client().Post(ts.URL+"/v3net/v1/subscribe", "application/json",
+		bytes.NewReader(registerBody2))
+	resp2.Body.Close()
+
+	// Create leaf 2 instance and post a gen.coding message.
+	leaf2Writer := &testJAMWriter{}
+	leaf2Dedup, _ := dedup.Open(filepath.Join(t.TempDir(), "dedup2.sqlite"))
+	t.Cleanup(func() { leaf2Dedup.Close() })
+	l2 := leaf.New(leaf.Config{
+		HubURL:       ts.URL,
+		Network:      "testnet",
+		AreaTags:     []string{"gen.coding"},
+		PollInterval: 50 * time.Millisecond,
+		Keystore:     leaf2KS,
+		DedupIndex:   leaf2Dedup,
+		JAMWriter:    leaf2Writer,
+	})
+
+	codingMsg := protocol.Message{
+		V3Net: "1.0", Network: "testnet", AreaTag: "gen.coding",
+		MsgUUID:     "990e8400-e29b-41d4-a716-446655440011",
+		ThreadUUID:  "990e8400-e29b-41d4-a716-446655440011",
+		OriginNode:  "leaf2.example.net", OriginBoard: "Coding",
+		From: "Leaf2 User", To: "All", Subject: "Coding msg",
+		DateUTC: "2026-03-16T04:20:00Z", Body: "Should NOT be received by leaf 1.",
+		Kludges: map[string]any{},
+	}
+	if err := l2.SendMessage(codingMsg); err != nil {
+		t.Fatalf("SendMessage gen.coding: %v", err)
+	}
+
+	// Poll with leaf 1 (gen.general only).
+	ctx := context.Background()
+	count, err := l.Poll(ctx)
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 message from poll (gen.general only), got %d", count)
+	}
+	if writer.count() != 1 {
+		t.Fatalf("expected 1 JAM write, got %d", writer.count())
+	}
+	got := writer.get(0)
+	if got.AreaTag != "gen.general" {
+		t.Errorf("expected area_tag gen.general, got %q", got.AreaTag)
+	}
+}
+
 func TestIntegration_PresenceEvents(t *testing.T) {
 	_, _, l, _, _, _, _ := setupIntegration(t)
 

--- a/internal/v3net/integration_test.go
+++ b/internal/v3net/integration_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"sync"
@@ -375,19 +376,31 @@ func TestIntegration_AreaFilteredPolling(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load leaf2 keystore: %v", err)
 	}
-	registerBody2, _ := json.Marshal(protocol.SubscribeRequest{
+	registerBody2, err := json.Marshal(protocol.SubscribeRequest{
 		Network: "testnet", NodeID: leaf2KS.NodeID(),
 		PubKeyB64: leaf2KS.PubKeyBase64(),
 		BBSName:   "Leaf 2 BBS", BBSHost: "leaf2.example.net",
 		AreaTags: []string{"gen.coding"},
 	})
-	resp2, _ := ts.Client().Post(ts.URL+"/v3net/v1/subscribe", "application/json",
+	if err != nil {
+		t.Fatalf("marshal leaf2 subscribe: %v", err)
+	}
+	resp2, err := ts.Client().Post(ts.URL+"/v3net/v1/subscribe", "application/json",
 		bytes.NewReader(registerBody2))
+	if err != nil {
+		t.Fatalf("subscribe leaf2: %v", err)
+	}
 	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("subscribe leaf2 expected 200, got %d", resp2.StatusCode)
+	}
 
 	// Create leaf 2 instance and post a gen.coding message.
 	leaf2Writer := &testJAMWriter{}
-	leaf2Dedup, _ := dedup.Open(filepath.Join(t.TempDir(), "dedup2.sqlite"))
+	leaf2Dedup, err := dedup.Open(filepath.Join(t.TempDir(), "dedup2.sqlite"))
+	if err != nil {
+		t.Fatalf("open leaf2 dedup: %v", err)
+	}
 	t.Cleanup(func() { leaf2Dedup.Close() })
 	l2 := leaf.New(leaf.Config{
 		HubURL:       ts.URL,

--- a/internal/v3net/integration_test.go
+++ b/internal/v3net/integration_test.go
@@ -333,9 +333,9 @@ func TestIntegration_AreaFilteredPolling(t *testing.T) {
 	// Post a message to gen.general via leaf 1.
 	msg := protocol.Message{
 		V3Net: "1.0", Network: "testnet", AreaTag: "gen.general",
-		MsgUUID:     "880e8400-e29b-41d4-a716-446655440010",
-		ThreadUUID:  "880e8400-e29b-41d4-a716-446655440010",
-		OriginNode:  "test.example.net", OriginBoard: "General",
+		MsgUUID:    "880e8400-e29b-41d4-a716-446655440010",
+		ThreadUUID: "880e8400-e29b-41d4-a716-446655440010",
+		OriginNode: "test.example.net", OriginBoard: "General",
 		From: "Tester", To: "All", Subject: "Area filtered test",
 		DateUTC: "2026-03-16T04:20:00Z", Body: "Should be received.",
 		Kludges: map[string]any{},
@@ -378,7 +378,7 @@ func TestIntegration_AreaFilteredPolling(t *testing.T) {
 	registerBody2, _ := json.Marshal(protocol.SubscribeRequest{
 		Network: "testnet", NodeID: leaf2KS.NodeID(),
 		PubKeyB64: leaf2KS.PubKeyBase64(),
-		BBSName: "Leaf 2 BBS", BBSHost: "leaf2.example.net",
+		BBSName:   "Leaf 2 BBS", BBSHost: "leaf2.example.net",
 		AreaTags: []string{"gen.coding"},
 	})
 	resp2, _ := ts.Client().Post(ts.URL+"/v3net/v1/subscribe", "application/json",
@@ -401,9 +401,9 @@ func TestIntegration_AreaFilteredPolling(t *testing.T) {
 
 	codingMsg := protocol.Message{
 		V3Net: "1.0", Network: "testnet", AreaTag: "gen.coding",
-		MsgUUID:     "990e8400-e29b-41d4-a716-446655440011",
-		ThreadUUID:  "990e8400-e29b-41d4-a716-446655440011",
-		OriginNode:  "leaf2.example.net", OriginBoard: "Coding",
+		MsgUUID:    "990e8400-e29b-41d4-a716-446655440011",
+		ThreadUUID: "990e8400-e29b-41d4-a716-446655440011",
+		OriginNode: "leaf2.example.net", OriginBoard: "Coding",
 		From: "Leaf2 User", To: "All", Subject: "Coding msg",
 		DateUTC: "2026-03-16T04:20:00Z", Body: "Should NOT be received by leaf 1.",
 		Kludges: map[string]any{},

--- a/internal/v3net/jam_adapter.go
+++ b/internal/v3net/jam_adapter.go
@@ -30,14 +30,13 @@ func (a *JAMAdapter) WriteMessage(msg protocol.Message) (int64, error) {
 	// Append tearline and origin so users can see where the message came from.
 	body = AppendV3NetOrigin(body, msg.Tearline, msg.Origin, msg.OriginNode)
 
-	// Parse the date for the message.
+	// Parse the wire date so JAM stores the original authored timestamp.
 	dateUTC, err := time.Parse(time.RFC3339, msg.DateUTC)
 	if err != nil {
 		return 0, fmt.Errorf("v3net jam: parse date: %w", err)
 	}
-	_ = dateUTC // AddMessage uses current time; the wire date is in the kludge
 
-	msgNum, err := a.mgr.AddMessage(a.areaID, msg.From, msg.To, msg.Subject, body, "")
+	msgNum, err := a.mgr.AddMessageWithDate(a.areaID, msg.From, msg.To, msg.Subject, body, "", dateUTC)
 	if err != nil {
 		return 0, fmt.Errorf("v3net jam: write message: %w", err)
 	}

--- a/internal/v3net/jam_router.go
+++ b/internal/v3net/jam_router.go
@@ -1,0 +1,35 @@
+package v3net
+
+import (
+	"log/slog"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/leaf"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+)
+
+// JAMRouter implements leaf.JAMWriter and dispatches messages to the
+// correct per-area JAMAdapter based on the message's AreaTag.
+type JAMRouter struct {
+	adapters map[string]leaf.JAMWriter
+}
+
+// NewJAMRouter creates a new JAMRouter with an empty set of adapters.
+func NewJAMRouter() *JAMRouter {
+	return &JAMRouter{adapters: make(map[string]leaf.JAMWriter)}
+}
+
+// Add registers a JAMWriter for the given area tag.
+func (r *JAMRouter) Add(areaTag string, writer leaf.JAMWriter) {
+	r.adapters[areaTag] = writer
+}
+
+// WriteMessage dispatches the message to the appropriate area adapter.
+// If no adapter exists for the message's AreaTag, it logs a warning and returns 0, nil.
+func (r *JAMRouter) WriteMessage(msg protocol.Message) (int64, error) {
+	adapter, ok := r.adapters[msg.AreaTag]
+	if !ok {
+		slog.Warn("v3net: no local area for tag, skipping", "area_tag", msg.AreaTag)
+		return 0, nil
+	}
+	return adapter.WriteMessage(msg)
+}

--- a/internal/v3net/jam_router_test.go
+++ b/internal/v3net/jam_router_test.go
@@ -1,0 +1,49 @@
+package v3net
+
+import (
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+)
+
+type mockWriter struct {
+	messages []protocol.Message
+}
+
+func (m *mockWriter) WriteMessage(msg protocol.Message) (int64, error) {
+	m.messages = append(m.messages, msg)
+	return int64(len(m.messages)), nil
+}
+
+func TestJAMRouter_DispatchesToCorrectAdapter(t *testing.T) {
+	general := &mockWriter{}
+	coding := &mockWriter{}
+	router := NewJAMRouter()
+	router.Add("gen.general", general)
+	router.Add("gen.coding", coding)
+
+	msg := protocol.Message{AreaTag: "gen.general", MsgUUID: "uuid-1"}
+	if _, err := router.WriteMessage(msg); err != nil {
+		t.Fatalf("WriteMessage: %v", err)
+	}
+
+	if len(general.messages) != 1 {
+		t.Errorf("expected 1 message to general, got %d", len(general.messages))
+	}
+	if len(coding.messages) != 0 {
+		t.Errorf("expected 0 messages to coding, got %d", len(coding.messages))
+	}
+}
+
+func TestJAMRouter_UnknownAreaTagReturnsZero(t *testing.T) {
+	router := NewJAMRouter()
+
+	msg := protocol.Message{AreaTag: "gen.unknown", MsgUUID: "uuid-1"}
+	num, err := router.WriteMessage(msg)
+	if err != nil {
+		t.Fatalf("WriteMessage: %v", err)
+	}
+	if num != 0 {
+		t.Errorf("expected 0 for unknown area, got %d", num)
+	}
+}

--- a/internal/v3net/keystore/keystore.go
+++ b/internal/v3net/keystore/keystore.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -29,7 +30,7 @@ type Keystore struct {
 // a new keypair was generated.
 func Load(path string) (*Keystore, bool, error) {
 	data, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return generate(path)
 	}
 	if err != nil {

--- a/internal/v3net/leaf/config.go
+++ b/internal/v3net/leaf/config.go
@@ -14,6 +14,7 @@ import (
 type Config struct {
 	HubURL       string
 	Network      string
+	AreaTags     []string // V3Net area tags to subscribe to
 	PollInterval time.Duration
 	Keystore     *keystore.Keystore
 	DedupIndex   *dedup.Index

--- a/internal/v3net/leaf/leaf.go
+++ b/internal/v3net/leaf/leaf.go
@@ -74,9 +74,23 @@ func (l *Leaf) Start(ctx context.Context) {
 	slog.Info("leaf: starting", "network", l.cfg.Network, "hub", l.cfg.HubURL)
 
 	// Subscribe to the hub (bootstrap — no auth required).
-	if err := l.subscribe(ctx); err != nil {
-		slog.Error("leaf: subscribe failed", "network", l.cfg.Network, "error", err)
-		return
+	// Retry with exponential backoff if the hub is temporarily unreachable.
+	subscribeBackoff := 5 * time.Second
+	for {
+		if err := l.subscribe(ctx); err != nil {
+			slog.Warn("leaf: subscribe failed, retrying", "network", l.cfg.Network, "error", err, "retry_in", subscribeBackoff)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(subscribeBackoff):
+			}
+			subscribeBackoff *= 2
+			if subscribeBackoff > 5*time.Minute {
+				subscribeBackoff = 5 * time.Minute
+			}
+			continue
+		}
+		break
 	}
 	slog.Info("leaf: subscribed to hub", "network", l.cfg.Network, "hub", l.cfg.HubURL)
 

--- a/internal/v3net/leaf/leaf_test.go
+++ b/internal/v3net/leaf/leaf_test.go
@@ -129,6 +129,7 @@ func testMessage(uuid string) protocol.Message {
 	return protocol.Message{
 		V3Net:       "1.0",
 		Network:     "testnet",
+		AreaTag:     "gen.general",
 		MsgUUID:     uuid,
 		ThreadUUID:  uuid,
 		OriginNode:  "test.example.net",

--- a/internal/v3net/leaf/poller.go
+++ b/internal/v3net/leaf/poller.go
@@ -26,7 +26,7 @@ func (l *Leaf) poll(ctx context.Context) (int, error) {
 		}
 
 		path := fmt.Sprintf("/v3net/v1/%s/messages?since=%s&limit=100", l.cfg.Network, cursor)
-		resp, err := l.signedGet(path)
+		resp, err := l.signedGetCtx(ctx, path)
 		if err != nil {
 			return total, fmt.Errorf("leaf: fetch messages: %w", err)
 		}
@@ -47,6 +47,15 @@ func (l *Leaf) poll(ctx context.Context) (int, error) {
 		}
 
 		for _, msg := range messages {
+			if err := msg.Validate(); err != nil {
+				slog.Warn("leaf: invalid message from hub, skipping", "uuid", msg.MsgUUID, "error", err)
+				cursor = msg.MsgUUID
+				continue
+			}
+			if msg.NeedsTruncation() {
+				msg.Truncate()
+			}
+
 			seen, err := l.cfg.DedupIndex.Seen(msg.MsgUUID)
 			if err != nil {
 				return total, fmt.Errorf("leaf: dedup check: %w", err)

--- a/internal/v3net/leaf/sender.go
+++ b/internal/v3net/leaf/sender.go
@@ -61,45 +61,61 @@ func (l *Leaf) subscribe(ctx context.Context) error {
 
 // SendMessage signs and POSTs a message to the hub.
 func (l *Leaf) SendMessage(msg protocol.Message) error {
+	return l.SendMessageCtx(context.Background(), msg)
+}
+
+// SendMessageCtx signs and POSTs a message to the hub with context.
+func (l *Leaf) SendMessageCtx(ctx context.Context, msg protocol.Message) error {
 	data, err := json.Marshal(msg)
 	if err != nil {
 		return fmt.Errorf("leaf: marshal message: %w", err)
 	}
 	path := fmt.Sprintf("/v3net/v1/%s/messages", l.cfg.Network)
-	return l.signedPost(path, data)
+	return l.signedPostCtx(ctx, path, data)
 }
 
 // SendChat sends an inter-BBS chat message to the hub.
 func (l *Leaf) SendChat(text, handle string) error {
+	return l.SendChatCtx(context.Background(), text, handle)
+}
+
+// SendChatCtx sends an inter-BBS chat message to the hub with context.
+func (l *Leaf) SendChatCtx(ctx context.Context, text, handle string) error {
 	data, err := json.Marshal(protocol.ChatRequest{From: handle, Text: text})
 	if err != nil {
 		return fmt.Errorf("leaf: marshal chat: %w", err)
 	}
 	path := fmt.Sprintf("/v3net/v1/%s/chat", l.cfg.Network)
-	return l.signedPost(path, data)
+	return l.signedPostCtx(ctx, path, data)
 }
 
 // SendLogon notifies the hub of a user logon.
 func (l *Leaf) SendLogon(handle string) error {
-	return l.sendPresence(protocol.EventLogon, handle)
+	return l.sendPresenceCtx(context.Background(), protocol.EventLogon, handle)
+}
+
+// SendLogonCtx notifies the hub of a user logon with context.
+func (l *Leaf) SendLogonCtx(ctx context.Context, handle string) error {
+	return l.sendPresenceCtx(ctx, protocol.EventLogon, handle)
 }
 
 // SendLogoff notifies the hub of a user logoff.
 func (l *Leaf) SendLogoff(handle string) error {
-	return l.sendPresence(protocol.EventLogoff, handle)
+	return l.sendPresenceCtx(context.Background(), protocol.EventLogoff, handle)
 }
 
-func (l *Leaf) sendPresence(eventType, handle string) error {
+// SendLogoffCtx notifies the hub of a user logoff with context.
+func (l *Leaf) SendLogoffCtx(ctx context.Context, handle string) error {
+	return l.sendPresenceCtx(ctx, protocol.EventLogoff, handle)
+}
+
+func (l *Leaf) sendPresenceCtx(ctx context.Context, eventType, handle string) error {
 	data, err := json.Marshal(protocol.PresenceRequest{Type: eventType, Handle: handle})
 	if err != nil {
 		return fmt.Errorf("leaf: marshal presence: %w", err)
 	}
 	path := fmt.Sprintf("/v3net/v1/%s/presence", l.cfg.Network)
-	return l.signedPost(path, data)
-}
-
-func (l *Leaf) signedPost(path string, body []byte) error {
-	return l.signedPostCtx(context.Background(), path, body)
+	return l.signedPostCtx(ctx, path, data)
 }
 
 func (l *Leaf) signedPostCtx(ctx context.Context, path string, body []byte) error {

--- a/internal/v3net/leaf/sender.go
+++ b/internal/v3net/leaf/sender.go
@@ -23,6 +23,7 @@ func (l *Leaf) subscribe(ctx context.Context) error {
 		PubKeyB64: l.cfg.Keystore.PubKeyBase64(),
 		BBSName:   l.cfg.BBSName,
 		BBSHost:   l.cfg.BBSHost,
+		AreaTags:  l.cfg.AreaTags,
 	}
 	data, err := json.Marshal(req)
 	if err != nil {

--- a/internal/v3net/leaf/sse.go
+++ b/internal/v3net/leaf/sse.go
@@ -66,6 +66,7 @@ func (l *Leaf) connectSSE(ctx context.Context) error {
 	slog.Info("leaf: SSE connected", "network", l.cfg.Network)
 
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 4096), 1<<20) // 1MB max token size
 	var eventType string
 
 	for scanner.Scan() {

--- a/internal/v3net/nal/nal.go
+++ b/internal/v3net/nal/nal.go
@@ -276,41 +276,41 @@ func (c *Cache) FetchAndVerify(ctx context.Context, url, network string) (*proto
 	// Check if cache is fresh.
 	c.mu.RLock()
 	e := c.entries[network]
-	c.mu.RUnlock()
-
 	if e != nil && time.Since(e.fetchedAt) < c.ttl {
+		c.mu.RUnlock()
 		return e.nal, nil
 	}
+	c.mu.RUnlock()
 
 	// Fetch and verify.
 	n, err := Fetch(ctx, url)
 	if err != nil {
-		if e != nil {
-			slog.Warn("nal: fetch failed, returning stale cache", "network", network, "error", err)
-			return e.nal, nil
-		}
-		return nil, fmt.Errorf("nal: fetch %s: %w", network, err)
+		return c.staleOrError(network, fmt.Errorf("nal: fetch %s: %w", network, err))
 	}
 
 	if err := Verify(n); err != nil {
-		if e != nil {
-			slog.Warn("nal: verification failed, returning stale cache", "network", network, "error", err)
-			return e.nal, nil
-		}
-		return nil, fmt.Errorf("nal: verify %s: %w", network, err)
+		return c.staleOrError(network, fmt.Errorf("nal: verify %s: %w", network, err))
 	}
 
 	if n.Network != network {
-		err := fmt.Errorf("nal: network mismatch: got %q want %q", n.Network, network)
-		if e != nil {
-			slog.Warn("nal: network mismatch, returning stale cache", "network", network, "error", err)
-			return e.nal, nil
-		}
-		return nil, err
+		return c.staleOrError(network, fmt.Errorf("nal: network mismatch: got %q want %q", n.Network, network))
 	}
 
 	c.Put(network, n)
 	return n, nil
+}
+
+// staleOrError returns the stale cached NAL if available, otherwise the error.
+// Re-reads the cache under lock to avoid using a stale pointer captured earlier.
+func (c *Cache) staleOrError(network string, err error) (*protocol.NAL, error) {
+	c.mu.RLock()
+	e := c.entries[network]
+	c.mu.RUnlock()
+	if e != nil {
+		slog.Warn("nal: returning stale cache", "network", network, "error", err)
+		return e.nal, nil
+	}
+	return nil, err
 }
 
 // Area returns the area with the given tag from the cached NAL.

--- a/internal/v3net/protocol/message.go
+++ b/internal/v3net/protocol/message.go
@@ -57,6 +57,12 @@ func (m *Message) Validate() error {
 	if m.ParentUUID != nil && !uuidRe.MatchString(*m.ParentUUID) {
 		return fmt.Errorf("invalid parent_uuid: %q", *m.ParentUUID)
 	}
+	if m.OriginNode == "" {
+		return fmt.Errorf("origin_node must not be empty")
+	}
+	if m.OriginBoard == "" {
+		return fmt.Errorf("origin_board must not be empty")
+	}
 	if _, err := time.Parse(time.RFC3339, m.DateUTC); err != nil {
 		return fmt.Errorf("invalid date_utc: %w", err)
 	}

--- a/internal/v3net/protocol/message.go
+++ b/internal/v3net/protocol/message.go
@@ -19,6 +19,7 @@ const MaxBodyBytes = 32768
 type Message struct {
 	V3Net       string         `json:"v3net"`
 	Network     string         `json:"network"`
+	AreaTag     string         `json:"area_tag"`
 	MsgUUID     string         `json:"msg_uuid"`
 	ThreadUUID  string         `json:"thread_uuid"`
 	ParentUUID  *string        `json:"parent_uuid"`
@@ -47,6 +48,9 @@ func (m *Message) Validate() error {
 	}
 	if !networkRe.MatchString(m.Network) {
 		return fmt.Errorf("invalid network name: %q", m.Network)
+	}
+	if !AreaTagRegexp.MatchString(m.AreaTag) {
+		return fmt.Errorf("invalid area_tag: %q", m.AreaTag)
 	}
 	if !uuidRe.MatchString(m.MsgUUID) {
 		return fmt.Errorf("invalid msg_uuid: %q", m.MsgUUID)

--- a/internal/v3net/protocol/message_test.go
+++ b/internal/v3net/protocol/message_test.go
@@ -9,6 +9,7 @@ func validMessage() Message {
 	return Message{
 		V3Net:       "1.0",
 		Network:     "felonynet",
+		AreaTag:     "fel.general",
 		MsgUUID:     "550e8400-e29b-41d4-a716-446655440000",
 		ThreadUUID:  "550e8400-e29b-41d4-a716-446655440000",
 		ParentUUID:  nil,
@@ -75,6 +76,16 @@ func TestValidate_InvalidFields(t *testing.T) {
 			name:    "network with spaces",
 			modify:  func(m *Message) { m.Network = "my net" },
 			wantErr: "invalid network name",
+		},
+		{
+			name:    "empty area_tag",
+			modify:  func(m *Message) { m.AreaTag = "" },
+			wantErr: "invalid area_tag",
+		},
+		{
+			name:    "invalid area_tag format",
+			modify:  func(m *Message) { m.AreaTag = "INVALID" },
+			wantErr: "invalid area_tag",
 		},
 		{
 			name:    "invalid msg_uuid",

--- a/internal/v3net/service.go
+++ b/internal/v3net/service.go
@@ -201,6 +201,7 @@ func (s *Service) AddLeaf(lcfg config.V3NetLeafConfig, writer JAMWriter, onEvent
 	l := leaf.New(leaf.Config{
 		HubURL:       lcfg.HubURL,
 		Network:      lcfg.Network,
+		AreaTags:     lcfg.Boards,
 		PollInterval: interval,
 		Keystore:     s.ks,
 		DedupIndex:   s.dedupIdx,

--- a/internal/v3net/wire.go
+++ b/internal/v3net/wire.go
@@ -43,7 +43,9 @@ func DefaultTearline() string {
 
 func newUUID() string {
 	var b [16]byte
-	_, _ = rand.Read(b[:])
+	if _, err := rand.Read(b[:]); err != nil {
+		panic("v3net: crypto/rand failed: " + err.Error())
+	}
 	b[6] = (b[6] & 0x0f) | 0x40 // version 4
 	b[8] = (b[8] & 0x3f) | 0x80 // variant bits
 	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",

--- a/internal/v3net/wire.go
+++ b/internal/v3net/wire.go
@@ -11,13 +11,15 @@ import (
 )
 
 // BuildWireMessage constructs a V3Net protocol message from local post data.
+// The areaTag parameter is the V3Net area tag (e.g. "gen.general").
 // The origin parameter is the user-defined origin line text (e.g. "My Cool BBS").
 // The tearline is always the standard ViSiON/3 software identifier.
-func BuildWireMessage(network, originNode, originBoard, from, to, subject, body, origin string) protocol.Message {
+func BuildWireMessage(network, areaTag, originNode, originBoard, from, to, subject, body, origin string) protocol.Message {
 	uuid := newUUID()
 	return protocol.Message{
 		V3Net:       protocol.ProtocolVersion,
 		Network:     network,
+		AreaTag:     areaTag,
 		MsgUUID:     uuid,
 		ThreadUUID:  uuid,
 		ParentUUID:  nil,

--- a/internal/v3net/wire.go
+++ b/internal/v3net/wire.go
@@ -1,13 +1,13 @@
 package v3net
 
 import (
+	"crypto/rand"
 	"fmt"
 	"runtime"
 	"time"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
 	"github.com/ViSiON-3/vision-3-bbs/internal/version"
-	"github.com/google/uuid"
 )
 
 // BuildWireMessage constructs a V3Net protocol message from local post data.
@@ -40,5 +40,10 @@ func DefaultTearline() string {
 }
 
 func newUUID() string {
-	return uuid.New().String()
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant bits
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
 }

--- a/internal/v3net/wire_test.go
+++ b/internal/v3net/wire_test.go
@@ -6,21 +6,21 @@ import (
 )
 
 func TestBuildWireMessageTearlineIsAlwaysDefault(t *testing.T) {
-	msg := BuildWireMessage("testnet", "abc123", "General", "Sysop", "All", "Hello", "body text", "My Cool BBS")
+	msg := BuildWireMessage("testnet", "gen.general", "abc123", "General", "Sysop", "All", "Hello", "body text", "My Cool BBS")
 	if !strings.HasPrefix(msg.Tearline, "--- ViSiON/3 ") {
 		t.Errorf("expected default ViSiON/3 tearline, got %q", msg.Tearline)
 	}
 }
 
 func TestBuildWireMessageOriginPassedThrough(t *testing.T) {
-	msg := BuildWireMessage("testnet", "abc123", "General", "Sysop", "All", "Hello", "body text", "My Cool BBS - bbs.example.com")
+	msg := BuildWireMessage("testnet", "gen.general", "abc123", "General", "Sysop", "All", "Hello", "body text", "My Cool BBS - bbs.example.com")
 	if msg.Origin != "My Cool BBS - bbs.example.com" {
 		t.Errorf("expected origin to be passed through, got %q", msg.Origin)
 	}
 }
 
 func TestBuildWireMessageEmptyOrigin(t *testing.T) {
-	msg := BuildWireMessage("testnet", "abc123", "General", "Sysop", "All", "Hello", "body text", "")
+	msg := BuildWireMessage("testnet", "gen.general", "abc123", "General", "Sysop", "All", "Hello", "body text", "")
 	if msg.Origin != "" {
 		t.Errorf("expected empty origin, got %q", msg.Origin)
 	}


### PR DESCRIPTION
## Summary

- Adds `area_tag` as a required field on `protocol.Message` with regex validation
- Enforces area-level access control on hub POST (NAL existence → area in NAL → node subscribed) and GET (filters messages to node's active area subscriptions)
- Adds `area_tag` column to messages table with composite index for efficient filtered queries
- Introduces `JAMRouter` for dispatching inbound messages to the correct local JAM message base by area tag
- Changes `V3NetLeafConfig.Board` (single string) to `Boards` (string slice) for multi-area support
- Updates leaf subscribe to send `area_tags`, enabling hub-side subscription tracking
- Updates config editor, area sync, wire message construction, and main startup loop for multi-board support

## Design

See [design spec](docs/plans/2026-03-19-v3net-area-level-message-access-design.md) and [implementation plan](docs/plans/2026-03-19-v3net-area-level-message-access.md).

## Test plan

- [x] `protocol.Message.Validate()` rejects missing/invalid `area_tag`
- [x] Hub POST returns 422 when no NAL exists
- [x] Hub POST returns 422 for unknown `area_tag`
- [x] Hub POST returns 403 when node not subscribed to area
- [x] Hub POST returns 200 with active subscription
- [x] Hub GET filters messages to node's subscribed areas
- [x] Hub GET returns empty array with no subscriptions
- [x] MessageStore.Fetch filters by area tags; empty tags short-circuits
- [x] JAMRouter dispatches to correct adapter; skips unknown tags
- [x] Integration test: two leaves with different subscriptions see only their areas' messages
- [x] All existing tests updated and passing (`go test ./... -count=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Area-level message access: hub enforces area tags on POST/GET and stores messages by area.
  * Multi-area subscriptions: leaves can subscribe to multiple areas per network; UI shows primary area with "(+N)" for extras.
  * Outbound messages carry area tags and preserve authored timestamps.

* **Bug Fixes / Reliability**
  * Improved retry/resilience for leaf subscriptions and larger SSE event handling.

* **Tests**
  * Added comprehensive area-access and routing integration/unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->