### PR TITLE
fix(menu): preserve download fail count and guard rename clobber

### DIFF
--- a/internal/menu/file_lightbar.go
+++ b/internal/menu/file_lightbar.go
@@ -1273,8 +1273,12 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			// Guard against clobbering an untracked file already on disk at the
 			// target path (the duplicate check above only consults DB records).
 			// os.SameFile permits a case-only rename of the same file on a
-			// case-insensitive filesystem.
-			if newInfo, statErr := os.Stat(newPath); statErr == nil {
+			// case-insensitive filesystem. A stat error other than "not exist"
+			// (e.g. a permission/IO fault) means we cannot prove the target is
+			// safe to overwrite, so refuse rather than risk a clobber.
+			newInfo, statErr := os.Stat(newPath)
+			switch {
+			case statErr == nil:
 				oldInfo, oldStatErr := os.Stat(oldPath)
 				if oldStatErr != nil || !os.SameFile(oldInfo, newInfo) {
 					log.Printf("ERROR: Node %d: Rename target %s already exists on disk.", lb.nodeNumber, newPath)
@@ -1283,6 +1287,12 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 					needFullRedraw = true
 					continue
 				}
+			case !errors.Is(statErr, os.ErrNotExist):
+				log.Printf("ERROR: Node %d: Cannot stat rename target %s: %v", lb.nodeNumber, newPath, statErr)
+				_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Rename failed.|07\r\n")), lb.outputMode)
+				time.Sleep(1 * time.Second)
+				needFullRedraw = true
+				continue
 			}
 			if renErr := os.Rename(oldPath, newPath); renErr != nil {
 				log.Printf("ERROR: Node %d: Failed to rename %s to %s: %v", lb.nodeNumber, rec.Filename, newName, renErr)

--- a/internal/menu/file_lightbar.go
+++ b/internal/menu/file_lightbar.go
@@ -1051,18 +1051,21 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 					}
 					log.Printf("ERROR: Node %d: Protocol selection error: %v", lb.nodeNumber, protoErr)
 					_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Error: No transfer protocols configured on this system.|07\r\n")), lb.outputMode)
-					failCount = len(filesToDownload)
+					failCount += len(filesToDownload)
 				} else if !protoOK {
 					_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|07Download cancelled.|07\r\n")), lb.outputMode)
 				} else {
-					successCount, failCount = lb.e.runTransferSend(lb.s, lb.terminal, proto, filesToDownload, fileIDsToDownload, lb.outputMode, lb.nodeNumber)
+					sentCount, sendFails := lb.e.runTransferSend(lb.s, lb.terminal, proto, filesToDownload, fileIDsToDownload, lb.outputMode, lb.nodeNumber)
+					successCount = sentCount
+					failCount += sendFails
 					lb.ih = getSessionIH(lb.s)
 				}
 				time.Sleep(1 * time.Second)
 			} else {
 				log.Printf("WARN: Node %d: No valid file paths found for tagged files.", lb.nodeNumber)
 				_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Could not find any of the marked files on the server.|07\r\n")), lb.outputMode)
-				failCount = len(lb.currentUser.TaggedFileIDs)
+				// failCount already equals the number of missing files (every
+				// tagged ID incremented it in the collection loop above).
 			}
 
 			// Clear tags, update download count, and save.
@@ -1267,6 +1270,20 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				continue
 			}
 			newPath := filepath.Join(filepath.Dir(oldPath), newName)
+			// Guard against clobbering an untracked file already on disk at the
+			// target path (the duplicate check above only consults DB records).
+			// os.SameFile permits a case-only rename of the same file on a
+			// case-insensitive filesystem.
+			if newInfo, statErr := os.Stat(newPath); statErr == nil {
+				oldInfo, oldStatErr := os.Stat(oldPath)
+				if oldStatErr != nil || !os.SameFile(oldInfo, newInfo) {
+					log.Printf("ERROR: Node %d: Rename target %s already exists on disk.", lb.nodeNumber, newPath)
+					_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|01A file with that name already exists.|07\r\n")), lb.outputMode)
+					time.Sleep(1 * time.Second)
+					needFullRedraw = true
+					continue
+				}
+			}
 			if renErr := os.Rename(oldPath, newPath); renErr != nil {
 				log.Printf("ERROR: Node %d: Failed to rename %s to %s: %v", lb.nodeNumber, rec.Filename, newName, renErr)
 				_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Rename failed.|07\r\n")), lb.outputMode)


### PR DESCRIPTION
Two pre-existing file-lightbar bugs surfaced during the #38 struct extraction and deferred there to keep that refactor behavior-preserving.

## Download fail count
The tagged-file collection loop increments `failCount` for each missing/unresolvable file, but the transfer branch then **overwrote** `failCount` with `runTransferSend`'s result:

```go
successCount, failCount = lb.e.runTransferSend(...)
```

So if 2 tagged files were missing and 3 transferred fine, the summary read `Failed: 0`. Now it accumulates (`failCount += sendFails`) so the summary reflects both missing files and transfer failures.

## Rename clobber guard
The sysop rename duplicate-name check only consulted DB records (`lb.allFiles`), so an **untracked** file already sitting at the target path would be silently overwritten by `os.Rename`. Added an `os.Stat` guard before the rename. `os.SameFile` is used so a case-only rename of the *same* file on a case-insensitive filesystem (e.g. macOS default) still succeeds.

## Testing
- `go build ./...` clean
- `go vet ./internal/menu/` clean, `gofmt` clean
- `go test ./internal/menu/` — all pass

These two code paths (transfer send, sysop rename of a real on-disk file) aren't exercised by the existing harness fixtures (DB records only, no disk files, no transfer mock), so the fixes are verified by inspection + build/vet/test rather than a new pinning test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk download progress tracking by accumulating failures incrementally and correctly reflecting transfer results.
  * Made download selection behavior more consistent when no valid file paths are found.
  * Prevented sysop renames from overwriting a different existing file by adding a safety check before renaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->