### PR TITLE
test(menu): pin runListFilesLightbar behavior (file_lightbar refactor, step 1)

### DIFF
--- a/internal/menu/file_lightbar_test.go
+++ b/internal/menu/file_lightbar_test.go
@@ -1,0 +1,106 @@
+package menu
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/file"
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+// runFileLightbar drives runListFilesLightbar through the harness with a small
+// in-memory file area (two files) and scripted keystrokes. It pins the control
+// flow (quit / EOF / navigation) so the function can be refactored safely.
+func runFileLightbar(t *testing.T, input string) (*user.User, string, error, string) {
+	t.Helper()
+	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	areasJSON := `[{"id":1,"tag":"UTILS","name":"Utilities","path":"utils","acs_list":""}]`
+	if err := os.WriteFile(filepath.Join(cfgDir, "file_areas.json"), []byte(areasJSON), 0644); err != nil {
+		t.Fatalf("write areas: %v", err)
+	}
+	fm, err := file.NewFileManager(dataDir, cfgDir)
+	if err != nil {
+		t.Fatalf("NewFileManager: %v", err)
+	}
+	for _, f := range []struct {
+		name string
+		size int64
+	}{{"readme.txt", 1024}, {"tool.zip", 2048}} {
+		if err := fm.AddFileRecord(file.FileRecord{
+			ID: uuid.New(), AreaID: 1, Filename: f.name, Description: "desc " + f.name,
+			Size: f.size, UploadedAt: time.Now(), UploadedBy: "sysop",
+		}); err != nil {
+			t.Fatalf("AddFileRecord: %v", err)
+		}
+	}
+	area, ok := fm.GetAreaByID(1)
+	if !ok {
+		t.Fatal("area 1 not found after load")
+	}
+
+	e := &MenuExecutor{FileMgr: fm}
+	u := &user.User{ID: 1, Handle: "Tester", AccessLevel: 255, Validated: true}
+	ts := newTestSession(input)
+	terminal := newTestTerminal(ts)
+
+	res, action, runErr := runListFilesLightbar(
+		e, ts, terminal, nil, u, 1, time.Now(),
+		1, "UTILS", area,
+		[]byte{}, "", []byte{}, // top / mid / bot templates
+		10, 2, 1, // filesPerPage, totalFiles, totalPages
+		nil, nil, // cmd/hi bar options -> defaults
+		ansi.OutputModeUTF8)
+	resetSessionIH(ts)
+	return res, action, runErr, ts.output()
+}
+
+func TestFileLightbar_QuitClean(t *testing.T) {
+	res, action, err, out := runFileLightbar(t, "q")
+	if res != nil || action != "" || err != nil {
+		t.Fatalf("quit = (%v, %q, %v), want (nil, \"\", nil)", res, action, err)
+	}
+	if len(out) == 0 {
+		t.Error("expected the browser to render something")
+	}
+}
+
+func TestFileLightbar_EOFLogsOff(t *testing.T) {
+	res, action, err, _ := runFileLightbar(t, "")
+	if res != nil || action != "LOGOFF" || !errors.Is(err, io.EOF) {
+		t.Fatalf("EOF = (%v, %q, %v), want (nil, \"LOGOFF\", io.EOF)", res, action, err)
+	}
+}
+
+func TestFileLightbar_NavigateDownThenQuit(t *testing.T) {
+	// Arrow-down then quit: exercises the move/re-render path before exit.
+	// (Navigation is via arrow keys here; 'j' is unmapped and 'k' is kill-file.)
+	res, action, err, out := runFileLightbar(t, "\x1b[Bq")
+	if res != nil || action != "" || err != nil {
+		t.Fatalf("nav+quit = (%v, %q, %v), want (nil, \"\", nil)", res, action, err)
+	}
+	if len(out) == 0 {
+		t.Error("expected rendered output after navigation")
+	}
+}
+
+func TestFileLightbar_NavigateUpThenQuit(t *testing.T) {
+	// Arrow-up at the top clamps, then quit.
+	res, action, err, _ := runFileLightbar(t, "\x1b[Aq")
+	if res != nil || action != "" || err != nil {
+		t.Fatalf("up+quit = (%v, %q, %v), want (nil, \"\", nil)", res, action, err)
+	}
+}
+
+func TestFileLightbar_EscQuits(t *testing.T) {
+	res, action, err, _ := runFileLightbar(t, "\x1b")
+	if res != nil || action != "" || err != nil {
+		t.Fatalf("esc = (%v, %q, %v), want (nil, \"\", nil)", res, action, err)
+	}
+}

