### PR TITLE
refactor(tui): extract shared text helpers into internal/uitext

### DIFF
--- a/internal/configeditor/dialogs.go
+++ b/internal/configeditor/dialogs.go
@@ -1,6 +1,7 @@
 package configeditor
 
 import (
+	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 	"strings"
 )
 
@@ -143,56 +144,11 @@ func (m Model) overlayHelpScreen(background string) string {
 
 // padToCol truncates or pads a line to reach a specific column.
 func padToCol(line string, col int) string {
-	vis := approximateVisibleLen(line)
+	vis := uitext.ApproximateVisibleLen(line)
 	if vis >= col {
-		return truncateToVisual(line, col)
+		return uitext.TruncateToVisual(line, col)
 	}
 	return line + strings.Repeat(" ", col-vis)
-}
-
-// truncateToVisual truncates a string to n visible characters, preserving ANSI.
-func truncateToVisual(s string, n int) string {
-	var b strings.Builder
-	inEsc := false
-	count := 0
-	for _, r := range s {
-		if count >= n && !inEsc {
-			break
-		}
-		b.WriteRune(r)
-		if r == '\x1b' {
-			inEsc = true
-			continue
-		}
-		if inEsc {
-			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
-				inEsc = false
-			}
-			continue
-		}
-		count++
-	}
-	return b.String()
-}
-
-// approximateVisibleLen estimates the visible length of a styled string.
-func approximateVisibleLen(s string) int {
-	inEsc := false
-	count := 0
-	for _, r := range s {
-		if r == '\x1b' {
-			inEsc = true
-			continue
-		}
-		if inEsc {
-			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
-				inEsc = false
-			}
-			continue
-		}
-		count++
-	}
-	return count
 }
 
 // skipToCol returns everything from visible column n onward.

--- a/internal/configeditor/dialogs_test.go
+++ b/internal/configeditor/dialogs_test.go
@@ -2,37 +2,6 @@ package configeditor
 
 import "testing"
 
