### PR TITLE
feat(configeditor): add network registry browser to V3Net subscriptions

### DIFF
--- a/docs/sysop/v3net/configuration.md
+++ b/docs/sysop/v3net/configuration.md
@@ -101,15 +101,17 @@ Enter - Select  |  ESC/Q - Return
 │   1  https://felonynet.org            felonynet      fn.general      │
 │                                                                      │
 └──────────────────────────────────────────────────────────────────────┘
-Enter - Edit  |  I - New (Wizard)  |  D - Delete  |  S - Save  |  ESC - Return
+Enter - Edit  |  I - New (Wizard)  |  B - Registry  |  D - Delete  |  S - Save  |  ESC - Return
 ```
 
-Press **I** to open the **Leaf Setup Wizard**:
+Press **B** to open the **Network Registry** and browse available networks, or
+press **I** to open the **Leaf Setup Wizard** manually:
 
 ```
 ┌──────────────────────────────────────────────────────────────────────┐
 │                     Leaf Setup — Join a Network                      │
 │                                                                      │
+│  Registry        : (press Enter to browse available networks)        │
 │  Hub URL         : https://felonynet.org                             │
 │  Network         : felonynet                                         │
 │  Areas           : (none — press Enter to browse)                    │
@@ -123,6 +125,7 @@ Enter - Edit  |  S - Save  |  ESC - Back
 
 | Field | Description |
 |-------|-------------|
+| **Registry** | Opens the network registry browser. Selecting a network fills in Hub URL and Network automatically. |
 | **Hub URL** | Full URL of the hub (e.g. `https://felonynet.org`) |
 | **Network** | Network name to subscribe to (e.g. `felonynet`) |
 | **Areas** | Press **Enter** to open the area browser and choose which areas to subscribe to |
@@ -209,6 +212,26 @@ See [V3Net Key Recovery](v3net/recovery.md) for full details.
 | `data/v3net.key` | Ed25519 keypair (auto-generated on first V3Net start) |
 | `data/v3net_dedup.sqlite` | Message deduplication database |
 | `data/v3net_hub/` | Hub data directory (SQLite DB, NAL files) |
+
+---
+
+## Security Considerations
+
+**TLS protects the wire, not the disk.** Enabling HTTPS encrypts traffic between leaf nodes and the hub. It does not encrypt data at rest. The following files are stored in plaintext:
+
+- `data/v3net_dedup.sqlite` — deduplication database containing message content
+- `data/v3net_hub/` — hub database (hub nodes only), fully readable by the hub operator and anyone with server access
+- Local message base files — JAM or squish files written when messages are imported into boards
+
+Restrict file permissions appropriately and consider the security of any backup systems that touch these paths.
+
+**Protect your private key.** `data/v3net.key` and any exported seed phrase files should be readable only by the BBS process user (`chmod 600`). A compromised key allows an attacker to impersonate your node on all V3Net networks. Do not include the key file in unencrypted backups or commit it to version control.
+
+**Hub operators can read all traffic.** V3Net is a federated public message network. TLS secures the connection to the hub, but the hub stores and forwards messages in plaintext. The hub sysop — and anyone with access to the hub server — can read all messages routed through it. This is the same trust model as FidoNet echomail and similar networks.
+
+**Auto-approve.** Setting `Auto Approve: Y` allows any node to subscribe to your hub and propose new areas without review. Appropriate for open public networks; set it to `N` and manually approve nodes for curated or private networks.
+
+**Public areas are public.** Messages posted to networked areas are replicated to every subscribed node and stored indefinitely on each. Do not post sensitive information in public message areas.
 
 ---
 

--- a/docs/sysop/v3net/felonynet.md
+++ b/docs/sysop/v3net/felonynet.md
@@ -10,6 +10,8 @@ not affect your existing FTN configuration.
 > may change without notice. Use it only if you are testing or contributing
 > to V3Net development. Do not rely on it for a live BBS.
 
