### PR TITLE
docs: dual-JS-engine decision + third_party patch provenance (audit #3)

### DIFF
--- a/docs-internal/decisions/0001-dual-javascript-engines.md
+++ b/docs-internal/decisions/0001-dual-javascript-engines.md
@@ -1,0 +1,51 @@
+# Decision: Two JavaScript engines (syncjs + scripting)
+
+*Status: accepted · Recorded: 2026-06-28 (documenting existing state)*
+
+## Context
+
+The codebase contains **two** JavaScript runtimes, both built on
+[`github.com/dop251/goja`](https://github.com/dop251/goja):
+
+| Package | Purpose | Wired in |
+| ------- | ------- | -------- |
+| `internal/syncjs` | **Synchronet-compatible** JS runtime for running existing Synchronet-style JS doors | `internal/menu/syncjs_door.go` |
+| `internal/scripting` | **Native ViSiON/3** scripting runtime for V3-authored scripts | `internal/menu/v3script_door.go` (+ `_windows.go`) |
+
+Each gives a connected user their own `goja.Runtime` instance per session.
+
+This was flagged in the [2026-06-27 technical audit](../specs/2026-06-27-technical-audit.md)
+as ~5K lines of parallel scripting infrastructure on the same engine — worth a
+recorded rationale so it isn't mistaken for accidental duplication.
+
+## Decision
+
+Keep both engines. They expose **deliberately different APIs** and serve
+different audiences:
+
+- **`syncjs`** mirrors the Synchronet global JS API so that doors written for
+  Synchronet run with little or no change. It exposes Synchronet's globals and
+  objects — e.g. `bbs`, `console`, `client`, `system`, `File`, `Queue`, and the
+  Synchronet top-level helper functions (`alert`, `ascii`, `center`, `clear`,
+  `cleartoeol`, …). Its config type is `SyncJSDoorConfig`.
+- **`scripting`** is the native V3 runtime with an idiomatic, sandboxed API —
+  e.g. `bbs`, `console`, `ansi`, `area`/`areas`, `color`, `broadcast`,
+  `activity`, with sandboxed file access via a providers layer. Its config type
+  is `ScriptConfig`.
+
+They are **not** interchangeable: a Synchronet door expects the Synchronet API
+shape, and a V3 script expects the native API. Collapsing them into one engine
+would mean either breaking Synchronet-door compatibility or bolting the
+Synchronet API onto the native runtime (and vice-versa).
+
+## Consequences
+
+- Two scripting surfaces to maintain. Changes to one do not automatically apply
+  to the other.
+- When adding a capability, decide which audience it serves: Synchronet-door
+  compatibility (`syncjs`) or native V3 scripting (`scripting`). Prefer adding
+  to `scripting` for new V3-native features; only extend `syncjs` to improve
+  Synchronet compatibility.
+- If Synchronet-door support is ever dropped, `internal/syncjs` and
+  `internal/menu/syncjs_door.go` can be removed wholesale without touching the
+  native scripting path.

--- a/docs-internal/specs/2026-06-27-technical-audit.md
+++ b/docs-internal/specs/2026-06-27-technical-audit.md
@@ -113,11 +113,17 @@ direct deps are imported. Usage spread:
 
 ## Prioritized Action List
 
-1. 🔴 **Decompose `executor.go`** via a command-context struct + domain file
-   splits (kills the 94× signature repetition as a side effect).
-2. 🔴 **Add tests to network-facing & data-mutating untested packages**:
-   `sshserver`, `telnetserver`, `usereditor`, then `configeditor`.
-3. 🟠 **Document the dual-scripting-engine decision** and the `third_party` patch
-   provenance.
+1. ✅ **Decompose `executor.go`** via a command-context struct + domain file
+   splits (kills the 94× signature repetition as a side effect). *Done: split
+   into domain files, `cmdCtx` struct introduced, the two ~800-line user-editor
+   functions consolidated, plus the pre-existing bugs the refactor surfaced.*
+2. ✅ **Add tests to network-facing & data-mutating untested packages**:
+   `sshserver`, `telnetserver`, `usereditor`, `configeditor`. *Done: all four
+   now have coverage of their unit-testable logic.*
+3. ✅ **Document the dual-scripting-engine decision** and the `third_party` patch
+   provenance. *Done: see [`docs-internal/decisions/0001-dual-javascript-engines.md`](../decisions/0001-dual-javascript-engines.md)
+   and [`third_party/README.md`](../../third_party/README.md).*
 4. 🟠 **Split the remaining 1K+ `menu` files** as they're touched (opportunistic,
-   not a campaign).
+   not a campaign). *In progress: shared TUI helpers extracted into
+   `internal/uitext`. Still large: `message_reader.go`, `file_lightbar.go`,
+   `door_handler.go`, `message_scan.go`, and `runUserEditor`'s render closures.*

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -1,0 +1,71 @@
+# Vendored & patched third-party packages
+
+This directory holds local, **patched** copies of upstream packages, wired in via
+`replace` directives in the repo-root `go.mod`:
+
+```
+replace (
+	github.com/charmbracelet/bubbletea v1.3.10 => ./third_party/charmbracelet-bubbletea
+	github.com/charmbracelet/x/term     => ./third_party/charmbracelet-x-term
+)
+```
+
+| Local copy | Upstream module | Pinned upstream version |
+| ---------- | --------------- | ----------------------- |
+| `charmbracelet-bubbletea/` | `github.com/charmbracelet/bubbletea` | `v1.3.10` |
+| `charmbracelet-x-term/` | `github.com/charmbracelet/x/term` | `v0.2.2` (indirect) |
+
+## Why these are patched
+
+On **Windows 10 32-bit / pre-1709** builds (and some other older consoles), the
+console does not support `ENABLE_VIRTUAL_TERMINAL_INPUT`. Upstream's
+`MakeRaw`/`makeRaw` calls `SetConsoleMode` with that flag and **returns the error**
+when the console rejects it, which makes the BBS client fail to start in raw
+input mode on those platforms.
+
+BubbleTea reads Windows console input via
+[`coninput`](https://github.com/erikgeiser/coninput) (raw console event records),
+so VT **input** mode is not actually required for input to work. The patch makes
+raw-mode setup degrade gracefully instead of failing.
+
+## The patch
+
+**`charmbracelet-x-term/term_windows.go` — `makeRaw`:** when
+`SetConsoleMode` with `ENABLE_VIRTUAL_TERMINAL_INPUT` fails, clear that bit and
+retry raw mode without it (only return an error if the retry also fails):
+
+```go
+raw |= windows.ENABLE_VIRTUAL_TERMINAL_INPUT
+if err := windows.SetConsoleMode(windows.Handle(fd), raw); err != nil {
+	// ENABLE_VIRTUAL_TERMINAL_INPUT is unsupported on Windows pre-1709 and some
+	// 32-bit builds. Fall back to raw mode without it; BubbleTea uses coninput
+	// to read Windows console events directly and does not require VT input mode.
+	raw &^= windows.ENABLE_VIRTUAL_TERMINAL_INPUT
+	if err2 := windows.SetConsoleMode(windows.Handle(fd), raw); err2 != nil {
+		return nil, err2
+	}
+}
+```
+
+The `charmbracelet-bubbletea` copy is the matching fork at the same upstream tag;
+its Windows input path (`inputreader_windows.go`, `key_windows.go`) relies on
+`coninput` so it pairs with the x/term fallback above.
+
+## Upgrading upstream
+
+These `replace` copies pin specific upstream versions, so `go get -u` will **not**
+move them. To upgrade:
+
+1. Re-vendor the new upstream version into the corresponding `third_party/`
+   directory.
+2. Re-apply the `makeRaw` fallback shown above (diff against the previous local
+   copy to recover the exact change), plus any other local deltas surfaced by:
+   ```
+   git diff <old-upstream-tag> -- term_windows.go      # in an upstream checkout
+   ```
+3. Bump the version in the root `go.mod` `replace`/`require` lines.
+4. Verify on a pre-1709 / 32-bit Windows console (or a VM) that raw mode starts
+   without error, then run `go build ./...` and `go test ./...`.
+
+If upstream adopts an equivalent graceful fallback, drop the `replace` directives
+and these copies entirely.


### PR DESCRIPTION
## Summary

Closes audit item **#3** (documentation) from the 2026-06-27 technical audit. Facts verified against the actual code, not written from memory.

## Added
- **`docs-internal/decisions/0001-dual-javascript-engines.md`** — why `internal/syncjs` (Synchronet-compatible JS doors) and `internal/scripting` (native V3 scripting) both exist on goja: their deliberately different APIs, where each is wired (`syncjs_door.go` vs `v3script_door.go`), and the maintenance/removal implications.
- **`third_party/README.md`** — provenance for the `replace`'d, patched copies of `charmbracelet/bubbletea` (v1.3.10) and `charmbracelet/x/term` (v0.2.2): the exact `ENABLE_VIRTUAL_TERMINAL_INPUT` `makeRaw` fallback (for Windows pre-1709 / 32-bit consoles), why it pairs with BubbleTea's `coninput`-based input path, and a re-apply-on-upgrade checklist.

## Also
- Updated the audit's action list: items **#1-#3 done**, **#4 in progress** (with `internal/uitext` extracted and the remaining 1K+ files listed).

Docs-only; `go build ./...` still clean. Independent; branched off `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an architectural note explaining the two supported JavaScript scripting engines and their separate runtime behavior.
  * Updated the technical audit notes to reflect recently completed work and current follow-up items.
  * Expanded third-party dependency documentation with patching, upgrade, and Windows compatibility guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->