### PR TITLE
fix: allow config editor to open with incomplete FTN config (#15)

### DIFF
--- a/cmd/v3mail/cmd_ftn.go
+++ b/cmd/v3mail/cmd_ftn.go
@@ -212,6 +212,9 @@ func loadFTNDeps(configDir, dataDir string) (config.FTNConfig, *message.MessageM
 	if err != nil {
 		return config.FTNConfig{}, nil, nil, fmt.Errorf("load ftn config: %w", err)
 	}
+	if err := config.ValidateFTNConfig(ftnCfg); err != nil {
+		return config.FTNConfig{}, nil, nil, fmt.Errorf("ftn config invalid: %w", err)
+	}
 
 	// BBS root = directory containing the data folder (for resolving relative FTN paths)
 	absData, err := filepath.Abs(dataDir)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1002,26 +1002,35 @@ func LoadFTNConfig(configPath string) (FTNConfig, error) {
 	}
 	log.Printf("INFO: Loaded FTN configuration: %d network(s), %d with internal tosser enabled", len(config.Networks), enabledCount)
 
-	// Validate required global path fields when any network has the internal tosser enabled.
-	if enabledCount > 0 {
+	return config, nil
+}
+
+// ValidateFTNConfig checks that all required global path fields are set for any
+// network that has internal_tosser_enabled=true. Call this before starting the
+// tosser, not during editing, so the config editor can open an incomplete config.
+func ValidateFTNConfig(cfg FTNConfig) error {
+	for name, net := range cfg.Networks {
+		if !net.InternalTosserEnabled {
+			continue
+		}
 		type requiredPath struct {
 			field string
 			value string
 		}
 		required := []requiredPath{
-			{"inbound_path", config.InboundPath},
-			{"outbound_path", config.OutboundPath},
-			{"binkd_outbound_path", config.BinkdOutboundPath},
-			{"temp_path", config.TempPath},
+			{"inbound_path", cfg.InboundPath},
+			{"outbound_path", cfg.OutboundPath},
+			{"binkd_outbound_path", cfg.BinkdOutboundPath},
+			{"temp_path", cfg.TempPath},
 		}
 		for _, r := range required {
 			if strings.TrimSpace(r.value) == "" {
-				return defaultConfig, fmt.Errorf("ftn.json: %q is required when internal_tosser_enabled is true", r.field)
+				return fmt.Errorf("ftn.json: %q is required when internal_tosser_enabled is true (network %q)", r.field, name)
 			}
 		}
+		break // All required paths are global; only need to check once.
 	}
-
-	return config, nil
+	return nil
 }
 
 // SaveServerConfig writes the ServerConfig back to config.json in the given configPath directory.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1009,26 +1009,30 @@ func LoadFTNConfig(configPath string) (FTNConfig, error) {
 // network that has internal_tosser_enabled=true. Call this before starting the
 // tosser, not during editing, so the config editor can open an incomplete config.
 func ValidateFTNConfig(cfg FTNConfig) error {
-	for name, net := range cfg.Networks {
-		if !net.InternalTosserEnabled {
-			continue
+	tosserEnabled := false
+	for _, net := range cfg.Networks {
+		if net.InternalTosserEnabled {
+			tosserEnabled = true
+			break
 		}
-		type requiredPath struct {
-			field string
-			value string
+	}
+	if !tosserEnabled {
+		return nil
+	}
+	type requiredPath struct {
+		field string
+		value string
+	}
+	required := []requiredPath{
+		{"inbound_path", cfg.InboundPath},
+		{"outbound_path", cfg.OutboundPath},
+		{"binkd_outbound_path", cfg.BinkdOutboundPath},
+		{"temp_path", cfg.TempPath},
+	}
+	for _, r := range required {
+		if strings.TrimSpace(r.value) == "" {
+			return fmt.Errorf("ftn.json: %q is required when internal_tosser_enabled is true", r.field)
 		}
-		required := []requiredPath{
-			{"inbound_path", cfg.InboundPath},
-			{"outbound_path", cfg.OutboundPath},
-			{"binkd_outbound_path", cfg.BinkdOutboundPath},
-			{"temp_path", cfg.TempPath},
-		}
-		for _, r := range required {
-			if strings.TrimSpace(r.value) == "" {
-				return fmt.Errorf("ftn.json: %q is required when internal_tosser_enabled is true (network %q)", r.field, name)
-			}
-		}
-		break // All required paths are global; only need to check once.
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -350,6 +350,20 @@ func TestValidateFTNConfig(t *testing.T) {
 	if err := ValidateFTNConfig(missing); err == nil {
 		t.Error("expected error when outbound_path is missing")
 	}
+
+	// Tosser enabled, missing binkd_outbound_path: should fail.
+	missing = full
+	missing.BinkdOutboundPath = ""
+	if err := ValidateFTNConfig(missing); err == nil {
+		t.Error("expected error when binkd_outbound_path is missing")
+	}
+
+	// Tosser enabled, missing temp_path: should fail.
+	missing = full
+	missing.TempPath = ""
+	if err := ValidateFTNConfig(missing); err == nil {
+		t.Error("expected error when temp_path is missing")
+	}
 }
 
 func TestFTNLinkConfig_LegacyPasswordMigration(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -313,6 +313,36 @@ func TestLoadFTNConfig_ValidFile(t *testing.T) {
 	}
 }
 
+// TestLoadFTNConfig_TosserEnabledMissingPaths is a regression test for issue #15.
+// LoadFTNConfig must succeed even when internal_tosser_enabled is true but the
+// global FTN paths are blank, so the config editor can open and let the sysop
+// correct the misconfiguration. ValidateFTNConfig is the appropriate place for
+// the runtime path check.
+func TestLoadFTNConfig_TosserEnabledMissingPaths(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := FTNConfig{
+		// Global paths intentionally blank — simulates post-first-run incomplete config.
+		Networks: map[string]FTNNetworkConfig{
+			"fsxnet": {InternalTosserEnabled: true, OwnAddress: "21:3/110"},
+		},
+	}
+	data, _ := json.Marshal(cfg)
+	os.WriteFile(filepath.Join(tmpDir, "ftn.json"), data, 0644)
+
+	result, err := LoadFTNConfig(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadFTNConfig must not fail with incomplete paths (issue #15): %v", err)
+	}
+	if !result.Networks["fsxnet"].InternalTosserEnabled {
+		t.Error("expected InternalTosserEnabled to be preserved after load")
+	}
+
+	// ValidateFTNConfig should catch the missing paths at runtime.
+	if err := ValidateFTNConfig(result); err == nil {
+		t.Error("ValidateFTNConfig should reject config with tosser enabled but no paths set")
+	}
+}
+
 func TestValidateFTNConfig(t *testing.T) {
 	makeNet := func(enabled bool) map[string]FTNNetworkConfig {
 		return map[string]FTNNetworkConfig{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -313,6 +313,45 @@ func TestLoadFTNConfig_ValidFile(t *testing.T) {
 	}
 }
 
+func TestValidateFTNConfig(t *testing.T) {
+	makeNet := func(enabled bool) map[string]FTNNetworkConfig {
+		return map[string]FTNNetworkConfig{
+			"fsxnet": {InternalTosserEnabled: enabled},
+		}
+	}
+
+	// No tosser enabled: no paths required.
+	if err := ValidateFTNConfig(FTNConfig{Networks: makeNet(false)}); err != nil {
+		t.Errorf("expected no error with tosser disabled, got: %v", err)
+	}
+
+	// Tosser enabled, all paths set: should pass.
+	full := FTNConfig{
+		InboundPath:       "data/ftn/in",
+		OutboundPath:      "data/ftn/out",
+		BinkdOutboundPath: "data/ftn/binkd",
+		TempPath:          "data/ftn/temp",
+		Networks:          makeNet(true),
+	}
+	if err := ValidateFTNConfig(full); err != nil {
+		t.Errorf("expected no error with all paths set, got: %v", err)
+	}
+
+	// Tosser enabled, missing inbound_path: should fail.
+	missing := full
+	missing.InboundPath = ""
+	if err := ValidateFTNConfig(missing); err == nil {
+		t.Error("expected error when inbound_path is missing")
+	}
+
+	// Tosser enabled, missing outbound_path: should fail.
+	missing = full
+	missing.OutboundPath = ""
+	if err := ValidateFTNConfig(missing); err == nil {
+		t.Error("expected error when outbound_path is missing")
+	}
+}
+
 func TestFTNLinkConfig_LegacyPasswordMigration(t *testing.T) {
 	// Legacy config uses "password"; new config uses "packet_password".
 	// When packet_password is absent (omitted), the legacy password should be used.


### PR DESCRIPTION
Fixes #15.

## Problem

After completing first-time setup with `./config`, a sysop who enabled `internal_tosser_enabled` on an FTN network but hadn't yet set the required global paths (`inbound_path`, `outbound_path`, `binkd_outbound_path`, `temp_path`) would see this error on every subsequent attempt to reopen the config editor:

```
Error initializing editor: loading configs: loading ftn: ftn.json: "inbound_path" is required when internal_tosser_enabled is true
```

`./vision3` would still start (it handles the FTN load error gracefully), but `./config` was unusable — preventing the sysop from ever correcting the misconfiguration.

## Root Cause

`LoadFTNConfig` ran path validation at load time. Since the config editor calls `LoadFTNConfig` on startup, any incomplete FTN config caused an immediate fatal error before the editor could open.

## Fix

- **`internal/config/config.go`** — Remove path validation from `LoadFTNConfig` (it now always succeeds for parseable configs). Add `ValidateFTNConfig(cfg FTNConfig) error` for callers that need the hard check at runtime.
- **`cmd/v3mail/cmd_ftn.go`** — Call `ValidateFTNConfig` in `loadFTNDeps` so `v3mail toss/scan/pack` still fails fast with a clear error when required paths are missing.
- **`internal/config/config_test.go`** — Add `TestValidateFTNConfig` covering: tosser disabled (no paths required), all paths set (passes), and missing individual paths (fails).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FTN configuration checks by validating settings immediately after loading, and failing fast with clearer errors when required paths are missing.
  * Added centralized FTN validation logic that verifies required global path fields are set when internal tossing is enabled.

* **Tests**
  * Added regression tests covering both successful validation cases and specific failure cases when required FTN path settings are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->