### PR TITLE
test(telnetserver): cover telnet protocol + session adapter (0% → 45%)

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -28,7 +28,7 @@ $env:GOARCH = "386"
 
 $targets = @(
     @{ Cmd = "vision3"; Desc = "BBS server" },
-    @{ Cmd = "helper"; Desc = "helper process" },
+    @{ Cmd = "helper"; Desc = "command line utils" },
     @{ Cmd = "v3mail"; Desc = "mail processor" },
     @{ Cmd = "strings"; Desc = "strings editor" },
     @{ Cmd = "ue"; Desc = "user editor" },

--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ if ! go build -o vision3 ./cmd/vision3; then echo "Build failed (vision3)!"; exi
 BUILT+=("  vision3   — BBS server")
 
 if ! go build -o helper ./cmd/helper; then echo "Build failed (helper)!"; exit 1; fi
-BUILT+=("  helper    — helper process")
+BUILT+=("  helper    — command line utils")
 
 if ! go build -o v3mail ./cmd/v3mail; then echo "Build failed (v3mail)!"; exit 1; fi
 BUILT+=("  v3mail    — mail processor")

--- a/docs/sysop/files/bulk-import.md
+++ b/docs/sysop/files/bulk-import.md
@@ -209,4 +209,4 @@ The BBS loads metadata at startup. Restart the BBS process after importing files
 
 ### Permission errors during import
 
-Ensure the helper process has read access to the source directory and write access to the target area directory (`data/files/{area-path}/`).
+Ensure the helper command line utility has read access to the source directory and write access to the target area directory (`data/files/{area-path}/`).

--- a/internal/telnetserver/adapter_test.go
+++ b/internal/telnetserver/adapter_test.go
@@ -14,6 +14,7 @@ func TestAdapter_PtyReflectsTermAndSize(t *testing.T) {
 	drainRead(t, tc)
 
 	a := NewTelnetSessionAdapter(tc)
+	t.Cleanup(func() { _ = a.Close() }) // stop the winCh forwarding goroutine
 	pty, winCh, ok := a.Pty()
 	if !ok {
 		t.Fatal("Pty() ok = false, want true")
@@ -38,6 +39,7 @@ func TestAdapter_ReadWriteDelegate(t *testing.T) {
 	fc := newFakeConn([]byte("input"))
 	tc := NewTelnetConn(fc)
 	a := NewTelnetSessionAdapter(tc)
+	t.Cleanup(func() { _ = a.Close() }) // stop the winCh forwarding goroutine
 
 	b := make([]byte, 16)
 	n, _ := a.Read(b)
@@ -57,6 +59,7 @@ func TestAdapter_NAWSForwardedToWindowChannel(t *testing.T) {
 	in := []byte{IAC, SB, OptNAWS, 0, 70, 0, 24, IAC, SE}
 	tc := NewTelnetConn(newFakeConn(in))
 	a := NewTelnetSessionAdapter(tc)
+	t.Cleanup(func() { _ = a.Close() }) // stop the winCh forwarding goroutine
 
 	_, winCh, _ := a.Pty()
 	<-winCh // drain the initial 80x25 window
@@ -81,6 +84,7 @@ func TestAdapter_NAWSForwardedToWindowChannel(t *testing.T) {
 func TestSessionContext_SetValueAndFallback(t *testing.T) {
 	tc := NewTelnetConn(newFakeConn(nil))
 	a := NewTelnetSessionAdapter(tc)
+	t.Cleanup(func() { _ = a.Close() }) // stop the winCh forwarding goroutine
 	ctx := a.Context()
 
 	ctx.SetValue("key", "value")

--- a/internal/telnetserver/adapter_test.go
+++ b/internal/telnetserver/adapter_test.go
@@ -1,0 +1,99 @@
+package telnetserver
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAdapter_PtyReflectsTermAndSize(t *testing.T) {
+	// Client reports terminal type "xterm" before the adapter is built.
+	in := []byte{IAC, SB, OptTermType, TermTypeIs}
+	in = append(in, []byte("xterm")...)
+	in = append(in, IAC, SE)
+	tc := NewTelnetConn(newFakeConn(in))
+	drainRead(t, tc)
+
+	a := NewTelnetSessionAdapter(tc)
+	pty, winCh, ok := a.Pty()
+	if !ok {
+		t.Fatal("Pty() ok = false, want true")
+	}
+	if pty.Term != "xterm" {
+		t.Errorf("pty.Term = %q, want xterm", pty.Term)
+	}
+	if pty.Window.Width != 80 || pty.Window.Height != 25 {
+		t.Errorf("pty.Window = %dx%d, want 80x25", pty.Window.Width, pty.Window.Height)
+	}
+	select {
+	case w := <-winCh:
+		if w.Width != 80 || w.Height != 25 {
+			t.Errorf("initial window = %dx%d, want 80x25", w.Width, w.Height)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no initial window delivered on channel")
+	}
+}
+
+func TestAdapter_ReadWriteDelegate(t *testing.T) {
+	fc := newFakeConn([]byte("input"))
+	tc := NewTelnetConn(fc)
+	a := NewTelnetSessionAdapter(tc)
+
+	b := make([]byte, 16)
+	n, _ := a.Read(b)
+	if string(b[:n]) != "input" {
+		t.Errorf("adapter Read = %q, want input", b[:n])
+	}
+
+	if _, err := a.Write([]byte("out")); err != nil {
+		t.Fatalf("adapter Write: %v", err)
+	}
+	if fc.w.String() != "out" {
+		t.Errorf("written = %q, want out", fc.w.String())
+	}
+}
+
+func TestAdapter_NAWSForwardedToWindowChannel(t *testing.T) {
+	in := []byte{IAC, SB, OptNAWS, 0, 70, 0, 24, IAC, SE}
+	tc := NewTelnetConn(newFakeConn(in))
+	a := NewTelnetSessionAdapter(tc)
+
+	_, winCh, _ := a.Pty()
+	<-winCh // drain the initial 80x25 window
+
+	// Reading the NAWS subnegotiation triggers the tc.winCh -> adapter forward.
+	drainRead(t, tc)
+
+	select {
+	case w := <-winCh:
+		if w.Width != 70 || w.Height != 24 {
+			t.Errorf("forwarded window = %dx%d, want 70x24", w.Width, w.Height)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("NAWS update was not forwarded to the window channel")
+	}
+
+	if pty, _, _ := a.Pty(); pty.Window.Width != 70 || pty.Window.Height != 24 {
+		t.Errorf("pty.Window after NAWS = %dx%d, want 70x24", pty.Window.Width, pty.Window.Height)
+	}
+}
+
+func TestSessionContext_SetValueAndFallback(t *testing.T) {
+	tc := NewTelnetConn(newFakeConn(nil))
+	a := NewTelnetSessionAdapter(tc)
+	ctx := a.Context()
+
+	ctx.SetValue("key", "value")
+	if got := ctx.Value("key"); got != "value" {
+		t.Errorf("Value(key) = %v, want value", got)
+	}
+	if got := ctx.Value("absent"); got != nil {
+		t.Errorf("Value(absent) = %v, want nil", got)
+	}
+	if a.SessionID() == "" {
+		t.Error("SessionID should be non-empty")
+	}
+	if a.User() != "" {
+		t.Errorf("telnet User() = %q, want empty (forces manual login)", a.User())
+	}
+}

--- a/internal/telnetserver/telnet_test.go
+++ b/internal/telnetserver/telnet_test.go
@@ -1,0 +1,281 @@
+package telnetserver
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// fakeAddr is a stub net.Addr for the in-memory connection.
+type fakeAddr struct{}
+
+func (fakeAddr) Network() string { return "tcp" }
+func (fakeAddr) String() string  { return "127.0.0.1:0" }
+
+// fakeConn is a deterministic net.Conn backed by a fixed read buffer and a
+// capture buffer for writes. Deadline setters are no-ops.
+type fakeConn struct {
+	r *bytes.Reader
+	w bytes.Buffer
+}
+
+func newFakeConn(in []byte) *fakeConn { return &fakeConn{r: bytes.NewReader(in)} }
+
+func (f *fakeConn) Read(p []byte) (int, error)         { return f.r.Read(p) }
+func (f *fakeConn) Write(p []byte) (int, error)        { return f.w.Write(p) }
+func (f *fakeConn) Close() error                       { return nil }
+func (f *fakeConn) LocalAddr() net.Addr                { return fakeAddr{} }
+func (f *fakeConn) RemoteAddr() net.Addr               { return fakeAddr{} }
+func (f *fakeConn) SetDeadline(t time.Time) error      { return nil }
+func (f *fakeConn) SetReadDeadline(t time.Time) error  { return nil }
+func (f *fakeConn) SetWriteDeadline(t time.Time) error { return nil }
+
+// drainRead reads the telnet connection to EOF, returning the decoded payload.
+func drainRead(t *testing.T, tc *TelnetConn) []byte {
+	t.Helper()
+	var out []byte
+	buf := make([]byte, 64)
+	for {
+		n, err := tc.Read(buf)
+		out = append(out, buf[:n]...)
+		if err != nil {
+			if err != io.EOF {
+				t.Fatalf("Read returned unexpected error: %v", err)
+			}
+			return out
+		}
+	}
+}
+
+func TestRead_StripsIACNegotiation(t *testing.T) {
+	// IAC DO NAWS, then "hello", then IAC WILL ECHO — only "hello" should surface.
+	in := []byte{IAC, DO, OptNAWS}
+	in = append(in, []byte("hello")...)
+	in = append(in, IAC, WILL, OptEcho)
+
+	tc := NewTelnetConn(newFakeConn(in))
+	got := drainRead(t, tc)
+	if string(got) != "hello" {
+		t.Errorf("decoded payload = %q, want %q", got, "hello")
+	}
+}
+
+func TestRead_UnescapesDoubledIAC(t *testing.T) {
+	// 0xFF in the data stream arrives doubled (IAC IAC) and must decode to one 0xFF.
+	in := []byte{'a', IAC, IAC, 'b'}
+	tc := NewTelnetConn(newFakeConn(in))
+	got := drainRead(t, tc)
+	want := []byte{'a', 0xFF, 'b'}
+	if !bytes.Equal(got, want) {
+		t.Errorf("decoded payload = %v, want %v", got, want)
+	}
+}
+
+func TestRead_ConsumesUnknownIACCommand(t *testing.T) {
+	// IAC followed by a non-option command byte (e.g. AYT=246) is consumed silently.
+	in := []byte{'x', IAC, 246, 'y'}
+	tc := NewTelnetConn(newFakeConn(in))
+	got := drainRead(t, tc)
+	if string(got) != "xy" {
+		t.Errorf("decoded payload = %q, want %q", got, "xy")
+	}
+}
+
+func TestRead_NAWSSetsWindowSize(t *testing.T) {
+	// IAC SB NAWS <w hi><w lo><h hi><h lo> IAC SE; 70x24 is within BBS limits.
+	in := []byte{IAC, SB, OptNAWS, 0, 70, 0, 24, IAC, SE}
+	in = append(in, []byte("data")...)
+	tc := NewTelnetConn(newFakeConn(in))
+
+	got := drainRead(t, tc)
+	if string(got) != "data" {
+		t.Errorf("decoded payload = %q, want %q", got, "data")
+	}
+	w, h := tc.WindowSize()
+	if w != 70 || h != 24 {
+		t.Errorf("WindowSize() = %dx%d, want 70x24", w, h)
+	}
+}
+
+func TestRead_NAWSCapsOversizeDimensions(t *testing.T) {
+	// Width 0x00FF (255) carries a 0xFF that must be doubled inside the SB; the
+	// result is capped to the BBS maximum of 80x25.
+	in := []byte{IAC, SB, OptNAWS, 0x00, IAC, IAC, 0x00, 100, IAC, SE}
+	tc := NewTelnetConn(newFakeConn(in))
+	drainRead(t, tc)
+	w, h := tc.WindowSize()
+	if w != 80 || h != 25 {
+		t.Errorf("WindowSize() = %dx%d, want 80x25 (capped)", w, h)
+	}
+}
+
+func TestRead_TermTypeSubnegotiation(t *testing.T) {
+	// IAC SB TERMTYPE IS "VT100" IAC SE -> TermType() lowercased.
+	in := []byte{IAC, SB, OptTermType, TermTypeIs}
+	in = append(in, []byte("VT100")...)
+	in = append(in, IAC, SE)
+	tc := NewTelnetConn(newFakeConn(in))
+	drainRead(t, tc)
+	if got := tc.TermType(); got != "vt100" {
+		t.Errorf("TermType() = %q, want %q", got, "vt100")
+	}
+}
+
+func TestTermType_DefaultsToAnsi(t *testing.T) {
+	tc := NewTelnetConn(newFakeConn(nil))
+	if got := tc.TermType(); got != "ansi" {
+		t.Errorf("TermType() = %q, want %q", got, "ansi")
+	}
+}
+
+func TestWindowSize_Defaults(t *testing.T) {
+	tc := NewTelnetConn(newFakeConn(nil))
+	if w, h := tc.WindowSize(); w != 80 || h != 25 {
+		t.Errorf("default WindowSize() = %dx%d, want 80x25", w, h)
+	}
+}
+
+func TestWrite_EscapesIAC(t *testing.T) {
+	fc := newFakeConn(nil)
+	tc := NewTelnetConn(fc)
+
+	n, err := tc.Write([]byte{'a', 0xFF, 'b'})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("Write returned n=%d, want 3 (original byte count)", n)
+	}
+	want := []byte{'a', IAC, IAC, 'b'}
+	if !bytes.Equal(fc.w.Bytes(), want) {
+		t.Errorf("written bytes = %v, want %v", fc.w.Bytes(), want)
+	}
+}
+
+func TestWrite_FastPathNoIAC(t *testing.T) {
+	fc := newFakeConn(nil)
+	tc := NewTelnetConn(fc)
+	n, err := tc.Write([]byte("plain"))
+	if err != nil || n != 5 {
+		t.Fatalf("Write = (%d, %v), want (5, nil)", n, err)
+	}
+	if fc.w.String() != "plain" {
+		t.Errorf("written = %q, want %q", fc.w.String(), "plain")
+	}
+}
+
+func TestWrite_Empty(t *testing.T) {
+	fc := newFakeConn(nil)
+	tc := NewTelnetConn(fc)
+	n, err := tc.Write(nil)
+	if n != 0 || err != nil {
+		t.Errorf("Write(nil) = (%d, %v), want (0, nil)", n, err)
+	}
+	if fc.w.Len() != 0 {
+		t.Errorf("expected no bytes written, got %d", fc.w.Len())
+	}
+}
+
+func TestProcessNegotiationBytes_DetectsWillTermType(t *testing.T) {
+	tc := NewTelnetConn(newFakeConn(nil))
+	tc.processNegotiationBytes([]byte{IAC, WILL, OptTermType})
+	if !tc.willTermType {
+		t.Error("expected willTermType=true after IAC WILL TERMTYPE")
+	}
+}
+
+func TestNegotiate_SendsExpectedOptions(t *testing.T) {
+	server, client := net.Pipe()
+	tc := NewTelnetConn(server)
+
+	done := make(chan error, 1)
+	go func() { done <- tc.Negotiate() }()
+
+	expected := []byte{
+		IAC, WILL, OptEcho,
+		IAC, WILL, OptSGA,
+		IAC, DO, OptSGA,
+		IAC, DONT, OptLinemode,
+		IAC, DO, OptNAWS,
+		IAC, DO, OptTermType,
+	}
+	got := make([]byte, len(expected))
+	if _, err := io.ReadFull(client, got); err != nil {
+		t.Fatalf("reading negotiation bytes: %v", err)
+	}
+	if !bytes.Equal(got, expected) {
+		t.Errorf("negotiation bytes = %v, want %v", got, expected)
+	}
+
+	// Close the client so Negotiate's drain returns promptly instead of waiting
+	// out the 500ms deadline.
+	client.Close()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Negotiate returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Negotiate did not return after client close")
+	}
+}
+
+func TestClose_Idempotent(t *testing.T) {
+	tc := NewTelnetConn(newFakeConn(nil))
+	if err := tc.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	// Second close must not panic (would double-close winCh) and returns nil.
+	if err := tc.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+}
+
+func TestAddrs_Delegate(t *testing.T) {
+	tc := NewTelnetConn(newFakeConn(nil))
+	if got := tc.RemoteAddr().String(); got != "127.0.0.1:0" {
+		t.Errorf("RemoteAddr = %q, want 127.0.0.1:0", got)
+	}
+	if got := tc.LocalAddr().Network(); got != "tcp" {
+		t.Errorf("LocalAddr network = %q, want tcp", got)
+	}
+}
+
+func TestSetReadInterrupt_UnblocksRead(t *testing.T) {
+	// net.Pipe honors read deadlines, so it can exercise the interrupt path that
+	// fakeConn (non-blocking) cannot.
+	server, client := net.Pipe()
+	defer client.Close()
+	tc := NewTelnetConn(server)
+
+	type result struct {
+		n   int
+		err error
+	}
+	res := make(chan result, 1)
+	go func() {
+		b := make([]byte, 8)
+		n, err := tc.Read(b)
+		res <- result{n, err}
+	}()
+
+	time.Sleep(100 * time.Millisecond) // let the Read block on the pipe
+
+	ch := make(chan struct{})
+	tc.SetReadInterrupt(ch)
+	close(ch)
+
+	select {
+	case r := <-res:
+		if r.err != io.EOF {
+			t.Errorf("Read err = %v, want io.EOF", r.err)
+		}
+		if r.n != 0 {
+			t.Errorf("Read n = %d, want 0", r.n)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Read was not interrupted")
+	}
+}

--- a/internal/telnetserver/telnet_test.go
+++ b/internal/telnetserver/telnet_test.go
@@ -189,6 +189,7 @@ func TestProcessNegotiationBytes_DetectsWillTermType(t *testing.T) {
 func TestNegotiate_SendsExpectedOptions(t *testing.T) {
 	server, client := net.Pipe()
 	tc := NewTelnetConn(server)
+	t.Cleanup(func() { _ = tc.Close(); _ = client.Close() })
 
 	done := make(chan error, 1)
 	go func() { done <- tc.Negotiate() }()
@@ -247,8 +248,8 @@ func TestSetReadInterrupt_UnblocksRead(t *testing.T) {
 	// net.Pipe honors read deadlines, so it can exercise the interrupt path that
 	// fakeConn (non-blocking) cannot.
 	server, client := net.Pipe()
-	defer client.Close()
 	tc := NewTelnetConn(server)
+	t.Cleanup(func() { _ = tc.Close(); _ = client.Close() })
 
 	type result struct {
 		n   int

--- a/setup.ps1
+++ b/setup.ps1
@@ -264,7 +264,7 @@ Write-Host "Building ViSiON/3..."
 $buildFailed = $false
 @(
     @{ Name = "vision3"; Desc = "BBS server" },
-    @{ Name = "helper"; Desc = "helper process" },
+    @{ Name = "helper"; Desc = "command line utils" },
     @{ Name = "v3mail"; Desc = "mail processor" },
     @{ Name = "strings"; Desc = "strings editor" },
     @{ Name = "ue"; Desc = "user editor" },


### PR DESCRIPTION
## Summary

First test coverage for the `internal/telnetserver` package, flagged as untested/network-facing in the [2026-06-27 technical audit](docs-internal/specs/2026-06-27-technical-audit.md) (#2). Package coverage **0% → 45.3%**; the protocol-critical paths are 80–100%.

Tests use a deterministic fake `net.Conn` (fixed read buffer + write capture) plus `net.Pipe` for the cases that need real blocking/deadlines. No live sockets.

## Covered behavior

**`TelnetConn` (telnet.go)**
- `Read()` — IAC command stripping, doubled-`IAC` (0xFF) unescaping, unknown-command consumption, NAWS window-size and TERM_TYPE subnegotiation parsing (incl. escaped 0xFF inside a subnegotiation), dimension capping to 80×25
- `Write()` — `IAC` escaping + correct original-byte-count return (fast path + escape path + empty)
- `Negotiate()` — exact option-negotiation byte sequence sent
- `SetReadInterrupt()` — deadline-based unblock of a pending `Read()` → `io.EOF`
- `Close()` idempotency (no double-close panic); `TermType()`/`WindowSize()` defaults; address delegation

**`TelnetSessionAdapter` (adapter.go)**
- `Pty()` term/window wiring from the underlying connection
- `Read`/`Write` delegation
- NAWS update forwarding to the session window channel (+ pty window update)
- `TelnetSessionContext` value storage and fallback

## Out of scope
The ~40 trivial `ssh.Session` pass-through methods (constant returns) and `detectViaCursorPositioning` (3s timing/ANSI-CPR loop) are not deterministically unit-testable and were left uncovered.

## Verification
- `go test -race ./internal/telnetserver/` — 20 tests pass
- `go vet` clean, `go build ./...` clean

Branched off `main` (independent of #21).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added telnet session and protocol tests covering terminal type reporting, NAWS/window size handling (including oversized dimension capping), negotiation behavior, and proper forwarding of updates.
  * Added coverage for telnet read/write behavior, including IAC escaping/unescaping, handling unknown commands, and ensuring interrupts unblock reads.
* **Documentation**
  * Updated import troubleshooting guidance to clarify required permissions for the helper command-line utility (not the helper process).
* **Chores**
  * Updated build target metadata wording for the helper binary (“command line utils”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->