--- a/internal/menu/file_lightbar_test.go
+++ b/internal/menu/file_lightbar_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,9 +16,13 @@ import (
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 )
 
+// fixedUploadTime keeps the fixture deterministic so two runs differ only by the
+// scripted input — letting navigation be pinned by comparing rendered output.
+var fixedUploadTime = time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
 // runFileLightbar drives runListFilesLightbar through the harness with a small
-// in-memory file area (two files) and scripted keystrokes. It pins the control
-// flow (quit / EOF / navigation) so the function can be refactored safely.
+// in-memory file area (two files) and scripted keystrokes. The mid template
+// renders each file's number/name/size so the output reflects the file list.
 func runFileLightbar(t *testing.T, input string) (*user.User, string, error, string) {
 	t.Helper()
 	dataDir, cfgDir := t.TempDir(), t.TempDir()
@@ -35,7 +40,7 @@ func runFileLightbar(t *testing.T, input string) (*user.User, string, error, str
 	}{{"readme.txt", 1024}, {"tool.zip", 2048}} {
 		if err := fm.AddFileRecord(file.FileRecord{
 			ID: uuid.New(), AreaID: 1, Filename: f.name, Description: "desc " + f.name,
-			Size: f.size, UploadedAt: time.Now(), UploadedBy: "sysop",
+			Size: f.size, UploadedAt: fixedUploadTime, UploadedBy: "sysop",
 		}); err != nil {
 			t.Fatalf("AddFileRecord: %v", err)
 		}
@@ -51,9 +56,9 @@ func runFileLightbar(t *testing.T, input string) (*user.User, string, error, str
 	terminal := newTestTerminal(ts)
 
 	res, action, runErr := runListFilesLightbar(
-		e, ts, terminal, nil, u, 1, time.Now(),
+		e, ts, terminal, nil, u, 1, fixedUploadTime,
 		1, "UTILS", area,
-		[]byte{}, "", []byte{}, // top / mid / bot templates
+		[]byte{}, "^NUM ^NAME ^SIZE", []byte{}, // top / mid / bot templates
 		10, 2, 1, // filesPerPage, totalFiles, totalPages
 		nil, nil, // cmd/hi bar options -> defaults
 		ansi.OutputModeUTF8)
@@ -66,8 +71,9 @@ func TestFileLightbar_QuitClean(t *testing.T) {
 	if res != nil || action != "" || err != nil {
 		t.Fatalf("quit = (%v, %q, %v), want (nil, \"\", nil)", res, action, err)
 	}
-	if len(out) == 0 {
-		t.Error("expected the browser to render something")
+	// The list rendered both files.
+	if !strings.Contains(out, "readme.txt") || !strings.Contains(out, "tool.zip") {
+		t.Errorf("expected both filenames in rendered output")
 	}
 }
 
@@ -78,29 +84,30 @@ func TestFileLightbar_EOFLogsOff(t *testing.T) {
 	}
 }
 
-func TestFileLightbar_NavigateDownThenQuit(t *testing.T) {
-	// Arrow-down then quit: exercises the move/re-render path before exit.
-	// (Navigation is via arrow keys here; 'j' is unmapped and 'k' is kill-file.)
-	res, action, err, out := runFileLightbar(t, "\x1b[Bq")
-	if res != nil || action != "" || err != nil {
-		t.Fatalf("nav+quit = (%v, %q, %v), want (nil, \"\", nil)", res, action, err)
-	}
-	if len(out) == 0 {
-		t.Error("expected rendered output after navigation")
-	}
-}
-
-func TestFileLightbar_NavigateUpThenQuit(t *testing.T) {
-	// Arrow-up at the top clamps, then quit.
-	res, action, err, _ := runFileLightbar(t, "\x1b[Aq")
-	if res != nil || action != "" || err != nil {
-		t.Fatalf("up+quit = (%v, %q, %v), want (nil, \"\", nil)", res, action, err)
-	}
-}
-
 func TestFileLightbar_EscQuits(t *testing.T) {
 	res, action, err, _ := runFileLightbar(t, "\x1b")
 	if res != nil || action != "" || err != nil {
 		t.Fatalf("esc = (%v, %q, %v), want (nil, \"\", nil)", res, action, err)
+	}
+}
+
+// TestFileLightbar_ArrowDownMovesSelection pins that arrow-down actually changes
+// the render (the highlight moves to the next file) — not just that the function
+// quits. The fixture is deterministic, so any difference is the navigation.
+func TestFileLightbar_ArrowDownMovesSelection(t *testing.T) {
+	_, _, _, noNav := runFileLightbar(t, "q")
+	_, _, _, down := runFileLightbar(t, "\x1b[Bq")
+	if down == noNav {
+		t.Error("arrow-down produced identical output — selection did not move")
+	}
+}
+
+// TestFileLightbar_ArrowUpAtTopClamps pins that arrow-up at the first file is a
+// no-op: its render must match the no-navigation render exactly.
+func TestFileLightbar_ArrowUpAtTopClamps(t *testing.T) {
+	_, _, _, noNav := runFileLightbar(t, "q")
+	_, _, _, up := runFileLightbar(t, "\x1b[Aq")
+	if up != noNav {
+		t.Error("arrow-up at the top changed the render — should clamp at the first file")
 	}
 }

--- a/internal/menu/harness_test.go
+++ b/internal/menu/harness_test.go
@@ -25,6 +25,13 @@ func newTestSession(input string) *testSession {
 func (ts *testSession) Read(p []byte) (int, error)  { return ts.in.Read(p) }
 func (ts *testSession) Write(p []byte) (int, error) { return ts.out.Write(p) }
 
+// Pty reports no PTY, so functions under test fall back to their default
+// dimensions (typically 80x24). Returning false avoids the nil-interface panic
+// the embedded ssh.Session would otherwise cause.
+func (ts *testSession) Pty() (ssh.Pty, <-chan ssh.Window, bool) {
+	return ssh.Pty{}, nil, false
+}
+
 // output returns everything written to the session so far.
 func (ts *testSession) output() string { return ts.out.String() }
 


### PR DESCRIPTION
## Summary

**Step 1 of the `file_lightbar.go` safe-refactor playbook**: pin `runListFilesLightbar`'s behavior before extracting it into a struct. Uses the TUI harness from #34, now with a `Pty()` stub so functions that query terminal size fall back to 80×24 instead of panicking on the nil session.

## What it pins
Builds a small in-memory file area (two files via `file.NewFileManager` + `AddFileRecord`) and drives the browser through scripted keystrokes:
- `q` → clean quit `(nil, "", nil)`
- `Esc` → clean quit
- EOF → `(nil, "LOGOFF", io.EOF)`
- arrow-down + `q`, arrow-up + `q` → navigation/re-render then clean exit

This locks the **control-flow skeleton** (input loop, navigation, exit paths).

## Scope note (honest)
These pins cover the control flow, **not** the action paths (download/view/upload/tag/kill/move/search) — those need on-disk files, transfer protocols, or confirm prompts and aren't cheaply drivable. The follow-up struct extraction is behavior-preserving by construction (moving closures into methods, not changing logic); these pins + the compiler guard the skeleton, and the extraction PR should be reviewed with that partial-coverage caveat in mind.

## Verification
- `go test -race ./internal/menu/` — 287 tests
- `go vet` clean, `go build ./...` clean, **1,441 total across 49 packages**

## Next
Merge this so the pins are on `main`, then the struct extraction lands as a follow-up PR they protect.

Test-only; independent; branched off `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added deterministic UI tests for the file lightbar, covering quitting with `q`, quitting with `ESC`, handling `EOF`/empty input by logging off, and keyboard navigation (arrow down moves selection; arrow up at the top clamps correctly).
* **Test Harness**
  * Improved the automated terminal session mock to provide safe default terminal dimensions, reducing flakiness and preventing nil-related panics during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->