### PR TITLE
refactor(scheduler): migrate to structured slog (Phase B pilot)

### DIFF
--- a/internal/scheduler/executor.go
+++ b/internal/scheduler/executor.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strconv"
@@ -21,7 +21,7 @@ func (s *Scheduler) executeEvent(ctx context.Context, event config.EventConfig) 
 		StartTime: time.Now(),
 	}
 
-	log.Printf("INFO: Event '%s' (%s) started", event.ID, event.Name)
+	slog.Info("event started", "id", event.ID, "name", event.Name)
 
 	// Build substitutions for placeholders
 	substitutions := s.buildSubstitutions(event)
@@ -71,7 +71,7 @@ func (s *Scheduler) executeEvent(ctx context.Context, event config.EventConfig) 
 			workDir = strings.ReplaceAll(workDir, key, val)
 		}
 		cmd.Dir = workDir
-		log.Printf("DEBUG: Event '%s': setting working directory to '%s'", event.ID, cmd.Dir)
+		slog.Debug("setting working directory", "id", event.ID, "dir", cmd.Dir)
 	}
 
 	// Set environment variables
@@ -103,26 +103,26 @@ func (s *Scheduler) executeEvent(ctx context.Context, event config.EventConfig) 
 		if cmdCtx.Err() == context.DeadlineExceeded {
 			result.Success = false
 			result.ExitCode = -1
-			log.Printf("ERROR: Event '%s' (%s) timed out after %ds", event.ID, event.Name, event.TimeoutSeconds)
+			slog.Error("event timed out", "id", event.ID, "name", event.Name, "timeout_s", event.TimeoutSeconds)
 		} else if exitErr, ok := err.(*exec.ExitError); ok {
 			result.Success = false
 			result.ExitCode = exitErr.ExitCode()
-			log.Printf("ERROR: Event '%s' (%s) failed with exit code %d", event.ID, event.Name, result.ExitCode)
+			slog.Error("event failed", "id", event.ID, "name", event.Name, "exit_code", result.ExitCode)
 			if result.ErrorOutput != "" {
-				log.Printf("ERROR: Event '%s' stderr: %s", event.ID, result.ErrorOutput)
+				slog.Error("event stderr", "id", event.ID, "stderr", result.ErrorOutput)
 			}
 		} else {
 			result.Success = false
 			result.ExitCode = -1
-			log.Printf("ERROR: Event '%s' (%s) failed to start: %v", event.ID, event.Name, err)
+			slog.Error("event failed to start", "id", event.ID, "name", event.Name, "error", err)
 		}
 	} else {
 		result.Success = true
 		result.ExitCode = 0
 		duration := result.EndTime.Sub(result.StartTime)
-		log.Printf("INFO: Event '%s' (%s) completed in %.3fs (exit code: 0)", event.ID, event.Name, duration.Seconds())
+		slog.Info("event completed", "id", event.ID, "name", event.Name, "duration_s", duration.Seconds())
 		if result.Output != "" {
-			log.Printf("DEBUG: Event '%s' output: %s", event.ID, result.Output)
+			slog.Debug("event output", "id", event.ID, "output", result.Output)
 		}
 	}
 
@@ -137,7 +137,7 @@ func (s *Scheduler) buildSubstitutions(event config.EventConfig) map[string]stri
 	// This should be the BBS installation root where the binary is running
 	bbsRoot, err := os.Getwd()
 	if err != nil {
-		log.Printf("WARN: Failed to get working directory: %v", err)
+		slog.Warn("failed to get working directory", "error", err)
 		bbsRoot = "."
 	}
 

