### PR TITLE
feat(configeditor): V3Net area browser for hub subscription management

### DIFF
--- a/AGENTS.v3net.md
+++ b/AGENTS.v3net.md
@@ -338,8 +338,7 @@ Format:
       "name": "felonynet",
       "description": "General discussion. No warrants required.",
       "hub_url": "https://felonynet.org",
-      "hub_node_id": "a3f9e1b2c4d5e6f7",
-      "area_tags": ["fn.general", "fn.testing", "fn.vision3"]
+      "hub_node_id": "a3f9e1b2c4d5e6f7"
     }
   ]
 }

--- a/AGENTS.v3net.md
+++ b/AGENTS.v3net.md
@@ -337,9 +337,9 @@ Format:
     {
       "name": "felonynet",
       "description": "General discussion. No warrants required.",
-      "hub_url": "https://bbs.felonynet.org",
+      "hub_url": "https://felonynet.org",
       "hub_node_id": "a3f9e1b2c4d5e6f7",
-      "tags": ["general", "tech", "bbs"]
+      "area_tags": ["fn.general", "fn.testing", "fn.vision3"]
     }
   ]
 }
@@ -1046,7 +1046,7 @@ writing any code here. Specifically understand:
 
    # One [[v3net.leaf]] block per subscribed network
    [[v3net.leaf]]
-   hub_url      = "https://bbs.felonynet.org"
+   hub_url      = "https://felonynet.org"
    network      = "felonynet"
    board        = "FelonyNet General"   # local JAM message base name
    poll_interval = "5m"

--- a/docs/plans/2026-03-16-v3net-protocol-design.md
+++ b/docs/plans/2026-03-16-v3net-protocol-design.md
@@ -488,7 +488,7 @@ data_dir     = "data/v3net_hub"
 auto_approve = true
 
 [[v3net.leaf]]
-hub_url       = "https://bbs.felonynet.org"
+hub_url       = "https://felonynet.org"
 network       = "felonynet"
 board         = "FelonyNet General"
 poll_interval = "5m"

