### PR TITLE
test(menu): interactive TUI test harness + user-browser coverage

### DIFF
--- a/internal/menu/admin_browser_test.go
+++ b/internal/menu/admin_browser_test.go
@@ -1,0 +1,95 @@
+package menu
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+// runAdminBrowser drives adminUserLightbarBrowser through the test harness with
+// the given scripted keystrokes, returning its result plus the captured output.
+func runAdminBrowser(t *testing.T, users []*user.User, input string, selectOnEnter bool) (*user.User, bool, error, string) {
+	t.Helper()
+	ts := newTestSession(input)
+	terminal := newTestTerminal(ts)
+	u, ok, err := adminUserLightbarBrowser(ts, terminal, users, "Test Title", "pick one", ansi.OutputModeUTF8, selectOnEnter)
+	resetSessionIH(ts)
+	return u, ok, err, ts.output()
+}
+
+func browserTestUsers() []*user.User {
+	return []*user.User{
+		{ID: 1, Handle: "Alice", Validated: true},
+		{ID: 2, Handle: "Bob", Validated: true},
+		{ID: 3, Handle: "Carol", Validated: true},
+	}
+}
+
+func TestAdminBrowser_QuitNoSelection(t *testing.T) {
+	u, ok, err, out := runAdminBrowser(t, browserTestUsers(), "Q", true)
+	if u != nil || ok || err != nil {
+		t.Fatalf("quit = (%v, %v, %v), want (nil, false, nil)", u, ok, err)
+	}
+	if !strings.Contains(out, "Test Title") {
+		t.Error("rendered output should contain the title")
+	}
+	if !strings.Contains(out, "Alice") {
+		t.Error("rendered output should list the users")
+	}
+}
+
+func TestAdminBrowser_EnterSelectsCurrent(t *testing.T) {
+	u, ok, err, _ := runAdminBrowser(t, browserTestUsers(), "\r", true)
+	if err != nil || !ok || u == nil || u.Handle != "Alice" {
+		t.Fatalf("enter selected (%v, %v, %v), want Alice/true/nil", u, ok, err)
+	}
+}
+
+func TestAdminBrowser_NavigateDownThenSelect(t *testing.T) {
+	u, ok, _, _ := runAdminBrowser(t, browserTestUsers(), "j\r", true)
+	if !ok || u == nil || u.Handle != "Bob" {
+		t.Fatalf("j then enter selected %v, want Bob", u)
+	}
+}
+
+func TestAdminBrowser_ArrowDownThenSelect(t *testing.T) {
+	// Exercises ANSI escape-sequence decoding end-to-end through the harness.
+	u, ok, _, _ := runAdminBrowser(t, browserTestUsers(), "\x1b[B\r", true)
+	if !ok || u == nil || u.Handle != "Bob" {
+		t.Fatalf("arrow-down then enter selected %v, want Bob", u)
+	}
+}
+
+func TestAdminBrowser_NavigateUpClampsAtTop(t *testing.T) {
+	// 'k' at the top stays on the first user.
+	u, ok, _, _ := runAdminBrowser(t, browserTestUsers(), "k\r", true)
+	if !ok || u == nil || u.Handle != "Alice" {
+		t.Fatalf("k then enter selected %v, want Alice (clamped at top)", u)
+	}
+}
+
+func TestAdminBrowser_EOFReturnsEOF(t *testing.T) {
+	u, ok, err, _ := runAdminBrowser(t, browserTestUsers(), "", true)
+	if !errors.Is(err, io.EOF) || u != nil || ok {
+		t.Fatalf("EOF case = (%v, %v, %v), want (nil, false, io.EOF)", u, ok, err)
+	}
+}
+
+func TestAdminBrowser_EnterIgnoredWhenSelectDisabled(t *testing.T) {
+	// With selectOnEnter=false, Enter does nothing; input then hits EOF.
+	u, ok, err, _ := runAdminBrowser(t, browserTestUsers(), "\r", false)
+	if !errors.Is(err, io.EOF) || u != nil || ok {
+		t.Fatalf("enter (selectOnEnter=false) = (%v, %v, %v), want (nil, false, io.EOF)", u, ok, err)
+	}
+}
+
+func TestAdminBrowser_EmptyUserList(t *testing.T) {
+	u, ok, err := adminUserLightbarBrowser(newTestSession(""), newTestTerminal(newTestSession("")), nil, "T", "i", ansi.OutputModeUTF8, true)
+	if u != nil || ok || err != nil {
+		t.Fatalf("empty list = (%v, %v, %v), want (nil, false, nil)", u, ok, err)
+	}
+}

