### PR TITLE
fix(logging): remove unused rollingWriter.currentPath

### DIFF
--- a/internal/logging/writer.go
+++ b/internal/logging/writer.go
@@ -99,14 +99,6 @@ func (w *rollingWriter) datedPath(day string) string {
 	return filepath.Join(w.dir, w.stem+"."+day+w.ext)
 }
 
-// currentPath returns the path the writer should currently be appending to.
-func (w *rollingWriter) currentPath() string {
-	if w.logType == config.LogTypeDaily {
-		return w.datedPath(w.day)
-	}
-	return w.basePath()
-}
-
 // openCurrent opens (creating if needed) the current target file for append and
 // initializes the cache and size/day tracking.
 func (w *rollingWriter) openCurrent() error {


### PR DESCRIPTION
Small dead-code removal. `rollingWriter.currentPath` became unused when `openCurrent` was refactored to compute the target path inline (during #41's review round). It has no callers — `go vet`/linters flag it as unused.

`basePath` and `datedPath` (which it delegated to) remain in use by `openCurrent`, `rotateSize`, and `pruneDaily`.

- `go build`/`go vet`/`go test ./internal/logging/` clean.