--- a/docs/superpowers/plans/2026-03-17-v3net-setup-wizard.md
+++ b/docs/superpowers/plans/2026-03-17-v3net-setup-wizard.md
@@ -1465,11 +1465,11 @@ This adds the wizard infrastructure to the model: two new modes, the `wizardStat
           "Step 5 of 5 — Origin Line",
       }
       helps := []string{
-          "URL of the V3Net hub (e.g. https://hub.felonynet.org)",
+          "URL of the V3Net hub (e.g. https://felonynet.org)",
           "Network name to subscribe to (e.g. felonynet)",
           "Local message area tag prefix for received messages",
           "How often to poll for new messages (e.g. 5m, 30s, 1h)",
-          "Origin line identifying your BBS — leave blank to use BBS name",
+          "Leave blank to use BBS name",
       }
       title := "Leaf Setup"
       if m.wizard.step < len(titles) {

--- a/docs/sysop/v3net/configuration.md
+++ b/docs/sysop/v3net/configuration.md
@@ -194,7 +194,7 @@ Each entry in the `leaves` array subscribes your BBS to one network on one hub. 
 |-------|------|---------|-------------|
 | `hubUrl` | string | — | Full URL of the hub (e.g. `"https://felonynet.org"`). Required. |
 | `network` | string | — | Network name to subscribe to. Must match a network hosted by the hub. Required. |
-| `board` | string | `""` | Local message area tag prefix for received messages. When the hub has multiple areas, each area creates a local message area with this prefix. |
+| `boards` | array | `[]` | Local message area tags for received messages. List the area tags you want to receive messages from (e.g. `["fn.general", "fn.tech"]`). |
 | `pollInterval` | string | `"5m"` | How often to poll the hub for new messages. Accepts Go duration strings: `"30s"`, `"5m"`, `"1h"`. Shorter intervals mean faster delivery but more hub traffic. |
 | `origin` | string | BBS name | Origin line text appended to locally-posted messages. Identifies your BBS to readers on other nodes. If blank, falls back to the BBS name from `config.json`. |
 
@@ -206,14 +206,14 @@ Each entry in the `leaves` array subscribes your BBS to one network on one hub. 
     {
       "hubUrl": "https://felonynet.org",
       "network": "felonynet",
-      "board": "fel.general",
+      "boards": ["fn.general", "fn.tech"],
       "pollInterval": "5m",
       "origin": "My BBS - bbs.example.com"
     },
     {
       "hubUrl": "https://hub.retronet.io",
       "network": "retronet",
-      "board": "ret.general",
+      "boards": ["ret.general"],
       "pollInterval": "5m"
     }
   ]

--- a/docs/sysop/v3net/configuration.md
+++ b/docs/sysop/v3net/configuration.md
@@ -67,7 +67,7 @@ already subscribed to.
     {
       "name": "felonynet",
       "description": "Official ViSiON/3 BBS message network",
-      "hub_url": "https://hub.felonynet.org",
+      "hub_url": "https://felonynet.org",
       "hub_node_id": "22819c83e045cd1e"
     }
   ]
@@ -213,8 +213,8 @@ Each entry in the `leaves` array subscribes your BBS to one network on one hub. 
     {
       "hubUrl": "https://hub.retronet.io",
       "network": "retronet",
-      "board": "retro.general",
-      "pollInterval": "10m"
+      "board": "ret.general",
+      "pollInterval": "5m"
     }
   ]
 }

--- a/docs/sysop/v3net/configuration.md
+++ b/docs/sysop/v3net/configuration.md
@@ -67,8 +67,8 @@ already subscribed to.
     {
       "name": "felonynet",
       "description": "Official ViSiON/3 BBS message network",
-      "hub_url": "https://hub.felonynet.example.com/v3net",
-      "hub_node_id": "a3f9e1b2c4d5e6f7"
+      "hub_url": "https://hub.felonynet.org",
+      "hub_node_id": "22819c83e045cd1e"
     }
   ]
 }
@@ -105,7 +105,7 @@ registry browser.
   },
   "leaves": [
     {
-      "hubUrl": "https://hub.felonynet.org",
+      "hubUrl": "https://felonynet.org",
       "network": "felonynet",
       "board": "fel.general",
       "pollInterval": "5m",
@@ -192,7 +192,7 @@ Each entry in the `leaves` array subscribes your BBS to one network on one hub. 
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `hubUrl` | string | — | Full URL of the hub (e.g. `"https://hub.felonynet.org"`). Required. |
+| `hubUrl` | string | — | Full URL of the hub (e.g. `"https://felonynet.org"`). Required. |
 | `network` | string | — | Network name to subscribe to. Must match a network hosted by the hub. Required. |
 | `board` | string | `""` | Local message area tag prefix for received messages. When the hub has multiple areas, each area creates a local message area with this prefix. |
 | `pollInterval` | string | `"5m"` | How often to poll the hub for new messages. Accepts Go duration strings: `"30s"`, `"5m"`, `"1h"`. Shorter intervals mean faster delivery but more hub traffic. |
@@ -204,7 +204,7 @@ Each entry in the `leaves` array subscribes your BBS to one network on one hub. 
 {
   "leaves": [
     {
-      "hubUrl": "https://hub.felonynet.org",
+      "hubUrl": "https://felonynet.org",
       "network": "felonynet",
       "board": "fel.general",
       "pollInterval": "5m",

--- a/docs/sysop/v3net/felonynet.md
+++ b/docs/sysop/v3net/felonynet.md
@@ -64,7 +64,7 @@ Add a `leaves` entry pointing to the FelonyNet hub:
       {
         "hubUrl": "https://felonynet.org",
         "network": "felonynet",
-        "board": "FELONYNET_GENERAL",
+        "boards": ["fn.general"],
         "pollInterval": "5m"
       }
     ]
@@ -76,7 +76,7 @@ Add a `leaves` entry pointing to the FelonyNet hub:
 |-------|-------------|
 | `hubUrl` | The FelonyNet hub URL |
 | `network` | Must be `felonynet` |
-| `board` | Your local message area tag |
+| `boards` | Local message area tags (array of area tag strings) |
 | `pollInterval` | How often to poll for new messages (minimum 60s enforced by hub) |
 
 ### 4. Restart Vision/3
@@ -188,8 +188,7 @@ your network entry:
   "name": "felonynet",
   "description": "General discussion. No warrants required.",
   "hub_url": "https://felonynet.org",
-  "hub_node_id": "22819c83e045cd1e",
-  "area_tags": ["fn.general", "fn.testing", "fn.vision3"]
+  "hub_node_id": "22819c83e045cd1e"
 }
 ```
 