--- a/internal/menu/harness_test.go
+++ b/internal/menu/harness_test.go
@@ -1,0 +1,35 @@
+package menu
+
+import (
+	"bytes"
+
+	"github.com/gliderlabs/ssh"
+	"golang.org/x/term"
+)
+
+// testSession is a minimal ssh.Session for driving interactive menu functions
+// in tests. Read replays scripted keystrokes and then returns io.EOF (which the
+// menu loops treat as a disconnect); Write captures everything the function
+// renders. The embedded nil ssh.Session supplies the rest of the interface —
+// only methods a function under test actually calls need to be overridden here.
+type testSession struct {
+	ssh.Session
+	in  *bytes.Reader
+	out bytes.Buffer
+}
+
+func newTestSession(input string) *testSession {
+	return &testSession{in: bytes.NewReader([]byte(input))}
+}
+
+func (ts *testSession) Read(p []byte) (int, error)  { return ts.in.Read(p) }
+func (ts *testSession) Write(p []byte) (int, error) { return ts.out.Write(p) }
+
+// output returns everything written to the session so far.
+func (ts *testSession) output() string { return ts.out.String() }
+
+// newTestTerminal wraps a test session in a term.Terminal for output capture,
+// mirroring how the real session handler builds the terminal.
+func newTestTerminal(ts *testSession) *term.Terminal {
+	return term.NewTerminal(ts, "")
+}


### PR DESCRIPTION
## Summary

Builds the **TUI test harness** needed to safely refactor the menu's large interactive functions (audit #4 prerequisite). Previously these key-loop/render functions were untestable, which is why the remaining #4 work (e.g. `file_lightbar.go`, `runUserEditor`) was deemed too risky to touch.

## What it adds
- **`harness_test.go`** — a reusable in-process harness:
  - `testSession`: a minimal `ssh.Session` whose `Read` replays scripted keystrokes then returns `io.EOF` (treated as a disconnect by the menu loops), and whose `Write` captures rendered output.
  - `newTestTerminal`: wraps it in a `term.Terminal` exactly as the real session handler does.
  - This works because `editor.NewInputHandler` takes an `io.Reader` and reads byte-by-byte until EOF, so scripted input flows through the real `InputHandler` → `ReadKey()` path (ASCII **and** ANSI escape sequences).
- **`admin_browser_test.go`** — first use, covering `adminUserLightbarBrowser`: quit, select-on-Enter, `j`/`k` navigation, **arrow-key escape-sequence** decoding, up-clamp at top, EOF disconnect, `selectOnEnter=false`, and the empty-list early return.

## Verification
- `go test -race ./internal/menu/` — 282 tests (the `InputHandler` goroutine path is race-clean)
- `go vet` clean, `go build ./...` clean
- **1,436 tests pass across 49 packages**

## Why this first
Test-only; no production change. With this harness in place, the larger interactive functions can be driven by scripted input and asserted on output/return value, so a subsequent struct-extraction refactor of `file_lightbar.go` / `runUserEditor` can be verified rather than done blind.

(Branch name is a misnomer — this is the harness, not the file_lightbar extract it unblocks.)

Independent; branched off `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for the admin browser flow, including selection, navigation with keyboard input, arrow-key handling, quit behavior, empty lists, and end-of-input cases.
  * Introduced a reusable interactive test harness to simulate terminal input and capture rendered output for menu-related tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->