### PR TITLE
feat(logging): wire vision3 + v3mail to logging.Init (Phase A wiring)

### DIFF
--- a/cmd/v3mail/main.go
+++ b/cmd/v3mail/main.go
@@ -34,6 +34,8 @@ func main() {
 	cfg, _ := config.LoadServerConfig("configs")
 	if _, closeLog, err := logging.Init(cfg.Logging, "v3mail.log", true); err == nil {
 		defer closeLog()
+	} else {
+		fmt.Fprintf(os.Stderr, "WARN: failed to initialize logging: %v\n", err)
 	}
 
 	if len(os.Args) < 2 {

--- a/cmd/v3mail/main.go
+++ b/cmd/v3mail/main.go
@@ -4,14 +4,14 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
 	"github.com/ViSiON-3/vision-3-bbs/internal/jam"
+	"github.com/ViSiON-3/vision-3-bbs/internal/logging"
 	"github.com/ViSiON-3/vision-3-bbs/internal/version"
 )
 
@@ -27,14 +27,13 @@ type areaConfig struct {
 }
 
 func main() {
-	// Set up logging to both stderr and data/logs/v3mail.log
-	logDir := filepath.Join("data", "logs")
-	os.MkdirAll(logDir, 0755)
-	logPath := filepath.Join(logDir, "v3mail.log")
-	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-	if err == nil {
-		log.SetOutput(io.MultiWriter(os.Stderr, logFile))
-		defer logFile.Close()
+	// Initialize logging from the shared config (rolling file + console echo).
+	// This also bridges stdlib log.Printf until Phase B migrates call sites to
+	// slog. LoadServerConfig returns defaults when configs/config.json is
+	// absent, and a logging-init failure leaves the stdlib default (stderr).
+	cfg, _ := config.LoadServerConfig("configs")
+	if _, closeLog, err := logging.Init(cfg.Logging, "v3mail.log", true); err == nil {
+		defer closeLog()
 	}
 
 	if len(os.Args) < 2 {

--- a/cmd/vision3/main.go
+++ b/cmd/vision3/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ViSiON-3/vision-3-bbs/internal/conference"
 	"github.com/ViSiON-3/vision-3-bbs/internal/config"
 	"github.com/ViSiON-3/vision-3-bbs/internal/file"
+	"github.com/ViSiON-3/vision-3-bbs/internal/logging"
 	"github.com/ViSiON-3/vision-3-bbs/internal/menu"
 	"github.com/ViSiON-3/vision-3-bbs/internal/message"
 	"github.com/ViSiON-3/vision-3-bbs/internal/scheduler"
@@ -1478,10 +1479,11 @@ func sessionHandler(s ssh.Session) {
 		}
 	} else if authenticatedUser.PreferredEncoding != "" {
 		// User has saved encoding preference - apply it
-		if authenticatedUser.PreferredEncoding == "cp437" {
+		switch authenticatedUser.PreferredEncoding {
+		case "cp437":
 			effectiveMode = ansi.OutputModeCP437
 			log.Printf("Node %d: Using saved encoding preference: CP437", nodeID)
-		} else if authenticatedUser.PreferredEncoding == "utf8" {
+		case "utf8":
 			effectiveMode = ansi.OutputModeUTF8
 			log.Printf("Node %d: Using saved encoding preference: UTF-8", nodeID)
 		}
@@ -1582,11 +1584,6 @@ func main() {
 	}
 	log.Printf("INFO: Output mode set to: %s", outputModeFlag)
 
-	log.SetOutput(os.Stderr) // Ensure logs go to stderr
-	log.Println("INFO: Starting ViSiON/3 BBS Server (using crypto/ssh)...")
-
-	// REMOVED if colorTestMode block
-
 	// --- Run Normal BBS Server --- //
 	var err error
 	fmt.Println("Starting ViSiON/3 BBS...") // Changed startup message
@@ -1601,32 +1598,28 @@ func main() {
 	rootAssetsPath := filepath.Join(basePath, "assets") // Keep this path definition for now
 	dataPath := filepath.Join(basePath, "data")         // For user data, logs, etc.
 	userDataPath := filepath.Join(dataPath, "users")
-	logFilePath := filepath.Join(dataPath, "logs", "vision3.log") // Example log path
 
 	// Pre-flight: ensure setup has been run and all required files/dirs exist
 	if !runPreflight(basePath) {
 		os.Exit(1)
 	}
 
-	// Ensure data directories exist (optional, depends on usage)
-	// os.MkdirAll(userDataPath, 0755)
-	os.MkdirAll(filepath.Dir(logFilePath), 0755) // Ensure the log directory exists
-
-	// Setup Logging (example - adapt to your logging package if different)
-	logFile, err := os.OpenFile(logFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		log.Printf("WARN: Failed to open log file %s: %v. Logging to stderr.", logFilePath, err)
-	} else {
-		log.SetOutput(io.MultiWriter(os.Stderr, logFile)) // Log to both file and stderr
-		log.Printf("INFO: Logging to file: %s", logFilePath)
-		defer logFile.Close()
-	}
-
-	// Load server configuration
+	// Load server configuration (needed before logging init, which reads the
+	// shared logging settings from it).
 	serverConfig, err := config.LoadServerConfig(rootConfigPath)
 	if err != nil {
 		log.Fatalf("Failed to load server configuration: %v", err)
 	}
+
+	// Initialize logging: a configurable rolling file plus console echo. This
+	// also bridges stdlib log.Printf to the same destinations until Phase B
+	// migrates those call sites to slog.
+	_, closeLog, err := logging.Init(serverConfig.Logging, "vision3.log", true)
+	if err != nil {
+		log.Fatalf("Failed to initialize logging: %v", err)
+	}
+	defer closeLog()
+	log.Println("INFO: Starting ViSiON/3 BBS Server (using crypto/ssh)...")
 
 	// Initialize connection tracker with configured limits and IP filter file paths
 	// This will load the initial lists and start watching for file changes

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -2,20 +2,31 @@ package logging
 
 import (
 	"context"
+	"io"
+	"log"
 	"log/slog"
+	"os"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/config"
 )
 
 // Init builds the rolling writer for cfg, wraps it in a JSON slog handler at the
 // configured level, installs it as slog.Default, and returns the logger plus a
-// close function the caller should defer (it flushes the cache and closes the
-// file). defaultFile is the binary-specific log filename (e.g. "vision3.log");
-// all other settings come from cfg.
+// close function the caller should defer (it flushes the cache, closes the
+// file, and restores the stdlib log output). defaultFile is the binary-specific
+// log filename (e.g. "vision3.log"); all other settings come from cfg.
+//
+// When console is true the logger (and the bridged stdlib log) also echo to
+// stderr, preserving live console visibility alongside the rolling file.
+//
+// Init also redirects the stdlib log package to the same destination so that
+// call sites not yet migrated to slog still land in the rolling file (and
+// console). This legacy bridge keeps Phase A behavior-preserving until the
+// Phase B slog migration converts those call sites.
 //
 // An unrecognized cfg.Level does not fail startup: Init falls back to INFO and
 // logs a warning through the freshly installed logger.
-func Init(cfg config.LoggingConfig, defaultFile string) (*slog.Logger, func() error, error) {
+func Init(cfg config.LoggingConfig, defaultFile string, console bool) (*slog.Logger, func() error, error) {
 	cfg.Normalize()
 
 	level, levelErr := ParseLevel(cfg.Level)
@@ -25,18 +36,31 @@ func Init(cfg config.LoggingConfig, defaultFile string) (*slog.Logger, func() er
 		return nil, nil, err
 	}
 
+	var out io.Writer = w
+	if console {
+		out = io.MultiWriter(w, os.Stderr)
+	}
+
 	handler := &flushHandler{
-		Handler: slog.NewJSONHandler(w, &slog.HandlerOptions{Level: level}),
+		Handler: slog.NewJSONHandler(out, &slog.HandlerOptions{Level: level}),
 		w:       w,
 	}
 	logger := slog.New(handler)
 	slog.SetDefault(logger)
 
+	// Bridge stdlib log so not-yet-migrated log.Printf calls reach the same
+	// destination(s) as slog.
+	log.SetOutput(out)
+
 	if levelErr != nil {
 		logger.Warn("invalid log level; defaulting to INFO", "configured", cfg.Level)
 	}
 
-	return logger, w.Close, nil
+	closeFn := func() error {
+		log.SetOutput(os.Stderr)
+		return w.Close()
+	}
+	return logger, closeFn, nil
 }
 
 // flushHandler wraps a slog.Handler so that Error-level records flush the

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -36,13 +36,20 @@ func Init(cfg config.LoggingConfig, defaultFile string, console bool) (*slog.Log
 		return nil, nil, err
 	}
 
-	var out io.Writer = w
+	// slog non-error records may sit in the cache (flushed by the ticker, on
+	// Close, and on Error via flushHandler). The stdlib-log bridge, however,
+	// never reaches flushHandler, so a bridged log.Fatalf would lose its final
+	// line on the immediate os.Exit; route the bridge through flushWriter so
+	// every bridged line is flushed as it is written.
+	var slogOut io.Writer = w
+	bridgeOut := io.Writer(flushWriter{w})
 	if console {
-		out = io.MultiWriter(w, os.Stderr)
+		slogOut = io.MultiWriter(w, os.Stderr)
+		bridgeOut = io.MultiWriter(flushWriter{w}, os.Stderr)
 	}
 
 	handler := &flushHandler{
-		Handler: slog.NewJSONHandler(out, &slog.HandlerOptions{Level: level}),
+		Handler: slog.NewJSONHandler(slogOut, &slog.HandlerOptions{Level: level}),
 		w:       w,
 	}
 	logger := slog.New(handler)
@@ -50,7 +57,7 @@ func Init(cfg config.LoggingConfig, defaultFile string, console bool) (*slog.Log
 
 	// Bridge stdlib log so not-yet-migrated log.Printf calls reach the same
 	// destination(s) as slog.
-	log.SetOutput(out)
+	log.SetOutput(bridgeOut)
 
 	if levelErr != nil {
 		logger.Warn("invalid log level; defaulting to INFO", "configured", cfg.Level)
@@ -61,6 +68,20 @@ func Init(cfg config.LoggingConfig, defaultFile string, console bool) (*slog.Log
 		return w.Close()
 	}
 	return logger, closeFn, nil
+}
+
+// flushWriter writes to the rolling writer and flushes its cache after every
+// write. It backs the stdlib-log bridge so a log.Fatalf line survives the
+// immediate os.Exit that follows it (bridged writes bypass flushHandler). When
+// caching is disabled, Flush is a no-op, so this adds no cost.
+type flushWriter struct {
+	w *rollingWriter
+}
+
+func (fw flushWriter) Write(p []byte) (int, error) {
+	n, err := fw.w.Write(p)
+	_ = fw.w.Flush()
+	return n, err
 }
 
 // flushHandler wraps a slog.Handler so that Error-level records flush the

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"bufio"
 	"encoding/json"
+	"log"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -52,7 +53,7 @@ func TestInit_HonorsLevelFiltering(t *testing.T) {
 	dir := t.TempDir()
 	cfg := config.LoggingConfig{Dir: dir, Level: "WARN", Cache: false, Type: config.LogTypeNone}
 
-	logger, closeFn, err := Init(cfg, "vision3.log")
+	logger, closeFn, err := Init(cfg, "vision3.log", false)
 	if err != nil {
 		t.Fatalf("Init: %v", err)
 	}
@@ -82,7 +83,7 @@ func TestInit_ErrorFlushesCache(t *testing.T) {
 	dir := t.TempDir()
 	cfg := config.LoggingConfig{Dir: dir, Level: "DEBUG", Cache: true, Type: config.LogTypeNone}
 
-	logger, closeFn, err := Init(cfg, "vision3.log")
+	logger, closeFn, err := Init(cfg, "vision3.log", false)
 	if err != nil {
 		t.Fatalf("Init: %v", err)
 	}
@@ -111,7 +112,7 @@ func TestInit_InvalidLevelFallsBackToInfo(t *testing.T) {
 	dir := t.TempDir()
 	cfg := config.LoggingConfig{Dir: dir, Level: "bogus", Cache: false, Type: config.LogTypeNone}
 
-	logger, closeFn, err := Init(cfg, "vision3.log")
+	logger, closeFn, err := Init(cfg, "vision3.log", false)
 	if err != nil {
 		t.Fatalf("Init should not fail on bad level: %v", err)
 	}
@@ -141,5 +142,36 @@ func TestInit_InvalidLevelFallsBackToInfo(t *testing.T) {
 	}
 	if sawDebug {
 		t.Error("DEBUG record should be dropped at the INFO fallback level")
+	}
+}
+
+func TestInit_BridgesStdlibLog(t *testing.T) {
+	withDefaultRestored(t)
+	prevFlags := log.Flags()
+	prevOut := log.Writer()
+	t.Cleanup(func() { log.SetFlags(prevFlags); log.SetOutput(prevOut) })
+
+	dir := t.TempDir()
+	cfg := config.LoggingConfig{Dir: dir, Level: "INFO", Cache: false, Type: config.LogTypeNone}
+	_, closeFn, err := Init(cfg, "vision3.log", false)
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	// A not-yet-migrated stdlib log call must land in the rolling file.
+	log.Printf("legacy line %d", 7)
+
+	data, _ := os.ReadFile(filepath.Join(dir, "vision3.log"))
+	if !strings.Contains(string(data), "legacy line 7") {
+		t.Errorf("bridged log.Printf output not found in log file; got %q", data)
+	}
+
+	// After close, the bridge is removed so stdlib log no longer targets the
+	// (now closed) writer.
+	if err := closeFn(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if log.Writer() == nil {
+		t.Error("close should have restored a non-nil stdlib log output")
 	}
 }

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -167,11 +167,36 @@ func TestInit_BridgesStdlibLog(t *testing.T) {
 	}
 
 	// After close, the bridge is removed so stdlib log no longer targets the
-	// (now closed) writer.
+	// (now closed) writer — it is restored to os.Stderr.
 	if err := closeFn(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
-	if log.Writer() == nil {
-		t.Error("close should have restored a non-nil stdlib log output")
+	if log.Writer() != os.Stderr {
+		t.Error("close should have restored stdlib log output to os.Stderr")
+	}
+}
+
+// TestInit_BridgeFlushesWithCache verifies the crash-safety fix: with caching
+// enabled, a bridged stdlib log line is flushed to disk immediately rather than
+// sitting in the cache (where an os.Exit from log.Fatalf would lose it).
+func TestInit_BridgeFlushesWithCache(t *testing.T) {
+	withDefaultRestored(t)
+	prevOut := log.Writer()
+	t.Cleanup(func() { log.SetOutput(prevOut) })
+
+	dir := t.TempDir()
+	cfg := config.LoggingConfig{Dir: dir, Level: "INFO", Cache: true, Type: config.LogTypeNone}
+	_, closeFn, err := Init(cfg, "vision3.log", false)
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	t.Cleanup(func() { closeFn() })
+
+	log.Printf("fatal-ish line")
+
+	// No Flush()/Close() call here: the bridge must have flushed on write.
+	data, _ := os.ReadFile(filepath.Join(dir, "vision3.log"))
+	if !strings.Contains(string(data), "fatal-ish line") {
+		t.Errorf("bridged write should be flushed immediately with cache on; file=%q", data)
 	}
 }


### PR DESCRIPTION
Phase A wiring of the logging overhaul ([design](docs-internal/plans/2026-06-28-logging-overhaul-design.md)). Builds on #41. Replaces the per-binary `log.SetOutput`/`os.OpenFile`/`io.MultiWriter` blocks in the two log-producing binaries with a single `logging.Init` call.

## `logging.Init` changes
- **`console` parameter** — when true, the JSON slog logger *also* echoes to stderr, preserving today's dual stderr+file behavior for terminal-run servers (per the console-echo decision). The configurable rolling file is always the primary sink.
- **Stdlib `log` bridge (CodeRabbit design note #1)** — `Init` now `log.SetOutput`s to the same destination(s), so not-yet-migrated `log.Printf` calls still land in the rolling file until Phase B converts them. This keeps Phase A behavior-preserving. The returned close func restores stdlib `log` to stderr.

## Binaries
| Binary | Change |
|---|---|
| `cmd/vision3` | Server config is now loaded **before** logging init (Init reads `serverConfig.Logging`); the hardcoded log-file block is removed. Logs to `vision3.log`. |
| `cmd/v3mail` | Loads the shared config (defaults when `config.json` is absent), routes through Init with `v3mail.log`. |
| `cmd/config` | **Unchanged** — intentionally left suppressing logs (`io.Discard`) per the design ("config editor continues to suppress logs during TUI operation"). |

## Testing
- Added `TestInit_BridgesStdlibLog`: a stdlib `log.Printf` after `Init` lands in the rolling file; close restores the default output.
- Smoke-tested `v3mail` end-to-end: runs, creates `data/logs/v3mail.log`, echoes legacy lines to stderr.
- Full suite: **1,473 pass / 50 packages**; `go vet` + `gofmt` clean.

## Remaining Phase A
- TUI Logging screen in `configeditor/fields_system.go` (next PR).

Then **Phase B** = mechanical `log.Printf` → `slog` migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logging now supports simultaneous output to both the log file and the console during startup and runtime.
  * Application startup now uses a shared configuration-based logging setup for more consistent log handling.

* **Bug Fixes**
  * Improved handling when logging cannot be initialized, allowing the app to continue with default error output instead of failing outright.
  * Standard log messages are now correctly routed and restored when logging is shut down.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->