-const esc = "\x1b"
-
-func TestApproximateVisibleLen(t *testing.T) {
-	cases := []struct {
-		in   string
-		want int
-	}{
-		{"hello", 5},
-		{"", 0},
-		{esc + "[31mhi" + esc + "[0m", 2},
-		{esc + "[1;32m", 0},
-	}
-	for _, tc := range cases {
-		if got := approximateVisibleLen(tc.in); got != tc.want {
-			t.Errorf("approximateVisibleLen(%q) = %d, want %d", tc.in, got, tc.want)
-		}
-	}
-}
-
-func TestTruncateToVisual_PreservesANSI(t *testing.T) {
-	in := esc + "[31mhello" + esc + "[0m"
-	got := truncateToVisual(in, 3)
-	want := esc + "[31mhel"
-	if got != want {
-		t.Errorf("truncateToVisual = %q, want %q", got, want)
-	}
-	if approximateVisibleLen(got) != 3 {
-		t.Errorf("visible len after truncate = %d, want 3", approximateVisibleLen(got))
-	}
-}
-
 func TestPadToCol(t *testing.T) {
 	if got := padToCol("abc", 5); got != "abc  " {
 		t.Errorf("padToCol pad = %q, want %q", got, "abc  ")

--- a/internal/configeditor/fields.go
+++ b/internal/configeditor/fields.go
@@ -1,7 +1,6 @@
 package configeditor
 
 import (
-	"fmt"
 	"strings"
 	"unicode/utf8"
 )
@@ -48,19 +47,6 @@ func maskValue(s string) string {
 	return strings.Repeat("*", utf8.RuneCountInString(s))
 }
 
-// boolToYN converts a bool to "Y" or "N".
-func boolToYN(b bool) string {
-	if b {
-		return "Y"
-	}
-	return "N"
-}
-
-// ynToBool converts "Y"/"y" to true, anything else to false.
-func ynToBool(s string) bool {
-	return strings.ToUpper(s) == "Y"
-}
-
 // padRight pads a string to width with spaces, truncating if longer.
 func padRight(s string, width int) string {
 	runes := []rune(s)
@@ -77,11 +63,6 @@ func padLeft(s string, width int) string {
 		return string(runes[:width])
 	}
 	return strings.Repeat(" ", width-len(runes)) + s
-}
-
-// intFieldLabel returns a formatted label with colon for field display.
-func intFieldLabel(label string) string {
-	return fmt.Sprintf("%s : ", label)
 }
 
 // centerText centers a string within a given width using visual (rune) width.

--- a/internal/configeditor/fields_areas.go
+++ b/internal/configeditor/fields_areas.go
@@ -2,6 +2,7 @@ package configeditor
 
 import (
 	"fmt"
+	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 	"strconv"
 	"strings"
 )
@@ -136,13 +137,13 @@ func (m *Model) fieldsMsgArea() []fieldDef {
 		},
 		{
 			Label: "Auto Join", Help: "Automatically join new users to this area", Type: ftYesNo, Col: 3, Row: 12, Width: 1,
-			Get: func() string { return boolToYN(a.AutoJoin) },
-			Set: func(val string) error { a.AutoJoin = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(a.AutoJoin) },
+			Set: func(val string) error { a.AutoJoin = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "Real Name Only", Help: "Require real name for posts (no aliases)", Type: ftYesNo, Col: 3, Row: 13, Width: 1,
-			Get: func() string { return boolToYN(a.RealNameOnly) },
-			Set: func(val string) error { a.RealNameOnly = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(a.RealNameOnly) },
+			Set: func(val string) error { a.RealNameOnly = uitext.YNToBool(val); return nil },
 		},
 	}
 

--- a/internal/configeditor/fields_doors.go
+++ b/internal/configeditor/fields_doors.go
@@ -2,6 +2,7 @@ package configeditor
 
 import (
 	"fmt"
+	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 	"sort"
 	"strconv"
 	"strings"
@@ -324,8 +325,8 @@ func (m *Model) fieldsDoor() []fieldDef {
 	row++
 	fields = append(fields, fieldDef{
 		Label: "Single Instance", Help: "Only allow one node to run this door at a time", Type: ftYesNo, Col: 3, Row: row, Width: 1,
-		Get: func() string { return boolToYN(dPtr.SingleInstance) },
-		Set: func(val string) error { dPtr.SingleInstance = ynToBool(val); save(); return nil },
+		Get: func() string { return uitext.BoolToYN(dPtr.SingleInstance) },
+		Set: func(val string) error { dPtr.SingleInstance = uitext.YNToBool(val); save(); return nil },
 	})
 
 	if !isSyncJS(dPtr) && !isV3Script(dPtr) {
@@ -427,14 +428,14 @@ func (m *Model) fieldsDoor() []fieldDef {
 		row++
 		fields = append(fields, fieldDef{
 			Label: "Raw Terminal", Help: "Allocate PTY for raw terminal I/O", Type: ftYesNo, Col: 3, Row: row, Width: 1,
-			Get: func() string { return boolToYN(dPtr.RequiresRawTerminal) },
-			Set: func(val string) error { dPtr.RequiresRawTerminal = ynToBool(val); save(); return nil },
+			Get: func() string { return uitext.BoolToYN(dPtr.RequiresRawTerminal) },
+			Set: func(val string) error { dPtr.RequiresRawTerminal = uitext.YNToBool(val); save(); return nil },
 		})
 		row++
 		fields = append(fields, fieldDef{
 			Label: "Use Shell", Help: "Wrap command in /bin/sh -c (Linux) or cmd /c (Windows)", Type: ftYesNo, Col: 3, Row: row, Width: 1,
-			Get: func() string { return boolToYN(dPtr.UseShell) },
-			Set: func(val string) error { dPtr.UseShell = ynToBool(val); save(); return nil },
+			Get: func() string { return uitext.BoolToYN(dPtr.UseShell) },
+			Set: func(val string) error { dPtr.UseShell = uitext.YNToBool(val); save(); return nil },
 		})
 	}
 

--- a/internal/configeditor/fields_events.go
+++ b/internal/configeditor/fields_events.go
@@ -2,6 +2,7 @@ package configeditor
 
 import (
 	"fmt"
+	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 	"regexp"
 	"strconv"
 	"strings"
@@ -112,13 +113,13 @@ func (m *Model) fieldsEvent() []fieldDef {
 		},
 		{
 			Label: "Enabled", Help: "Enable or disable this event", Type: ftYesNo, Col: 3, Row: 7, Width: 1,
-			Get: func() string { return boolToYN(e.Enabled) },
-			Set: func(val string) error { e.Enabled = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(e.Enabled) },
+			Set: func(val string) error { e.Enabled = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "Run At Start", Help: "Run when the BBS starts", Type: ftYesNo, Col: 3, Row: 8, Width: 1,
-			Get: func() string { return boolToYN(e.RunAtStartup) },
-			Set: func(val string) error { e.RunAtStartup = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(e.RunAtStartup) },
+			Set: func(val string) error { e.RunAtStartup = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "Run After", Help: "Run after this event completes", Type: ftLookup, Col: 3, Row: 9, Width: 20,

--- a/internal/configeditor/fields_ftn.go
+++ b/internal/configeditor/fields_ftn.go
@@ -2,6 +2,7 @@ package configeditor
 
 import (
 	"fmt"
+	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 	"sort"
 	"strconv"
 	"strings"
@@ -73,8 +74,8 @@ func (m *Model) fieldsFTNLink() []fieldDef {
 		},
 		{
 			Label: "Tosser Enabled", Help: "Enable built-in echomail tosser", Type: ftYesNo, Col: 3, Row: 3, Width: 1,
-			Get: func() string { return boolToYN(netPtr.InternalTosserEnabled) },
-			Set: func(val string) error { netPtr.InternalTosserEnabled = ynToBool(val); save(); return nil },
+			Get: func() string { return uitext.BoolToYN(netPtr.InternalTosserEnabled) },
+			Set: func(val string) error { netPtr.InternalTosserEnabled = uitext.YNToBool(val); save(); return nil },
 		},
 		{
 			Label: "Poll Seconds", Help: "Seconds between inbound directory polls", Type: ftInteger, Col: 3, Row: 4, Width: 6, Min: 0, Max: 999999,

--- a/internal/configeditor/fields_protocols.go
+++ b/internal/configeditor/fields_protocols.go
@@ -3,6 +3,7 @@ package configeditor
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 	"log"
 	"strconv"
 	"strings"
@@ -109,18 +110,18 @@ func (m *Model) fieldsProtocol() []fieldDef {
 		},
 		{
 			Label: "Batch Send", Help: "Supports sending multiple files at once", Type: ftYesNo, Col: 3, Row: 8, Width: 1,
-			Get: func() string { return boolToYN(p.BatchSend) },
-			Set: func(val string) error { p.BatchSend = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(p.BatchSend) },
+			Set: func(val string) error { p.BatchSend = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "Use PTY", Help: "Allocate PTY for protocol I/O", Type: ftYesNo, Col: 3, Row: 9, Width: 1,
-			Get: func() string { return boolToYN(p.UsePTY) },
-			Set: func(val string) error { p.UsePTY = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(p.UsePTY) },
+			Set: func(val string) error { p.UsePTY = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "Default", Help: "Set as the default transfer protocol", Type: ftYesNo, Col: 3, Row: 10, Width: 1,
-			Get: func() string { return boolToYN(p.Default) },
-			Set: func(val string) error { p.Default = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(p.Default) },
+			Set: func(val string) error { p.Default = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "Conn Type", Help: "Connection filter: ssh, telnet, or blank=all", Type: ftString, Col: 3, Row: 11, Width: 10,
@@ -160,13 +161,13 @@ func (m *Model) fieldsArchiver() []fieldDef {
 		},
 		{
 			Label: "Native", Help: "Use Go native implementation (no external cmd)", Type: ftYesNo, Col: 3, Row: 5, Width: 1,
-			Get: func() string { return boolToYN(a.Native) },
-			Set: func(val string) error { a.Native = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(a.Native) },
+			Set: func(val string) error { a.Native = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "Enabled", Help: "Enable or disable this archiver", Type: ftYesNo, Col: 3, Row: 6, Width: 1,
-			Get: func() string { return boolToYN(a.Enabled) },
-			Set: func(val string) error { a.Enabled = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(a.Enabled) },
+			Set: func(val string) error { a.Enabled = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "Pack Cmd", Help: "Command to create archives", Type: ftString, Col: 3, Row: 7, Width: 30,
@@ -293,13 +294,13 @@ func (m *Model) fieldsLogin() []fieldDef {
 		},
 		{
 			Label: "Clear Screen", Help: "Clear screen before this step", Type: ftYesNo, Col: 3, Row: 3, Width: 1,
-			Get: func() string { return boolToYN(l.ClearScreen) },
-			Set: func(val string) error { l.ClearScreen = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(l.ClearScreen) },
+			Set: func(val string) error { l.ClearScreen = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "Pause After", Help: "Wait for keypress after this step", Type: ftYesNo, Col: 3, Row: 4, Width: 1,
-			Get: func() string { return boolToYN(l.PauseAfter) },
-			Set: func(val string) error { l.PauseAfter = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(l.PauseAfter) },
+			Set: func(val string) error { l.PauseAfter = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "Sec Level", Help: "Minimum security level to show this step (0=all)", Type: ftInteger, Col: 3, Row: 5, Width: 3, Min: 0, Max: 255,

--- a/internal/configeditor/fields_system.go
+++ b/internal/configeditor/fields_system.go
@@ -1,6 +1,7 @@
 package configeditor
 
 import (
+	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 	"strconv"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/config"
@@ -154,8 +155,8 @@ func (m *Model) sysFieldsNetwork(cfg *config.ServerConfig) []fieldDef {
 	return []fieldDef{
 		{
 			Label: "SSH Enabled", Help: "Enable SSH server", Type: ftYesNo, Col: 3, Row: 1, Width: 1,
-			Get: func() string { return boolToYN(cfg.SSHEnabled) },
-			Set: func(val string) error { cfg.SSHEnabled = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(cfg.SSHEnabled) },
+			Set: func(val string) error { cfg.SSHEnabled = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "SSH Host", Help: "Listen address (blank=all interfaces)", Type: ftString, Col: 3, Row: 2, Width: 20,
@@ -176,13 +177,13 @@ func (m *Model) sysFieldsNetwork(cfg *config.ServerConfig) []fieldDef {
 		},
 		{
 			Label: "Legacy SSH", Help: "Allow legacy algorithms for older clients", Type: ftYesNo, Col: 3, Row: 4, Width: 1,
-			Get: func() string { return boolToYN(cfg.LegacySSHAlgorithms) },
-			Set: func(val string) error { cfg.LegacySSHAlgorithms = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(cfg.LegacySSHAlgorithms) },
+			Set: func(val string) error { cfg.LegacySSHAlgorithms = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "Telnet Enabled", Help: "Enable Telnet server", Type: ftYesNo, Col: 3, Row: 6, Width: 1,
-			Get: func() string { return boolToYN(cfg.TelnetEnabled) },
-			Set: func(val string) error { cfg.TelnetEnabled = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(cfg.TelnetEnabled) },
+			Set: func(val string) error { cfg.TelnetEnabled = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "Telnet Host", Help: "Listen address (blank=all interfaces)", Type: ftString, Col: 3, Row: 7, Width: 20,
@@ -203,8 +204,8 @@ func (m *Model) sysFieldsNetwork(cfg *config.ServerConfig) []fieldDef {
 		},
 		{
 			Label: "V3Net", Help: "Enable V3Net networking", Type: ftYesNo, Col: 3, Row: 10, Width: 1,
-			Get: func() string { return boolToYN(v3.Enabled) },
-			Set: func(val string) error { v3.Enabled = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(v3.Enabled) },
+			Set: func(val string) error { v3.Enabled = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "Keystore Path", Help: "Path to Ed25519 keypair file", Type: ftString, Col: 3, Row: 11, Width: 40,
@@ -223,8 +224,8 @@ func (m *Model) sysFieldsNetwork(cfg *config.ServerConfig) []fieldDef {
 		},
 		{
 			Label: "V3Net Hub", Help: "Run a V3Net hub server on this node", Type: ftYesNo, Col: 3, Row: 15, Width: 1,
-			Get: func() string { return boolToYN(hub.Enabled) },
-			Set: func(val string) error { hub.Enabled = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(hub.Enabled) },
+			Set: func(val string) error { hub.Enabled = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "Hub Host", Help: "Hub listen address (blank=all interfaces)", Type: ftString, Col: 3, Row: 16, Width: 20,
@@ -256,8 +257,8 @@ func (m *Model) sysFieldsNetwork(cfg *config.ServerConfig) []fieldDef {
 		},
 		{
 			Label: "Auto Approve", Help: "Automatically approve new leaf subscriptions", Type: ftYesNo, Col: 3, Row: 19, Width: 1,
-			Get: func() string { return boolToYN(hub.AutoApprove) },
-			Set: func(val string) error { hub.AutoApprove = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(hub.AutoApprove) },
+			Set: func(val string) error { hub.AutoApprove = uitext.YNToBool(val); return nil },
 		},
 	}
 }
@@ -435,8 +436,8 @@ func sysFieldsDefaults(cfg *config.ServerConfig) []fieldDef {
 	return []fieldDef{
 		{
 			Label: "Allow New Users", Help: "Allow new user registration", Type: ftYesNo, Col: 3, Row: 1, Width: 1,
-			Get: func() string { return boolToYN(cfg.AllowNewUsers) },
-			Set: func(val string) error { cfg.AllowNewUsers = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(cfg.AllowNewUsers) },
+			Set: func(val string) error { cfg.AllowNewUsers = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "File List Mode", Help: "File listing style", Type: ftLookup, Col: 3, Row: 2, Width: 15,
@@ -485,13 +486,13 @@ func sysFieldsNUV(cfg *config.ServerConfig) []fieldDef {
 	return []fieldDef{
 		{
 			Label: "Use NUV", Help: "Enable New User Voting system", Type: ftYesNo, Col: 3, Row: 1, Width: 1,
-			Get: func() string { return boolToYN(cfg.UseNUV) },
-			Set: func(val string) error { cfg.UseNUV = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(cfg.UseNUV) },
+			Set: func(val string) error { cfg.UseNUV = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "Auto Add NUV", Help: "Automatically queue new registrations for voting", Type: ftYesNo, Col: 3, Row: 2, Width: 1,
-			Get: func() string { return boolToYN(cfg.AutoAddNUV) },
-			Set: func(val string) error { cfg.AutoAddNUV = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(cfg.AutoAddNUV) },
+			Set: func(val string) error { cfg.AutoAddNUV = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "NUV Use Level", Help: "Minimum access level required to vote", Type: ftInteger, Col: 3, Row: 3, Width: 3, Min: 0, Max: 255,
@@ -531,13 +532,13 @@ func sysFieldsNUV(cfg *config.ServerConfig) []fieldDef {
 		},
 		{
 			Label: "NUV Validate", Help: "Auto-validate user when yes threshold reached", Type: ftYesNo, Col: 3, Row: 6, Width: 1,
-			Get: func() string { return boolToYN(cfg.NUVValidate) },
-			Set: func(val string) error { cfg.NUVValidate = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(cfg.NUVValidate) },
+			Set: func(val string) error { cfg.NUVValidate = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "NUV Kill", Help: "Auto-delete user when no threshold reached", Type: ftYesNo, Col: 3, Row: 7, Width: 1,
-			Get: func() string { return boolToYN(cfg.NUVKill) },
-			Set: func(val string) error { cfg.NUVKill = ynToBool(val); return nil },
+			Get: func() string { return uitext.BoolToYN(cfg.NUVKill) },
+			Set: func(val string) error { cfg.NUVKill = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "NUV Level", Help: "Access level assigned to auto-validated NUV users", Type: ftInteger, Col: 3, Row: 8, Width: 3, Min: 0, Max: 255,

--- a/internal/configeditor/fields_test.go
+++ b/internal/configeditor/fields_test.go
@@ -15,18 +15,6 @@ func TestMaskValue(t *testing.T) {
 	}
 }
 
-func TestBoolYN(t *testing.T) {
-	if boolToYN(true) != "Y" || boolToYN(false) != "N" {
-		t.Error("boolToYN wrong")
-	}
-	if !ynToBool("Y") || !ynToBool("y") {
-		t.Error("ynToBool should accept Y/y")
-	}
-	if ynToBool("N") || ynToBool("yes") || ynToBool("") {
-		t.Error("ynToBool should only accept exactly Y/y")
-	}
-}
-
 func TestPadRightLeft_RuneAware(t *testing.T) {
 	if got := padRight("ab", 5); got != "ab   " {
 		t.Errorf("padRight short = %q", got)
@@ -53,11 +41,5 @@ func TestCenterText(t *testing.T) {
 	}
 	if got := centerText("toolong", 3); got != "toolong" {
 		t.Errorf("centerText overflow = %q, want toolong", got)
-	}
-}
-
-func TestIntFieldLabel(t *testing.T) {
-	if got := intFieldLabel("Port"); got != "Port : " {
-		t.Errorf("intFieldLabel = %q, want %q", got, "Port : ")
 	}
 }

--- a/internal/configeditor/fields_wizard.go
+++ b/internal/configeditor/fields_wizard.go
@@ -2,6 +2,7 @@ package configeditor
 
 import (
 	"fmt"
+	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 	"strconv"
 	"strings"
 	"time"
@@ -125,9 +126,9 @@ func (m *Model) fieldsHubWizard() []fieldDef {
 		},
 		{
 			Label: "Auto-Approve", Help: "Auto-approve new leaf connections", Type: ftYesNo, Col: 3, Row: 4, Width: 1,
-			Get: func() string { return boolToYN(w.autoApprove) },
+			Get: func() string { return uitext.BoolToYN(w.autoApprove) },
 			Set: func(val string) error {
-				w.autoApprove = ynToBool(val)
+				w.autoApprove = uitext.YNToBool(val)
 				return nil
 			},
 		},

--- a/internal/configeditor/view_list.go
+++ b/internal/configeditor/view_list.go
@@ -2,6 +2,7 @@ package configeditor
 
 import (
 	"fmt"
+	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 	"strings"
 )
 
@@ -245,14 +246,14 @@ func (m Model) renderRecordRow(idx, boxW int) string {
 	case "event":
 		if idx < len(m.configs.Events.Events) {
 			e := m.configs.Events.Events[idx]
-			content = fmt.Sprintf(" %3d  %-56s %s", idx+1, padRight(e.Name, 56), boolToYN(e.Enabled))
+			content = fmt.Sprintf(" %3d  %-56s %s", idx+1, padRight(e.Name, 56), uitext.BoolToYN(e.Enabled))
 		}
 	case "ftn":
 		keys := m.ftnNetworkKeys()
 		if idx < len(keys) {
 			k := keys[idx]
 			n := m.configs.FTN.Networks[k]
-			content = fmt.Sprintf("  %-22s %-28s %s", padRight(k, 22), padRight(n.OwnAddress, 28), boolToYN(n.InternalTosserEnabled))
+			content = fmt.Sprintf("  %-22s %-28s %s", padRight(k, 22), padRight(n.OwnAddress, 28), uitext.BoolToYN(n.InternalTosserEnabled))
 		}
 	case "ftnlink":
 		refs := m.ftnAllLinkRefs()
@@ -275,7 +276,7 @@ func (m Model) renderRecordRow(idx, boxW int) string {
 	case "archiver":
 		if idx < len(m.configs.Archivers.Archivers) {
 			a := m.configs.Archivers.Archivers[idx]
-			content = fmt.Sprintf("  %-6s  %-20s %-8s %s", padRight(a.ID, 6), padRight(a.Name, 20), padRight(a.Extension, 8), boolToYN(a.Enabled))
+			content = fmt.Sprintf("  %-6s  %-20s %-8s %s", padRight(a.ID, 6), padRight(a.Name, 20), padRight(a.Extension, 8), uitext.BoolToYN(a.Enabled))
 		}
 	case "login":
 		if idx < len(m.configs.LoginSeq) {

--- a/internal/menueditor/fields.go
+++ b/internal/menueditor/fields.go
@@ -2,6 +2,7 @@ package menueditor
 
 import (
 	"fmt"
+	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 	"strconv"
 	"strings"
 
@@ -19,14 +20,14 @@ const (
 
 // fieldDef defines a single editable field on an edit screen.
 type fieldDef struct {
-	Label  string    // Display label (e.g. "Clear Screen")
-	Type   fieldType
-	Row    int // Row position (y) relative to box interior top
-	Width  int // Input field width
-	GetM   func(d *MenuData) string
-	SetM   func(d *MenuData, val string) error
-	GetC   func(d *CmdData) string
-	SetC   func(d *CmdData, val string) error
+	Label string // Display label (e.g. "Clear Screen")
+	Type  fieldType
+	Row   int // Row position (y) relative to box interior top
+	Width int // Input field width
+	GetM  func(d *MenuData) string
+	SetM  func(d *MenuData, val string) error
+	GetC  func(d *CmdData) string
+	SetC  func(d *CmdData, val string) error
 	// Render, if non-nil, renders the display value with pipe-code translation.
 	// Called only in the normal (non-active) display path; active/edit paths
 	// always show the raw value so the user can see what they're editing.
@@ -44,13 +45,13 @@ func menuFields() []fieldDef {
 		},
 		{
 			Label: "Clear Screen   ", Type: ftYesNo, Row: 4, Width: 1,
-			GetM: func(d *MenuData) string { return boolToYN(d.CLR) },
-			SetM: func(d *MenuData, val string) error { d.CLR = ynToBool(val); return nil },
+			GetM: func(d *MenuData) string { return uitext.BoolToYN(d.CLR) },
+			SetM: func(d *MenuData, val string) error { d.CLR = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "Use Prompt     ", Type: ftYesNo, Row: 5, Width: 1,
-			GetM: func(d *MenuData) string { return boolToYN(d.UsePrompt) },
-			SetM: func(d *MenuData, val string) error { d.UsePrompt = ynToBool(val); return nil },
+			GetM: func(d *MenuData) string { return uitext.BoolToYN(d.UsePrompt) },
+			SetM: func(d *MenuData, val string) error { d.UsePrompt = uitext.YNToBool(val); return nil },
 		},
 		{
 			// Max width: boxW(74) - lpad(2) - labelLen(17) = 55
@@ -124,8 +125,8 @@ func menuFields() []fieldDef {
 		},
 		{
 			Label: "Force HotKey   ", Type: ftYesNo, Row: 15, Width: 1,
-			GetM: func(d *MenuData) string { return boolToYN(d.ForceHotKey) },
-			SetM: func(d *MenuData, val string) error { d.ForceHotKey = ynToBool(val); return nil },
+			GetM: func(d *MenuData) string { return uitext.BoolToYN(d.ForceHotKey) },
+			SetM: func(d *MenuData, val string) error { d.ForceHotKey = uitext.YNToBool(val); return nil },
 		},
 	}
 }
@@ -156,8 +157,8 @@ func cmdFields() []fieldDef {
 		},
 		{
 			Label: "Hidden?        ", Type: ftYesNo, Row: 7, Width: 1,
-			GetC: func(d *CmdData) string { return boolToYN(d.Hidden) },
-			SetC: func(d *CmdData, val string) error { d.Hidden = ynToBool(val); return nil },
+			GetC: func(d *CmdData) string { return uitext.BoolToYN(d.Hidden) },
+			SetC: func(d *CmdData, val string) error { d.Hidden = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "Auto Run       ", Type: ftString, Row: 8, Width: 30,
@@ -165,19 +166,6 @@ func cmdFields() []fieldDef {
 			SetC: func(d *CmdData, val string) error { d.AutoRun = val; return nil },
 		},
 	}
-}
-
-// boolToYN converts a bool to "Y" or "N".
-func boolToYN(b bool) string {
-	if b {
-		return "Y"
-	}
-	return "N"
-}
-
-// ynToBool converts "Y"/"y" to true, anything else to false.
-func ynToBool(s string) bool {
-	return strings.ToUpper(s) == "Y"
 }
 
 // padRight pads a string to width with spaces, truncating if longer.
@@ -196,9 +184,3 @@ func centerText(s string, width int) string {
 	pad := (width - len(s)) / 2
 	return strings.Repeat(" ", pad) + s + strings.Repeat(" ", width-pad-len(s))
 }
-
-// intFieldLabel returns a formatted label with colon for field display.
-func intFieldLabel(label string) string {
-	return fmt.Sprintf("%s : ", label)
-}
-

--- a/internal/menueditor/view.go
+++ b/internal/menueditor/view.go
@@ -1,6 +1,7 @@
 package menueditor
 
 import (
+	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 	"strings"
 )
 
@@ -35,36 +36,11 @@ func boxBotBorder(boxW int, borderStyle interface{ Render(...string) string }) s
 
 // padToCol truncates or pads a line to reach a specific visible column.
 func padToCol(line string, col int) string {
-	vis := approximateVisibleLen(line)
+	vis := uitext.ApproximateVisibleLen(line)
 	if vis >= col {
-		return truncateToVisual(line, col)
+		return uitext.TruncateToVisual(line, col)
 	}
 	return line + strings.Repeat(" ", col-vis)
-}
-
-// truncateToVisual truncates a string to n visible characters, preserving ANSI.
-func truncateToVisual(s string, n int) string {
-	var b strings.Builder
-	inEsc := false
-	count := 0
-	for _, r := range s {
-		if count >= n && !inEsc {
-			break
-		}
-		b.WriteRune(r)
-		if r == '\x1b' {
-			inEsc = true
-			continue
-		}
-		if inEsc {
-			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
-				inEsc = false
-			}
-			continue
-		}
-		count++
-	}
-	return b.String()
 }
 
 // skipToCol returns everything in a string from visible column n onward,
@@ -96,24 +72,4 @@ func skipToCol(s string, n int) string {
 		count++
 	}
 	return ""
-}
-
-// approximateVisibleLen estimates the visible length of a styled string.
-func approximateVisibleLen(s string) int {
-	inEsc := false
-	count := 0
-	for _, r := range s {
-		if r == '\x1b' {
-			inEsc = true
-			continue
-		}
-		if inEsc {
-			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
-				inEsc = false
-			}
-			continue
-		}
-		count++
-	}
-	return count
 }

--- a/internal/uitext/uitext.go
+++ b/internal/uitext/uitext.go
@@ -1,0 +1,66 @@
+// Package uitext provides small text helpers shared by the terminal UI editors
+// (configeditor, usereditor, menueditor). These were previously duplicated
+// verbatim in each package.
+package uitext
+
+import "strings"
+
+// BoolToYN converts a bool to "Y" or "N".
+func BoolToYN(b bool) string {
+	if b {
+		return "Y"
+	}
+	return "N"
+}
+
+// YNToBool converts "Y"/"y" to true, anything else to false.
+func YNToBool(s string) bool {
+	return strings.ToUpper(s) == "Y"
+}
+
+// ApproximateVisibleLen estimates the visible width of a styled string by
+// counting runes outside of ANSI escape sequences (ESC ... terminating letter).
+func ApproximateVisibleLen(s string) int {
+	inEsc := false
+	count := 0
+	for _, r := range s {
+		if r == '\x1b' {
+			inEsc = true
+			continue
+		}
+		if inEsc {
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+				inEsc = false
+			}
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+// TruncateToVisual truncates s to n visible characters, preserving (and not
+// counting) ANSI escape sequences.
+func TruncateToVisual(s string, n int) string {
+	var b strings.Builder
+	inEsc := false
+	count := 0
+	for _, r := range s {
+		if count >= n && !inEsc {
+			break
+		}
+		b.WriteRune(r)
+		if r == '\x1b' {
+			inEsc = true
+			continue
+		}
+		if inEsc {
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+				inEsc = false
+			}
+			continue
+		}
+		count++
+	}
+	return b.String()
+}

--- a/internal/uitext/uitext_test.go
+++ b/internal/uitext/uitext_test.go
@@ -1,0 +1,47 @@
+package uitext
+
+import "testing"
+
+const esc = "\x1b"
+
+func TestBoolYN(t *testing.T) {
+	if BoolToYN(true) != "Y" || BoolToYN(false) != "N" {
+		t.Errorf("BoolToYN: got %q/%q", BoolToYN(true), BoolToYN(false))
+	}
+	if !YNToBool("Y") || !YNToBool("y") {
+		t.Error("YNToBool should accept Y/y")
+	}
+	if YNToBool("N") || YNToBool("") || YNToBool("yes") {
+		t.Error("YNToBool should only accept exactly Y/y")
+	}
+}
+
+func TestApproximateVisibleLen(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"hello", 5},
+		{"", 0},
+		{esc + "[31mhi" + esc + "[0m", 2},
+		{esc + "[1;32m", 0},
+	}
+	for _, tc := range cases {
+		if got := ApproximateVisibleLen(tc.in); got != tc.want {
+			t.Errorf("ApproximateVisibleLen(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestTruncateToVisual(t *testing.T) {
+	in := esc + "[31mhello" + esc + "[0m"
+	if got := TruncateToVisual(in, 3); got != esc+"[31mhel" {
+		t.Errorf("TruncateToVisual = %q, want %q", got, esc+"[31mhel")
+	}
+	if got := TruncateToVisual(in, 3); ApproximateVisibleLen(got) != 3 {
+		t.Errorf("truncated visible len = %d, want 3", ApproximateVisibleLen(got))
+	}
+	if got := TruncateToVisual("ab", 10); got != "ab" {
+		t.Errorf("TruncateToVisual(short) = %q, want ab", got)
+	}
+}

--- a/internal/usereditor/fields.go
+++ b/internal/usereditor/fields.go
@@ -2,6 +2,7 @@ package usereditor
 
 import (
 	"fmt"
+	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -24,15 +25,15 @@ const (
 
 // fieldDef defines a single editable field on the edit screen.
 type fieldDef struct {
-	Label   string    // Display label (e.g., "User Handle")
-	Type    fieldType // Edit type
-	Col     int       // Column position (x) — 3 for left, 50 for right
-	Row     int       // Row position (y) — relative to edit area top
-	Width   int       // Input field width
-	Min     int       // Minimum value (for ftInteger)
-	Max     int       // Maximum value (for ftInteger)
-	Get     func(u *user.User) string
-	Set     func(u *user.User, val string) error
+	Label string    // Display label (e.g., "User Handle")
+	Type  fieldType // Edit type
+	Col   int       // Column position (x) — 3 for left, 50 for right
+	Row   int       // Row position (y) — relative to edit area top
+	Width int       // Input field width
+	Min   int       // Minimum value (for ftInteger)
+	Max   int       // Maximum value (for ftInteger)
+	Get   func(u *user.User) string
+	Set   func(u *user.User, val string) error
 }
 
 // editFields returns the ordered list of editable fields.
@@ -131,18 +132,18 @@ func editFields() []fieldDef {
 		// Right column (x=50, rows 4-16)
 		{
 			Label: "Validated", Type: ftYesNo, Col: 50, Row: 4, Width: 1,
-			Get: func(u *user.User) string { return boolToYN(u.Validated) },
-			Set: func(u *user.User, val string) error { u.Validated = ynToBool(val); return nil },
+			Get: func(u *user.User) string { return uitext.BoolToYN(u.Validated) },
+			Set: func(u *user.User, val string) error { u.Validated = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "Hot Keys", Type: ftYesNo, Col: 50, Row: 5, Width: 1,
-			Get: func(u *user.User) string { return boolToYN(u.HotKeys) },
-			Set: func(u *user.User, val string) error { u.HotKeys = ynToBool(val); return nil },
+			Get: func(u *user.User) string { return uitext.BoolToYN(u.HotKeys) },
+			Set: func(u *user.User, val string) error { u.HotKeys = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "More Prompts", Type: ftYesNo, Col: 50, Row: 6, Width: 1,
-			Get: func(u *user.User) string { return boolToYN(u.MorePrompts) },
-			Set: func(u *user.User, val string) error { u.MorePrompts = ynToBool(val); return nil },
+			Get: func(u *user.User) string { return uitext.BoolToYN(u.MorePrompts) },
+			Set: func(u *user.User, val string) error { u.MorePrompts = uitext.YNToBool(val); return nil },
 		},
 		{
 			Label: "Screen Width", Type: ftInteger, Col: 50, Row: 7, Width: 3, Min: 40, Max: 200,
@@ -202,7 +203,7 @@ func editFields() []fieldDef {
 		},
 		{
 			Label: "Deleted User", Type: ftDisplay, Col: 50, Row: 12, Width: 1,
-			Get: func(u *user.User) string { return boolToYN(u.DeletedUser) },
+			Get: func(u *user.User) string { return uitext.BoolToYN(u.DeletedUser) },
 		},
 		{
 			Label: "Deleted At", Type: ftDisplay, Col: 50, Row: 13, Width: 16,
@@ -252,19 +253,6 @@ func editFields() []fieldDef {
 			Get: func(u *user.User) string { return formatTime(u.LastBulletinRead) },
 		},
 	}
-}
-
-// boolToYN converts a bool to "Y" or "N".
-func boolToYN(b bool) string {
-	if b {
-		return "Y"
-	}
-	return "N"
-}
-
-// ynToBool converts "Y"/"y" to true, anything else to false.
-func ynToBool(s string) bool {
-	return strings.ToUpper(s) == "Y"
 }
 
 // formatTime formats a time for display in the editor (compact to fit right column).
@@ -324,9 +312,4 @@ func padLeft(s string, width int) string {
 		return s[:width]
 	}
 	return strings.Repeat(" ", width-len(s)) + s
-}
-
-// intFieldLabel returns a formatted label with colon for field display.
-func intFieldLabel(label string) string {
-	return fmt.Sprintf("%s : ", label)
 }

--- a/internal/usereditor/fields_test.go
+++ b/internal/usereditor/fields_test.go
@@ -5,18 +5,6 @@ import (
 	"time"
 )
 
-func TestBoolYNRoundTrip(t *testing.T) {
-	if boolToYN(true) != "Y" || boolToYN(false) != "N" {
-		t.Errorf("boolToYN: got %q/%q", boolToYN(true), boolToYN(false))
-	}
-	if !ynToBool("Y") || !ynToBool("y") {
-		t.Error("ynToBool should accept Y/y")
-	}
-	if ynToBool("N") || ynToBool("") || ynToBool("yes") {
-		t.Error("ynToBool should only accept exactly Y/y")
-	}
-}
-
 func TestTimeFormatters(t *testing.T) {
 	zero := time.Time{}
 	if got := formatTime(zero); got != "Never" {
@@ -53,11 +41,5 @@ func TestPadRightLeft(t *testing.T) {
 	}
 	if got := padLeft("abcdef", 3); got != "abc" {
 		t.Errorf("padLeft truncate = %q, want abc", got)
-	}
-}
-
-func TestIntFieldLabel(t *testing.T) {
-	if got := intFieldLabel("Level"); got != "Level : " {
-		t.Errorf("intFieldLabel = %q, want %q", got, "Level : ")
 	}
 }

--- a/internal/usereditor/view.go
+++ b/internal/usereditor/view.go
@@ -2,6 +2,7 @@ package usereditor
 
 import (
 	"fmt"
+	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -264,7 +265,7 @@ func (m Model) renderUserRow(idx int, isHighlight bool, boxW int) string {
 		dataCols = padRight(u.GroupLocation, 19)
 	case 3:
 		dataCols = padRight(fmt.Sprintf("%d", u.MessagesPosted), 8) +
-			padRight(boolToYN(u.Validated), 11)
+			padRight(uitext.BoolToYN(u.Validated), 11)
 	case 4:
 		dataCols = padRight(formatDate(u.LastLogin), 11) +
 			padRight(formatTimeOnly(u.LastLogin), 8)

--- a/internal/usereditor/view_edit.go
+++ b/internal/usereditor/view_edit.go
@@ -2,6 +2,7 @@ package usereditor
 
 import (
 	"fmt"
+	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 	"strings"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
@@ -239,27 +240,6 @@ func (m Model) renderField(fieldIdx int, f fieldDef, u *userType) (string, int) 
 	}
 }
 
-// approximateVisibleLen estimates the visible length of a styled string
-// by stripping ANSI escape sequences.
-func approximateVisibleLen(s string) int {
-	inEsc := false
-	count := 0
-	for _, r := range s {
-		if r == '\x1b' {
-			inEsc = true
-			continue
-		}
-		if inEsc {
-			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
-				inEsc = false
-			}
-			continue
-		}
-		count++
-	}
-	return count
-}
-
 // overlayPasswordDialog renders a password entry dialog over the background.
 func (m Model) overlayPasswordDialog(background string) string {
 	lines := strings.Split(background, "\n")
@@ -285,7 +265,7 @@ func (m Model) overlayPasswordDialog(background string) string {
 	// textinput.View() width varies (cursor, placeholder styling, etc).
 	// Measure actual visible width to compute correct right padding.
 	tiView := m.textInput.View()
-	inputVisLen := 1 + approximateVisibleLen(tiView) // 1 for left space
+	inputVisLen := 1 + uitext.ApproximateVisibleLen(tiView) // 1 for left space
 	innerW := dialogW - 2
 	rightPad := max(0, innerW-inputVisLen)
 	inputLine := side +
@@ -312,36 +292,11 @@ func (m Model) overlayPasswordDialog(background string) string {
 
 // padToCol truncates or pads a line to reach a specific column.
 func padToCol(line string, col int) string {
-	vis := approximateVisibleLen(line)
+	vis := uitext.ApproximateVisibleLen(line)
 	if vis >= col {
-		return truncateToVisual(line, col)
+		return uitext.TruncateToVisual(line, col)
 	}
 	return line + strings.Repeat(" ", col-vis)
-}
-
-// truncateToVisual truncates a string to n visible characters, preserving ANSI.
-func truncateToVisual(s string, n int) string {
-	var b strings.Builder
-	inEsc := false
-	count := 0
-	for _, r := range s {
-		if count >= n && !inEsc {
-			break
-		}
-		b.WriteRune(r)
-		if r == '\x1b' {
-			inEsc = true
-			continue
-		}
-		if inEsc {
-			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
-				inEsc = false
-			}
-			continue
-		}
-		count++
-	}
-	return b.String()
 }
 
 // skipToCol returns everything in a string from visible column n onward,

--- a/internal/usereditor/view_edit_test.go
+++ b/internal/usereditor/view_edit_test.go
@@ -2,44 +2,6 @@ package usereditor
 
 import "testing"
 
-const esc = "\x1b"
-
-func TestApproximateVisibleLen(t *testing.T) {
-	cases := []struct {
-		name string
-		in   string
-		want int
-	}{
-		{"plain", "hello", 5},
-		{"empty", "", 0},
-		{"with color codes", esc + "[31mhi" + esc + "[0m", 2},
-		{"only escape", esc + "[1;32m", 0},
-	}
-	for _, tc := range cases {
-		if got := approximateVisibleLen(tc.in); got != tc.want {
-			t.Errorf("%s: approximateVisibleLen(%q) = %d, want %d", tc.name, tc.in, got, tc.want)
-		}
-	}
-}
-
-func TestTruncateToVisual_PreservesANSI(t *testing.T) {
-	in := esc + "[31mhello" + esc + "[0m"
-	got := truncateToVisual(in, 3)
-	want := esc + "[31mhel"
-	if got != want {
-		t.Errorf("truncateToVisual = %q, want %q", got, want)
-	}
-	if approximateVisibleLen(got) != 3 {
-		t.Errorf("truncated visible len = %d, want 3", approximateVisibleLen(got))
-	}
-}
-
-func TestTruncateToVisual_ShorterThanLimit(t *testing.T) {
-	if got := truncateToVisual("ab", 10); got != "ab" {
-		t.Errorf("truncateToVisual(short) = %q, want ab", got)
-	}
-}
-
 func TestPadToCol(t *testing.T) {
 	if got := padToCol("abc", 5); got != "abc  " {
 		t.Errorf("padToCol pad = %q, want %q", got, "abc  ")


### PR DESCRIPTION
## Summary

DRY consolidation surfaced while adding editor test coverage (audit #4). `boolToYN`, `ynToBool`, `truncateToVisual`, and `approximateVisibleLen` were **duplicated verbatim** across `configeditor`, `usereditor`, and `menueditor`. This extracts them into a new, documented, unit-tested `internal/uitext` package and removes the duplicates.

## Changes
- **New `internal/uitext`** — `BoolToYN`, `YNToBool`, `ApproximateVisibleLen`, `TruncateToVisual` (exported, doc-commented) + `uitext_test.go`.
- Updated **~80 call sites** across the three editor packages; removed the **12 duplicate definitions**.
- Removed **`intFieldLabel`** from all three packages — it was **dead code** (zero call sites) duplicated in each.
- Removed the now-redundant per-package unit tests for the migrated functions (coverage moved to `uitext_test.go`); kept editor-specific tests.

## Safety
Only **byte-for-byte identical** copies were consolidated (verified by diffing each function body across packages). The helpers that **diverge** between packages are intentionally left untouched for a separate, careful follow-up:
- `centerText` — configeditor differs from usereditor/menueditor
- `padRight`/`padLeft` — byte-based (usereditor) vs rune-based (configeditor), plus a third variant in `menu`
- `padToCol` — stringeditor differs from the editor trio

## Verification
- `go build ./...` clean, `go vet` clean
- **1,423 tests pass across 49 packages** (the editor tests added in #25/#26 guard this refactor)
- No behavior change; gofmt-only cosmetic edits on unrelated files were reverted to keep the diff focused.

Independent; branched off `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared terminal text helpers for Y/N conversion and ANSI-aware length/truncation handling.
* **Bug Fixes**
  * Improved display and editing of boolean fields across configuration, menu, and user editors for more consistent Y/N behavior.
  * Made text padding and truncation more reliable when colored text is shown in dialogs and lists.
* **Chores**
  * Cleaned up duplicated helper logic and simplified related tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->