### PR TITLE
refactor(menu): extract file-lightbar command-bar + size helpers

### DIFF
--- a/internal/menu/file_lightbar.go
+++ b/internal/menu/file_lightbar.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ViSiON-3/vision-3-bbs/internal/ziplab"
 )
 
-
 // fileListPlaceholderRegex matches @FPAGE@, @FTOTAL@, @FCONFPATH@ with optional alignment and width.
 // Modifier: | (0x7C) or │ (CP437 0xB3, common in ANSI art) followed by L/R/C — matches message-header format.
 // Groups: 1=code (FPAGE|FTOTAL|FCONFPATH), 2=modifier (L|R|C), 3=:N digits, 4=# sequence
@@ -111,82 +110,9 @@ func runListFilesLightbar(e *MenuExecutor, s ssh.Session, terminal *term.Termina
 	cmdIndex := 0
 	ih := getSessionIH(s)
 
-	// Build command bar entries from BAR file or defaults.
-	type cmdEntry struct {
-		label          string
-		hotkey         string
-		highlightColor string
-		regularColor   string
-	}
-
-	var cmdEntries []cmdEntry
-	if len(cmdBarOptions) > 0 {
-		for _, opt := range cmdBarOptions {
-			cmdEntries = append(cmdEntries, cmdEntry{
-				label:          opt.Text,
-				hotkey:         strings.ToLower(opt.HotKey),
-				highlightColor: colorCodeToAnsi(opt.HighlightColor),
-				regularColor:   colorCodeToAnsi(opt.RegularColor),
-			})
-		}
-	} else {
-		// Default entries using theme colors.
-		defHi := colorCodeToAnsi(e.Theme.YesNoHighlightColor)
-		defLo := colorCodeToAnsi(e.Theme.YesNoRegularColor)
-		defaults := []struct {
-			label  string
-			hotkey string
-		}{
-			{"Mark", " "},
-			{"Info", "i"},
-			{"View", "v"},
-			{"Download", "d"},
-			{"Upload", "u"},
-			{"Quit", "q"},
-		}
-		for _, d := range defaults {
-			cmdEntries = append(cmdEntries, cmdEntry{
-				label:          d.label,
-				hotkey:         d.hotkey,
-				highlightColor: defHi,
-				regularColor:   defLo,
-			})
-		}
-	}
-
-	// Build sysop-only entries (toggled with * key).
-	isSysop := e.isCoSysOpOrAbove(currentUser)
-	var sysopEntries []cmdEntry
-	if isSysop {
-		defHiSysop := colorCodeToAnsi(e.Theme.YesNoHighlightColor)
-		defLoSysop := colorCodeToAnsi(e.Theme.YesNoRegularColor)
-		sysopCmds := []struct {
-			label  string
-			hotkey string
-		}{
-			{"Edit", "e"},
-			{"Kill", "k"},
-			{"Move", "m"},
-			{"Rename", "r"},
-		}
-		for _, d := range sysopCmds {
-			sysopEntries = append(sysopEntries, cmdEntry{
-				label:          d.label,
-				hotkey:         d.hotkey,
-				highlightColor: defHiSysop,
-				regularColor:   defLoSysop,
-			})
-		}
-	}
-	userEntries := make([]cmdEntry, len(cmdEntries))
-	copy(userEntries, cmdEntries)
+	// Build command bar entries (user bar, sysop bar) and the file-row highlight.
+	cmdEntries, sysopEntries, userEntries, hiColorSeq, isSysop := buildFileListCmdBar(e, currentUser, cmdBarOptions, hiBarOptions)
 	showSysopBar := false
-
-	// Highlight colors for file rows.
-	hiColorSeq := colorCodeToAnsi(e.Theme.YesNoHighlightColor)
-	if len(hiBarOptions) > 0 {
-		hiColorSeq = colorCodeToAnsi(hiBarOptions[0].HighlightColor)
-	}
 
 	// Determine terminal dimensions.
 	termHeight := 24
@@ -233,16 +159,6 @@ func runListFilesLightbar(e *MenuExecutor, s ssh.Session, terminal *term.Termina
 			}
 		}
 		return false
