### PR TITLE
feat(configeditor): add Logging screen to System Configuration (Phase A)

### DIFF
--- a/internal/configeditor/fields_logging_test.go
+++ b/internal/configeditor/fields_logging_test.go
@@ -1,0 +1,112 @@
+package configeditor
+
+import (
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+)
+
+func fieldByLabel(t *testing.T, fields []fieldDef, label string) *fieldDef {
+	t.Helper()
+	for i := range fields {
+		if fields[i].Label == label {
+			return &fields[i]
+		}
+	}
+	t.Fatalf("field %q not found", label)
+	return nil
+}
+
+func TestSysFieldsLogging_GetSet(t *testing.T) {
+	cfg := &config.ServerConfig{Logging: config.LoggingConfig{
+		Dir: "data/logs", Level: "INFO", Cache: true,
+		Type: config.LogTypeNone, MaxFiles: 5, MaxSizeKB: 1024,
+	}}
+	fields := sysFieldsLogging(cfg)
+	if len(fields) != 6 {
+		t.Fatalf("expected 6 logging fields, got %d", len(fields))
+	}
+
+	// Directory round-trips.
+	dir := fieldByLabel(t, fields, "Log Directory")
+	if dir.Get() != "data/logs" {
+		t.Errorf("Dir Get = %q", dir.Get())
+	}
+	if err := dir.Set("/var/log/bbs"); err != nil || cfg.Logging.Dir != "/var/log/bbs" {
+		t.Errorf("Dir Set: err=%v dir=%q", err, cfg.Logging.Dir)
+	}
+
+	// Min Level lookup round-trips and offers all four levels.
+	lvl := fieldByLabel(t, fields, "Min Level")
+	if lvl.Type != ftLookup {
+		t.Error("Min Level should be ftLookup")
+	}
+	if got := len(lvl.LookupItems()); got != 4 {
+		t.Errorf("expected 4 level options, got %d", got)
+	}
+	if err := lvl.Set("WARN"); err != nil || cfg.Logging.Level != "WARN" {
+		t.Errorf("Level Set: err=%v level=%q", err, cfg.Logging.Level)
+	}
+	if lvl.Get() != "WARN" {
+		t.Errorf("Level Get = %q, want WARN", lvl.Get())
+	}
+
+	// Cache toggles via Y/N.
+	cache := fieldByLabel(t, fields, "Cache Writes")
+	if cache.Get() != "Y" {
+		t.Errorf("Cache Get = %q, want Y", cache.Get())
+	}
+	if err := cache.Set("N"); err != nil || cfg.Logging.Cache {
+		t.Errorf("Cache Set N: err=%v cache=%v", err, cfg.Logging.Cache)
+	}
+
+	// Max Files validates integers.
+	mf := fieldByLabel(t, fields, "Max Files")
+	if err := mf.Set("3"); err != nil || cfg.Logging.MaxFiles != 3 {
+		t.Errorf("MaxFiles Set: err=%v val=%d", err, cfg.Logging.MaxFiles)
+	}
+	if err := mf.Set("notanint"); err == nil {
+		t.Error("MaxFiles Set should reject non-integer input")
+	}
+}
+
+func TestSysFieldsLogging_RollingTypeLabelMapping(t *testing.T) {
+	cfg := &config.ServerConfig{Logging: config.LoggingConfig{Type: config.LogTypeNone}}
+	rt := fieldByLabel(t, sysFieldsLogging(cfg), "Rolling Type")
+
+	if rt.Get() != "None" {
+		t.Errorf("Type 0 Get = %q, want None", rt.Get())
+	}
+	cases := map[string]int{
+		"Size":  config.LogTypeSize,
+		"Daily": config.LogTypeDaily,
+		"None":  config.LogTypeNone,
+	}
+	for label, want := range cases {
+		if err := rt.Set(label); err != nil {
+			t.Fatalf("Set(%q): %v", label, err)
+		}
+		if cfg.Logging.Type != want {
+			t.Errorf("Set(%q) -> Type %d, want %d", label, cfg.Logging.Type, want)
+		}
+		if rt.Get() != label {
+			t.Errorf("after Set(%q), Get = %q", label, rt.Get())
+		}
+	}
+	// The picker offers exactly the three rolling types.
+	if got := len(rt.LookupItems()); got != 3 {
+		t.Errorf("expected 3 rolling-type options, got %d", got)
+	}
+}
+
+func TestBuildSysFields_LoggingScreenWired(t *testing.T) {
+	m := &Model{configs: &allConfigs{}}
+	m.configs.Server.Logging = config.LoggingConfig{Dir: "data/logs", Level: "INFO"}
+
+	fields := m.buildSysFields(8)
+	if len(fields) != 6 {
+		t.Fatalf("buildSysFields(8) returned %d fields, want 6 (Logging screen)", len(fields))
+	}
+	// Sanity: it's the logging screen, not some other screen's fields.
+	fieldByLabel(t, fields, "Rolling Type")
+}