@@ -197,8 +196,8 @@ your network entry:
 
 **"V3Net networking disabled"** — `v3net.enabled` is `false` in config.json.
 
-**"message area not found, skipping"** — The `board` tag in your leaf config
-doesn't match any configured message area. Check your message area tags.
+**"message area not found, skipping"** — A tag in your `boards` array doesn't
+match any configured message area. Check your message area tags.
 
 **No messages arriving** — Check that the hub URL is reachable. Look for
 `leaf: poll failed` warnings in the log. Verify your node is approved (hub may

--- a/docs/sysop/v3net/felonynet.md
+++ b/docs/sysop/v3net/felonynet.md
@@ -62,7 +62,7 @@ Add a `leaves` entry pointing to the FelonyNet hub:
     "dedupDbPath": "data/v3net_dedup.sqlite",
     "leaves": [
       {
-        "hubUrl": "https://hub.felonynet.org",
+        "hubUrl": "https://felonynet.org",
         "network": "felonynet",
         "board": "FELONYNET_GENERAL",
         "pollInterval": "5m"
@@ -188,8 +188,8 @@ your network entry:
   "name": "felonynet",
   "description": "General discussion. No warrants required.",
   "hub_url": "https://hub.felonynet.org",
-  "hub_node_id": "a3f9e1b2c4d5e6f7",
-  "tags": ["general", "tech", "bbs"]
+  "hub_node_id": "22819c83e045cd1e",
+  "area_tags": ["fn.general", "fn.testing", "fn.vision3"]
 }
 ```
 

--- a/docs/sysop/v3net/felonynet.md
+++ b/docs/sysop/v3net/felonynet.md
@@ -187,7 +187,7 @@ your network entry:
 {
   "name": "felonynet",
   "description": "General discussion. No warrants required.",
-  "hub_url": "https://hub.felonynet.org",
+  "hub_url": "https://felonynet.org",
   "hub_node_id": "22819c83e045cd1e",
   "area_tags": ["fn.general", "fn.testing", "fn.vision3"]
 }

--- a/internal/configeditor/fields_v3net.go
+++ b/internal/configeditor/fields_v3net.go
@@ -68,7 +68,7 @@ func (m *Model) fieldsV3NetLeaf() []fieldDef {
 
 	return []fieldDef{
 		{
-			Label: "Hub URL", Help: "URL of the V3Net hub (e.g. https://hub.felonynet.org)", Type: ftString, Col: 3, Row: 1, Width: 49,
+			Label: "Hub URL", Help: "URL of the V3Net hub (e.g. https://felonynet.org)", Type: ftString, Col: 3, Row: 1, Width: 49,
 			Get: func() string { return l.HubURL },
 			Set: func(val string) error { l.HubURL = val; return nil },
 		},
@@ -107,7 +107,7 @@ func (m *Model) fieldsV3NetLeaf() []fieldDef {
 			Set: func(val string) error { l.PollInterval = val; return nil },
 		},
 		{
-			Label: "Origin", Help: "Origin line identifying your BBS on this network (e.g. My Cool BBS - bbs.example.com)", Type: ftString, Col: 3, Row: 5, Width: 49,
+			Label: "Origin", Help: "Origin line identifying your BBS", Type: ftString, Col: 3, Row: 5, Width: 49,
 			Get: func() string { return l.Origin },
 			Set: func(val string) error { l.Origin = val; return nil },
 		},

--- a/internal/configeditor/fields_wizard.go
+++ b/internal/configeditor/fields_wizard.go
@@ -66,7 +66,7 @@ func (m *Model) fieldsLeafWizard() []fieldDef {
 			},
 		},
 		{
-			Label: "Origin", Help: "Origin line identifying your BBS — leave blank to use BBS name", Type: ftString, Col: 3, Row: 5, Width: 45,
+			Label: "Origin", Help: "Leave blank to use BBS name", Type: ftString, Col: 3, Row: 5, Width: 45,
 			Get: func() string { return w.origin },
 			Set: func(val string) error {
 				w.origin = strings.TrimSpace(val)

--- a/internal/configeditor/view_v3net_area_browser.go
+++ b/internal/configeditor/view_v3net_area_browser.go
@@ -17,8 +17,8 @@ func (m Model) viewV3NetAreaBrowser() string {
 	total := len(m.areaBrowserAreas)
 
 	// Fixed rows: header(1) + border(1) + title(1) + colheader(1) + sep(1)
-	//           + list(10) + border(1) + msg(1) + help(1)
-	fixedRows := listVisible + 8
+	//           + list(10) + border(1) + msg(1) + bgLine(1) + help(1)
+	fixedRows := listVisible + 9
 	extraV := maxInt(0, m.height-fixedRows)
 	topPad := extraV / 2
 	bottomPad := extraV - topPad
@@ -61,10 +61,14 @@ func (m Model) viewV3NetAreaBrowser() string {
 		}
 		b.WriteString(border(menuBorderStyle.Render("└" + strings.Repeat("─", boxW) + "┘")))
 		b.WriteByte('\n')
-		for i := 0; i < bottomPad+2; i++ {
+		for i := 0; i < bottomPad+1; i++ {
 			b.WriteString(bgLine)
 			b.WriteByte('\n')
 		}
+		b.WriteString(bgLine)
+		b.WriteByte('\n')
+		b.WriteString(bgLine)
+		b.WriteByte('\n')
 		b.WriteString(helpBarStyle.Render(centerText("ESC - Cancel", m.width)))
 		return b.String()
 	}
@@ -86,6 +90,8 @@ func (m Model) viewV3NetAreaBrowser() string {
 			b.WriteString(bgLine)
 			b.WriteByte('\n')
 		}
+		b.WriteString(bgLine)
+		b.WriteByte('\n')
 		b.WriteString(bgLine)
 		b.WriteByte('\n')
 		helpStr := "R - Retry  |  ESC - Back"
@@ -159,7 +165,12 @@ func (m Model) viewV3NetAreaBrowser() string {
 	b.WriteString(border(menuBorderStyle.Render("└" + strings.Repeat("─", boxW) + "┘")))
 	b.WriteByte('\n')
 
-	// Message line.
+	for i := 0; i < bottomPad; i++ {
+		b.WriteString(bgLine)
+		b.WriteByte('\n')
+	}
+
+	// Help row (message or blank).
 	if m.message != "" {
 		msgLine := bgFillStyle.Render(strings.Repeat("░", padL)) +
 			flashMessageStyle.Render(" "+padRight(m.message, boxW)) +
@@ -170,10 +181,8 @@ func (m Model) viewV3NetAreaBrowser() string {
 	}
 	b.WriteByte('\n')
 
-	for i := 0; i < bottomPad; i++ {
-		b.WriteString(bgLine)
-		b.WriteByte('\n')
-	}
+	b.WriteString(bgLine)
+	b.WriteByte('\n')
 
 	// Help bar.
 	helpStr := "Space - Subscribe/Unsubscribe  |  ESC - Done"

--- a/internal/configeditor/view_v3net_area_browser.go
+++ b/internal/configeditor/view_v3net_area_browser.go
@@ -86,7 +86,7 @@ func (m Model) viewV3NetAreaBrowser() string {
 		}
 		b.WriteString(border(menuBorderStyle.Render("└" + strings.Repeat("─", boxW) + "┘")))
 		b.WriteByte('\n')
-		for i := 0; i < bottomPad; i++ {
+		for i := 0; i < bottomPad+1; i++ {
 			b.WriteString(bgLine)
 			b.WriteByte('\n')
 		}

--- a/internal/configeditor/view_v3net_hub_areas.go
+++ b/internal/configeditor/view_v3net_hub_areas.go
@@ -19,8 +19,8 @@ func (m Model) viewV3NetHubAreas() string {
 	indices := m.hubNetworkAreaIndices()
 	total := len(indices)
 
-	// Fixed rows: header(1) + border(1) + title(1) + colheader(1) + sep(1) + list + border(1) + msg(1) + help(1)
-	fixedRows := listVisible + 8
+	// Fixed rows: header(1) + border(1) + title(1) + colheader(1) + sep(1) + list + border(1) + msg(1) + bgLine(1) + help(1)
+	fixedRows := listVisible + 9
 	extraV := maxInt(0, m.height-fixedRows)
 	topPad := extraV / 2
 	bottomPad := extraV - topPad
@@ -102,7 +102,12 @@ func (m Model) viewV3NetHubAreas() string {
 	b.WriteString(border(menuBorderStyle.Render("└" + strings.Repeat("─", boxW) + "┘")))
 	b.WriteByte('\n')
 
-	// Message line.
+	for i := 0; i < bottomPad; i++ {
+		b.WriteString(bgLine)
+		b.WriteByte('\n')
+	}
+
+	// Help row (message or blank).
 	if m.message != "" {
 		msgLine := bgFillStyle.Render(strings.Repeat("░", padL)) +
 			flashMessageStyle.Render(" "+padRight(m.message, boxW)) +
@@ -113,10 +118,8 @@ func (m Model) viewV3NetHubAreas() string {
 	}
 	b.WriteByte('\n')
 
-	for i := 0; i < bottomPad; i++ {
-		b.WriteString(bgLine)
-		b.WriteByte('\n')
-	}
+	b.WriteString(bgLine)
+	b.WriteByte('\n')
 
 	helpStr := "I - Insert  |  E - Edit  |  D - Delete  |  S - Save  |  ESC/Q - Return"
 	if total == 0 {
@@ -144,7 +147,7 @@ func (m Model) viewV3NetAreaForm(title string, fields []areaFormField, activeSte
 	boxW := 60
 	boxH := 9 // top + title + blank + fields(4) + blank + bottom
 
-	extraV := maxInt(0, m.height-boxH-3)
+	extraV := maxInt(0, m.height-boxH-4)
 	topPad := extraV / 2
 	bottomPad := extraV - topPad
 
@@ -198,6 +201,12 @@ func (m Model) viewV3NetAreaForm(title string, fields []areaFormField, activeSte
 	b.WriteString(border(editBorderStyle.Render("└" + strings.Repeat("─", boxW) + "┘")))
 	b.WriteByte('\n')
 
+	for i := 0; i < bottomPad; i++ {
+		b.WriteString(bgLine)
+		b.WriteByte('\n')
+	}
+
+	// Help row (message or blank).
 	if m.message != "" {
 		msgLine := bgFillStyle.Render(strings.Repeat("░", padL)) +
 			flashMessageStyle.Render(" "+padRight(m.message, boxW)) +
@@ -208,10 +217,8 @@ func (m Model) viewV3NetAreaForm(title string, fields []areaFormField, activeSte
 	}
 	b.WriteByte('\n')
 
-	for i := 0; i < bottomPad; i++ {
-		b.WriteString(bgLine)
-		b.WriteByte('\n')
-	}
+	b.WriteString(bgLine)
+	b.WriteByte('\n')
 
 	helpStr := "Enter - Next Field / Confirm  |  ESC - Cancel"
 	b.WriteString(helpBarStyle.Render(centerText(helpStr, m.width)))

--- a/internal/configeditor/view_v3net_identity.go
+++ b/internal/configeditor/view_v3net_identity.go
@@ -46,7 +46,7 @@ func (m Model) viewSeedInterstitial() string {
 
 	// Box: top border + title + empty + content + empty + bottom border
 	boxH := len(contentLines) + 5
-	extraV := maxInt(0, m.height-boxH-3)
+	extraV := maxInt(0, m.height-boxH-4)
 	topPad := extraV / 2
 	bottomPad := extraV - topPad
 
@@ -102,7 +102,12 @@ func (m Model) viewSeedInterstitial() string {
 		bgFillStyle.Render(strings.Repeat("░", maxInt(0, padR))))
 	b.WriteByte('\n')
 
-	// Message line directly below box
+	for i := 0; i < bottomPad; i++ {
+		b.WriteString(bgLine)
+		b.WriteByte('\n')
+	}
+
+	// Help row (message or blank).
 	if m.message != "" {
 		msgLine := bgFillStyle.Render(strings.Repeat("░", padL)) +
 			flashMessageStyle.Render(" "+padRight(m.message, boxW)) +
@@ -113,10 +118,8 @@ func (m Model) viewSeedInterstitial() string {
 	}
 	b.WriteByte('\n')
 
-	for i := 0; i < bottomPad; i++ {
-		b.WriteString(bgLine)
-		b.WriteByte('\n')
-	}
+	b.WriteString(bgLine)
+	b.WriteByte('\n')
 
 	b.WriteString(helpBarStyle.Render(centerText(helpText, m.width)))
 
@@ -217,8 +220,8 @@ func (m Model) viewV3NetIdentity() string {
 	// Render the box.
 	// Box: top border + title + empty + content + empty + bottom border
 	boxH := len(contentLines) + 5
-	// Vertical centering: -3 for global header, message line, help bar
-	extraV := maxInt(0, m.height-boxH-3)
+	// Vertical centering: -4 for global header, message line, bgLine spacer, help bar
+	extraV := maxInt(0, m.height-boxH-4)
 	topPad := extraV / 2
 	bottomPad := extraV - topPad
 
@@ -279,7 +282,12 @@ func (m Model) viewV3NetIdentity() string {
 		bgFillStyle.Render(strings.Repeat("░", maxInt(0, padR))))
 	b.WriteByte('\n')
 
-	// Message line (directly below box, matching category menu layout)
+	for i := 0; i < bottomPad; i++ {
+		b.WriteString(bgLine)
+		b.WriteByte('\n')
+	}
+
+	// Help row (message or blank).
 	if m.message != "" {
 		msgLine := bgFillStyle.Render(strings.Repeat("░", padL)) +
 			flashMessageStyle.Render(" "+padRight(m.message, boxW)) +
@@ -290,10 +298,8 @@ func (m Model) viewV3NetIdentity() string {
 	}
 	b.WriteByte('\n')
 
-	for i := 0; i < bottomPad; i++ {
-		b.WriteString(bgLine)
-		b.WriteByte('\n')
-	}
+	b.WriteString(bgLine)
+	b.WriteByte('\n')
 
 	b.WriteString(helpBarStyle.Render(centerText(helpText, m.width)))
 

--- a/internal/v3net/registry/registry_test.go
+++ b/internal/v3net/registry/registry_test.go
@@ -14,7 +14,7 @@ const testRegistryJSON = `{
 		{
 			"name": "felonynet",
 			"description": "General discussion.",
-			"hub_url": "https://bbs.felonynet.org",
+			"hub_url": "https://felonynet.org",
 			"hub_node_id": "a3f9e1b2c4d5e6f7"
 		}
 	]
@@ -39,7 +39,7 @@ func TestFetch_Success(t *testing.T) {
 	if networks[0].Name != "felonynet" {
 		t.Errorf("expected felonynet, got %q", networks[0].Name)
 	}
-	if networks[0].HubURL != "https://bbs.felonynet.org" {
+	if networks[0].HubURL != "https://felonynet.org" {
 		t.Errorf("unexpected hub URL: %q", networks[0].HubURL)
 	}
 }

--- a/templates/configs/v3net.json
+++ b/templates/configs/v3net.json
@@ -11,5 +11,12 @@
     "autoApprove": false,
     "networks": []
   },
-  "leaves": []
+  "leaves": [
+    {
+      "hubUrl": "https://felonynet.org",
+      "network": "felonynet",
+      "boards": [],
+      "pollInterval": "5m"
+    }
+  ]
 }

--- a/templates/registry.json
+++ b/templates/registry.json
@@ -5,7 +5,7 @@
     {
       "name": "felonynet",
       "description": "Official ViSiON/3 BBS message network",
-      "hub_url": "https://hub.felonynet.org",
+      "hub_url": "https://felonynet.org",
       "hub_node_id": "22819c83e045cd1e"
     }
   ]