-	}
-
-	formatSize := func(size int64) string {
-		if size < 1024 {
-			return fmt.Sprintf("%dB", size)
-		}
-		if size < 10*1024*1024 {
-			return fmt.Sprintf("%dk", size/1024)
-		}
-		return fmt.Sprintf("%dM", size/(1024*1024))
 	}
 
 	// stripAnsi removes all ANSI escape sequences from a string.
@@ -431,7 +347,7 @@ func runListFilesLightbar(e *MenuExecutor, s ssh.Session, terminal *term.Termina
 		}
 		fileNameStr := fmt.Sprintf("%-12s", name)
 		dateStr := fileRec.UploadedAt.Format("01/02/06")
-		sizeStr := fmt.Sprintf("%5s", formatSize(fileRec.Size))
+		sizeStr := fmt.Sprintf("%5s", compactFileSize(fileRec.Size))
 
 		markStr := " "
 		if isFileTagged(fileRec.ID) {
@@ -887,7 +803,7 @@ func runListFilesLightbar(e *MenuExecutor, s ssh.Session, terminal *term.Termina
 				_ = terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 
 				d1 := fmt.Sprintf("|15Filename  : |07%s\r\n", sel.Filename)
-				d2 := fmt.Sprintf("|15Size      : |07%s\r\n", formatSize(sel.Size))
+				d2 := fmt.Sprintf("|15Size      : |07%s\r\n", compactFileSize(sel.Size))
 				_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(d1)), outputMode)
 				_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(d2)), outputMode)
 

--- a/internal/menu/file_lightbar_cmdbar.go
+++ b/internal/menu/file_lightbar_cmdbar.go
@@ -1,0 +1,103 @@
+package menu
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+// cmdEntry is one entry in the file-lightbar command bar.
+type cmdEntry struct {
+	label          string
+	hotkey         string
+	highlightColor string
+	regularColor   string
+}
+
+// buildFileListCmdBar builds the command-bar entries for the file lightbar: the
+// user bar (from a configured BAR file, or theme-colored defaults), the
+// sysop-only bar (toggled with '*'), and a copy of the user bar used to restore
+// it. It also returns the file-row highlight color and whether the current user
+// is a sysop.
+func buildFileListCmdBar(e *MenuExecutor, currentUser *user.User, cmdBarOptions, hiBarOptions []LightbarOption) (cmdEntries, sysopEntries, userEntries []cmdEntry, hiColorSeq string, isSysop bool) {
+	if len(cmdBarOptions) > 0 {
+		for _, opt := range cmdBarOptions {
+			cmdEntries = append(cmdEntries, cmdEntry{
+				label:          opt.Text,
+				hotkey:         strings.ToLower(opt.HotKey),
+				highlightColor: colorCodeToAnsi(opt.HighlightColor),
+				regularColor:   colorCodeToAnsi(opt.RegularColor),
+			})
+		}
+	} else {
+		// Default entries using theme colors.
+		defHi := colorCodeToAnsi(e.Theme.YesNoHighlightColor)
+		defLo := colorCodeToAnsi(e.Theme.YesNoRegularColor)
+		defaults := []struct {
+			label  string
+			hotkey string
+		}{
+			{"Mark", " "},
+			{"Info", "i"},
+			{"View", "v"},
+			{"Download", "d"},
+			{"Upload", "u"},
+			{"Quit", "q"},
+		}
+		for _, d := range defaults {
+			cmdEntries = append(cmdEntries, cmdEntry{
+				label:          d.label,
+				hotkey:         d.hotkey,
+				highlightColor: defHi,
+				regularColor:   defLo,
+			})
+		}
+	}
+
+	// Build sysop-only entries (toggled with the '*' key).
+	isSysop = e.isCoSysOpOrAbove(currentUser)
+	if isSysop {
+		defHiSysop := colorCodeToAnsi(e.Theme.YesNoHighlightColor)
+		defLoSysop := colorCodeToAnsi(e.Theme.YesNoRegularColor)
+		sysopCmds := []struct {
+			label  string
+			hotkey string
+		}{
+			{"Edit", "e"},
+			{"Kill", "k"},
+			{"Move", "m"},
+			{"Rename", "r"},
+		}
+		for _, d := range sysopCmds {
+			sysopEntries = append(sysopEntries, cmdEntry{
+				label:          d.label,
+				hotkey:         d.hotkey,
+				highlightColor: defHiSysop,
+				regularColor:   defLoSysop,
+			})
+		}
+	}
+
+	userEntries = make([]cmdEntry, len(cmdEntries))
+	copy(userEntries, cmdEntries)
+
+	// File-row highlight color.
+	hiColorSeq = colorCodeToAnsi(e.Theme.YesNoHighlightColor)
+	if len(hiBarOptions) > 0 {
+		hiColorSeq = colorCodeToAnsi(hiBarOptions[0].HighlightColor)
+	}
+	return cmdEntries, sysopEntries, userEntries, hiColorSeq, isSysop
+}
+
+// compactFileSize renders a byte count compactly: bytes (B), kilobytes (k), or
+// megabytes (M).
+func compactFileSize(size int64) string {
+	if size < 1024 {
+		return fmt.Sprintf("%dB", size)
+	}
+	if size < 10*1024*1024 {
+		return fmt.Sprintf("%dk", size/1024)
+	}
+	return fmt.Sprintf("%dM", size/(1024*1024))
+}

