### PR TITLE
fix(menu): message-reader robustness (deferred from #30 review)

### DIFF
--- a/internal/menu/message_reader_headers.go
+++ b/internal/menu/message_reader_headers.go
@@ -356,12 +356,12 @@ func runGetHeaderType(c *cmdCtx, args string) (*user.User, string, error) {
 			}
 
 			if pickYes {
-				// User selected this header - save preference
-				currentUser.MsgHdr = templateNum
-				if saveErr := userManager.UpdateUser(currentUser); saveErr != nil {
-					log.Printf("ERROR: Node %d: Failed to save user after header selection: %v", nodeNumber, saveErr)
+				// User selected this header - save preference. On failure, stay in
+				// the selection flow rather than exit as if the save succeeded.
+				if saveHeaderSelection(userManager, currentUser, templateNum, nodeNumber) != nil {
+					redrawAll()
+					continue
 				}
-				log.Printf("INFO: Node %d: User %s selected header style %d", nodeNumber, currentUser.Handle, templateNum)
 				break
 			}
 
@@ -374,11 +374,10 @@ func runGetHeaderType(c *cmdCtx, args string) (*user.User, string, error) {
 		if key == ' ' {
 			opt := options[selectedIndex]
 			templateNum, _ := strconv.Atoi(opt.ReturnValue)
-			currentUser.MsgHdr = templateNum
-			if saveErr := userManager.UpdateUser(currentUser); saveErr != nil {
-				log.Printf("ERROR: Node %d: Failed to save user after header selection: %v", nodeNumber, saveErr)
+			if saveHeaderSelection(userManager, currentUser, templateNum, nodeNumber) != nil {
+				redrawAll()
+				continue
 			}
-			log.Printf("INFO: Node %d: User %s selected header style %d", nodeNumber, currentUser.Handle, templateNum)
 			break
 		}
 
@@ -401,4 +400,20 @@ func runGetHeaderType(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	return nil, "", nil
+}
+
+// saveHeaderSelection persists the user's chosen message-header template. If the
+// save fails it reverts the in-memory MsgHdr so it stays consistent with disk,
+// logs the error, and returns it (callers stay in the selection flow instead of
+// exiting as if the preference was saved).
+func saveHeaderSelection(userManager *user.UserMgr, u *user.User, templateNum, nodeNumber int) error {
+	prev := u.MsgHdr
+	u.MsgHdr = templateNum
+	if err := userManager.UpdateUser(u); err != nil {
+		u.MsgHdr = prev
+		log.Printf("ERROR: Node %d: Failed to save header selection for %s: %v", nodeNumber, u.Handle, err)
+		return err
+	}
+	log.Printf("INFO: Node %d: User %s selected header style %d", nodeNumber, u.Handle, templateNum)
+	return nil
 }

--- a/internal/menu/message_reader_subst.go
+++ b/internal/menu/message_reader_subst.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/message"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
@@ -61,8 +62,9 @@ func buildMsgSubstitutions(msg *message.DisplayMessage, areaTag string, msgNum, 
 	// Truncate user note if too long (max 25 characters for display)
 	const maxUserNoteLen = 25
 	truncatedNote := userNoteToUse
-	if len(userNoteToUse) > maxUserNoteLen {
-		truncatedNote = userNoteToUse[:maxUserNoteLen-3] + "..."
+	if utf8.RuneCountInString(userNoteToUse) > maxUserNoteLen {
+		r := []rune(userNoteToUse)
+		truncatedNote = string(r[:maxUserNoteLen-3]) + "..."
 	}
 
 	// Build From field with user note and/or network address.
@@ -172,16 +174,21 @@ func buildMsgSubstitutions(msg *message.DisplayMessage, areaTag string, msgNum, 
 func buildNameWithAddr(name, addr string) string {
 	const maxLen = 45
 	suffix := " (" + addr + ")"
-	combined := name + suffix
-	if len(combined) <= maxLen {
-		return combined
+	if utf8.RuneCountInString(name)+utf8.RuneCountInString(suffix) <= maxLen {
+		return name + suffix
 	}
-	// Truncate name to fit, preserving the address suffix
-	nameMax := maxLen - len(suffix)
+	// Truncate name (by rune) to fit, preserving the address suffix. Clamp to the
+	// name's rune length so a short multi-byte name can't trigger an out-of-range
+	// or UTF-8-splitting slice.
+	nameMax := maxLen - utf8.RuneCountInString(suffix)
 	if nameMax < 3 {
 		nameMax = 3
 	}
-	return name[:nameMax] + suffix
+	r := []rune(name)
+	if nameMax > len(r) {
+		nameMax = len(r)
+	}
+	return string(r[:nameMax]) + suffix
 }
 
 // buildAutoWidths calculates the maximum display width for each placeholder code.

--- a/internal/menu/message_reader_test.go
+++ b/internal/menu/message_reader_test.go
@@ -1,0 +1,77 @@
+package menu
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+func TestBuildNameWithAddr_ShortFits(t *testing.T) {
+	if got := buildNameWithAddr("Bob", "21:1/100"); got != "Bob (21:1/100)" {
+		t.Errorf("buildNameWithAddr = %q, want %q", got, "Bob (21:1/100)")
+	}
+}
+
+func TestBuildNameWithAddr_TruncatesPreservingSuffix(t *testing.T) {
+	name := strings.Repeat("X", 60)
+	got := buildNameWithAddr(name, "21:1/100")
+	if !strings.HasSuffix(got, " (21:1/100)") {
+		t.Errorf("address suffix not preserved: %q", got)
+	}
+	if utf8.RuneCountInString(got) > 45 {
+		t.Errorf("result %d runes, want <= 45", utf8.RuneCountInString(got))
+	}
+}
+
+func TestBuildNameWithAddr_ShortNameLongAddrNoPanic(t *testing.T) {
+	// Regression: a short name with a very long address forced nameMax to 3,
+	// and the old byte-slice name[:3] panicked when len(name) < 3.
+	longAddr := strings.Repeat("a", 50)
+	got := buildNameWithAddr("Jo", longAddr) // must not panic
+	if !strings.HasSuffix(got, "("+longAddr+")") {
+		t.Errorf("suffix not preserved: %q", got)
+	}
+	if !strings.HasPrefix(got, "Jo") {
+		t.Errorf("short name should be preserved as-is: %q", got)
+	}
+}
+
+func TestBuildNameWithAddr_MultibyteTruncationStaysValid(t *testing.T) {
+	// Multibyte name that must be truncated: result must remain valid UTF-8
+	// (the old byte-slice could split a rune).
+	name := strings.Repeat("é", 50) // 50 runes, 100 bytes
+	got := buildNameWithAddr(name, "1:2/3")
+	if !utf8.ValidString(got) {
+		t.Errorf("truncation produced invalid UTF-8: %q", got)
+	}
+	if !strings.HasSuffix(got, " (1:2/3)") {
+		t.Errorf("suffix not preserved: %q", got)
+	}
+}
+
+func TestSaveHeaderSelection_Persists(t *testing.T) {
+	um, err := user.NewUserManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewUserManager: %v", err)
+	}
+	u, err := um.AddUser("password", "Bob", "Real Name", "Loc")
+	if err != nil {
+		t.Fatalf("AddUser: %v", err)
+	}
+
+	if err := saveHeaderSelection(um, u, 3, 1); err != nil {
+		t.Fatalf("saveHeaderSelection: %v", err)
+	}
+	if u.MsgHdr != 3 {
+		t.Errorf("in-memory MsgHdr = %d, want 3", u.MsgHdr)
+	}
+	got, ok := um.GetUserByID(u.ID)
+	if !ok {
+		t.Fatal("user not found after save")
+	}
+	if got.MsgHdr != 3 {
+		t.Errorf("persisted MsgHdr = %d, want 3", got.MsgHdr)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the three pre-existing robustness issues surfaced (in moved code) during the #30 review, kept out of that pure-code-movement PR. All three were latent before the split.

## Fixes
- **`buildNameWithAddr` panic + UTF-8** — truncate the name **by rune** and clamp `nameMax` to the name's rune length. A short multibyte name with a long address previously forced `nameMax = 3` and byte-sliced `name[:3]`, which could panic (name shorter than 3 bytes) or split a UTF-8 rune.
- **User-note truncation UTF-8** — `buildMsgSubstitutions` now truncates the author's note by rune, so multibyte notes aren't split mid-character.
- **`runGetHeaderType` save-failure handling** — extracted `saveHeaderSelection`, which **reverts the in-memory `MsgHdr`** (keeping it consistent with disk) and returns the error when `UpdateUser` fails. Both save paths now stay in the selection flow instead of logging success and exiting as if the preference was saved.

## Tests added
- `buildNameWithAddr`: fits / truncates-preserving-suffix / **short-name + long-addr (no panic)** / **multibyte stays valid UTF-8**.
- `saveHeaderSelection`: persists the choice (in-memory + on disk).

## Verification
- `go vet` clean, `go build ./...` clean
- `go test -race ./internal/menu/` — 274 tests
- **1,428 tests pass across 49 packages**

Independent; branched off `main`. Resolves the three deferred threads on #30.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Header template selections are now saved more reliably, so the chosen option stays applied after confirmation.
  * Display names and notes now truncate correctly for UTF-8 text, preventing broken characters and keeping addresses visible.
* **Tests**
  * Added coverage for name formatting, safe truncation, and selection persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->