### PR TITLE
feat(logging): internal/logging package + LoggingConfig (Phase A foundation)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -775,12 +775,12 @@ func LoadThemeConfig(menuSetPath string) (ThemeConfig, error) {
 // Echo area routing is derived from message_areas.json (areas where Network matches),
 // not stored per-link. The Message Areas TUI is the canonical place to manage subscriptions.
 type FTNLinkConfig struct {
-	Address         string `json:"address"`                     // e.g., "21:1/100"
-	PacketPassword  string `json:"packet_password"`             // Packet password (formerly "password")
-	SessionPassword string `json:"session_password,omitempty"`  // BinkP session/connection password
-	AreafixPassword string `json:"areafix_password,omitempty"`  // Password for AreaFix netmail (subject line)
-	Name            string `json:"name"`                        // Human-readable name
-	Flavour         string `json:"flavour,omitempty"`           // Delivery flavour: Normal (default), Crash, Hold, Direct
+	Address         string `json:"address"`                    // e.g., "21:1/100"
+	PacketPassword  string `json:"packet_password"`            // Packet password (formerly "password")
+	SessionPassword string `json:"session_password,omitempty"` // BinkP session/connection password
+	AreafixPassword string `json:"areafix_password,omitempty"` // Password for AreaFix netmail (subject line)
+	Name            string `json:"name"`                       // Human-readable name
+	Flavour         string `json:"flavour,omitempty"`          // Delivery flavour: Normal (default), Crash, Hold, Direct
 }
 
 // UnmarshalJSON supports backward compatibility: "password" is read into PacketPassword
@@ -893,6 +893,59 @@ type ServerConfig struct {
 	// DOS emulation — system-wide dosemu2 settings for DOS door games.
 	DosemuPath string `json:"dosemuPath,omitempty"` // Path to dosemu2 binary (default: /usr/libexec/dosemu2/dosemu2.bin)
 
+	// Logging configuration (file location, level, caching, rolling). Shared by
+	// all binaries; each supplies its own default log filename in code.
+	Logging LoggingConfig `json:"logging"`
+}
+
+// Log rolling types persisted in LoggingConfig.Type.
+const (
+	LogTypeNone  = 0 // append to a single file indefinitely
+	LogTypeSize  = 1 // roll by size, keeping MaxFiles numbered backups
+	LogTypeDaily = 2 // roll daily, keeping MaxFiles days of dated files
+)
+
+// Default logging values, applied when the "logging" key is absent or a field
+// is left at its zero value.
+const (
+	DefaultLogDir       = "data/logs"
+	DefaultLogLevel     = "INFO"
+	DefaultLogMaxFiles  = 5
+	DefaultLogMaxSizeKB = 1024 // 1 MB
+)
+
+// LoggingConfig controls log file location, minimum level, write caching, and
+// rolling behavior. It is persisted under the "logging" key in config.json.
+type LoggingConfig struct {
+	Dir       string `json:"dir"`       // directory for log files (default "data/logs")
+	Level     string `json:"level"`     // DEBUG|INFO|WARN|ERROR minimum level (default INFO)
+	Cache     bool   `json:"cache"`     // buffer writes in an 8KB cache (default true)
+	Type      int    `json:"type"`      // 0=none 1=size 2=daily (default 0)
+	MaxFiles  int    `json:"maxFiles"`  // retained backups (type 1) / days (type 2)
+	MaxSizeKB int    `json:"maxSizeKb"` // rotate threshold in KB (type 1)
+}
+
+// Normalize fills empty strings with defaults and clamps numeric fields to safe
+// lower bounds so a config typo (e.g. MaxSizeKB=0) cannot cause immediate log
+// loss or rotate-on-every-write. The level string is validated separately by
+// the logging package at Init time.
+func (c *LoggingConfig) Normalize() {
+	if strings.TrimSpace(c.Dir) == "" {
+		c.Dir = DefaultLogDir
+	}
+	if strings.TrimSpace(c.Level) == "" {
+		c.Level = DefaultLogLevel
+	}
+	// MaxFiles bounds the number of retained backups (type 1) or days (type 2);
+	// it must be positive whenever rolling is enabled.
+	if c.Type != LogTypeNone && c.MaxFiles < 1 {
+		c.MaxFiles = DefaultLogMaxFiles
+	}
+	// MaxSizeKB only applies to size-based rolling; a non-positive threshold
+	// would rotate on every write.
+	if c.Type == LogTypeSize && c.MaxSizeKB < 1 {
+		c.MaxSizeKB = DefaultLogMaxSizeKB
+	}
 }
 
 // V3NetConfig holds V3Net networking configuration.
@@ -943,11 +996,11 @@ type V3NetHubArea struct {
 
 // V3NetLeafConfig configures a subscription to a V3Net network.
 type V3NetLeafConfig struct {
-	HubURL         string   `json:"hubUrl"`
-	Network        string   `json:"network"`
-	Boards         []string `json:"boards"`                    // Local message area tags to write received messages
-	PollInterval   string   `json:"pollInterval"`              // Duration string (e.g., "5m")
-	Origin         string   `json:"origin,omitempty"`          // Origin line text (e.g. "My Cool BBS - bbs.example.com")
+	HubURL       string   `json:"hubUrl"`
+	Network      string   `json:"network"`
+	Boards       []string `json:"boards"`           // Local message area tags to write received messages
+	PollInterval string   `json:"pollInterval"`     // Duration string (e.g., "5m")
+	Origin       string   `json:"origin,omitempty"` // Origin line text (e.g. "My Cool BBS - bbs.example.com")
 }
 
 // EventConfig defines a scheduled event configuration
@@ -1012,6 +1065,14 @@ func LoadServerConfig(configPath string) (ServerConfig, error) {
 		NUVKill:                   false,
 		NUVLevel:                  25,
 		NUVForm:                   1,
+		Logging: LoggingConfig{
+			Dir:       DefaultLogDir,
+			Level:     DefaultLogLevel,
+			Cache:     true,
+			Type:      LogTypeNone,
+			MaxFiles:  DefaultLogMaxFiles,
+			MaxSizeKB: DefaultLogMaxSizeKB,
+		},
 	}
 
 	data, err := os.ReadFile(filePath)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -922,7 +922,7 @@ type LoggingConfig struct {
 	Cache     bool   `json:"cache"`     // buffer writes in an 8KB cache (default true)
 	Type      int    `json:"type"`      // 0=none 1=size 2=daily (default 0)
 	MaxFiles  int    `json:"maxFiles"`  // retained backups (type 1) / days (type 2)
-	MaxSizeKB int    `json:"maxSizeKb"` // rotate threshold in KB (type 1)
+	MaxSizeKB int    `json:"maxSizeKB"` // rotate threshold in KB (type 1)
 }
 
 // Normalize fills empty strings with defaults and clamps numeric fields to safe

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -451,6 +451,98 @@ func TestLoadServerConfig_PartialOverlayPreservesDefaults(t *testing.T) {
 	}
 }
 
+func TestLoadServerConfig_LoggingDefaults(t *testing.T) {
+	tmpDir := t.TempDir()
+	// config.json with no "logging" key — back-compat: defaults must apply.
+	data, _ := json.Marshal(map[string]interface{}{"boardName": "X"})
+	os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644)
+
+	result, err := LoadServerConfig(tmpDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	lg := result.Logging
+	if lg.Dir != DefaultLogDir {
+		t.Errorf("Dir = %q, want %q", lg.Dir, DefaultLogDir)
+	}
+	if lg.Level != DefaultLogLevel {
+		t.Errorf("Level = %q, want %q", lg.Level, DefaultLogLevel)
+	}
+	if !lg.Cache {
+		t.Error("Cache should default to true")
+	}
+	if lg.Type != LogTypeNone {
+		t.Errorf("Type = %d, want %d", lg.Type, LogTypeNone)
+	}
+	if lg.MaxFiles != DefaultLogMaxFiles || lg.MaxSizeKB != DefaultLogMaxSizeKB {
+		t.Errorf("MaxFiles/MaxSizeKB = %d/%d, want %d/%d", lg.MaxFiles, lg.MaxSizeKB, DefaultLogMaxFiles, DefaultLogMaxSizeKB)
+	}
+}
+
+func TestLoadServerConfig_LoggingPartialOverlay(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Only override level; sibling logging fields keep their defaults.
+	data, _ := json.Marshal(map[string]interface{}{
+		"logging": map[string]interface{}{"level": "DEBUG"},
+	})
+	os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644)
+
+	result, err := LoadServerConfig(tmpDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Logging.Level != "DEBUG" {
+		t.Errorf("Level = %q, want DEBUG", result.Logging.Level)
+	}
+	if result.Logging.Dir != DefaultLogDir {
+		t.Errorf("Dir = %q, want default %q (partial overlay should preserve siblings)", result.Logging.Dir, DefaultLogDir)
+	}
+}
+
+func TestLoggingConfig_Normalize(t *testing.T) {
+	t.Run("empty strings get defaults", func(t *testing.T) {
+		c := LoggingConfig{}
+		c.Normalize()
+		if c.Dir != DefaultLogDir || c.Level != DefaultLogLevel {
+			t.Errorf("Dir/Level = %q/%q, want %q/%q", c.Dir, c.Level, DefaultLogDir, DefaultLogLevel)
+		}
+	})
+	t.Run("size type clamps non-positive MaxFiles and MaxSizeKB", func(t *testing.T) {
+		c := LoggingConfig{Type: LogTypeSize, MaxFiles: 0, MaxSizeKB: 0}
+		c.Normalize()
+		if c.MaxFiles != DefaultLogMaxFiles {
+			t.Errorf("MaxFiles = %d, want clamped to %d", c.MaxFiles, DefaultLogMaxFiles)
+		}
+		if c.MaxSizeKB != DefaultLogMaxSizeKB {
+			t.Errorf("MaxSizeKB = %d, want clamped to %d", c.MaxSizeKB, DefaultLogMaxSizeKB)
+		}
+	})
+	t.Run("daily type clamps MaxFiles but leaves MaxSizeKB", func(t *testing.T) {
+		c := LoggingConfig{Type: LogTypeDaily, MaxFiles: -3, MaxSizeKB: 0}
+		c.Normalize()
+		if c.MaxFiles != DefaultLogMaxFiles {
+			t.Errorf("MaxFiles = %d, want clamped to %d", c.MaxFiles, DefaultLogMaxFiles)
+		}
+		if c.MaxSizeKB != 0 {
+			t.Errorf("MaxSizeKB = %d, want left at 0 (not used by daily type)", c.MaxSizeKB)
+		}
+	})
+	t.Run("none type leaves numeric fields untouched", func(t *testing.T) {
+		c := LoggingConfig{Type: LogTypeNone, MaxFiles: 0, MaxSizeKB: 0}
+		c.Normalize()
+		if c.MaxFiles != 0 || c.MaxSizeKB != 0 {
+			t.Errorf("none type should not clamp; got MaxFiles=%d MaxSizeKB=%d", c.MaxFiles, c.MaxSizeKB)
+		}
+	})
+	t.Run("valid values preserved", func(t *testing.T) {
+		c := LoggingConfig{Dir: "/var/log/bbs", Level: "WARN", Type: LogTypeSize, MaxFiles: 10, MaxSizeKB: 512}
+		c.Normalize()
+		if c.Dir != "/var/log/bbs" || c.Level != "WARN" || c.MaxFiles != 10 || c.MaxSizeKB != 512 {
+			t.Errorf("valid config mutated: %+v", c)
+		}
+	})
+}
+
 func TestLoadStrings_ValidFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := map[string]interface{}{

--- a/internal/logging/level.go
+++ b/internal/logging/level.go
@@ -1,0 +1,52 @@
+// Package logging owns all of ViSiON/3's logging concerns: a configurable
+// rolling file writer, level parsing, and a one-call Init that installs a
+// structured slog logger as the process default. Binaries call Init once at
+// startup; every other package logs through stdlib slog with no import coupling
+// to this package.
+package logging
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// securityCategory is attached to Security records so security-relevant events
+// can be filtered in the JSON logs (replacing the old "SECURITY:" prefix).
+const securityCategory = "security"
+
+// osExit is indirected for testing Fatal without terminating the test process.
+var osExit = os.Exit
+
+// ParseLevel maps a case-insensitive level name to a slog.Level. Recognized
+// names are DEBUG, INFO, WARN (or WARNING), and ERROR. Unknown input returns
+// slog.LevelInfo and a non-nil error so callers can fall back safely.
+func ParseLevel(s string) (slog.Level, error) {
+	switch strings.ToUpper(strings.TrimSpace(s)) {
+	case "DEBUG":
+		return slog.LevelDebug, nil
+	case "INFO":
+		return slog.LevelInfo, nil
+	case "WARN", "WARNING":
+		return slog.LevelWarn, nil
+	case "ERROR":
+		return slog.LevelError, nil
+	default:
+		return slog.LevelInfo, fmt.Errorf("unknown log level %q", s)
+	}
+}
+
+// Fatal logs msg at Error level on the default logger, then exits the process
+// with status 1. It replaces the old "FATAL:"/log.Fatalf pattern, which has no
+// native slog level.
+func Fatal(msg string, args ...any) {
+	slog.Error(msg, args...)
+	osExit(1)
+}
+
+// Security logs msg at Warn level with a category=security attribute. It
+// replaces the old "SECURITY:" prefix, which has no native slog level.
+func Security(msg string, args ...any) {
+	slog.Warn(msg, append([]any{slog.String("category", securityCategory)}, args...)...)
+}

--- a/internal/logging/level_test.go
+++ b/internal/logging/level_test.go
@@ -1,0 +1,90 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"testing"
+)
+
+func TestParseLevel(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    slog.Level
+		wantErr bool
+	}{
+		{"DEBUG", slog.LevelDebug, false},
+		{"debug", slog.LevelDebug, false},
+		{"  Info ", slog.LevelInfo, false},
+		{"WARN", slog.LevelWarn, false},
+		{"warning", slog.LevelWarn, false},
+		{"ERROR", slog.LevelError, false},
+		{"", slog.LevelInfo, true},
+		{"verbose", slog.LevelInfo, true},
+	}
+	for _, tc := range cases {
+		got, err := ParseLevel(tc.in)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("ParseLevel(%q) err = %v, wantErr %v", tc.in, err, tc.wantErr)
+		}
+		if got != tc.want {
+			t.Errorf("ParseLevel(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// captureDefault installs a JSON logger over buf as slog.Default for the test,
+// restoring the prior default afterward.
+func captureDefault(t *testing.T, buf *bytes.Buffer) {
+	t.Helper()
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+}
+
+func TestSecurity_AttachesCategory(t *testing.T) {
+	var buf bytes.Buffer
+	captureDefault(t, &buf)
+
+	Security("login failed", "user", "alice")
+
+	var rec map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+		t.Fatalf("log line is not valid JSON: %v (%q)", err, buf.String())
+	}
+	if rec["level"] != "WARN" {
+		t.Errorf("Security level = %v, want WARN", rec["level"])
+	}
+	if rec["category"] != "security" {
+		t.Errorf("category = %v, want security", rec["category"])
+	}
+	if rec["user"] != "alice" {
+		t.Errorf("user attr = %v, want alice", rec["user"])
+	}
+}
+
+func TestFatal_LogsErrorThenExits(t *testing.T) {
+	var buf bytes.Buffer
+	captureDefault(t, &buf)
+
+	var gotCode int
+	prevExit := osExit
+	osExit = func(code int) { gotCode = code }
+	t.Cleanup(func() { osExit = prevExit })
+
+	Fatal("boom", "reason", "disk")
+
+	if gotCode != 1 {
+		t.Errorf("Fatal exit code = %d, want 1", gotCode)
+	}
+	var rec map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+		t.Fatalf("log line is not valid JSON: %v (%q)", err, buf.String())
+	}
+	if rec["level"] != "ERROR" {
+		t.Errorf("Fatal level = %v, want ERROR", rec["level"])
+	}
+	if rec["msg"] != "boom" || rec["reason"] != "disk" {
+		t.Errorf("Fatal record = %v, want msg=boom reason=disk", rec)
+	}
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,64 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+)
+
+// Init builds the rolling writer for cfg, wraps it in a JSON slog handler at the
+// configured level, installs it as slog.Default, and returns the logger plus a
+// close function the caller should defer (it flushes the cache and closes the
+// file). defaultFile is the binary-specific log filename (e.g. "vision3.log");
+// all other settings come from cfg.
+//
+// An unrecognized cfg.Level does not fail startup: Init falls back to INFO and
+// logs a warning through the freshly installed logger.
+func Init(cfg config.LoggingConfig, defaultFile string) (*slog.Logger, func() error, error) {
+	cfg.Normalize()
+
+	level, levelErr := ParseLevel(cfg.Level)
+
+	w, err := newRollingWriter(cfg, defaultFile, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	handler := &flushHandler{
+		Handler: slog.NewJSONHandler(w, &slog.HandlerOptions{Level: level}),
+		w:       w,
+	}
+	logger := slog.New(handler)
+	slog.SetDefault(logger)
+
+	if levelErr != nil {
+		logger.Warn("invalid log level; defaulting to INFO", "configured", cfg.Level)
+	}
+
+	return logger, w.Close, nil
+}
+
+// flushHandler wraps a slog.Handler so that Error-level records flush the
+// write cache immediately, ensuring failures are durable even if the process
+// dies before the next ticker flush.
+type flushHandler struct {
+	slog.Handler
+	w *rollingWriter
+}
+
+func (h *flushHandler) Handle(ctx context.Context, r slog.Record) error {
+	err := h.Handler.Handle(ctx, r)
+	if r.Level >= slog.LevelError {
+		_ = h.w.Flush()
+	}
+	return err
+}
+
+func (h *flushHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &flushHandler{Handler: h.Handler.WithAttrs(attrs), w: h.w}
+}
+
+func (h *flushHandler) WithGroup(name string) slog.Handler {
+	return &flushHandler{Handler: h.Handler.WithGroup(name), w: h.w}
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -29,6 +29,7 @@ func readJSONLines(t *testing.T, path string) []map[string]any {
 	defer f.Close()
 	var out []map[string]any
 	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for sc.Scan() {
 		line := sc.Bytes()
 		if len(strings.TrimSpace(string(line))) == 0 {
@@ -39,6 +40,9 @@ func readJSONLines(t *testing.T, path string) []map[string]any {
 			t.Fatalf("line is not JSON: %v (%q)", err, string(line))
 		}
 		out = append(out, m)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan %s: %v", path, err)
 	}
 	return out
 }

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,141 @@
+package logging
+
+import (
+	"bufio"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+)
+
+// withDefaultRestored saves and restores slog.Default around a test, since Init
+// mutates global logger state.
+func withDefaultRestored(t *testing.T) {
+	t.Helper()
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+}
+
+func readJSONLines(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+	var out []map[string]any
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(strings.TrimSpace(string(line))) == 0 {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal(line, &m); err != nil {
+			t.Fatalf("line is not JSON: %v (%q)", err, string(line))
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func TestInit_HonorsLevelFiltering(t *testing.T) {
+	withDefaultRestored(t)
+	dir := t.TempDir()
+	cfg := config.LoggingConfig{Dir: dir, Level: "WARN", Cache: false, Type: config.LogTypeNone}
+
+	logger, closeFn, err := Init(cfg, "vision3.log")
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	logger.Debug("debug msg")
+	logger.Info("info msg")
+	logger.Warn("warn msg")
+	logger.Error("error msg")
+	if err := closeFn(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	lines := readJSONLines(t, filepath.Join(dir, "vision3.log"))
+	msgs := map[string]bool{}
+	for _, l := range lines {
+		msgs[l["msg"].(string)] = true
+	}
+	if msgs["debug msg"] || msgs["info msg"] {
+		t.Error("sub-threshold (DEBUG/INFO) records should be dropped at WARN level")
+	}
+	if !msgs["warn msg"] || !msgs["error msg"] {
+		t.Error("WARN and ERROR records should be present at WARN level")
+	}
+}
+
+func TestInit_ErrorFlushesCache(t *testing.T) {
+	withDefaultRestored(t)
+	dir := t.TempDir()
+	cfg := config.LoggingConfig{Dir: dir, Level: "DEBUG", Cache: true, Type: config.LogTypeNone}
+
+	logger, closeFn, err := Init(cfg, "vision3.log")
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	t.Cleanup(func() { closeFn() })
+	path := filepath.Join(dir, "vision3.log")
+
+	// An INFO record stays buffered (cache enabled, well under 8KB).
+	logger.Info("buffered info")
+	if got, _ := os.ReadFile(path); len(got) != 0 {
+		t.Errorf("INFO should remain cached, found %q on disk", got)
+	}
+
+	// An ERROR record must flush the cache, making both records durable.
+	logger.Error("flushing error")
+	lines := readJSONLines(t, path)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 records on disk after Error flush, got %d", len(lines))
+	}
+	if lines[0]["msg"] != "buffered info" || lines[1]["msg"] != "flushing error" {
+		t.Errorf("unexpected records on disk: %v", lines)
+	}
+}
+
+func TestInit_InvalidLevelFallsBackToInfo(t *testing.T) {
+	withDefaultRestored(t)
+	dir := t.TempDir()
+	cfg := config.LoggingConfig{Dir: dir, Level: "bogus", Cache: false, Type: config.LogTypeNone}
+
+	logger, closeFn, err := Init(cfg, "vision3.log")
+	if err != nil {
+		t.Fatalf("Init should not fail on bad level: %v", err)
+	}
+	logger.Debug("dropped at info")
+	logger.Info("kept at info")
+	if err := closeFn(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	lines := readJSONLines(t, filepath.Join(dir, "vision3.log"))
+	var sawWarning, sawInfo, sawDebug bool
+	for _, l := range lines {
+		switch l["msg"] {
+		case "invalid log level; defaulting to INFO":
+			sawWarning = true
+		case "kept at info":
+			sawInfo = true
+		case "dropped at info":
+			sawDebug = true
+		}
+	}
+	if !sawWarning {
+		t.Error("expected a warning about the invalid level")
+	}
+	if !sawInfo {
+		t.Error("INFO record should be kept at the INFO fallback level")
+	}
+	if sawDebug {
+		t.Error("DEBUG record should be dropped at the INFO fallback level")
+	}
+}

--- a/internal/logging/writer.go
+++ b/internal/logging/writer.go
@@ -22,7 +22,9 @@ const (
 	dateLayout = "2006-01-02"
 )
 
-// errClosed is returned by Write/Flush after the writer has been closed.
+// errClosed is returned by Write after the writer has been closed. Flush is
+// intentionally a no-op once closed (so the background ticker cannot race a
+// concurrent Close), so it does not return this error.
 var errClosed = errors.New("logging: writer closed")
 
 // rollingWriter is a mutex-guarded io.WriteCloser implementing the three Mystic
@@ -108,10 +110,13 @@ func (w *rollingWriter) currentPath() string {
 // openCurrent opens (creating if needed) the current target file for append and
 // initializes the cache and size/day tracking.
 func (w *rollingWriter) openCurrent() error {
+	day := w.day
+	path := w.basePath()
 	if w.logType == config.LogTypeDaily {
-		w.day = w.now().Format(dateLayout)
+		day = w.now().Format(dateLayout)
+		path = w.datedPath(day)
 	}
-	f, err := os.OpenFile(w.currentPath(), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
 		return err
 	}
@@ -122,6 +127,11 @@ func (w *rollingWriter) openCurrent() error {
 	}
 	w.f = f
 	w.size = fi.Size()
+	// Only advance w.day once the new dated file is open: if the open fails, a
+	// later write must still attempt the rotation rather than assume success.
+	if w.logType == config.LogTypeDaily {
+		w.day = day
+	}
 	if w.cache {
 		w.bw = bufio.NewWriterSize(f, cacheBufSize)
 	} else {
@@ -198,14 +208,17 @@ func (w *rollingWriter) rotateDaily() error {
 	return nil
 }
 
-// pruneDaily removes dated log files whose date is more than maxFiles days
-// before today. Errors are ignored: pruning is best-effort housekeeping.
+// pruneDaily removes dated log files older than the retention window, keeping
+// exactly maxFiles days including today. Errors are ignored: pruning is
+// best-effort housekeeping.
 func (w *rollingWriter) pruneDaily() {
 	matches, err := filepath.Glob(filepath.Join(w.dir, w.stem+".*"+w.ext))
 	if err != nil {
 		return
 	}
-	cutoff := w.now().AddDate(0, 0, -w.maxFiles)
+	n := w.now()
+	today := time.Date(n.Year(), n.Month(), n.Day(), 0, 0, 0, 0, n.Location())
+	cutoff := today.AddDate(0, 0, -(w.maxFiles - 1))
 	for _, m := range matches {
 		name := filepath.Base(m)
 		datePart := strings.TrimSuffix(strings.TrimPrefix(name, w.stem+"."), w.ext)
@@ -225,11 +238,17 @@ func (w *rollingWriter) rotateSize() error {
 	if err := w.closeCurrent(); err != nil {
 		return err
 	}
-	os.Remove(w.backupPath(w.maxFiles)) // discard the oldest
-	for i := w.maxFiles - 1; i >= 1; i-- {
-		os.Rename(w.backupPath(i), w.backupPath(i+1))
+	if err := os.Remove(w.backupPath(w.maxFiles)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
 	}
-	os.Rename(w.basePath(), w.backupPath(1))
+	for i := w.maxFiles - 1; i >= 1; i-- {
+		if err := os.Rename(w.backupPath(i), w.backupPath(i+1)); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	if err := os.Rename(w.basePath(), w.backupPath(1)); err != nil {
+		return err
+	}
 	return w.openCurrent()
 }
 

--- a/internal/logging/writer.go
+++ b/internal/logging/writer.go
@@ -1,0 +1,272 @@
+package logging
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+)
+
+const (
+	// cacheBufSize is the buffered-write cache size (matches the design's 8KB).
+	cacheBufSize = 8 * 1024
+	// flushInterval bounds how long a cached line can sit unwritten.
+	flushInterval = 5 * time.Second
+	// dateLayout is the date stamp used for daily-rolled filenames and pruning.
+	dateLayout = "2006-01-02"
+)
+
+// errClosed is returned by Write/Flush after the writer has been closed.
+var errClosed = errors.New("logging: writer closed")
+
+// rollingWriter is a mutex-guarded io.WriteCloser implementing the three Mystic
+// log types (none/size/daily) plus an optional 8KB write cache. A clock is
+// injected so rolling behavior is deterministically testable.
+type rollingWriter struct {
+	mu       sync.Mutex
+	dir      string
+	stem     string // filename without extension, e.g. "vision3"
+	ext      string // extension including the dot, e.g. ".log"
+	logType  int
+	maxFiles int
+	maxSize  int64 // rotate threshold in bytes (size type); 0 disables rolling
+	cache    bool
+	now      func() time.Time
+
+	f    *os.File
+	bw   *bufio.Writer
+	size int64  // bytes in the current file (size type)
+	day  string // date stamp of the open file (daily type)
+
+	ticker   *time.Ticker
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	closed   bool
+}
+
+// newRollingWriter creates the writer for cfg, logging to defaultFile within
+// cfg.Dir. cfg is assumed already Normalize()d. now supplies the current time
+// (pass time.Now in production).
+func newRollingWriter(cfg config.LoggingConfig, defaultFile string, now func() time.Time) (*rollingWriter, error) {
+	if now == nil {
+		now = time.Now
+	}
+	if err := os.MkdirAll(cfg.Dir, 0o755); err != nil {
+		return nil, err
+	}
+	ext := filepath.Ext(defaultFile)
+	w := &rollingWriter{
+		dir:      cfg.Dir,
+		stem:     strings.TrimSuffix(defaultFile, ext),
+		ext:      ext,
+		logType:  cfg.Type,
+		maxFiles: cfg.MaxFiles,
+		maxSize:  int64(cfg.MaxSizeKB) * 1024,
+		cache:    cfg.Cache,
+		now:      now,
+		stopCh:   make(chan struct{}),
+	}
+	if err := w.openCurrent(); err != nil {
+		return nil, err
+	}
+	if w.cache {
+		w.ticker = time.NewTicker(flushInterval)
+		go w.flushLoop()
+	}
+	return w, nil
+}
+
+// basePath is the unrolled file path (none/size types).
+func (w *rollingWriter) basePath() string {
+	return filepath.Join(w.dir, w.stem+w.ext)
+}
+
+// backupPath is the Nth numbered backup for size rolling (e.g. vision3.log.1).
+func (w *rollingWriter) backupPath(n int) string {
+	return w.basePath() + "." + strconv.Itoa(n)
+}
+
+// datedPath is the date-stamped file for daily rolling (e.g. vision3.2026-06-28.log).
+func (w *rollingWriter) datedPath(day string) string {
+	return filepath.Join(w.dir, w.stem+"."+day+w.ext)
+}
+
+// currentPath returns the path the writer should currently be appending to.
+func (w *rollingWriter) currentPath() string {
+	if w.logType == config.LogTypeDaily {
+		return w.datedPath(w.day)
+	}
+	return w.basePath()
+}
+
+// openCurrent opens (creating if needed) the current target file for append and
+// initializes the cache and size/day tracking.
+func (w *rollingWriter) openCurrent() error {
+	if w.logType == config.LogTypeDaily {
+		w.day = w.now().Format(dateLayout)
+	}
+	f, err := os.OpenFile(w.currentPath(), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return err
+	}
+	w.f = f
+	w.size = fi.Size()
+	if w.cache {
+		w.bw = bufio.NewWriterSize(f, cacheBufSize)
+	} else {
+		w.bw = nil
+	}
+	return nil
+}
+
+// closeCurrent flushes the cache and closes the open file.
+func (w *rollingWriter) closeCurrent() error {
+	var ferr error
+	if w.bw != nil {
+		ferr = w.bw.Flush()
+		w.bw = nil
+	}
+	if w.f != nil {
+		if cerr := w.f.Close(); ferr == nil {
+			ferr = cerr
+		}
+		w.f = nil
+	}
+	return ferr
+}
+
+// dst returns the active write destination (cache or raw file).
+func (w *rollingWriter) dst() interface{ Write([]byte) (int, error) } {
+	if w.bw != nil {
+		return w.bw
+	}
+	return w.f
+}
+
+// Write implements io.Writer, rolling the file first if the type and current
+// state call for it.
+func (w *rollingWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return 0, errClosed
+	}
+
+	switch w.logType {
+	case config.LogTypeDaily:
+		if today := w.now().Format(dateLayout); today != w.day {
+			if err := w.rotateDaily(); err != nil {
+				return 0, err
+			}
+		}
+	case config.LogTypeSize:
+		// Roll when the write would exceed the threshold, but never roll an
+		// empty file (a single oversized line is written as-is).
+		if w.maxSize > 0 && w.size > 0 && w.size+int64(len(p)) > w.maxSize {
+			if err := w.rotateSize(); err != nil {
+				return 0, err
+			}
+		}
+	}
+
+	n, err := w.dst().Write(p)
+	w.size += int64(n)
+	return n, err
+}
+
+// rotateDaily closes the current dated file, opens today's, and prunes dated
+// files older than maxFiles days.
+func (w *rollingWriter) rotateDaily() error {
+	if err := w.closeCurrent(); err != nil {
+		return err
+	}
+	if err := w.openCurrent(); err != nil {
+		return err
+	}
+	w.pruneDaily()
+	return nil
+}
+
+// pruneDaily removes dated log files whose date is more than maxFiles days
+// before today. Errors are ignored: pruning is best-effort housekeeping.
+func (w *rollingWriter) pruneDaily() {
+	matches, err := filepath.Glob(filepath.Join(w.dir, w.stem+".*"+w.ext))
+	if err != nil {
+		return
+	}
+	cutoff := w.now().AddDate(0, 0, -w.maxFiles)
+	for _, m := range matches {
+		name := filepath.Base(m)
+		datePart := strings.TrimSuffix(strings.TrimPrefix(name, w.stem+"."), w.ext)
+		d, perr := time.Parse(dateLayout, datePart)
+		if perr != nil {
+			continue // not a dated file (e.g. a size-style backup)
+		}
+		if d.Before(cutoff) {
+			os.Remove(m)
+		}
+	}
+}
+
+// rotateSize shifts the numbered backups (deleting the oldest) and opens a
+// fresh base file.
+func (w *rollingWriter) rotateSize() error {
+	if err := w.closeCurrent(); err != nil {
+		return err
+	}
+	os.Remove(w.backupPath(w.maxFiles)) // discard the oldest
+	for i := w.maxFiles - 1; i >= 1; i-- {
+		os.Rename(w.backupPath(i), w.backupPath(i+1))
+	}
+	os.Rename(w.basePath(), w.backupPath(1))
+	return w.openCurrent()
+}
+
+// Flush flushes the write cache. It is a no-op when caching is disabled.
+func (w *rollingWriter) Flush() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed || w.bw == nil {
+		return nil
+	}
+	return w.bw.Flush()
+}
+
+// flushLoop periodically flushes the cache until the writer is closed.
+func (w *rollingWriter) flushLoop() {
+	for {
+		select {
+		case <-w.ticker.C:
+			_ = w.Flush()
+		case <-w.stopCh:
+			return
+		}
+	}
+}
+
+// Close stops the flush loop, flushes the cache, and closes the file. It is
+// safe to call more than once.
+func (w *rollingWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+	if w.ticker != nil {
+		w.ticker.Stop()
+	}
+	w.stopOnce.Do(func() { close(w.stopCh) })
+	return w.closeCurrent()
+}

--- a/internal/logging/writer_test.go
+++ b/internal/logging/writer_test.go
@@ -1,0 +1,201 @@
+package logging
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+)
+
+// fakeClock is a goroutine-safe, manually advanced clock for deterministic
+// rolling tests.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+func newWriter(t *testing.T, cfg config.LoggingConfig, file string, clk *fakeClock) *rollingWriter {
+	t.Helper()
+	w, err := newRollingWriter(cfg, file, clk.now)
+	if err != nil {
+		t.Fatalf("newRollingWriter: %v", err)
+	}
+	t.Cleanup(func() { w.Close() })
+	return w
+}
+
+func mustRead(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func TestWriter_None_AppendsToSingleFile(t *testing.T) {
+	dir := t.TempDir()
+	clk := &fakeClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	cfg := config.LoggingConfig{Dir: dir, Type: config.LogTypeNone, Cache: false}
+	w := newWriter(t, cfg, "vision3.log", clk)
+
+	w.Write([]byte("one\n"))
+	w.Write([]byte("two\n"))
+
+	got := mustRead(t, filepath.Join(dir, "vision3.log"))
+	if got != "one\ntwo\n" {
+		t.Errorf("content = %q, want %q", got, "one\ntwo\n")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "vision3.log.1")); !os.IsNotExist(err) {
+		t.Error("none type should never create a numbered backup")
+	}
+}
+
+func TestWriter_Cache_BuffersUntilFlush(t *testing.T) {
+	dir := t.TempDir()
+	clk := &fakeClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	cfg := config.LoggingConfig{Dir: dir, Type: config.LogTypeNone, Cache: true}
+	w := newWriter(t, cfg, "vision3.log", clk)
+	path := filepath.Join(dir, "vision3.log")
+
+	w.Write([]byte("buffered\n"))
+	if got := mustRead(t, path); got != "" {
+		t.Errorf("cached write should not be on disk yet, got %q", got)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if got := mustRead(t, path); got != "buffered\n" {
+		t.Errorf("after Flush content = %q, want %q", got, "buffered\n")
+	}
+}
+
+func TestWriter_Cache_CloseFlushes(t *testing.T) {
+	dir := t.TempDir()
+	clk := &fakeClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	cfg := config.LoggingConfig{Dir: dir, Type: config.LogTypeNone, Cache: true}
+	w, err := newRollingWriter(cfg, "vision3.log", clk.now)
+	if err != nil {
+		t.Fatalf("newRollingWriter: %v", err)
+	}
+	w.Write([]byte("on close\n"))
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := mustRead(t, filepath.Join(dir, "vision3.log")); got != "on close\n" {
+		t.Errorf("Close should flush; content = %q", got)
+	}
+}
+
+func TestWriter_Size_RotatesAndCapsBackups(t *testing.T) {
+	dir := t.TempDir()
+	clk := &fakeClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	cfg := config.LoggingConfig{Dir: dir, Type: config.LogTypeSize, Cache: false, MaxFiles: 2, MaxSizeKB: 1}
+	w := newWriter(t, cfg, "vision3.log", clk)
+
+	line := strings.Repeat("x", 600) + "\n" // 601 bytes; two lines exceed 1KB
+	for i := 0; i < 4; i++ {
+		w.Write([]byte(line))
+	}
+
+	// Base exists; backups .1 and .2 exist; .3 must not (oldest dropped).
+	for _, p := range []string{"vision3.log", "vision3.log.1", "vision3.log.2"} {
+		if _, err := os.Stat(filepath.Join(dir, p)); err != nil {
+			t.Errorf("expected %s to exist: %v", p, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "vision3.log.3")); !os.IsNotExist(err) {
+		t.Errorf("vision3.log.3 should not exist (MaxFiles=2)")
+	}
+}
+
+func TestWriter_Size_OversizedLineWrittenWhole(t *testing.T) {
+	dir := t.TempDir()
+	clk := &fakeClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	cfg := config.LoggingConfig{Dir: dir, Type: config.LogTypeSize, Cache: false, MaxFiles: 2, MaxSizeKB: 1}
+	w := newWriter(t, cfg, "vision3.log", clk)
+
+	big := strings.Repeat("y", 2000) + "\n" // exceeds 1KB on an empty file
+	w.Write([]byte(big))
+	if got := mustRead(t, filepath.Join(dir, "vision3.log")); got != big {
+		t.Errorf("oversized first line should be written whole, got %d bytes", len(got))
+	}
+}
+
+func TestWriter_Daily_RollsAndPrunes(t *testing.T) {
+	dir := t.TempDir()
+	clk := &fakeClock{t: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)}
+	cfg := config.LoggingConfig{Dir: dir, Type: config.LogTypeDaily, Cache: false, MaxFiles: 2}
+	w := newWriter(t, cfg, "vision3.log", clk)
+
+	w.Write([]byte("day1\n"))
+	day1 := filepath.Join(dir, "vision3.2026-01-01.log")
+	if mustRead(t, day1) != "day1\n" {
+		t.Fatalf("day1 file not written")
+	}
+
+	// Jump well past MaxFiles days; the next write should roll to a new dated
+	// file and prune the now-stale day1 file.
+	clk.advance(10 * 24 * time.Hour)
+	w.Write([]byte("day11\n"))
+
+	day11 := filepath.Join(dir, "vision3.2026-01-11.log")
+	if mustRead(t, day11) != "day11\n" {
+		t.Errorf("day11 file not written")
+	}
+	if _, err := os.Stat(day1); !os.IsNotExist(err) {
+		t.Errorf("day1 file should have been pruned (older than MaxFiles=2 days)")
+	}
+}
+
+func TestWriter_Daily_KeepsRecentFiles(t *testing.T) {
+	dir := t.TempDir()
+	clk := &fakeClock{t: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)}
+	cfg := config.LoggingConfig{Dir: dir, Type: config.LogTypeDaily, Cache: false, MaxFiles: 5}
+	w := newWriter(t, cfg, "vision3.log", clk)
+
+	w.Write([]byte("d1\n"))
+	clk.advance(24 * time.Hour)
+	w.Write([]byte("d2\n"))
+
+	// Within MaxFiles=5 days, both files survive.
+	if _, err := os.Stat(filepath.Join(dir, "vision3.2026-01-01.log")); err != nil {
+		t.Errorf("recent day1 file should survive: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "vision3.2026-01-02.log")); err != nil {
+		t.Errorf("day2 file should exist: %v", err)
+	}
+}
+
+func TestWriter_WriteAfterCloseErrors(t *testing.T) {
+	dir := t.TempDir()
+	clk := &fakeClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	cfg := config.LoggingConfig{Dir: dir, Type: config.LogTypeNone, Cache: false}
+	w, err := newRollingWriter(cfg, "vision3.log", clk.now)
+	if err != nil {
+		t.Fatalf("newRollingWriter: %v", err)
+	}
+	w.Close()
+	if _, err := w.Write([]byte("nope\n")); err == nil {
+		t.Error("Write after Close should return an error")
+	}
+	if err := w.Close(); err != nil {
+		t.Errorf("second Close should be a no-op, got %v", err)
+	}
+}

--- a/internal/logging/writer_test.go
+++ b/internal/logging/writer_test.go
@@ -183,6 +183,30 @@ func TestWriter_Daily_KeepsRecentFiles(t *testing.T) {
 	}
 }
 
+func TestWriter_Daily_KeepsExactlyMaxFilesDays(t *testing.T) {
+	dir := t.TempDir()
+	clk := &fakeClock{t: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)}
+	cfg := config.LoggingConfig{Dir: dir, Type: config.LogTypeDaily, Cache: false, MaxFiles: 2}
+	w := newWriter(t, cfg, "vision3.log", clk)
+
+	// Write on three consecutive days; with MaxFiles=2 only the two most
+	// recent dated files (including today) should survive.
+	w.Write([]byte("d1\n"))
+	clk.advance(24 * time.Hour)
+	w.Write([]byte("d2\n"))
+	clk.advance(24 * time.Hour)
+	w.Write([]byte("d3\n"))
+
+	if _, err := os.Stat(filepath.Join(dir, "vision3.2026-01-01.log")); !os.IsNotExist(err) {
+		t.Error("day1 should be pruned (only MaxFiles=2 days kept incl. today)")
+	}
+	for _, day := range []string{"2026-01-02", "2026-01-03"} {
+		if _, err := os.Stat(filepath.Join(dir, "vision3."+day+".log")); err != nil {
+			t.Errorf("%s should survive: %v", day, err)
+		}
+	}
+}
+
 func TestWriter_WriteAfterCloseErrors(t *testing.T) {
 	dir := t.TempDir()
 	clk := &fakeClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}


### PR DESCRIPTION
First slice of the logging overhaul ([design](docs-internal/plans/2026-06-28-logging-overhaul-design.md)): the self-contained `internal/logging` package and its config schema.

**No binary is wired to it yet**, so runtime behavior is unchanged. The wiring (`logging.Init` into the three `main.go`s + legacy `log` bridge), the TUI Logging screen, and Phase B's call-site migration come in follow-up PRs.

## `internal/logging`
| File | Contents |
|---|---|
| `level.go` | `ParseLevel` (DEBUG/INFO/WARN/ERROR), `Fatal` (log Error + exit 1), `Security` (log Warn + `category=security`) — absorbing the old `FATAL:`/`SECURITY:` prefixes that have no native slog level. |
| `writer.go` | Mutex-guarded rolling `io.WriteCloser`: the three Mystic log types (none / size+count / daily) + an 8KB write cache. A clock is injected so rolling is deterministically testable. |
| `logging.go` | `Init` wraps the writer in a JSON slog handler at the configured level and installs it as `slog.Default`; a `flushHandler` flushes the cache on **Error** records for crash safety. An unrecognized level falls back to INFO **with a warning** instead of failing startup. |

## `internal/config`
- `LoggingConfig` persisted under the `"logging"` key. Defaults applied when the key is absent → existing `config.json` files keep working unchanged.
- `Normalize()` clamps `MaxFiles`/`MaxSizeKB` to safe lower bounds so a config typo can't cause log loss or rotate-on-every-write — **CodeRabbit design note #2**.

## Design notes status
- ✅ Note #2 (validate lower bounds) — done here via `Normalize()`.
- ⏳ Note #1 (bridge stdlib `log` before Phase A) — belongs with the binary-wiring PR, where `Init` will also `log.SetOutput(writer)` so untouched `log.Printf` calls still hit the rolling file until Phase B.

## Testing
- `internal/logging`: 87.6% coverage, **race-clean** (`go test -race`). Covers each log type, size-rotation backup capping, oversized-line passthrough, daily roll + prune, cache buffer/flush/close, level filtering, error-flush durability, and the invalid-level fallback.
- `internal/config`: logging defaults, partial-overlay preservation, and all `Normalize` clamp cases.
- Full suite: 1,471 passed across 50 packages; `go vet` + `gofmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persisted, configurable logging settings including directory, level, and rolling behavior (none/size/daily).
  * Introduced JSON logging with safer helpers for parsing levels, security messages, and fatal errors.
  * Added rolling log writer with size- or daily-based rotation and automatic pruning of older logs.

* **Bug Fixes**
  * Default logging values now apply automatically when configuration is missing or partially specified.
  * Improved behavior when the configured level is invalid by falling back to INFO.
  * Ensured error-level (and fatal) messages flush promptly so they’re written to disk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->