### PR TITLE
test(usereditor): cover file I/O, cloning, sorting, and field helpers

### DIFF
--- a/internal/usereditor/fields_test.go
+++ b/internal/usereditor/fields_test.go
@@ -1,0 +1,63 @@
+package usereditor
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBoolYNRoundTrip(t *testing.T) {
+	if boolToYN(true) != "Y" || boolToYN(false) != "N" {
+		t.Errorf("boolToYN: got %q/%q", boolToYN(true), boolToYN(false))
+	}
+	if !ynToBool("Y") || !ynToBool("y") {
+		t.Error("ynToBool should accept Y/y")
+	}
+	if ynToBool("N") || ynToBool("") || ynToBool("yes") {
+		t.Error("ynToBool should only accept exactly Y/y")
+	}
+}
+
+func TestTimeFormatters(t *testing.T) {
+	zero := time.Time{}
+	if got := formatTime(zero); got != "Never" {
+		t.Errorf("formatTime(zero) = %q, want Never", got)
+	}
+	if got := formatDate(zero); got != "Never" {
+		t.Errorf("formatDate(zero) = %q, want Never", got)
+	}
+	if got := formatTimeOnly(zero); got != "" {
+		t.Errorf("formatTimeOnly(zero) = %q, want empty", got)
+	}
+
+	ts := time.Date(2026, 1, 2, 15, 4, 0, 0, time.UTC)
+	if got := formatTime(ts); got != "01/02/26 3:04PM" {
+		t.Errorf("formatTime = %q, want %q", got, "01/02/26 3:04PM")
+	}
+	if got := formatDate(ts); got != "01/02/26" {
+		t.Errorf("formatDate = %q, want %q", got, "01/02/26")
+	}
+	if got := formatTimeOnly(ts); got != "03:04 PM" {
+		t.Errorf("formatTimeOnly = %q, want %q", got, "03:04 PM")
+	}
+}
+
+func TestPadRightLeft(t *testing.T) {
+	if got := padRight("ab", 5); got != "ab   " {
+		t.Errorf("padRight short = %q", got)
+	}
+	if got := padRight("abcdef", 3); got != "abc" {
+		t.Errorf("padRight truncate = %q, want abc", got)
+	}
+	if got := padLeft("ab", 5); got != "   ab" {
+		t.Errorf("padLeft short = %q", got)
+	}
+	if got := padLeft("abcdef", 3); got != "abc" {
+		t.Errorf("padLeft truncate = %q, want abc", got)
+	}
+}
+
+func TestIntFieldLabel(t *testing.T) {
+	if got := intFieldLabel("Level"); got != "Level : " {
+		t.Errorf("intFieldLabel = %q, want %q", got, "Level : ")
+	}
+}