--- a/internal/menu/file_lightbar_cmdbar_test.go
+++ b/internal/menu/file_lightbar_cmdbar_test.go
@@ -1,0 +1,105 @@
+package menu
+
+import (
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+func TestCompactFileSize(t *testing.T) {
+	cases := []struct {
+		size int64
+		want string
+	}{
+		{0, "0B"},
+		{512, "512B"},
+		{1023, "1023B"},
+		{1024, "1k"},
+		{2048, "2k"},
+		{10*1024*1024 - 1, "10239k"},
+		{10 * 1024 * 1024, "10M"},
+		{25 * 1024 * 1024, "25M"},
+	}
+	for _, tc := range cases {
+		if got := compactFileSize(tc.size); got != tc.want {
+			t.Errorf("compactFileSize(%d) = %q, want %q", tc.size, got, tc.want)
+		}
+	}
+}
+
+func hotkeys(entries []cmdEntry) []string {
+	out := make([]string, len(entries))
+	for i, e := range entries {
+		out[i] = e.hotkey
+	}
+	return out
+}
+
+func TestBuildFileListCmdBar_Defaults(t *testing.T) {
+	e := &MenuExecutor{ServerCfg: config.ServerConfig{CoSysOpLevel: 100}}
+	regular := &user.User{Handle: "Reg", AccessLevel: 10}
+
+	cmd, sysop, userBar, _, isSysop := buildFileListCmdBar(e, regular, nil, nil)
+
+	if isSysop {
+		t.Error("regular user (level 10 < CoSysOp 100) should not be sysop")
+	}
+	if len(sysop) != 0 {
+		t.Errorf("non-sysop should get no sysop entries, got %d", len(sysop))
+	}
+	gotHK := hotkeys(cmd)
+	wantHK := []string{" ", "i", "v", "d", "u", "q"}
+	if len(gotHK) != len(wantHK) {
+		t.Fatalf("default cmd bar = %v, want %v", gotHK, wantHK)
+	}
+	for i := range wantHK {
+		if gotHK[i] != wantHK[i] {
+			t.Errorf("default hotkey[%d] = %q, want %q", i, gotHK[i], wantHK[i])
+		}
+	}
+	// userEntries is a copy of the user bar.
+	if len(userBar) != len(cmd) {
+		t.Errorf("userEntries len = %d, want %d", len(userBar), len(cmd))
+	}
+}
+
+func TestBuildFileListCmdBar_SysopEntries(t *testing.T) {
+	e := &MenuExecutor{ServerCfg: config.ServerConfig{CoSysOpLevel: 100}}
+	sysopUser := &user.User{Handle: "Sys", AccessLevel: 255}
+
+	_, sysop, _, _, isSysop := buildFileListCmdBar(e, sysopUser, nil, nil)
+	if !isSysop {
+		t.Fatal("level-255 user should be a sysop with CoSysOp 100")
+	}
+	wantHK := []string{"e", "k", "m", "r"}
+	gotHK := hotkeys(sysop)
+	if len(gotHK) != len(wantHK) {
+		t.Fatalf("sysop bar = %v, want %v", gotHK, wantHK)
+	}
+	for i := range wantHK {
+		if gotHK[i] != wantHK[i] {
+			t.Errorf("sysop hotkey[%d] = %q, want %q", i, gotHK[i], wantHK[i])
+		}
+	}
+}
+
+func TestBuildFileListCmdBar_UsesConfiguredOptions(t *testing.T) {
+	e := &MenuExecutor{ServerCfg: config.ServerConfig{CoSysOpLevel: 100}}
+	regular := &user.User{Handle: "Reg", AccessLevel: 10}
+	opts := []LightbarOption{
+		{Text: "Go", HotKey: "G"},
+		{Text: "Back", HotKey: "B"},
+	}
+	cmd, _, _, _, _ := buildFileListCmdBar(e, regular, opts, nil)
+	if len(cmd) != 2 {
+		t.Fatalf("configured cmd bar = %d entries, want 2", len(cmd))
+	}
+	// HotKeys are lowercased.
+	if cmd[0].hotkey != "g" || cmd[1].hotkey != "b" {
+		t.Errorf("configured hotkeys = %q/%q, want g/b", cmd[0].hotkey, cmd[1].hotkey)
+	}
+	if cmd[0].label != "Go" {
+		t.Errorf("label = %q, want Go", cmd[0].label)
+	}
+}


### PR DESCRIPTION
## Summary

Reduces `runListFilesLightbar` by extracting its reliably-isolatable pieces into tested package functions. Verified behavior-preserving by the merged pins (#35/#36).

## Why not the full struct rewrite
After reading the whole 1,176-line function, a closures→struct conversion proved too risky to do behavior-preservingly **right now**:
- handlers locally redeclare `termWidth, termHeight := getTerminalSize(s)` (shadowing the would-be struct fields — a mechanical `→ lb.field` rewrite breaks here),
- `ih` is reassigned mid-loop after a transfer,
- the six file-operation paths (`v`/`d`/`u`/`e`/`k`/`m`) call transfer protocols / prompts / ziplab and aren't drivable by the current pins.

So instead of a high-risk ~1,100-line blind rewrite of a now-well-tested function, this extracts the self-contained parts:

| Extracted | What |
| --------- | ---- |
| `cmdEntry` (package type) | promoted out of the function |
| `buildFileListCmdBar(...)` | the ~70-line command-bar construction (user bar, sysop bar, highlight color, isSysop) |
| `compactFileSize(size)` | the compact `B`/`k`/`M` formatter (distinct from the decimal `util.FormatFileSize`) |

`file_lightbar.go`: **1,297 → 1,213**; the extracted logic is now unit-tested.

## Tests added
- `compactFileSize`: B/k/M thresholds incl. the 10 MB k→M boundary
- `buildFileListCmdBar`: default bar, sysop entries (level-gated), configured-options path, lowercased hotkeys

## Verification
- merged `runListFilesLightbar` pins still pass (behavior preserved)
- `go vet` clean, `go build ./...` clean, `go test -race ./internal/menu/` — 295 tests

The remaining closures/event-loop stay as-is; a full struct extraction would need the file-op paths pinned first (or a careful dedicated pass handling the shadowing). Independent; branched off `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a refreshed file-list command bar with clearer default actions and support for additional privileged actions when available.
  * Improved file size display to use more compact, human-friendly units in file listings and the info overlay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->