--- a/internal/configeditor/fields_logging_test.go
+++ b/internal/configeditor/fields_logging_test.go
@@ -97,6 +97,12 @@ func TestSysFieldsLogging_RollingTypeLabelMapping(t *testing.T) {
 	if got := len(rt.LookupItems()); got != 3 {
 		t.Errorf("expected 3 rolling-type options, got %d", got)
 	}
+
+	// An unmapped/hand-edited type falls back to "None" rather than blank.
+	cfg.Logging.Type = 99
+	if got := rt.Get(); got != "None" {
+		t.Errorf("unmapped type Get = %q, want None fallback", got)
+	}
 }
 
 func TestBuildSysFields_LoggingScreenWired(t *testing.T) {

--- a/internal/configeditor/fields_system.go
+++ b/internal/configeditor/fields_system.go
@@ -580,23 +580,46 @@ func sysFieldsDOS(cfg *config.ServerConfig) []fieldDef {
 	}
 }
 
-// logTypeLabels maps the persisted LoggingConfig.Type to the word shown in the
-// TUI lookup; logLabelToType is the inverse used when a value is picked.
-var logTypeLabels = map[int]string{
-	config.LogTypeNone:  "None",
-	config.LogTypeSize:  "Size",
-	config.LogTypeDaily: "Daily",
+// logRollingTypes is the single source of truth for the Rolling Type lookup:
+// the persisted LoggingConfig.Type, the short label shown in the form, and the
+// picker description. logTypeToLabel / logLabelToType convert against it.
+var logRollingTypes = []struct {
+	typ     int
+	label   string
+	display string
+}{
+	{config.LogTypeNone, "None", "None - single file, no rotation"},
+	{config.LogTypeSize, "Size", "Size - rotate at Max Size KB, keep Max Files"},
+	{config.LogTypeDaily, "Daily", "Daily - new file per day, keep Max Files days"},
+}
+
+// logTypeToLabel maps a persisted type to its label, falling back to "None" for
+// an unmapped/hand-edited value (the rolling writer treats unknown types as
+// no-rotation, so "None" is the consistent display).
+func logTypeToLabel(typ int) string {
+	for _, t := range logRollingTypes {
+		if t.typ == typ {
+			return t.label
+		}
+	}
+	return "None"
 }
 
 func logLabelToType(label string) int {
-	switch label {
-	case "Size":
-		return config.LogTypeSize
-	case "Daily":
-		return config.LogTypeDaily
-	default:
-		return config.LogTypeNone
+	for _, t := range logRollingTypes {
+		if t.label == label {
+			return t.typ
+		}
 	}
+	return config.LogTypeNone
+}
+
+func logRollingTypeItems() []LookupItem {
+	items := make([]LookupItem, len(logRollingTypes))
+	for i, t := range logRollingTypes {
+		items[i] = LookupItem{Value: t.label, Display: t.display}
+	}
+	return items
 }
 
 // sysFieldsLogging returns fields for the Logging sub-screen.
@@ -604,7 +627,7 @@ func sysFieldsLogging(cfg *config.ServerConfig) []fieldDef {
 	lg := &cfg.Logging
 	return []fieldDef{
 		{
-			Label: "Log Directory", Help: "Directory for log files (relative to BBS root)", Type: ftString, Col: 3, Row: 1, Width: 40,
+			Label: "Log Directory", Help: "Directory for log files (absolute, or relative to BBS root)", Type: ftString, Col: 3, Row: 1, Width: 40,
 			Get: func() string { return lg.Dir },
 			Set: func(val string) error { lg.Dir = val; return nil },
 		},
@@ -623,15 +646,9 @@ func sysFieldsLogging(cfg *config.ServerConfig) []fieldDef {
 		},
 		{
 			Label: "Rolling Type", Help: "How log files are rotated", Type: ftLookup, Col: 3, Row: 3, Width: 8,
-			Get: func() string { return logTypeLabels[lg.Type] },
-			Set: func(val string) error { lg.Type = logLabelToType(val); return nil },
-			LookupItems: func() []LookupItem {
-				return []LookupItem{
-					{Value: "None", Display: "None - single file, no rotation"},
-					{Value: "Size", Display: "Size - rotate at Max Size KB, keep Max Files"},
-					{Value: "Daily", Display: "Daily - new file per day, keep Max Files days"},
-				}
-			},
+			Get:         func() string { return logTypeToLabel(lg.Type) },
+			Set:         func(val string) error { lg.Type = logLabelToType(val); return nil },
+			LookupItems: logRollingTypeItems,
 		},
 		{
 			Label: "Cache Writes", Help: "Buffer writes in an 8KB cache (flushed on errors/exit)", Type: ftYesNo, Col: 3, Row: 4, Width: 1,

--- a/internal/configeditor/fields_system.go
+++ b/internal/configeditor/fields_system.go
@@ -95,6 +95,8 @@ func (m *Model) buildSysFields(screen int) []fieldDef {
 		return sysFieldsNUV(cfg)
 	case 7:
 		return sysFieldsDOS(cfg)
+	case 8:
+		return sysFieldsLogging(cfg)
 	}
 	return nil
 }
@@ -574,6 +576,91 @@ func sysFieldsDOS(cfg *config.ServerConfig) []fieldDef {
 			Label: "DOSemu Path", Help: "Path to dosemu2 binary (blank=auto-detect)", Type: ftString, Col: 3, Row: 1, Width: 45,
 			Get: func() string { return cfg.DosemuPath },
 			Set: func(val string) error { cfg.DosemuPath = val; return nil },
+		},
+	}
+}
+
+// logTypeLabels maps the persisted LoggingConfig.Type to the word shown in the
+// TUI lookup; logLabelToType is the inverse used when a value is picked.
+var logTypeLabels = map[int]string{
+	config.LogTypeNone:  "None",
+	config.LogTypeSize:  "Size",
+	config.LogTypeDaily: "Daily",
+}
+
+func logLabelToType(label string) int {
+	switch label {
+	case "Size":
+		return config.LogTypeSize
+	case "Daily":
+		return config.LogTypeDaily
+	default:
+		return config.LogTypeNone
+	}
+}
+
+// sysFieldsLogging returns fields for the Logging sub-screen.
+func sysFieldsLogging(cfg *config.ServerConfig) []fieldDef {
+	lg := &cfg.Logging
+	return []fieldDef{
+		{
+			Label: "Log Directory", Help: "Directory for log files (relative to BBS root)", Type: ftString, Col: 3, Row: 1, Width: 40,
+			Get: func() string { return lg.Dir },
+			Set: func(val string) error { lg.Dir = val; return nil },
+		},
+		{
+			Label: "Min Level", Help: "Minimum level written to the log", Type: ftLookup, Col: 3, Row: 2, Width: 8,
+			Get: func() string { return lg.Level },
+			Set: func(val string) error { lg.Level = val; return nil },
+			LookupItems: func() []LookupItem {
+				return []LookupItem{
+					{Value: "DEBUG", Display: "DEBUG - most verbose"},
+					{Value: "INFO", Display: "INFO - normal operation"},
+					{Value: "WARN", Display: "WARN - warnings and errors"},
+					{Value: "ERROR", Display: "ERROR - errors only"},
+				}
+			},
+		},
+		{
+			Label: "Rolling Type", Help: "How log files are rotated", Type: ftLookup, Col: 3, Row: 3, Width: 8,
+			Get: func() string { return logTypeLabels[lg.Type] },
+			Set: func(val string) error { lg.Type = logLabelToType(val); return nil },
+			LookupItems: func() []LookupItem {
+				return []LookupItem{
+					{Value: "None", Display: "None - single file, no rotation"},
+					{Value: "Size", Display: "Size - rotate at Max Size KB, keep Max Files"},
+					{Value: "Daily", Display: "Daily - new file per day, keep Max Files days"},
+				}
+			},
+		},
+		{
+			Label: "Cache Writes", Help: "Buffer writes in an 8KB cache (flushed on errors/exit)", Type: ftYesNo, Col: 3, Row: 4, Width: 1,
+			Get: func() string { return uitext.BoolToYN(lg.Cache) },
+			Set: func(val string) error { lg.Cache = uitext.YNToBool(val); return nil },
+		},
+		{
+			Label: "Max Files", Help: "Retained backups (Size type) or days (Daily type)", Type: ftInteger, Col: 3, Row: 5, Width: 5, Min: 1, Max: 9999,
+			Get: func() string { return strconv.Itoa(lg.MaxFiles) },
+			Set: func(val string) error {
+				n, err := strconv.Atoi(val)
+				if err != nil {
+					return err
+				}
+				lg.MaxFiles = n
+				return nil
+			},
+		},
+		{
+			Label: "Max Size KB", Help: "Rotation threshold in KB (Size type only)", Type: ftInteger, Col: 3, Row: 6, Width: 7, Min: 1, Max: 1048576,
+			Get: func() string { return strconv.Itoa(lg.MaxSizeKB) },
+			Set: func(val string) error {
+				n, err := strconv.Atoi(val)
+				if err != nil {
+					return err
+				}
+				lg.MaxSizeKB = n
+				return nil
+			},
 		},
 	}
 }

--- a/internal/configeditor/model.go
+++ b/internal/configeditor/model.go
@@ -296,6 +296,7 @@ func New(configPath string) (Model, error) {
 		{"IP Blocklist/Allowlist"},
 		{"New User Voting (NUV)"},
 		{"DOS Emulation"},
+		{"Logging"},
 	}
 
 	return Model{


### PR DESCRIPTION
Final Phase A piece of the logging overhaul ([design](docs-internal/plans/2026-06-28-logging-overhaul-design.md)). A TUI screen for editing the shared `LoggingConfig` (added in #41), in the System Configuration section. **Independent of #43** — branches off `main`, touches only `internal/configeditor`.

## What's added
- New **"Logging"** sub-screen (`case 8` in `buildSysFields`) + menu entry in `sysMenuItems`.
- Fields reuse existing field types:

| Field | Type | Notes |
|---|---|---|
| Log Directory | `ftString` | relative to BBS root |
| Min Level | `ftLookup` | DEBUG / INFO / WARN / ERROR |
| Rolling Type | `ftLookup` | None / Size / Daily |
| Cache Writes | `ftYesNo` | 8KB buffer |
| Max Files | `ftInteger` (min 1) | backups (Size) or days (Daily) |
| Max Size KB | `ftInteger` (min 1) | Size-type threshold |

- **Rolling Type** maps the int `LoggingConfig.Type` ↔ friendly labels (None/Size/Daily) via `logTypeLabels`/`logLabelToType`, so the form shows a word rather than `0`/`1`/`2`.
- Edits flow through the existing dirty-tracking + `SaveServerConfig` path; `LoggingConfig` already serializes under the `"logging"` key.

## Testing
- `sysFieldsLogging`: field count, Get/Set round-trips (Dir, Level, Cache, Max Files integer validation)
- Rolling Type label↔int mapping in both directions
- `buildSysFields(8)` wiring returns the Logging screen
- `go build ./...`, `go vet`, `gofmt` clean; full suite passes

## Phase A status
With this + #43, **Phase A is complete**: package + config (#41), binary wiring + log bridge (#43), and the TUI screen (this PR). Next is **Phase B** — the mechanical `log.Printf` → `slog`/`logging` migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Logging section to system settings, making log-related options available in the configuration UI.
  * Users can now adjust log location, minimum log level, rotation mode, cache writes, and retention limits from the same screen.

* **Bug Fixes**
  * Improved consistency between selected logging options and the values saved in configuration, including validation for numeric fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->