--- a/internal/usereditor/fileio_test.go
+++ b/internal/usereditor/fileio_test.go
@@ -1,0 +1,129 @@
+package usereditor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+func TestSaveLoadUsers_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "users.json")
+
+	in := []*user.User{
+		{ID: 3, Handle: "Charlie", AccessLevel: 10},
+		{ID: 1, Handle: "Alice", AccessLevel: 255},
+		{ID: 2, Handle: "Bob", AccessLevel: 20},
+	}
+
+	if _, err := SaveUsers(path, in); err != nil {
+		t.Fatalf("SaveUsers: %v", err)
+	}
+
+	out, _, err := LoadUsers(path)
+	if err != nil {
+		t.Fatalf("LoadUsers: %v", err)
+	}
+	if len(out) != 3 {
+		t.Fatalf("loaded %d users, want 3", len(out))
+	}
+	// Both save and load sort by ID.
+	for i, wantID := range []int{1, 2, 3} {
+		if out[i].ID != wantID {
+			t.Errorf("user[%d].ID = %d, want %d (should be ID-sorted)", i, out[i].ID, wantID)
+		}
+	}
+	if out[0].Handle != "Alice" {
+		t.Errorf("user[0].Handle = %q, want Alice", out[0].Handle)
+	}
+}
+
+func TestLoadUsers_MissingFile(t *testing.T) {
+	_, _, err := LoadUsers(filepath.Join(t.TempDir(), "nope.json"))
+	if err == nil {
+		t.Fatal("expected error loading a missing file")
+	}
+}
+
+func TestCheckFileChanged(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "users.json")
+	mtime, err := SaveUsers(path, []*user.User{{ID: 1, Handle: "A"}})
+	if err != nil {
+		t.Fatalf("SaveUsers: %v", err)
+	}
+
+	if CheckFileChanged(path, mtime) {
+		t.Error("file should be unchanged immediately after save")
+	}
+	// A clearly different stored mtime must read as changed.
+	if !CheckFileChanged(path, mtime.Add(-time.Hour)) {
+		t.Error("expected changed=true for a stale stored mtime")
+	}
+	// Missing file is treated as unchanged (can't stat).
+	if CheckFileChanged(filepath.Join(dir, "gone.json"), mtime) {
+		t.Error("missing file should report unchanged")
+	}
+}
+
+func TestCloneUser_IsDeepCopy(t *testing.T) {
+	now := time.Now()
+	orig := &user.User{
+		ID:                    7,
+		Handle:                "Orig",
+		LastReadMessageIDs:    map[int]string{1: "uuid-a"},
+		TaggedFileIDs:         []uuid.UUID{uuid.New()},
+		TaggedMessageAreaTags: []string{"GENERAL"},
+		DeletedAt:             &now,
+	}
+
+	clone := CloneUser(orig)
+	if clone == orig {
+		t.Fatal("clone must be a distinct pointer")
+	}
+
+	// Mutating the clone's reference-type fields must not touch the original.
+	clone.LastReadMessageIDs[1] = "mutated"
+	clone.LastReadMessageIDs[2] = "added"
+	clone.TaggedFileIDs[0] = uuid.New()
+	clone.TaggedMessageAreaTags[0] = "CHANGED"
+	*clone.DeletedAt = now.Add(time.Hour)
+
+	if orig.LastReadMessageIDs[1] != "uuid-a" {
+		t.Errorf("original map mutated: %q", orig.LastReadMessageIDs[1])
+	}
+	if _, ok := orig.LastReadMessageIDs[2]; ok {
+		t.Error("original map gained an entry from clone mutation")
+	}
+	if orig.TaggedMessageAreaTags[0] != "GENERAL" {
+		t.Errorf("original slice mutated: %q", orig.TaggedMessageAreaTags[0])
+	}
+	if !orig.DeletedAt.Equal(now) {
+		t.Error("original DeletedAt mutated through the clone pointer")
+	}
+}
+
+func TestCloneUser_Nil(t *testing.T) {
+	if CloneUser(nil) != nil {
+		t.Error("CloneUser(nil) should return nil")
+	}
+}
+
+func TestSaveUsers_AtomicNoTempLeftBehind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "users.json")
+	if _, err := SaveUsers(path, []*user.User{{ID: 1, Handle: "A"}}); err != nil {
+		t.Fatalf("SaveUsers: %v", err)
+	}
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".tmp" || filepath.Base(e.Name()) != "users.json" {
+			t.Errorf("unexpected leftover file after atomic save: %s", e.Name())
+		}
+	}
+}