--- a/internal/scheduler/executor.go
+++ b/internal/scheduler/executor.go
@@ -103,11 +103,11 @@ func (s *Scheduler) executeEvent(ctx context.Context, event config.EventConfig) 
 		if cmdCtx.Err() == context.DeadlineExceeded {
 			result.Success = false
 			result.ExitCode = -1
-			slog.Error("event timed out", "id", event.ID, "name", event.Name, "timeout_s", event.TimeoutSeconds)
+			slog.Error("event timed out", "id", event.ID, "name", event.Name, "timeout_s", event.TimeoutSeconds, "error", err)
 		} else if exitErr, ok := err.(*exec.ExitError); ok {
 			result.Success = false
 			result.ExitCode = exitErr.ExitCode()
-			slog.Error("event failed", "id", event.ID, "name", event.Name, "exit_code", result.ExitCode)
+			slog.Error("event failed", "id", event.ID, "name", event.Name, "exit_code", result.ExitCode, "error", err)
 			if result.ErrorOutput != "" {
 				slog.Error("event stderr", "id", event.ID, "stderr", result.ErrorOutput)
 			}

--- a/internal/scheduler/history.go
+++ b/internal/scheduler/history.go
@@ -119,6 +119,6 @@ func (s *Scheduler) updateHistory(result EventResult) {
 		h.FailureCount++
 	}
 
-	slog.Debug("updated event history", "event", result.EventID, "status", h.LastStatus,
+	slog.Debug("updated event history", "id", result.EventID, "status", h.LastStatus,
 		"duration_ms", h.LastDuration, "runs", h.RunCount, "success", h.SuccessCount, "failures", h.FailureCount)
 }

--- a/internal/scheduler/history.go
+++ b/internal/scheduler/history.go
@@ -2,7 +2,7 @@ package scheduler
 
 import (
 	"encoding/json"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 )
@@ -13,7 +13,7 @@ func LoadHistory(path string) (map[string]*EventHistory, error) {
 
 	// Check if file exists
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		log.Printf("INFO: Event history file not found at %s, starting with empty history", path)
+		slog.Info("event history file not found; starting with empty history", "path", path)
 		return history, nil
 	}
 
@@ -34,7 +34,7 @@ func LoadHistory(path string) (map[string]*EventHistory, error) {
 		history[historyList[i].EventID] = &historyList[i]
 	}
 
-	log.Printf("INFO: Loaded event history for %d events from %s", len(history), path)
+	slog.Info("loaded event history", "events", len(history), "path", path)
 	return history, nil
 }
 
@@ -84,7 +84,7 @@ func SaveHistory(path string, history map[string]*EventHistory) error {
 		return err
 	}
 
-	log.Printf("DEBUG: Saved event history for %d events to %s", len(history), path)
+	slog.Debug("saved event history", "events", len(history), "path", path)
 	return nil
 }
 
@@ -119,6 +119,6 @@ func (s *Scheduler) updateHistory(result EventResult) {
 		h.FailureCount++
 	}
 