+> **Security note:** TLS encrypts traffic in transit. Messages are stored unencrypted on disk at both leaf and hub nodes. FelonyNet is a public network — treat everything you post as public and permanent. See [Security Considerations](configuration.md#security-considerations) for full details.
+
 ## What You Get
 
 - **Message networking** — public message areas synced across all member BBSes
@@ -64,12 +66,27 @@ From the main config menu, open the V3Net networking section:
 Enter - Select  |  ESC/Q - Return
 ```
 
-Select **2. Subscriptions**, then press **I** to launch the **Leaf Setup Wizard**:
+Select **2. Subscriptions**, then press **B** to open the **Network Registry**:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                        Network Registry                              │
+│  Network        Description                    Hub URL               │
+│──────────────────────────────────────────────────────────────────────│
+│  felonynet      Official ViSiON/3 BBS network  https://felonynet.org │
+│                                                                      │
+└──────────────────────────────────────────────────────────────────────┘
+Enter - Select  |  ESC - Back
+```
+
+Select **felonynet** and press **Enter**. The **Leaf Setup Wizard** opens with
+the Hub URL and Network pre-filled:
 
 ```
 ┌──────────────────────────────────────────────────────────────────────┐
 │                     Leaf Setup — Join a Network                      │
 │                                                                      │
+│  Registry        : (press Enter to browse available networks)        │
 │  Hub URL         : https://felonynet.org                             │
 │  Network         : felonynet                                         │
 │  Areas           : (none — press Enter to browse)                    │
@@ -81,15 +98,16 @@ Select **2. Subscriptions**, then press **I** to launch the **Leaf Setup Wizard*
 Enter - Edit  |  S - Save  |  ESC - Back
 ```
 
-Fill in the fields:
+Fill in any remaining fields:
 
 | Field | Value |
 |-------|-------|
-| Hub URL | `https://felonynet.org` |
-| Network | `felonynet` |
 | Areas | Press **Enter** to open the area browser and subscribe |
 | Poll Interval | `5m` (minimum enforced by hub is 60s) |
 | Origin | Your BBS name and address, e.g. `My BBS - bbs.example.com` |
+
+> **Tip:** You can also press **I** on the Subscriptions screen to open a blank
+> wizard and type the Hub URL and Network manually.
 
 Press **Enter** on **Areas** to open the area browser and choose which FelonyNet
 areas to subscribe to:

--- a/docs/sysop/v3net/hub-tls.md
+++ b/docs/sysop/v3net/hub-tls.md
@@ -13,6 +13,13 @@ The V3Net hub uses a standard HTTP server for its WebSocket transport. By
 default it listens on plain HTTP. When both `tlsCert` and `tlsKey` are set
 in the hub configuration, the server switches to HTTPS automatically.
 
+> **TLS covers the wire only.** Enabling HTTPS prevents eavesdropping on
+> connections between leaf nodes and your hub. It does not encrypt messages
+> stored in the hub database — hub operators have full read access to all
+> messages in plaintext. See
+> [Security Considerations](configuration.md#security-considerations) for
+> the full picture.
+
 You have two options:
 
 | Approach | Best For |

--- a/internal/configeditor/fields_wizard.go
+++ b/internal/configeditor/fields_wizard.go
@@ -14,7 +14,11 @@ func (m *Model) fieldsLeafWizard() []fieldDef {
 	w := m.wizard
 	return []fieldDef{
 		{
-			Label: "Hub URL", Help: "URL of the V3Net hub (e.g. https://hub.example.org)", Type: ftString, Col: 3, Row: 1, Width: 45,
+			Label: "Registry", Help: "Press Enter to browse known networks", Type: ftDisplay, Col: 3, Row: 1, Width: 45,
+			Get: func() string { return "(press Enter to browse available networks)" },
+		},
+		{
+			Label: "Hub URL", Help: "URL of the V3Net hub (e.g. https://hub.example.org)", Type: ftString, Col: 3, Row: 2, Width: 45,
 			Get: func() string { return w.hubURL },
 			Set: func(val string) error {
 				val = strings.TrimSpace(val)
@@ -26,7 +30,7 @@ func (m *Model) fieldsLeafWizard() []fieldDef {
 			},
 		},
 		{
-			Label: "Network", Help: "Network name to subscribe to (e.g. felonynet)", Type: ftString, Col: 3, Row: 2, Width: 30,
+			Label: "Network", Help: "Network name to subscribe to (e.g. felonynet)", Type: ftString, Col: 3, Row: 3, Width: 30,
 			Get: func() string { return w.networkName },
 			Set: func(val string) error {
 				val = strings.TrimSpace(val)
@@ -38,7 +42,7 @@ func (m *Model) fieldsLeafWizard() []fieldDef {
 			},
 		},
 		{
-			Label: "Areas", Help: "Press Enter to browse and subscribe to network areas", Type: ftDisplay, Col: 3, Row: 3, Width: 45,
+			Label: "Areas", Help: "Press Enter to browse and subscribe to network areas", Type: ftDisplay, Col: 3, Row: 4, Width: 45,
 			Get: func() string {
 				n := 0
 				for _, a := range w.selectedAreas {
@@ -53,7 +57,7 @@ func (m *Model) fieldsLeafWizard() []fieldDef {
 			},
 		},
 		{
-			Label: "Poll Interval", Help: "How often to poll for new messages (e.g. 5m, 30s, 1h)", Type: ftString, Col: 3, Row: 4, Width: 10,
+			Label: "Poll Interval", Help: "How often to poll for new messages (e.g. 5m, 30s, 1h)", Type: ftString, Col: 3, Row: 5, Width: 10,
 			Get: func() string { return w.pollInterval },
 			Set: func(val string) error {
 				val = strings.TrimSpace(val)
@@ -66,7 +70,7 @@ func (m *Model) fieldsLeafWizard() []fieldDef {
 			},
 		},
 		{
-			Label: "Origin", Help: "Leave blank to use BBS name", Type: ftString, Col: 3, Row: 5, Width: 45,
+			Label: "Origin", Help: "Leave blank to use BBS name", Type: ftString, Col: 3, Row: 6, Width: 45,
 			Get: func() string { return w.origin },
 			Set: func(val string) error {
 				w.origin = strings.TrimSpace(val)

--- a/internal/configeditor/model.go
+++ b/internal/configeditor/model.go
@@ -1,6 +1,7 @@
 package configeditor
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -218,9 +219,11 @@ type Model struct {
 	regBrowserEntries []protocol.RegistryEntry // fetched networks
 	regBrowserCursor  int                      // highlighted row
 	regBrowserScroll  int                      // scroll offset
-	regBrowserLoading bool                     // true while fetch in flight
-	regBrowserError   string                   // error from fetch
-	regBrowserReturn  editorMode               // mode to return to on ESC
+	regBrowserLoading   bool                     // true while fetch in flight
+	regBrowserCancel    context.CancelFunc        // cancels the in-flight fetch
+	regBrowserRequestID uint64                    // monotonic; stale responses are ignored
+	regBrowserError     string                   // error from fetch
+	regBrowserReturn    editorMode               // mode to return to on ESC
 
 	// Seed phrase interstitial (shown after first-time wizard save)
 	showSeedInterstitial   bool

--- a/internal/configeditor/model.go
+++ b/internal/configeditor/model.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
 )
 
 const (
@@ -46,6 +47,7 @@ const (
 	modeNavSaveConfirm                           // Save-and-continue confirm (does not quit)
 	modeWizardExitConfirm                        // Wizard discard/save confirm
 	modeV3NetAreaBrowser                         // Area browser (NAL fetch + subscribe)
+	modeRegistryBrowser                          // Registry browser (discover networks)
 )
 
 // topMenuItem defines an entry in the top-level menu.
@@ -212,6 +214,14 @@ type Model struct {
 	areaBrowserError   string            // error from fetch/subscribe
 	areaBrowserReturn editorMode // mode to return to on ESC
 
+	// V3Net registry browser state
+	regBrowserEntries []protocol.RegistryEntry // fetched networks
+	regBrowserCursor  int                      // highlighted row
+	regBrowserScroll  int                      // scroll offset
+	regBrowserLoading bool                     // true while fetch in flight
+	regBrowserError   string                   // error from fetch
+	regBrowserReturn  editorMode               // mode to return to on ESC
+
 	// Seed phrase interstitial (shown after first-time wizard save)
 	showSeedInterstitial   bool
 	seedInterstitialPhrase string
@@ -304,6 +314,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case subscribeAreasMsg:
 		return m.handleSubscribeAreasMsg(msg)
 
+	case fetchRegistryMsg:
+		return m.handleFetchRegistryMsg(msg)
+
 	case tea.KeyMsg:
 		prevMode := m.mode
 		var result tea.Model
@@ -355,6 +368,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			result, cmd = m.updateWizardExitConfirm(msg)
 		case modeV3NetAreaBrowser:
 			result, cmd = m.updateV3NetAreaBrowser(msg)
+		case modeRegistryBrowser:
+			result, cmd = m.updateRegistryBrowser(msg)
 		default:
 			return m, nil
 		}

--- a/internal/configeditor/model.go
+++ b/internal/configeditor/model.go
@@ -213,7 +213,7 @@ type Model struct {
 	areaBrowserScroll  int               // scroll offset
 	areaBrowserLoading bool              // true while NAL fetch in flight
 	areaBrowserError   string            // error from fetch/subscribe
-	areaBrowserReturn editorMode // mode to return to on ESC
+	areaBrowserReturn  editorMode // mode to return to on ESC
 
 	// V3Net registry browser state
 	regBrowserEntries []protocol.RegistryEntry // fetched networks

--- a/internal/configeditor/update_records.go
+++ b/internal/configeditor/update_records.go
@@ -104,6 +104,11 @@ func (m Model) updateRecordList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.saveAll()
 			}
 			return m, nil
+		case "b", "B":
+			if m.recordType == "v3netleaf" {
+				return m.enterRegistryBrowserForLeafList()
+			}
+			return m, nil
 		case "p", "P":
 			if total > 0 && m.recordTypeSupportsReorder() {
 				m.reorderSourceIdx = m.recordCursor

--- a/internal/configeditor/update_v3net_registry_browser.go
+++ b/internal/configeditor/update_v3net_registry_browser.go
@@ -1,0 +1,151 @@
+package configeditor
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/registry"
+)
+
+// updateRegistryBrowser handles key events in the registry browser.
+func (m Model) updateRegistryBrowser(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.regBrowserLoading {
+		if msg.Type == tea.KeyEscape {
+			m.regBrowserLoading = false
+			m.mode = m.regBrowserReturn
+		}
+		return m, nil
+	}
+
+	total := len(m.regBrowserEntries)
+
+	switch msg.Type {
+	case tea.KeyUp:
+		if m.regBrowserCursor > 0 {
+			m.regBrowserCursor--
+		}
+		m.clampRegBrowserScroll()
+
+	case tea.KeyDown:
+		if m.regBrowserCursor < total-1 {
+			m.regBrowserCursor++
+		}
+		m.clampRegBrowserScroll()
+
+	case tea.KeyHome:
+		m.regBrowserCursor = 0
+		m.clampRegBrowserScroll()
+
+	case tea.KeyEnd:
+		if total > 0 {
+			m.regBrowserCursor = total - 1
+		}
+		m.clampRegBrowserScroll()
+
+	case tea.KeyEnter:
+		if total == 0 || m.regBrowserCursor >= total {
+			return m, nil
+		}
+		entry := m.regBrowserEntries[m.regBrowserCursor]
+		return m.selectRegistryEntry(entry)
+
+	case tea.KeyEscape:
+		m.mode = m.regBrowserReturn
+		return m, nil
+
+	default:
+		switch msg.String() {
+		case "r", "R":
+			if m.regBrowserError != "" {
+				return m.enterRegistryBrowser(m.regBrowserReturn)
+			}
+		}
+	}
+
+	return m, nil
+}
+
+// handleFetchRegistryMsg processes the result of a registry fetch.
+func (m Model) handleFetchRegistryMsg(msg fetchRegistryMsg) (tea.Model, tea.Cmd) {
+	m.regBrowserLoading = false
+	if msg.err != nil {
+		m.regBrowserError = msg.err.Error()
+		return m, nil
+	}
+	m.regBrowserError = ""
+	m.regBrowserEntries = msg.entries
+	return m, nil
+}
+
+// enterRegistryBrowser opens the registry browser, fetching from the configured
+// registry URL (or the default).
+func (m Model) enterRegistryBrowser(returnMode editorMode) (tea.Model, tea.Cmd) {
+	url := registry.DefaultURL
+	if m.configs != nil && m.configs.V3Net.RegistryURL != "" {
+		url = m.configs.V3Net.RegistryURL
+	}
+	m.regBrowserEntries = nil
+	m.regBrowserCursor = 0
+	m.regBrowserScroll = 0
+	m.regBrowserLoading = true
+	m.regBrowserError = ""
+	m.regBrowserReturn = returnMode
+	m.message = ""
+	m.mode = modeRegistryBrowser
+	return m, fetchRegistry(url)
+}
+
+// selectRegistryEntry fills the wizard fields from a selected registry entry
+// and returns to the wizard form. If no wizard is active (browsing from the
+// record list), a new leaf wizard is created pre-filled with the entry.
+func (m Model) selectRegistryEntry(entry protocol.RegistryEntry) (tea.Model, tea.Cmd) {
+	if m.wizard == nil {
+		// Launched from the record list — create a pre-filled leaf wizard.
+		var boardName string
+		if m.configs != nil {
+			boardName = m.configs.Server.BoardName
+		}
+		m.wizard = &wizardState{
+			flow:         "leaf",
+			hubURL:       entry.HubURL,
+			networkName:  entry.Name,
+			pollInterval: "5m",
+			origin:       boardName,
+		}
+		m.wizardTitle = "Leaf Setup — Join a Network"
+		m.wizardFields = m.fieldsLeafWizard()
+		m.editField = 0
+		m.fieldScroll = 0
+		m.message = "Selected " + entry.Name
+		m.mode = modeWizardForm
+		return m, nil
+	}
+
+	// Already in wizard — update its fields and return.
+	m.wizard.hubURL = entry.HubURL
+	m.wizard.networkName = entry.Name
+	m.wizardFields = m.fieldsLeafWizard()
+	m.message = "Selected " + entry.Name
+	m.mode = m.regBrowserReturn
+	return m, nil
+}
+
+// enterRegistryBrowserForLeafList opens the registry browser from the leaf
+// subscription list. On selection it creates a pre-filled leaf wizard.
+func (m Model) enterRegistryBrowserForLeafList() (tea.Model, tea.Cmd) {
+	return m.enterRegistryBrowser(modeRecordList)
+}
+
+// clampRegBrowserScroll ensures the cursor is visible in the registry list.
+func (m *Model) clampRegBrowserScroll() {
+	visible := regBrowserListVisible
+	if m.regBrowserScroll > m.regBrowserCursor {
+		m.regBrowserScroll = m.regBrowserCursor
+	}
+	if m.regBrowserCursor >= m.regBrowserScroll+visible {
+		m.regBrowserScroll = m.regBrowserCursor - visible + 1
+	}
+	if m.regBrowserScroll < 0 {
+		m.regBrowserScroll = 0
+	}
+}

--- a/internal/configeditor/update_v3net_registry_browser.go
+++ b/internal/configeditor/update_v3net_registry_browser.go
@@ -2,6 +2,9 @@ package configeditor
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net/url"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -88,7 +91,12 @@ func (m Model) handleFetchRegistryMsg(msg fetchRegistryMsg) (tea.Model, tea.Cmd)
 		m.regBrowserCancel = nil
 	}
 	if msg.err != nil {
-		m.regBrowserError = msg.err.Error()
+		cause := msg.err
+		var urlErr *url.Error
+		if errors.As(msg.err, &urlErr) {
+			cause = urlErr.Err
+		}
+		m.regBrowserError = fmt.Sprintf("Could not fetch registry: %v", cause)
 		return m, nil
 	}
 	m.regBrowserError = ""

--- a/internal/configeditor/update_v3net_registry_browser.go
+++ b/internal/configeditor/update_v3net_registry_browser.go
@@ -1,6 +1,9 @@
 package configeditor
 
 import (
+	"context"
+	"time"
+
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
@@ -11,6 +14,10 @@ import (
 func (m Model) updateRegistryBrowser(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.regBrowserLoading {
 		if msg.Type == tea.KeyEscape {
+			if m.regBrowserCancel != nil {
+				m.regBrowserCancel()
+				m.regBrowserCancel = nil
+			}
 			m.regBrowserLoading = false
 			m.mode = m.regBrowserReturn
 		}
@@ -71,7 +78,15 @@ func (m Model) updateRegistryBrowser(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 // handleFetchRegistryMsg processes the result of a registry fetch.
 func (m Model) handleFetchRegistryMsg(msg fetchRegistryMsg) (tea.Model, tea.Cmd) {
+	// Ignore stale responses from a previous (cancelled or retried) fetch.
+	if msg.requestID != m.regBrowserRequestID {
+		return m, nil
+	}
 	m.regBrowserLoading = false
+	if m.regBrowserCancel != nil {
+		m.regBrowserCancel()
+		m.regBrowserCancel = nil
+	}
 	if msg.err != nil {
 		m.regBrowserError = msg.err.Error()
 		return m, nil
@@ -88,15 +103,22 @@ func (m Model) enterRegistryBrowser(returnMode editorMode) (tea.Model, tea.Cmd) 
 	if m.configs != nil && m.configs.V3Net.RegistryURL != "" {
 		url = m.configs.V3Net.RegistryURL
 	}
+	// Cancel any previous in-flight fetch.
+	if m.regBrowserCancel != nil {
+		m.regBrowserCancel()
+	}
+	m.regBrowserRequestID++
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	m.regBrowserEntries = nil
 	m.regBrowserCursor = 0
 	m.regBrowserScroll = 0
 	m.regBrowserLoading = true
+	m.regBrowserCancel = cancel
 	m.regBrowserError = ""
 	m.regBrowserReturn = returnMode
 	m.message = ""
 	m.mode = modeRegistryBrowser
-	return m, fetchRegistry(url)
+	return m, fetchRegistry(ctx, m.regBrowserRequestID, url)
 }
 
 // selectRegistryEntry fills the wizard fields from a selected registry entry

--- a/internal/configeditor/update_v3net_registry_browser.go
+++ b/internal/configeditor/update_v3net_registry_browser.go
@@ -47,6 +47,10 @@ func (m Model) updateRegistryBrowser(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		entry := m.regBrowserEntries[m.regBrowserCursor]
+		if m.isLeafSubscribed(entry.Name) {
+			m.message = "Already subscribed to " + entry.Name
+			return m, nil
+		}
 		return m.selectRegistryEntry(entry)
 
 	case tea.KeyEscape:
@@ -134,6 +138,20 @@ func (m Model) selectRegistryEntry(entry protocol.RegistryEntry) (tea.Model, tea
 // subscription list. On selection it creates a pre-filled leaf wizard.
 func (m Model) enterRegistryBrowserForLeafList() (tea.Model, tea.Cmd) {
 	return m.enterRegistryBrowser(modeRecordList)
+}
+
+// isLeafSubscribed returns true if a leaf subscription already exists for the
+// given network name.
+func (m Model) isLeafSubscribed(network string) bool {
+	if m.configs == nil {
+		return false
+	}
+	for _, l := range m.configs.V3Net.Leaves {
+		if l.Network == network {
+			return true
+		}
+	}
+	return false
 }
 
 // clampRegBrowserScroll ensures the cursor is visible in the registry list.

--- a/internal/configeditor/update_v3net_registry_browser.go
+++ b/internal/configeditor/update_v3net_registry_browser.go
@@ -96,7 +96,7 @@ func (m Model) handleFetchRegistryMsg(msg fetchRegistryMsg) (tea.Model, tea.Cmd)
 		if errors.As(msg.err, &urlErr) {
 			cause = urlErr.Err
 		}
-		m.regBrowserError = fmt.Sprintf("Could not fetch registry: %v", cause)
+		m.regBrowserError = fmt.Sprintf("Could not fetch registry: %v", sanitizeRegistryField(cause.Error()))
 		return m, nil
 	}
 	m.regBrowserError = ""

--- a/internal/configeditor/update_wizard_form.go
+++ b/internal/configeditor/update_wizard_form.go
@@ -39,6 +39,10 @@ func (m Model) updateWizardForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.mode = modeV3NetWizardStep
 			return m, nil
 		}
+		// Leaf wizard "Registry" field opens the registry browser.
+		if f.Type == ftDisplay && m.wizard.flow == "leaf" && f.Label == "Registry" {
+			return m.enterRegistryBrowser(modeWizardForm)
+		}
 		// Leaf wizard "Areas" field opens the area browser.
 		if f.Type == ftDisplay && m.wizard.flow == "leaf" && f.Label == "Areas" {
 			if m.wizard.hubURL == "" {

--- a/internal/configeditor/v3net_area_browser_helpers.go
+++ b/internal/configeditor/v3net_area_browser_helpers.go
@@ -7,6 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/conference"
 	"github.com/ViSiON-3/vision-3-bbs/internal/message"
 )
 
@@ -179,19 +180,53 @@ func (m *Model) createBrowserMsgAreaIfNeeded(tag, name, network string) {
 	if safeName == "" {
 		safeName = fmt.Sprintf("unnamed_%d", newID)
 	}
+	confID := m.findOrCreateNetworkConference(network)
 	m.configs.MsgAreas = append(m.configs.MsgAreas, message.MessageArea{
-		ID:       newID,
-		Position: maxPos + 1,
-		Tag:      tag,
-		Name:     name,
-		AreaType: "v3net",
-		Network:  network,
-		EchoTag:  tag,
-		AutoJoin: true,
-		ACSRead:  "s10",
-		ACSWrite: "s20",
-		BasePath: filepath.Join("msgbases", safeName),
+		ID:           newID,
+		Position:     maxPos + 1,
+		Tag:          tag,
+		Name:         name,
+		AreaType:     "v3net",
+		Network:      network,
+		EchoTag:      tag,
+		AutoJoin:     true,
+		ACSRead:      "s10",
+		ACSWrite:     "s20",
+		BasePath:     filepath.Join("msgbases", safeName),
+		ConferenceID: confID,
 	})
+}
+
+// findOrCreateNetworkConference returns the conference ID for a V3Net network,
+// creating one if none exists. It looks for an existing conference whose tag
+// matches the uppercase network name.
+func (m *Model) findOrCreateNetworkConference(network string) int {
+	upperNet := strings.ToUpper(network)
+	for _, c := range m.configs.Conferences {
+		if strings.ToUpper(c.Tag) == upperNet {
+			return c.ID
+		}
+	}
+	// Create a new conference for this network.
+	newID := 1
+	maxPos := 0
+	for _, c := range m.configs.Conferences {
+		if c.ID >= newID {
+			newID = c.ID + 1
+		}
+		if c.Position > maxPos {
+			maxPos = c.Position
+		}
+	}
+	m.configs.Conferences = append(m.configs.Conferences, conference.Conference{
+		ID:          newID,
+		Position:    maxPos + 1,
+		Tag:         upperNet,
+		Name:        network,
+		Description: network + " message network",
+		ACS:         "s10",
+	})
+	return newID
 }
 
 // clampAreaBrowserScroll ensures the cursor is visible in the list window.

--- a/internal/configeditor/v3net_area_browser_helpers.go
+++ b/internal/configeditor/v3net_area_browser_helpers.go
@@ -1,7 +1,9 @@
 package configeditor
 
 import (
+	"errors"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -30,7 +32,12 @@ func defaultLocalBoardName(network, areaName string) string {
 func (m Model) handleFetchNALMsg(msg fetchNALMsg) (tea.Model, tea.Cmd) {
 	m.areaBrowserLoading = false
 	if msg.err != nil {
-		m.areaBrowserError = fmt.Sprintf("Could not fetch areas: %v", msg.err)
+		cause := msg.err
+		var urlErr *url.Error
+		if errors.As(msg.err, &urlErr) {
+			cause = urlErr.Err
+		}
+		m.areaBrowserError = fmt.Sprintf("Could not fetch areas: %v", cause)
 		return m, nil
 	}
 

--- a/internal/configeditor/v3net_registry_browser_cmds.go
+++ b/internal/configeditor/v3net_registry_browser_cmds.go
@@ -1,0 +1,24 @@
+package configeditor
+
+import (
+	"context"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/registry"
+)
+
+// fetchRegistryMsg is the result of fetching the V3Net network registry.
+type fetchRegistryMsg struct {
+	entries []protocol.RegistryEntry
+	err     error
+}
+
+// fetchRegistry returns a tea.Cmd that fetches the V3Net network registry.
+func fetchRegistry(url string) tea.Cmd {
+	return func() tea.Msg {
+		entries, err := registry.Fetch(context.Background(), url)
+		return fetchRegistryMsg{entries: entries, err: err}
+	}
+}

--- a/internal/configeditor/v3net_registry_browser_cmds.go
+++ b/internal/configeditor/v3net_registry_browser_cmds.go
@@ -11,14 +11,15 @@ import (
 
 // fetchRegistryMsg is the result of fetching the V3Net network registry.
 type fetchRegistryMsg struct {
-	entries []protocol.RegistryEntry
-	err     error
+	requestID uint64
+	entries   []protocol.RegistryEntry
+	err       error
 }
 
 // fetchRegistry returns a tea.Cmd that fetches the V3Net network registry.
-func fetchRegistry(url string) tea.Cmd {
+func fetchRegistry(ctx context.Context, requestID uint64, url string) tea.Cmd {
 	return func() tea.Msg {
-		entries, err := registry.Fetch(context.Background(), url)
-		return fetchRegistryMsg{entries: entries, err: err}
+		entries, err := registry.Fetch(ctx, url)
+		return fetchRegistryMsg{requestID: requestID, entries: entries, err: err}
 	}
 }

--- a/internal/configeditor/view.go
+++ b/internal/configeditor/view.go
@@ -65,6 +65,8 @@ func (m Model) View() string {
 			"Rename JAM base path on disk?")
 	case modeV3NetAreaBrowser:
 		return m.viewV3NetAreaBrowser()
+	case modeRegistryBrowser:
+		return m.viewRegistryBrowser()
 	}
 	return m.viewTopMenu()
 }

--- a/internal/configeditor/view_list.go
+++ b/internal/configeditor/view_list.go
@@ -132,7 +132,9 @@ func (m Model) viewRecordList() string {
 		helpStr = "Enter - Edit  |  I - Insert  |  D - Delete  |  P - Position  |  ESC - Return"
 	} else if m.recordType == "ftn" {
 		helpStr = "Enter - Edit  |  I - Insert  |  D - Delete  |  G - Global  |  ESC - Return"
-	} else if m.recordType == "v3netleaf" || m.recordType == "v3nethub" {
+	} else if m.recordType == "v3netleaf" {
+		helpStr = "Enter - Edit  |  I - New (Wizard)  |  B - Registry  |  D - Delete  |  S - Save  |  ESC - Return"
+	} else if m.recordType == "v3nethub" {
 		helpStr = "Enter - Edit  |  I - New (Wizard)  |  D - Delete  |  S - Save  |  ESC - Return"
 	} else if m.recordType == "ftnlink" {
 		helpStr = "Enter - Edit  |  I - Insert  |  D - Delete  |  ESC - Return"

--- a/internal/configeditor/view_v3net_area_browser.go
+++ b/internal/configeditor/view_v3net_area_browser.go
@@ -74,8 +74,12 @@ func (m Model) viewV3NetAreaBrowser() string {
 	}
 
 	if m.areaBrowserError != "" && total == 0 {
+		errText := " " + m.areaBrowserError
+		if len([]rune(errText)) > boxW {
+			errText = string([]rune(errText)[:boxW-3]) + "..."
+		}
 		b.WriteString(border(menuBorderStyle.Render("│") +
-			flashMessageStyle.Render(padRight(" "+m.areaBrowserError, boxW)) +
+			flashMessageStyle.Render(padRight(errText, boxW)) +
 			menuBorderStyle.Render("│")))
 		b.WriteByte('\n')
 		for i := 0; i < listVisible+1; i++ {

--- a/internal/configeditor/view_v3net_registry_browser.go
+++ b/internal/configeditor/view_v3net_registry_browser.go
@@ -89,8 +89,12 @@ func (m Model) viewRegistryBrowser() string {
 	}
 
 	if m.regBrowserError != "" && total == 0 {
+		errText := " " + m.regBrowserError
+		if len([]rune(errText)) > boxW {
+			errText = string([]rune(errText)[:boxW-3]) + "..."
+		}
 		b.WriteString(border(menuBorderStyle.Render("│") +
-			flashMessageStyle.Render(padRight(" "+m.regBrowserError, boxW)) +
+			flashMessageStyle.Render(padRight(errText, boxW)) +
 			menuBorderStyle.Render("│")))
 		b.WriteByte('\n')
 		for i := 0; i < listVisible+1; i++ {

--- a/internal/configeditor/view_v3net_registry_browser.go
+++ b/internal/configeditor/view_v3net_registry_browser.go
@@ -3,10 +3,22 @@ package configeditor
 import (
 	"fmt"
 	"strings"
+	"unicode"
 )
 
 // regBrowserListVisible is the number of visible rows in the registry list.
 const regBrowserListVisible = 10
+
+// sanitizeRegistryField strips control characters from untrusted registry
+// data to prevent ANSI/OSC escape injection in the TUI.
+func sanitizeRegistryField(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
+}
 
 // viewRegistryBrowser renders the registry browser screen.
 func (m Model) viewRegistryBrowser() string {
@@ -64,7 +76,7 @@ func (m Model) viewRegistryBrowser() string {
 		}
 		b.WriteString(border(menuBorderStyle.Render("└" + strings.Repeat("─", boxW) + "┘")))
 		b.WriteByte('\n')
-		for i := 0; i < bottomPad+1; i++ {
+		for i := 0; i < bottomPad; i++ {
 			b.WriteString(bgLine)
 			b.WriteByte('\n')
 		}
@@ -89,7 +101,7 @@ func (m Model) viewRegistryBrowser() string {
 		}
 		b.WriteString(border(menuBorderStyle.Render("└" + strings.Repeat("─", boxW) + "┘")))
 		b.WriteByte('\n')
-		for i := 0; i < bottomPad+1; i++ {
+		for i := 0; i < bottomPad; i++ {
 			b.WriteString(bgLine)
 			b.WriteByte('\n')
 		}
@@ -127,15 +139,15 @@ func (m Model) viewRegistryBrowser() string {
 			if subscribed {
 				tag = "* "
 			}
-			name := padRight(e.Name, 14)
+			name := padRight(sanitizeRegistryField(e.Name), 14)
 			if len(name) > 14 {
 				name = name[:14]
 			}
-			desc := padRight(e.Description, 28)
+			desc := padRight(sanitizeRegistryField(e.Description), 28)
 			if len(desc) > 28 {
 				desc = desc[:28]
 			}
-			hubURL := e.HubURL
+			hubURL := sanitizeRegistryField(e.HubURL)
 			maxURL := boxW - 14 - 28 - 6
 			if len(hubURL) > maxURL {
 				hubURL = hubURL[:maxURL]

--- a/internal/configeditor/view_v3net_registry_browser.go
+++ b/internal/configeditor/view_v3net_registry_browser.go
@@ -103,7 +103,7 @@ func (m Model) viewRegistryBrowser() string {
 	}
 
 	// Column header.
-	colHeader := fmt.Sprintf("  %-14s %-30s %s", "Network", "Description", "Hub URL")
+	colHeader := fmt.Sprintf("  %-14s %-28s %s", "Network", "Description", "Hub URL")
 	b.WriteString(border(menuBorderStyle.Render("│") +
 		menuHeaderStyle.Render(padRight(colHeader, boxW)) +
 		menuBorderStyle.Render("│")))
@@ -122,20 +122,25 @@ func (m Model) viewRegistryBrowser() string {
 
 		if visIdx >= 0 && visIdx < total {
 			e := m.regBrowserEntries[visIdx]
+			subscribed := m.isLeafSubscribed(e.Name)
+			tag := "  "
+			if subscribed {
+				tag = "* "
+			}
 			name := padRight(e.Name, 14)
 			if len(name) > 14 {
 				name = name[:14]
 			}
-			desc := padRight(e.Description, 30)
-			if len(desc) > 30 {
-				desc = desc[:30]
+			desc := padRight(e.Description, 28)
+			if len(desc) > 28 {
+				desc = desc[:28]
 			}
 			hubURL := e.HubURL
-			maxURL := boxW - 14 - 30 - 4
+			maxURL := boxW - 14 - 28 - 6
 			if len(hubURL) > maxURL {
 				hubURL = hubURL[:maxURL]
 			}
-			content = fmt.Sprintf("  %-14s %-30s %s", name, desc, hubURL)
+			content = fmt.Sprintf("%s%-14s %-28s %s", tag, name, desc, hubURL)
 		}
 
 		if content == "" {
@@ -182,7 +187,7 @@ func (m Model) viewRegistryBrowser() string {
 	b.WriteByte('\n')
 
 	// Help bar.
-	helpStr := "Enter - Select  |  ESC - Back"
+	helpStr := "Enter - Select  |  ESC - Back  |  * = subscribed"
 	b.WriteString(helpBarStyle.Render(centerText(helpStr, m.width)))
 
 	return b.String()

--- a/internal/configeditor/view_v3net_registry_browser.go
+++ b/internal/configeditor/view_v3net_registry_browser.go
@@ -140,17 +140,11 @@ func (m Model) viewRegistryBrowser() string {
 				tag = "* "
 			}
 			name := padRight(sanitizeRegistryField(e.Name), 14)
-			if len(name) > 14 {
-				name = name[:14]
-			}
 			desc := padRight(sanitizeRegistryField(e.Description), 28)
-			if len(desc) > 28 {
-				desc = desc[:28]
-			}
 			hubURL := sanitizeRegistryField(e.HubURL)
 			maxURL := boxW - 14 - 28 - 6
-			if len(hubURL) > maxURL {
-				hubURL = hubURL[:maxURL]
+			if runeLen := len([]rune(hubURL)); runeLen > maxURL {
+				hubURL = string([]rune(hubURL)[:maxURL])
 			}
 			content = fmt.Sprintf("%s%-14s %-28s %s", tag, name, desc, hubURL)
 		}

--- a/internal/configeditor/view_v3net_registry_browser.go
+++ b/internal/configeditor/view_v3net_registry_browser.go
@@ -1,0 +1,189 @@
+package configeditor
+
+import (
+	"fmt"
+	"strings"
+)
+
+// regBrowserListVisible is the number of visible rows in the registry list.
+const regBrowserListVisible = 10
+
+// viewRegistryBrowser renders the registry browser screen.
+func (m Model) viewRegistryBrowser() string {
+	var b strings.Builder
+	b.WriteString(m.globalHeaderLine())
+	b.WriteByte('\n')
+
+	bgLine := bgFillStyle.Render(strings.Repeat("░", m.width))
+	boxW := 70
+	listVisible := regBrowserListVisible
+	total := len(m.regBrowserEntries)
+
+	// Fixed rows: header(1) + border(1) + title(1) + colheader(1) + sep(1)
+	//           + list(10) + border(1) + msg(1) + bgLine(1) + help(1)
+	fixedRows := listVisible + 9
+	extraV := maxInt(0, m.height-fixedRows)
+	topPad := extraV / 2
+	bottomPad := extraV - topPad
+
+	for i := 0; i < topPad; i++ {
+		b.WriteString(bgLine)
+		b.WriteByte('\n')
+	}
+
+	padL := maxInt(0, (m.width-boxW-2)/2)
+	padR := maxInt(0, m.width-padL-boxW-2)
+
+	border := func(s string) string {
+		return bgFillStyle.Render(strings.Repeat("░", padL)) + s +
+			bgFillStyle.Render(strings.Repeat("░", maxInt(0, padR)))
+	}
+
+	// Top border.
+	b.WriteString(border(menuBorderStyle.Render("┌" + strings.Repeat("─", boxW) + "┐")))
+	b.WriteByte('\n')
+
+	// Title.
+	title := "Network Registry"
+	b.WriteString(border(menuBorderStyle.Render("│") +
+		menuHeaderStyle.Render(centerText(title, boxW)) +
+		menuBorderStyle.Render("│")))
+	b.WriteByte('\n')
+
+	// Handle special states.
+	if m.regBrowserLoading {
+		b.WriteString(border(menuBorderStyle.Render("│") +
+			menuItemStyle.Render(centerText("Fetching registry...", boxW)) +
+			menuBorderStyle.Render("│")))
+		b.WriteByte('\n')
+		for i := 0; i < listVisible+1; i++ {
+			b.WriteString(border(menuBorderStyle.Render("│") +
+				menuItemStyle.Render(strings.Repeat(" ", boxW)) +
+				menuBorderStyle.Render("│")))
+			b.WriteByte('\n')
+		}
+		b.WriteString(border(menuBorderStyle.Render("└" + strings.Repeat("─", boxW) + "┘")))
+		b.WriteByte('\n')
+		for i := 0; i < bottomPad+1; i++ {
+			b.WriteString(bgLine)
+			b.WriteByte('\n')
+		}
+		b.WriteString(bgLine)
+		b.WriteByte('\n')
+		b.WriteString(bgLine)
+		b.WriteByte('\n')
+		b.WriteString(helpBarStyle.Render(centerText("ESC - Cancel", m.width)))
+		return b.String()
+	}
+
+	if m.regBrowserError != "" && total == 0 {
+		b.WriteString(border(menuBorderStyle.Render("│") +
+			flashMessageStyle.Render(padRight(" "+m.regBrowserError, boxW)) +
+			menuBorderStyle.Render("│")))
+		b.WriteByte('\n')
+		for i := 0; i < listVisible+1; i++ {
+			b.WriteString(border(menuBorderStyle.Render("│") +
+				menuItemStyle.Render(strings.Repeat(" ", boxW)) +
+				menuBorderStyle.Render("│")))
+			b.WriteByte('\n')
+		}
+		b.WriteString(border(menuBorderStyle.Render("└" + strings.Repeat("─", boxW) + "┘")))
+		b.WriteByte('\n')
+		for i := 0; i < bottomPad+1; i++ {
+			b.WriteString(bgLine)
+			b.WriteByte('\n')
+		}
+		b.WriteString(bgLine)
+		b.WriteByte('\n')
+		b.WriteString(bgLine)
+		b.WriteByte('\n')
+		helpStr := "R - Retry  |  ESC - Back"
+		b.WriteString(helpBarStyle.Render(centerText(helpStr, m.width)))
+		return b.String()
+	}
+
+	// Column header.
+	colHeader := fmt.Sprintf("  %-14s %-30s %s", "Network", "Description", "Hub URL")
+	b.WriteString(border(menuBorderStyle.Render("│") +
+		menuHeaderStyle.Render(padRight(colHeader, boxW)) +
+		menuBorderStyle.Render("│")))
+	b.WriteByte('\n')
+
+	// Separator.
+	b.WriteString(border(menuBorderStyle.Render("│") +
+		separatorStyle.Render(strings.Repeat("─", boxW)) +
+		menuBorderStyle.Render("│")))
+	b.WriteByte('\n')
+
+	// List rows.
+	for row := 0; row < listVisible; row++ {
+		visIdx := m.regBrowserScroll + row
+		var content string
+
+		if visIdx >= 0 && visIdx < total {
+			e := m.regBrowserEntries[visIdx]
+			name := padRight(e.Name, 14)
+			if len(name) > 14 {
+				name = name[:14]
+			}
+			desc := padRight(e.Description, 30)
+			if len(desc) > 30 {
+				desc = desc[:30]
+			}
+			hubURL := e.HubURL
+			maxURL := boxW - 14 - 30 - 4
+			if len(hubURL) > maxURL {
+				hubURL = hubURL[:maxURL]
+			}
+			content = fmt.Sprintf("  %-14s %-30s %s", name, desc, hubURL)
+		}
+
+		if content == "" {
+			content = strings.Repeat(" ", boxW)
+		}
+		if len(content) < boxW {
+			content += strings.Repeat(" ", boxW-len(content))
+		} else if len(content) > boxW {
+			content = content[:boxW]
+		}
+
+		var styled string
+		if visIdx == m.regBrowserCursor {
+			styled = menuHighlightStyle.Render(content)
+		} else {
+			styled = menuItemStyle.Render(content)
+		}
+
+		b.WriteString(border(menuBorderStyle.Render("│") + styled + menuBorderStyle.Render("│")))
+		b.WriteByte('\n')
+	}
+
+	// Bottom border.
+	b.WriteString(border(menuBorderStyle.Render("└" + strings.Repeat("─", boxW) + "┘")))
+	b.WriteByte('\n')
+
+	for i := 0; i < bottomPad; i++ {
+		b.WriteString(bgLine)
+		b.WriteByte('\n')
+	}
+
+	// Help row (message or blank).
+	if m.message != "" {
+		msgLine := bgFillStyle.Render(strings.Repeat("░", padL)) +
+			flashMessageStyle.Render(" "+padRight(m.message, boxW)) +
+			bgFillStyle.Render(strings.Repeat("░", maxInt(0, padR+1)))
+		b.WriteString(msgLine)
+	} else {
+		b.WriteString(bgLine)
+	}
+	b.WriteByte('\n')
+
+	b.WriteString(bgLine)
+	b.WriteByte('\n')
+
+	// Help bar.
+	helpStr := "Enter - Select  |  ESC - Back"
+	b.WriteString(helpBarStyle.Render(centerText(helpStr, m.width)))
+
+	return b.String()
+}

--- a/internal/v3net/hub/handlers.go
+++ b/internal/v3net/hub/handlers.go
@@ -405,8 +405,9 @@ func (h *Hub) handleSubscribe(w http.ResponseWriter, r *http.Request) {
 		}
 
 		writeJSON(w, http.StatusOK, protocol.SubscribeWithAreasResponse{
-			OK:    true,
-			Areas: areaStatuses,
+			OK:     true,
+			Status: actualStatus,
+			Areas:  areaStatuses,
 		})
 		return
 	}

--- a/internal/v3net/leaf/sender.go
+++ b/internal/v3net/leaf/sender.go
@@ -48,7 +48,7 @@ func (l *Leaf) subscribe(ctx context.Context) error {
 		return fmt.Errorf("leaf: subscribe returned %d: %s", resp.StatusCode, string(body))
 	}
 
-	var sr protocol.SubscribeResponse
+	var sr protocol.SubscribeWithAreasResponse
 	if err := json.Unmarshal(body, &sr); err != nil {
 		return fmt.Errorf("leaf: parse subscribe response: %w", err)
 	}

--- a/internal/v3net/protocol/network.go
+++ b/internal/v3net/protocol/network.go
@@ -154,8 +154,9 @@ type AreaSubscriptionStatus struct {
 
 // SubscribeWithAreasResponse is the response when area_tags are provided.
 type SubscribeWithAreasResponse struct {
-	OK    bool                     `json:"ok"`
-	Areas []AreaSubscriptionStatus `json:"areas,omitempty"`
+	OK     bool                     `json:"ok"`
+	Status string                   `json:"status"`
+	Areas  []AreaSubscriptionStatus `json:"areas,omitempty"`
 }
 
 // CoordTransferRequest is the body of POST /coordinator/transfer.

--- a/internal/v3net/protocol/network.go
+++ b/internal/v3net/protocol/network.go
@@ -153,6 +153,8 @@ type AreaSubscriptionStatus struct {
 }
 
 // SubscribeWithAreasResponse is the response when area_tags are provided.
+// Status is the network-level subscription status (e.g. "active", "pending").
+// Areas contains per-area subscription statuses; may be empty if no areas were processed.
 type SubscribeWithAreasResponse struct {
 	OK     bool                     `json:"ok"`
 	Status string                   `json:"status"`

--- a/internal/v3net/registry/registry.go
+++ b/internal/v3net/registry/registry.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"sync"
@@ -20,6 +21,9 @@ const cacheTTL = 1 * time.Hour
 
 // httpTimeout is the maximum time allowed for a registry fetch.
 const httpTimeout = 30 * time.Second
+
+// maxRegistryBytes caps the response body size to prevent memory exhaustion.
+const maxRegistryBytes = 1 << 20 // 1 MB
 
 type cacheEntry struct {
 	networks  []protocol.RegistryEntry
@@ -79,8 +83,16 @@ func fetchRemote(ctx context.Context, url string) ([]protocol.RegistryEntry, err
 		return nil, fmt.Errorf("GET %s returned %d", url, resp.StatusCode)
 	}
 
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxRegistryBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read registry: %w", err)
+	}
+	if len(body) > maxRegistryBytes {
+		return nil, fmt.Errorf("registry: response too large (max %d bytes)", maxRegistryBytes)
+	}
+
 	var reg protocol.Registry
-	if err := json.NewDecoder(resp.Body).Decode(&reg); err != nil {
+	if err := json.Unmarshal(body, &reg); err != nil {
 		return nil, fmt.Errorf("decode registry: %w", err)
 	}
 

--- a/templates/configs/v3net.json
+++ b/templates/configs/v3net.json
@@ -13,7 +13,7 @@
   },
   "leaves": [
     {
-      "hubUrl": "http://felonynet.org",
+      "hubUrl": "https://felonynet.org",
       "network": "felonynet",
       "boards": [],
       "pollInterval": "5m"

--- a/templates/configs/v3net.json
+++ b/templates/configs/v3net.json
@@ -13,7 +13,7 @@
   },
   "leaves": [
     {
-      "hubUrl": "https://felonynet.org",
+      "hubUrl": "http://felonynet.org",
       "network": "felonynet",
       "boards": [],
       "pollInterval": "5m"


### PR DESCRIPTION
## Summary

Adds a **Network Registry Browser** to the V3Net Subscriptions screen, allowing sysops to discover and join available V3Net networks directly from the TUI config editor.

## What's New

### Registry Browser (3 new files)
- **`v3net_registry_browser_cmds.go`** — Async Bubbletea command to fetch registry data via `registry.Fetch()`
- **`update_v3net_registry_browser.go`** — Key handlers (navigation, selection, retry), `enterRegistryBrowser()`, `selectRegistryEntry()` logic
- **`view_v3net_registry_browser.go`** — TUI rendering with loading, error, and normal list states; 3-column layout (Name, Description, Hub URL)

### Two Entry Points
1. **`B` key on Subscriptions record list** — Opens registry browser; selecting a network creates a pre-filled leaf wizard
2. **`Registry` field in leaf wizard** — Press Enter to browse; selecting fills Hub URL and Network Name automatically

### Changes to Existing Files
- **`model.go`** — New `modeRegistryBrowser` mode constant, state fields, `fetchRegistryMsg` wiring in `Update()` type switch
- **`fields_wizard.go`** — Added `Registry` display field at top of leaf wizard (Row 1), shifted other fields down
- **`update_wizard_form.go`** — Handler for Registry field Enter key
- **`update_records.go`** — `B` key handler for `v3netleaf` record type
- **`view_list.go`** — Split `v3netleaf`/`v3nethub` help bars; leaf now shows `B - Registry`
- **`view.go`** — Mode dispatch for registry browser

### Documentation Updates
- **`configuration.md`** — Documents registry browser, updated wizard fields, updated help bar
- **`felonynet.md`** — Step 2 updated with registry browser flow (B → browse → select → wizard)
- **`hub-tls.md`** — Fixed broken relative doc links

## Testing
- `go build ./...` ✅
- `go test ./...` ✅
- `go vet ./internal/configeditor/...` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Network Registry browser allows discovering and selecting available networks
  * Added Registry entry point (B key) as alternative to manual wizard setup

* **Bug Fixes**
  * Improved error message truncation for terminal display
  * Added security size limit to remote registry fetches

* **Documentation**
  * New Security Considerations section detailing plaintext storage behavior
  * Clarified TLS encryption applies only to in-transit traffic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->