--- a/internal/usereditor/sort_test.go
+++ b/internal/usereditor/sort_test.go
@@ -1,0 +1,63 @@
+package usereditor
+
+import (
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+func ids(users []*user.User) []int {
+	out := make([]int, len(users))
+	for i, u := range users {
+		out[i] = u.ID
+	}
+	return out
+}
+
+func TestSortUsers_ByID_DeletedLast(t *testing.T) {
+	users := []*user.User{
+		{ID: 2, Handle: "Bob"},
+		{ID: 1, Handle: "Alice", DeletedUser: true},
+		{ID: 3, Handle: "Carol"},
+	}
+	sortUsers(users, false)
+	// Non-deleted come first (by ID), deleted last.
+	got := ids(users)
+	want := []int{2, 3, 1}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("by-ID order = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestSortUsers_Alpha_DeletedLast(t *testing.T) {
+	users := []*user.User{
+		{ID: 1, Handle: "charlie"},
+		{ID: 2, Handle: "Alice"},
+		{ID: 3, Handle: "bob", DeletedUser: true},
+	}
+	sortUsers(users, true)
+	// Case-insensitive handle order among non-deleted, deleted ("bob") last.
+	if users[0].Handle != "Alice" || users[1].Handle != "charlie" {
+		t.Fatalf("alpha order = [%s, %s, %s], want [Alice, charlie, bob]",
+			users[0].Handle, users[1].Handle, users[2].Handle)
+	}
+	if !users[2].DeletedUser {
+		t.Errorf("deleted user should sort last, got %s", users[2].Handle)
+	}
+}
+
+func TestShouldSwap_DeletedAlwaysAfter(t *testing.T) {
+	active := &user.User{ID: 5, Handle: "z", DeletedUser: false}
+	deleted := &user.User{ID: 1, Handle: "a", DeletedUser: true}
+	less := func(a, b *user.User) bool { return a.ID < b.ID }
+
+	// Active before deleted regardless of the less() result.
+	if !shouldSwap(active, deleted, less) {
+		t.Error("active user should sort before a deleted user")
+	}
+	if shouldSwap(deleted, active, less) {
+		t.Error("deleted user should not sort before an active user")
+	}
+}

--- a/internal/usereditor/view_edit_test.go
+++ b/internal/usereditor/view_edit_test.go
@@ -1,0 +1,50 @@
+package usereditor
+
+import "testing"
+
+const esc = "\x1b"
+
+func TestApproximateVisibleLen(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{"plain", "hello", 5},
+		{"empty", "", 0},
+		{"with color codes", esc + "[31mhi" + esc + "[0m", 2},
+		{"only escape", esc + "[1;32m", 0},
+	}
+	for _, tc := range cases {
+		if got := approximateVisibleLen(tc.in); got != tc.want {
+			t.Errorf("%s: approximateVisibleLen(%q) = %d, want %d", tc.name, tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestTruncateToVisual_PreservesANSI(t *testing.T) {
+	in := esc + "[31mhello" + esc + "[0m"
+	got := truncateToVisual(in, 3)
+	want := esc + "[31mhel"
+	if got != want {
+		t.Errorf("truncateToVisual = %q, want %q", got, want)
+	}
+	if approximateVisibleLen(got) != 3 {
+		t.Errorf("truncated visible len = %d, want 3", approximateVisibleLen(got))
+	}
+}
+
+func TestTruncateToVisual_ShorterThanLimit(t *testing.T) {
+	if got := truncateToVisual("ab", 10); got != "ab" {
+		t.Errorf("truncateToVisual(short) = %q, want ab", got)
+	}
+}
+
+func TestPadToCol(t *testing.T) {
+	if got := padToCol("abc", 5); got != "abc  " {
+		t.Errorf("padToCol pad = %q, want %q", got, "abc  ")
+	}
+	if got := padToCol("abcdef", 3); got != "abc" {
+		t.Errorf("padToCol truncate = %q, want abc", got)
+	}
+}


### PR DESCRIPTION
## Summary

First test coverage for `internal/usereditor`, flagged as untested + data-mutating in the [2026-06-27 technical audit](docs-internal/specs/2026-06-27-technical-audit.md) (item #2). Focuses on the data-integrity-critical and pure-logic surface; the interactive bubbletea `Update`/`View` (the package's bulk) is not unit-testable without a TUI harness and is left uncovered.

## Covered
- **fileio** — `SaveUsers`/`LoadUsers` round-trip (both ID-sort), `CheckFileChanged`, atomic-write leaves no `.tmp` behind, and **`CloneUser` deep-copy independence** (mutating a clone's map / slice / `DeletedAt` pointer must not affect the original — the property the editor relies on for edit-then-cancel).
- **fields** — `boolToYN`/`ynToBool`, time/date formatters incl. zero-time, `padRight`/`padLeft` truncation, `intFieldLabel`.
- **model** — `sortUsers` by ID and alpha with deleted-users-last; `shouldSwap`.
- **view_edit** — `approximateVisibleLen` / `truncateToVisual` / `padToCol` ANSI-aware visible-width helpers.

## Verification
- `go test -race ./internal/usereditor/` — 17 tests pass
- `go vet` clean, `go build ./...` clean
- Targeted functions: `CloneUser` 100%, field helpers 100%, sort 100%, visual helpers 100%, `LoadUsers` 86%

Independent of other branches; branched off `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added broader unit test coverage for user editor behavior, including formatting helpers, visual-length calculations, padding/truncation, sorting rules, and file save/load flows.
  * Verified that user data round-trips correctly, deleted users stay last in lists, timestamps and zero values are formatted as expected, and cloned data remains independent.
  * Added checks for missing files, change detection, and cleanup after saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->