-	log.Printf("DEBUG: Updated history for event '%s': status=%s, duration=%dms, runs=%d, success=%d, failures=%d",
-		result.EventID, h.LastStatus, h.LastDuration, h.RunCount, h.SuccessCount, h.FailureCount)
+	slog.Debug("updated event history", "event", result.EventID, "status", h.LastStatus,
+		"duration_ms", h.LastDuration, "runs", h.RunCount, "success", h.SuccessCount, "failures", h.FailureCount)
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -2,7 +2,7 @@ package scheduler
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"sync"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/config"
@@ -33,7 +33,7 @@ func NewScheduler(cfg config.EventsConfig, historyPath string) *Scheduler {
 	// Load history
 	history, err := LoadHistory(historyPath)
 	if err != nil {
-		log.Printf("WARN: Failed to load event history from %s: %v", historyPath, err)
+		slog.Warn("failed to load event history", "path", historyPath, "error", err)
 		history = make(map[string]*EventHistory)
 	}
 
@@ -59,7 +59,7 @@ func (s *Scheduler) Start(ctx context.Context) {
 	startupCount := 0
 	for _, event := range s.config.Events {
 		if !event.Enabled {
-			log.Printf("DEBUG: Event '%s' (%s) is disabled, skipping", event.ID, event.Name)
+			slog.Debug("event disabled; skipping", "id", event.ID, "name", event.Name)
 			continue
 		}
 
@@ -70,7 +70,7 @@ func (s *Scheduler) Start(ctx context.Context) {
 			s.startupWg.Add(1)
 			go func() {
 				defer s.startupWg.Done()
-				log.Printf("INFO: Startup event '%s' (%s) launching", e.ID, e.Name)
+				slog.Info("startup event launching", "id", e.ID, "name", e.Name)
 				s.executeEventWithConcurrency(e)
 			}()
 		}
@@ -78,31 +78,31 @@ func (s *Scheduler) Start(ctx context.Context) {
 		// Schedule cron events (startup-only events have no schedule)
 		if event.Schedule != "" {
 			if err := s.scheduleEvent(event); err != nil {
-				log.Printf("ERROR: Failed to schedule event '%s' (%s): %v", event.ID, event.Name, err)
+				slog.Error("failed to schedule event", "id", event.ID, "name", event.Name, "error", err)
 			} else {
 				enabledCount++
-				log.Printf("INFO: Event '%s' (%s) scheduled: %s", event.ID, event.Name, event.Schedule)
+				slog.Info("event scheduled", "id", event.ID, "name", event.Name, "schedule", event.Schedule)
 			}
 		} else if !event.RunAtStartup {
-			log.Printf("WARN: Event '%s' (%s) has no schedule and run_at_startup is false, skipping", event.ID, event.Name)
+			slog.Warn("event has no schedule and run_at_startup is false; skipping", "id", event.ID, "name", event.Name)
 		}
 	}
 
 	if enabledCount == 0 && startupCount == 0 {
-		log.Printf("WARN: No enabled events to schedule")
+		slog.Warn("no enabled events to schedule")
 		return
 	}
 
 	// Start the cron scheduler
 	s.cron.Start()
-	log.Printf("INFO: Event scheduler running with %d scheduled + %d startup events (max concurrent: %d)",
-		enabledCount, startupCount, s.config.MaxConcurrentEvents)
+	slog.Info("event scheduler running", "scheduled", enabledCount, "startup", startupCount,
+		"max_concurrent", s.config.MaxConcurrentEvents)
 
 	// Wait for context cancellation
 	<-s.ctx.Done()
 
 	// Graceful shutdown
-	log.Printf("INFO: Event scheduler stopping...")
+	slog.Info("event scheduler stopping")
 	s.Stop()
 }
 
@@ -114,18 +114,18 @@ func (s *Scheduler) Stop() {
 
 		// Wait for running jobs to complete
 		<-cronCtx.Done()
-		log.Printf("INFO: All scheduled events completed")
+		slog.Info("all scheduled events completed")
 	}
 
 	// Wait for startup events to complete
 	s.startupWg.Wait()
-	log.Printf("INFO: All startup events completed")
+	slog.Info("all startup events completed")
 
 	// Save history
 	if err := SaveHistory(s.historyPath, s.history); err != nil {
-		log.Printf("ERROR: Failed to save event history: %v", err)
+		slog.Error("failed to save event history", "error", err)
 	} else {
-		log.Printf("INFO: Event history saved to %s", s.historyPath)
+		slog.Info("event history saved", "path", s.historyPath)
 	}
 }
 
@@ -144,7 +144,7 @@ func (s *Scheduler) executeEventWithConcurrency(event config.EventConfig) {
 	s.mu.Lock()
 	if s.runningEvents[event.ID] {
 		s.mu.Unlock()
-		log.Printf("WARN: Event '%s' (%s) skipped: already running", event.ID, event.Name)
+		slog.Warn("event skipped: already running", "id", event.ID, "name", event.Name)
 		return
 	}
 
@@ -158,8 +158,8 @@ func (s *Scheduler) executeEventWithConcurrency(event config.EventConfig) {
 	default:
 		s.mu.Unlock()
 		// At concurrency limit, skip execution
-		log.Printf("WARN: Event '%s' (%s) skipped: max concurrent events reached (%d)",
-			event.ID, event.Name, s.config.MaxConcurrentEvents)
+		slog.Warn("event skipped: max concurrent events reached",
+			"id", event.ID, "name", event.Name, "max_concurrent", s.config.MaxConcurrentEvents)
 		return
 	}
 


### PR DESCRIPTION
First package of **Phase B** — the `log.Printf` → `slog` migration ([design](docs-internal/plans/2026-06-28-logging-overhaul-design.md)). `internal/scheduler` (28 call sites) is the pilot to establish the conversion conventions before the full sweep (~1,475 sites across 23 packages).

## Conventions established here
| Old | New |
|---|---|
| `log.Printf("INFO: …")` | `slog.Info(…)` |
| `log.Printf("WARN: …")` | `slog.Warn(…)` |
| `log.Printf("ERROR: …")` | `slog.Error(…)` |
| `log.Printf("DEBUG:"/"TRACE: …")` | `slog.Debug(…)` |
| `log.Printf("SECURITY: …")` | `logging.Security(…)` |
| `log.Printf("CRITICAL: …")` | `slog.Error(…)` (no native slog level above Error) |
| `log.Fatalf`/`"FATAL:"` | `logging.Fatal(…)` |

- Message → short lowercase string, **no level prefix**.
- `printf` args → **structured attributes** where they map cleanly (`id`, `name`, `path`, counts); a trailing error always becomes `"error", err`.
- Where interpolation is intrusive, a literal/`fmt.Sprintf` message is acceptable (per the design) — not needed in this package.

Example:
```go
// before
log.Printf("ERROR: Failed to schedule event '%s' (%s): %v", event.ID, event.Name, err)
// after
slog.Error("failed to schedule event", "id", event.ID, "name", event.Name, "error", err)
```

## Scope/behavior
- Only `internal/scheduler` (history.go, executor.go, scheduler.go). No `log.` calls remain in the package.
- No behavior change beyond log format — the slog default + stdlib bridge are installed by `logging.Init` (Phase A).
- `go build ./...`, `go vet ./internal/scheduler/`, `go test ./internal/scheduler/` all pass.

**Requesting style sign-off** on this before I scale the same conventions across the remaining packages (small/medium first, then cmd/vision3 and the 900-site internal/menu split across several PRs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved scheduler logging by switching to structured messages for lifecycle events, history load/save, and detailed execution diagnostics.
  * Enhanced error and status visibility with clearer timing, timeout handling, exit codes, stderr-related output, and concurrency-based skip reasoning.
  * Added more informative log levels for normal operations vs. debugging and warning scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->