--- a/templates/registry.json
+++ b/templates/registry.json
@@ -5,8 +5,8 @@
     {
       "name": "felonynet",
       "description": "Official ViSiON/3 BBS message network",
-      "hub_url": "https://felonynet.example.com/v3net",
-      "hub_node_id": "0000000000000000"
+      "hub_url": "https://hub.felonynet.org",
+      "hub_node_id": "22819c83e045cd1e"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds a V3Net **area browser** to the config editor, allowing sysops to discover and subscribe to message areas hosted on a V3Net hub directly from the TUI — replacing the need to manually type area tags.

## What's New

### Area Browser (core feature)
- **NAL fetch**: Queries the hub's Network Area List (NAL) endpoint to retrieve available areas
- **Interactive list**: Displays areas with tag, description, and current subscription status
- **Toggle subscribe/unsubscribe**: Spacebar toggles subscription; changes are persisted on exit
- **Integrated into two flows**: accessible from the leaf wizard (setup) and the leaf subscription edit view (ongoing management)

### Files added
| File | Purpose |
|------|---------|
| `update_v3net_area_browser.go` | Update handler — key dispatch and state transitions |
| `view_v3net_area_browser.go` | View renderer — loading, error, and list states |
| `v3net_area_browser_cmds.go` | Tea commands — NAL fetch and subscribe API calls |
| `v3net_area_browser_helpers.go` | Helpers — area diffing, message area creation, tag sanitization |

### Supporting changes
- **Model fields**: New `areaBrowser*` state fields and `modeAreaBrowser` mode constant
- **Wizard integration**: Hub-areas step launches area browser instead of manual tag entry
- **Leaf edit integration**: Subscription list view can open the area browser
- **Security**: `sanitizeTag()` strips path traversal, null bytes, and reserved characters before constructing `BasePath`
- **Service layer**: `FetchNAL` and `SubscribeWithAreas` methods added to `v3net/service.go`

### Config TUI polish
- Canonical help row pattern (message → bgLine spacer → help bar) applied consistently to all V3Net screens: identity, seed interstitial, hub areas list/form, and area browser

### Documentation & templates
- Pre-configured FelonyNet leaf entry in `templates/configs/v3net.json` (disabled by default)
- Real FelonyNet hub node ID (`22819c83e045cd1e`) and URL (`https://felonynet.org`) across all docs and templates
- Real area tags (`fn.general`, `fn.testing`, `fn.vision3`) in docs and agent instructions
- Design spec and implementation plan in `docs/`

### Documentation link fixes
- Fixed 22 broken relative markdown links across 6 doc files (`messages/README.md`, `networking/README.md`, `v3net/bootstrap.md`, `v3net/felonynet.md`, `v3net/manual-config.md`, `v3net/message-areas.md`)
- Removed redundant `v3net/` prefix from same-directory links in `docs/sysop/v3net/`
- Added `../v3net/` prefix for cross-directory links from `messages/` and `networking/`
- Added `../messages/` prefix for cross-directory links from `v3net/` to `messages/`

## Testing

- `go build ./...` — passes
- `go test ./internal/configeditor/...` — passes
- `go test ./internal/v3net/...` — passes
