### PR TITLE
test(menu): widen file-lightbar pins to action paths (extraction prep)

### DIFF
--- a/internal/menu/file_lightbar_test.go
+++ b/internal/menu/file_lightbar_test.go
@@ -2,6 +2,7 @@ package menu
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -17,13 +18,14 @@ import (
 )
 
 // fixedUploadTime keeps the fixture deterministic so two runs differ only by the
-// scripted input — letting navigation be pinned by comparing rendered output.
+// scripted input — letting navigation/paging be pinned by comparing output.
 var fixedUploadTime = time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 
-// runFileLightbar drives runListFilesLightbar through the harness with a small
-// in-memory file area (two files) and scripted keystrokes. The mid template
-// renders each file's number/name/size so the output reflects the file list.
-func runFileLightbar(t *testing.T, input string) (*user.User, string, error, string) {
+// runFileLightbarN drives runListFilesLightbar through the harness with an
+// in-memory area of numFiles files (file00.txt, file01.txt, …) and a real user
+// manager (the tag path persists via UpdateUser). The mid template renders each
+// file's mark/number/name/size so output reflects selection and tagging.
+func runFileLightbarN(t *testing.T, input string, numFiles int) (*user.User, string, error, string) {
 	t.Helper()
 	dataDir, cfgDir := t.TempDir(), t.TempDir()
 	areasJSON := `[{"id":1,"tag":"UTILS","name":"Utilities","path":"utils","acs_list":""}]`
@@ -34,13 +36,10 @@ func runFileLightbar(t *testing.T, input string) (*user.User, string, error, str
 	if err != nil {
 		t.Fatalf("NewFileManager: %v", err)
 	}
-	for _, f := range []struct {
-		name string
-		size int64
-	}{{"readme.txt", 1024}, {"tool.zip", 2048}} {
+	for i := 0; i < numFiles; i++ {
 		if err := fm.AddFileRecord(file.FileRecord{
-			ID: uuid.New(), AreaID: 1, Filename: f.name, Description: "desc " + f.name,
-			Size: f.size, UploadedAt: fixedUploadTime, UploadedBy: "sysop",
+			ID: uuid.New(), AreaID: 1, Filename: fmt.Sprintf("file%02d.txt", i),
+			Size: int64(1024 * (i + 1)), UploadedAt: fixedUploadTime, UploadedBy: "sysop",
 		}); err != nil {
 			t.Fatalf("AddFileRecord: %v", err)
 		}
@@ -50,20 +49,34 @@ func runFileLightbar(t *testing.T, input string) (*user.User, string, error, str
 		t.Fatal("area 1 not found after load")
 	}
 
+	um, err := user.NewUserManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewUserManager: %v", err)
+	}
+	u, err := um.AddUser("password", "Tester", "Real Name", "Loc")
+	if err != nil {
+		t.Fatalf("AddUser: %v", err)
+	}
+	u.AccessLevel = 255
+
 	e := &MenuExecutor{FileMgr: fm}
-	u := &user.User{ID: 1, Handle: "Tester", AccessLevel: 255, Validated: true}
 	ts := newTestSession(input)
 	terminal := newTestTerminal(ts)
 
 	res, action, runErr := runListFilesLightbar(
-		e, ts, terminal, nil, u, 1, fixedUploadTime,
+		e, ts, terminal, um, u, 1, fixedUploadTime,
 		1, "UTILS", area,
-		[]byte{}, "^NUM ^NAME ^SIZE", []byte{}, // top / mid / bot templates
-		10, 2, 1, // filesPerPage, totalFiles, totalPages
+		[]byte{}, "^MARK^NUM ^NAME ^SIZE", []byte{}, // top / mid / bot templates
+		10, numFiles, (numFiles+9)/10, // filesPerPage, totalFiles, totalPages
 		nil, nil, // cmd/hi bar options -> defaults
 		ansi.OutputModeUTF8)
 	resetSessionIH(ts)
 	return res, action, runErr, ts.output()
+}
+
+func runFileLightbar(t *testing.T, input string) (*user.User, string, error, string) {
+	t.Helper()
+	return runFileLightbarN(t, input, 2)
 }
 
 func TestFileLightbar_QuitClean(t *testing.T) {
@@ -71,8 +84,7 @@ func TestFileLightbar_QuitClean(t *testing.T) {
 	if res != nil || action != "" || err != nil {
 		t.Fatalf("quit = (%v, %q, %v), want (nil, \"\", nil)", res, action, err)
 	}
-	// The list rendered both files.
-	if !strings.Contains(out, "readme.txt") || !strings.Contains(out, "tool.zip") {
+	if !strings.Contains(out, "file00.txt") || !strings.Contains(out, "file01.txt") {
 		t.Errorf("expected both filenames in rendered output")
 	}
 }
@@ -91,9 +103,6 @@ func TestFileLightbar_EscQuits(t *testing.T) {
 	}
 }
 
-// TestFileLightbar_ArrowDownMovesSelection pins that arrow-down actually changes
-// the render (the highlight moves to the next file) — not just that the function
-// quits. The fixture is deterministic, so any difference is the navigation.
 func TestFileLightbar_ArrowDownMovesSelection(t *testing.T) {
 	_, _, _, noNav := runFileLightbar(t, "q")
 	_, _, _, down := runFileLightbar(t, "\x1b[Bq")
@@ -102,12 +111,60 @@ func TestFileLightbar_ArrowDownMovesSelection(t *testing.T) {
 	}
 }
 
-// TestFileLightbar_ArrowUpAtTopClamps pins that arrow-up at the first file is a
-// no-op: its render must match the no-navigation render exactly.
 func TestFileLightbar_ArrowUpAtTopClamps(t *testing.T) {
 	_, _, _, noNav := runFileLightbar(t, "q")
 	_, _, _, up := runFileLightbar(t, "\x1b[Aq")
 	if up != noNav {
 		t.Error("arrow-up at the top changed the render — should clamp at the first file")
+	}
+}
+
+// TestFileLightbar_SpaceTogglesTag pins the tag path: Space marks the selected
+// file (persisting via UpdateUser), which renders as a '*' in the ^MARK column.
+func TestFileLightbar_SpaceTogglesTag(t *testing.T) {
+	_, _, _, untagged := runFileLightbar(t, "q")
+	_, _, _, tagged := runFileLightbar(t, " q")
+	if strings.Contains(untagged, "*") {
+		t.Error("no file should be marked before tagging")
+	}
+	if !strings.Contains(tagged, "*") {
+		t.Error("Space should mark the selected file with '*'")
+	}
+}
+
+// TestFileLightbar_CmdBarNavChangesRender pins that arrow-right moves the command
+// bar selection (re-rendering the bar differently).
+func TestFileLightbar_CmdBarNavChangesRender(t *testing.T) {
+	_, _, _, noNav := runFileLightbar(t, "q")
+	_, _, _, right := runFileLightbar(t, "\x1b[Cq")
+	if right == noNav {
+		t.Error("arrow-right produced identical output — command-bar selection did not move")
+	}
+}
+
+// TestFileLightbar_PageDownChangesView pins paging: with more files than fit on
+// one screen, PageDown shows a different slice of the list.
+func TestFileLightbar_PageDownChangesView(t *testing.T) {
+	_, _, _, page1 := runFileLightbarN(t, "q", 30)
+	_, _, _, paged := runFileLightbarN(t, "\x1b[6~q", 30)
+	if paged == page1 {
+		t.Error("PageDown produced identical output with 30 files — paging did not advance")
+	}
+}
+
+// TestFileLightbar_EndJumpsToLastFile pins End: with more files than fit on a
+// screen, End scrolls to the last page (a different rendered slice than the top).
+func TestFileLightbar_EndJumpsToLastFile(t *testing.T) {
+	_, _, _, top := runFileLightbarN(t, "q", 30)
+	_, _, _, end := runFileLightbarN(t, "\x1b[Fq", 30)
+	if end == top {
+		t.Error("End produced identical output with 30 files — did not jump to the last page")
+	}
+	// The last file should be visible after End but not on the first screen.
+	if strings.Contains(top, "file29.txt") {
+		t.Skip("all files fit on one screen; End-paging not exercised")
+	}
+	if !strings.Contains(end, "file29.txt") {
+		t.Error("End should scroll the last file (file29.txt) into view")
 	}
 }


### PR DESCRIPTION
## Summary

Widens the `runListFilesLightbar` behavior pins beyond the control-flow skeleton (#35) so the upcoming struct extraction is **verifiable** across more paths. Uses a real `user.UserMgr` (the tag path persists via `UpdateUser`) and a `^MARK`-rendering mid template, all driven through the TUI harness.

## Newly pinned (action paths)
- **Space** tags the selected file → renders `*` in the mark column
- **arrow-right** moves the command-bar selection (re-renders the bar)
- **PageDown** advances the view (30-file fixture → multiple pages)
- **End** scrolls the last file (`file29.txt`) into view

Plus the existing quit / EOF / Esc / arrow-down-moves / arrow-up-clamps.

## Honest residual
The **file-operation** actions — download (`d`), view (`v`), upload (`u`), edit (`e`), kill (`k`), move (`m`) — need on-disk files, transfer-protocol mocking, or confirm prompts and remain unpinned. The struct-extraction PR that follows will refactor those paths with this caveat called out for review.

## Verification
- `go test -race ./internal/menu/` — 291 tests
- `go vet` clean, `go build ./...` clean, **1,445 total across 49 packages**

Test-only; independent; branched off `main`. Next: the `fileLightbar` struct extraction, protected by these pins.