### PR TITLE
refactor: migrate small packages to slog (Phase B)

### DIFF
--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -11,7 +11,7 @@ package archiver
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -252,14 +252,14 @@ func DefaultConfig() Config {
 // config directory. Returns defaults if the file doesn't exist.
 func LoadConfig(configPath string) (Config, error) {
 	filePath := filepath.Join(configPath, "archivers.json")
-	log.Printf("INFO: Loading archivers config from %s", filePath)
+	slog.Info("loading archivers config", "path", filePath)
 
 	cfg := DefaultConfig()
 
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("INFO: archivers.json not found at %s, using defaults", filePath)
+			slog.Info("archivers.json not found; using defaults", "path", filePath)
 			return cfg, nil
 		}
 		return cfg, fmt.Errorf("failed to read archivers config %s: %w", filePath, err)
@@ -269,7 +269,7 @@ func LoadConfig(configPath string) (Config, error) {
 		return Config{}, fmt.Errorf("failed to parse archivers config %s: %w", filePath, err)
 	}
 
-	log.Printf("INFO: Loaded %d archiver definitions from %s", len(cfg.Archivers), filePath)
+	slog.Info("loaded archiver definitions", "count", len(cfg.Archivers), "path", filePath)
 	return cfg, nil
 }
 

--- a/internal/conference/conference.go
+++ b/internal/conference/conference.go
@@ -3,7 +3,7 @@ package conference
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -19,7 +19,7 @@ type Conference struct {
 	Tag         string `json:"tag"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
-	ACS         string `json:"acs"` // ACS string — who can see/enter this conference
+	ACS         string `json:"acs"`                       // ACS string — who can see/enter this conference
 	AllowAnon   *bool  `json:"allow_anonymous,omitempty"` // Optional: allow anonymous posts (nil defaults to true)
 }
 
@@ -42,13 +42,13 @@ func NewConferenceManager(configPath string) (*ConferenceManager, error) {
 
 	if err := cm.loadConferences(); err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("INFO: %s not found. Starting with no conferences.", conferencesFile)
+			slog.Info("conferences file not found; starting with none", "file", conferencesFile)
 			return cm, nil
 		}
 		return nil, fmt.Errorf("failed to load conferences: %w", err)
 	}
 
-	log.Printf("INFO: ConferenceManager initialized. Loaded %d conferences.", len(cm.conferencesByID))
+	slog.Info("conference manager initialized", "count", len(cm.conferencesByID))
 	return cm, nil
 }
 
@@ -60,7 +60,7 @@ func (cm *ConferenceManager) loadConferences() error {
 	}
 
 	if len(data) == 0 {
-		log.Printf("INFO: %s is empty. No conferences loaded.", cm.configPath)
+		slog.Info("conferences file is empty; none loaded", "path", cm.configPath)
 		return nil
 	}
 
@@ -80,16 +80,16 @@ func (cm *ConferenceManager) loadConferences() error {
 			continue
 		}
 		if _, exists := cm.conferencesByID[conf.ID]; exists {
-			log.Printf("WARN: Duplicate conference ID %d in %s. Skipping.", conf.ID, cm.configPath)
+			slog.Warn("duplicate conference ID; skipping", "id", conf.ID, "path", cm.configPath)
 			continue
 		}
 		if _, exists := cm.conferencesByTag[conf.Tag]; exists {
-			log.Printf("WARN: Duplicate conference Tag '%s' in %s. Skipping.", conf.Tag, cm.configPath)
+			slog.Warn("duplicate conference tag; skipping", "tag", conf.Tag, "path", cm.configPath)
 			continue
 		}
 		cm.conferencesByID[conf.ID] = conf
 		cm.conferencesByTag[conf.Tag] = conf
-		log.Printf("TRACE: Loaded conference ID %d, Tag '%s', Name '%s'", conf.ID, conf.Tag, conf.Name)
+		slog.Debug("loaded conference", "id", conf.ID, "tag", conf.Tag, "name", conf.Name)
 	}
 
 	// Migration: assign positions to any conferences that have Position <= 0.
@@ -118,7 +118,7 @@ func (cm *ConferenceManager) loadConferences() error {
 			maxPos++
 			conf.Position = maxPos
 		}
-		log.Printf("INFO: Auto-assigned positions to %d conferences (migration)", len(sorted))
+		slog.Info("auto-assigned conference positions (migration)", "count", len(sorted))
 	}
 
 	return nil

--- a/internal/configeditor/fields_protocols.go
+++ b/internal/configeditor/fields_protocols.go
@@ -3,10 +3,11 @@ package configeditor
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
-	"log"
+	"log/slog"
 	"strconv"
 	"strings"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 )
 
 // joinArgs converts an array of arguments into a JSON-encoded string.
@@ -19,7 +20,7 @@ func joinArgs(args []string) string {
 	// Encode as JSON array for lossless round-trip
 	data, err := json.Marshal(args)
 	if err != nil {
-		log.Printf("WARN: Failed to encode args as JSON: %v", err)
+		slog.Warn("failed to encode args as JSON", "error", err)
 		return ""
 	}
 	return string(data)

--- a/internal/qwk/reader.go
+++ b/internal/qwk/reader.go
@@ -63,13 +63,13 @@ func parseREPMessages(data []byte) ([]REPMessage, error) {
 		blkStr := strings.TrimSpace(string(header[116:122]))
 		numBlocks, err := strconv.Atoi(blkStr)
 		if err != nil || numBlocks < 1 {
-			slog.Warn("QWK REP: invalid block count", "value", blkStr, "offset", pos)
+			slog.Warn("invalid QWK REP block count", "value", blkStr, "offset", pos)
 			break
 		}
 
 		totalBytes := numBlocks * BlockSize
 		if pos+totalBytes > len(data) {
-			slog.Warn("QWK REP: message extends past end of data", "offset", pos)
+			slog.Warn("QWK REP message extends past end of data", "offset", pos)
 			break
 		}
 
@@ -94,7 +94,7 @@ func parseREPMessages(data []byte) ([]REPMessage, error) {
 		pos += totalBytes
 	}
 
-	slog.Info("QWK REP: parsed messages", "count", len(messages))
+	slog.Info("parsed QWK REP messages", "count", len(messages))
 	return messages, nil
 }
 

--- a/internal/qwk/reader.go
+++ b/internal/qwk/reader.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"strconv"
 	"strings"
 )
@@ -63,13 +63,13 @@ func parseREPMessages(data []byte) ([]REPMessage, error) {
 		blkStr := strings.TrimSpace(string(header[116:122]))
 		numBlocks, err := strconv.Atoi(blkStr)
 		if err != nil || numBlocks < 1 {
-			log.Printf("WARN: QWK REP: invalid block count %q at offset %d", blkStr, pos)
+			slog.Warn("QWK REP: invalid block count", "value", blkStr, "offset", pos)
 			break
 		}
 
 		totalBytes := numBlocks * BlockSize
 		if pos+totalBytes > len(data) {
-			log.Printf("WARN: QWK REP: message extends past end of data at offset %d", pos)
+			slog.Warn("QWK REP: message extends past end of data", "offset", pos)
 			break
 		}
 
@@ -94,7 +94,7 @@ func parseREPMessages(data []byte) ([]REPMessage, error) {
 		pos += totalBytes
 	}
 
-	log.Printf("INFO: QWK REP: parsed %d messages", len(messages))
+	slog.Info("QWK REP: parsed messages", "count", len(messages))
 	return messages, nil
 }
 

--- a/internal/qwk/writer.go
+++ b/internal/qwk/writer.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"math"
 	"strings"
 	"time"
@@ -187,7 +187,7 @@ func (pw *PacketWriter) writeMessagesDAT(zw *zip.Writer) (map[int][]byte, []byte
 		return nil, nil, err
 	}
 
-	log.Printf("INFO: QWK packet: %d messages, %d blocks", len(pw.messages), currentBlock-1)
+	slog.Info("QWK packet written", "messages", len(pw.messages), "blocks", currentBlock-1)
 	return ndxData, personalNDX, nil
 }
 

--- a/internal/scripting/engine.go
+++ b/internal/scripting/engine.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -106,7 +106,7 @@ func (eng *Engine) Run(scriptPath string) error {
 		return fmt.Errorf("reading script %s: %w", scriptPath, err)
 	}
 
-	log.Printf("INFO: V3Script: Running %s for node %d", scriptPath, eng.session.NodeNumber)
+	slog.Info("V3Script: running script", "path", scriptPath, "node", eng.session.NodeNumber)
 
 	_, err = eng.vm.RunScript(scriptPath, string(data))
 	if err != nil {
@@ -136,7 +136,7 @@ func (eng *Engine) Close() {
 		select {
 		case <-eng.copierDone:
 		case <-time.After(2 * time.Second):
-			log.Printf("WARN: V3Script: copier goroutine did not exit within 2s; proceeding with cleanup")
+			slog.Warn("V3Script: copier goroutine did not exit within 2s; proceeding with cleanup")
 		}
 	}
 	if eng.pipeReader != nil {

--- a/internal/scripting/engine.go
+++ b/internal/scripting/engine.go
@@ -106,7 +106,7 @@ func (eng *Engine) Run(scriptPath string) error {
 		return fmt.Errorf("reading script %s: %w", scriptPath, err)
 	}
 
-	slog.Info("V3Script: running script", "path", scriptPath, "node", eng.session.NodeNumber)
+	slog.Info("running V3 script", "path", scriptPath, "node", eng.session.NodeNumber)
 
 	_, err = eng.vm.RunScript(scriptPath, string(data))
 	if err != nil {
@@ -136,7 +136,7 @@ func (eng *Engine) Close() {
 		select {
 		case <-eng.copierDone:
 		case <-time.After(2 * time.Second):
-			slog.Warn("V3Script: copier goroutine did not exit within 2s; proceeding with cleanup")
+			slog.Warn("V3 script copier goroutine did not exit within 2s; proceeding with cleanup")
 		}
 	}
 	if eng.pipeReader != nil {

--- a/internal/sshserver/server.go
+++ b/internal/sshserver/server.go
@@ -181,9 +181,9 @@ func WrapSession(s ssh.Session) *BBSSession {
 	// gliderlabs applies when a PTY is accepted.
 	bs.rawCh = extractRawChannel(s)
 	if bs.rawCh != nil {
-		slog.Debug("BBSSession: raw channel extracted for binary transfer support")
+		slog.Debug("raw channel extracted for binary transfer support")
 	} else {
-		slog.Warn("BBSSession: could not extract raw channel; binary transfers may be corrupted by CRLF conversion")
+		slog.Warn("could not extract raw channel; binary transfers may be corrupted by CRLF conversion")
 	}
 	return bs
 }

--- a/internal/sshserver/server.go
+++ b/internal/sshserver/server.go
@@ -7,7 +7,7 @@ package sshserver
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"os"
 	"reflect"
@@ -60,7 +60,7 @@ func NewServer(cfg Config) (*Server, error) {
 		PasswordHandler: cfg.PasswordHandler,
 		Version:         cfg.Version,
 		ConnectionFailedCallback: func(conn net.Conn, err error) {
-			log.Printf("WARN: SSH connection failed from %s: %v", conn.RemoteAddr(), err)
+			slog.Warn("SSH connection failed", "remote", conn.RemoteAddr(), "error", err)
 		},
 	}
 	if cfg.KeyboardInteractiveHandler != nil {
@@ -75,7 +75,7 @@ func NewServer(cfg Config) (*Server, error) {
 	srv.ServerConfigCallback = func(ctx ssh.Context) *gossh.ServerConfig {
 		sc := &gossh.ServerConfig{}
 		if legacy {
-			log.Printf("DEBUG: SSH legacy algorithms enabled for retro BBS client compatibility")
+			slog.Debug("SSH legacy algorithms enabled for retro BBS client compatibility")
 			sc.Config.KeyExchanges = []string{
 				"curve25519-sha256",
 				"curve25519-sha256@libssh.org",
@@ -181,9 +181,9 @@ func WrapSession(s ssh.Session) *BBSSession {
 	// gliderlabs applies when a PTY is accepted.
 	bs.rawCh = extractRawChannel(s)
 	if bs.rawCh != nil {
-		log.Printf("DEBUG: BBSSession: raw channel extracted for binary transfer support")
+		slog.Debug("BBSSession: raw channel extracted for binary transfer support")
 	} else {
-		log.Printf("WARN: BBSSession: could not extract raw channel; binary transfers may be corrupted by CRLF conversion")
+		slog.Warn("BBSSession: could not extract raw channel; binary transfers may be corrupted by CRLF conversion")
 	}
 	return bs
 }


### PR DESCRIPTION
Continues **Phase B** (slog migration) with the smallest packages, applying the conventions from the scheduler pilot (#46).

## Packages (21 sites)
| Package | Sites |
|---|---|
| conference | 7 |
| sshserver | 4 |
| qwk | 4 |
| archiver | 3 |
| scripting | 2 |
| configeditor | 1 |

- `log.Printf("LEVEL: …")` → `slog.Info/Warn/Error/Debug` (TRACE→Debug)
- Messages → short lowercase, no prefix; printf args → structured attrs (`path`, `id`, `name`, `count`, `remote`, `offset`); trailing errors → `"error", err`

No behavior change beyond log format. `go build ./...`, `go vet`, and package tests pass.

_Part of the per-package Phase B sweep. Independent of #46 (different packages)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved logging across several features to use structured, more consistent messages.
  * Added clearer details to startup, file-loading, parsing, and session logs to help diagnose issues.
  * Kept existing behavior unchanged for loading, parsing, and runtime processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->