### PR TITLE
refactor: migrate user, message, telnetserver to slog (Phase B)

### DIFF
--- a/internal/message/manager.go
+++ b/internal/message/manager.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -90,13 +90,13 @@ func NewMessageManager(dataPath, configPath, boardName string, networkTearlines 
 
 	if err := mm.loadMessageAreas(); err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("INFO: %s not found. Starting with no message areas.", messageAreaFile)
+			slog.Info("message areas file not found; starting with none", "file", messageAreaFile)
 		} else {
 			return nil, fmt.Errorf("failed to load message areas: %w", err)
 		}
 	}
 
-	log.Printf("INFO: MessageManager initialized. Loaded %d areas.", len(mm.areasByID))
+	slog.Info("message manager initialized", "areas", len(mm.areasByID))
 	return mm, nil
 }
 
@@ -162,7 +162,7 @@ func (mm *MessageManager) loadMessageAreas() error {
 			continue
 		}
 		if _, exists := mm.areasByID[area.ID]; exists {
-			log.Printf("WARN: Duplicate area ID %d, skipping.", area.ID)
+			slog.Warn("duplicate area ID; skipping", "id", area.ID)
 			continue
 		}
 		mm.areasByID[area.ID] = area
@@ -171,7 +171,7 @@ func (mm *MessageManager) loadMessageAreas() error {
 		if area.EchoTag != "" && area.EchoTag != area.Tag {
 			mm.areasByEchoTag[area.EchoTag] = area
 		}
-		log.Printf("TRACE: Loaded area ID %d, Tag '%s', Type '%s'", area.ID, area.Tag, area.AreaType)
+		slog.Debug("loaded area", "id", area.ID, "tag", area.Tag, "type", area.AreaType)
 	}
 
 	// Migration: assign positions to any areas that have Position <= 0.
@@ -200,7 +200,7 @@ func (mm *MessageManager) loadMessageAreas() error {
 			maxPos++
 			area.Position = maxPos
 		}
-		log.Printf("INFO: Auto-assigned positions to %d message areas (migration)", len(sorted))
+		slog.Info("auto-assigned message area positions (migration)", "count", len(sorted))
 	}
 
 	return nil
@@ -340,7 +340,7 @@ func (mm *MessageManager) AddArea(area MessageArea) (int, error) {
 	}
 	mm.mu.Unlock()
 
-	log.Printf("INFO: Auto-created message area ID %d, Tag %q, Type %q", area.ID, area.Tag, area.AreaType)
+	slog.Info("auto-created message area", "id", area.ID, "tag", area.Tag, "type", area.AreaType)
 
 	if err := mm.SaveAreas(); err != nil {
 		// Rollback in-memory state so it stays consistent with disk.
@@ -351,7 +351,7 @@ func (mm *MessageManager) AddArea(area MessageArea) (int, error) {
 			delete(mm.areasByEchoTag, area.EchoTag)
 		}
 		mm.mu.Unlock()
-		log.Printf("ERROR: Rolling back area %q after save failure: %v", area.Tag, err)
+		slog.Error("rolling back area after save failure", "tag", area.Tag, "error", err)
 		return 0, fmt.Errorf("save areas after add: %w", err)
 	}
 	return area.ID, nil
@@ -860,7 +860,7 @@ func (mm *MessageManager) buildThreadIndex(b *jam.Base, total int, modCounter ui
 	for i := 1; i <= total; i++ {
 		hdr, err := b.ReadMessageHeader(i)
 		if err != nil {
-			log.Printf("WARN: Failed to read message header %d: %v", i, err)
+			slog.Warn("failed to read message header", "index", i, "error", err)
 			continue
 		}
 		if hdr.Attribute&jam.MsgDeleted != 0 {
@@ -946,7 +946,7 @@ func (mm *MessageManager) buildMSGIDIndex(b *jam.Base, total int, modCounter uin
 	for i := 1; i <= total; i++ {
 		hdr, err := b.ReadMessageHeader(i)
 		if err != nil {
-			log.Printf("WARN: Failed to read message header %d for MSGID index: %v", i, err)
+			slog.Warn("failed to read message header for MSGID index", "index", i, "error", err)
 			continue
 		}
 		if hdr.Attribute&jam.MsgDeleted != 0 {

--- a/internal/message/manager.go
+++ b/internal/message/manager.go
@@ -96,7 +96,7 @@ func NewMessageManager(dataPath, configPath, boardName string, networkTearlines 
 		}
 	}
 
-	slog.Info("message manager initialized", "areas", len(mm.areasByID))
+	slog.Info("message manager initialized", "count", len(mm.areasByID))
 	return mm, nil
 }
 

--- a/internal/telnetserver/server.go
+++ b/internal/telnetserver/server.go
@@ -2,7 +2,7 @@ package telnetserver
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"sync"
 )
@@ -52,7 +52,7 @@ func (s *Server) ListenAndServe() error {
 	s.listener = listener
 	s.mu.Unlock()
 
-	log.Printf("INFO: Telnet server listening on %s", addr)
+	slog.Info("telnet server listening", "addr", addr)
 
 	for {
 		conn, err := listener.Accept()
@@ -64,7 +64,7 @@ func (s *Server) ListenAndServe() error {
 			if closed {
 				return nil // Clean shutdown
 			}
-			log.Printf("ERROR: Telnet accept error: %v", err)
+			slog.Error("telnet accept error", "error", err)
 			continue
 		}
 
@@ -75,14 +75,14 @@ func (s *Server) ListenAndServe() error {
 // handleConnection processes a new telnet connection.
 func (s *Server) handleConnection(conn net.Conn) {
 	remoteAddr := conn.RemoteAddr().String()
-	log.Printf("INFO: Telnet connection from %s", remoteAddr)
+	slog.Info("telnet connection", "remote", remoteAddr)
 
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("ERROR: Telnet panic handling %s: %v", remoteAddr, r)
+			slog.Error("telnet panic handling connection", "remote", remoteAddr, "panic", r)
 		}
 		conn.Close()
-		log.Printf("INFO: Telnet connection closed from %s", remoteAddr)
+		slog.Info("telnet connection closed", "remote", remoteAddr)
 	}()
 
 	// Create telnet-aware connection wrapper
@@ -90,14 +90,14 @@ func (s *Server) handleConnection(conn net.Conn) {
 
 	// Negotiate telnet options (ECHO, SGA, NAWS, etc.)
 	if err := tc.Negotiate(); err != nil {
-		log.Printf("ERROR: Telnet negotiation failed for %s: %v", remoteAddr, err)
+		slog.Error("telnet negotiation failed", "remote", remoteAddr, "error", err)
 		return
 	}
 
 	// Detect actual usable terminal size via ANSI CPR (primary), NAWS (fallback), defaults
 	// CPR detects status bars (e.g., SyncTerm reports 25 via NAWS but only 24 rows usable)
 	w, h, method := tc.DetectTerminalSize()
-	log.Printf("INFO: Telnet session from %s - terminal size: %dx%d (via %s)", remoteAddr, w, h, method)
+	slog.Info("telnet session", "remote", remoteAddr, "width", w, "height", h, "method", method)
 
 	// Create session adapter that implements ssh.Session
 	adapter := NewTelnetSessionAdapter(tc)

--- a/internal/telnetserver/telnet.go
+++ b/internal/telnetserver/telnet.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net"
 	"regexp"
 	"strings"
@@ -54,8 +54,8 @@ const (
 // TelnetConn wraps a net.Conn with telnet protocol awareness.
 // Read() strips IAC commands transparently; Write() escapes 0xFF bytes.
 type TelnetConn struct {
-	conn   net.Conn
-	reader *bufio.Reader
+	conn    net.Conn
+	reader  *bufio.Reader
 	writeMu sync.Mutex // protects writes to conn
 
 	width  int
@@ -197,7 +197,7 @@ func (tc *TelnetConn) processNegotiationBytes(data []byte) {
 
 		case stateWill, stateWont, stateDo, stateDont:
 			// Consume the option byte
-			log.Printf("DEBUG: Telnet negotiation: cmd=%d option=%d", tc.state, b)
+			slog.Debug("telnet negotiation", "cmd", tc.state, "option", b)
 			if tc.state == stateWill && b == OptTermType {
 				tc.willTermType = true
 			}
@@ -243,11 +243,11 @@ func (tc *TelnetConn) handleSubnegotiation() {
 		width := int(tc.sbData[0])<<8 | int(tc.sbData[1])
 		height := int(tc.sbData[2])<<8 | int(tc.sbData[3])
 
-		log.Printf("INFO: Telnet NAWS: %dx%d", width, height)
+		slog.Info("telnet NAWS", "width", width, "height", height)
 
 		// Validate and cap dimensions
 		if width <= 0 || height <= 0 || width > 255 || height > 255 {
-			log.Printf("WARN: Telnet NAWS: invalid dimensions %dx%d, using defaults", width, height)
+			slog.Warn("telnet NAWS invalid dimensions; using defaults", "width", width, "height", height)
 			width = 80
 			height = 25
 		}
@@ -277,7 +277,7 @@ func (tc *TelnetConn) handleSubnegotiation() {
 				tc.termTypeMu.Lock()
 				tc.termType = t
 				tc.termTypeMu.Unlock()
-				log.Printf("INFO: Telnet TERM_TYPE: %s", t)
+				slog.Info("telnet TERM_TYPE", "term", t)
 			}
 		}
 	}
@@ -507,11 +507,11 @@ func (tc *TelnetConn) DetectTerminalSize() (width, height int, method string) {
 		default:
 		}
 
-		log.Printf("INFO: Telnet terminal size detected via ANSI CPR: %dx%d", w, h)
+		slog.Info("telnet terminal size detected via ANSI CPR", "width", w, "height", h)
 		return w, h, "ANSI"
 	}
 	if err != nil {
-		log.Printf("DEBUG: Telnet ANSI CPR detection failed: %v", err)
+		slog.Debug("telnet ANSI CPR detection failed", "error", err)
 	}
 
 	// Step 2: Fall back to NAWS values (already populated by Negotiate)
@@ -520,7 +520,7 @@ func (tc *TelnetConn) DetectTerminalSize() (width, height int, method string) {
 	tc.sizeMu.RUnlock()
 
 	if nawsW > 0 && nawsH > 0 && nawsW <= 80 && nawsH <= 25 {
-		log.Printf("INFO: Telnet terminal size via NAWS: %dx%d", nawsW, nawsH)
+		slog.Info("telnet terminal size via NAWS", "width", nawsW, "height", nawsH)
 		return nawsW, nawsH, "NAWS"
 	}
 
@@ -530,7 +530,7 @@ func (tc *TelnetConn) DetectTerminalSize() (width, height int, method string) {
 	tc.height = 25
 	tc.sizeMu.Unlock()
 
-	log.Printf("INFO: Telnet terminal size using defaults: 80x25")
+	slog.Info("telnet terminal size using defaults (80x25)")
 	return 80, 25, "DEFAULT"
 }
 

--- a/internal/telnetserver/telnet.go
+++ b/internal/telnetserver/telnet.go
@@ -277,7 +277,7 @@ func (tc *TelnetConn) handleSubnegotiation() {
 				tc.termTypeMu.Lock()
 				tc.termType = t
 				tc.termTypeMu.Unlock()
-				slog.Info("telnet TERM_TYPE", "term", t)
+				slog.Info("telnet terminal type", "term", t)
 			}
 		}
 	}
@@ -530,7 +530,7 @@ func (tc *TelnetConn) DetectTerminalSize() (width, height int, method string) {
 	tc.height = 25
 	tc.sizeMu.Unlock()
 
-	slog.Info("telnet terminal size using defaults (80x25)")
+	slog.Info("telnet terminal size using defaults", "width", 80, "height", 25)
 	return 80, 25, "DEFAULT"
 }
 

--- a/internal/user/manager.go
+++ b/internal/user/manager.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,11 +22,11 @@ var (
 
 const (
 	userFile         = "users.json"
-	callHistoryFile  = "callhistory.json"  // Filename for call history
-	callNumberFile   = "callnumber.json"   // Filename for the next call number
+	callHistoryFile  = "callhistory.json"    // Filename for call history
+	callNumberFile   = "callnumber.json"     // Filename for the next call number
 	adminLogFile     = "admin_activity.json" // Filename for admin activity log
-	callHistoryLimit = 20                  // Max number of call records to keep
-	adminLogLimit    = 1000                // Max number of admin log entries to keep
+	callHistoryLimit = 20                    // Max number of call records to keep
+	adminLogLimit    = 1000                  // Max number of admin log entries to keep
 )
 
 // StripUTF8BOM returns data with UTF-8 BOM (EF BB BF) removed if present.
@@ -42,13 +42,13 @@ func StripUTF8BOM(data []byte) []byte {
 type UserMgr struct {
 	users          map[string]*User
 	mu             sync.RWMutex
-	path           string // Path to users.json
-	dataPath       string // Path to the data directory (for callhistory.json etc)
-	newUserLevel   int    // Access level assigned to new signups (from config)
-	nextUserID     int    // Added to track the next available user ID
-	callHistory    []CallRecord    // Added slice for call history
-	nextCallNumber uint64          // Added counter for overall calls
-	activeUserIDs  map[int32]bool  // Track which user IDs are currently online
+	path           string         // Path to users.json
+	dataPath       string         // Path to the data directory (for callhistory.json etc)
+	newUserLevel   int            // Access level assigned to new signups (from config)
+	nextUserID     int            // Added to track the next available user ID
+	callHistory    []CallRecord   // Added slice for call history
+	nextCallNumber uint64         // Added counter for overall calls
+	activeUserIDs  map[int32]bool // Track which user IDs are currently online
 }
 
 // NewUserManager creates and initializes a new user manager
@@ -57,7 +57,7 @@ func NewUserManager(dataPath string) (*UserMgr, error) { // Return renamed type
 		users:        make(map[string]*User),
 		path:         filepath.Join(dataPath, userFile), // userFile path uses dataPath now
 		newUserLevel: 1,                                 // Default to 1, will be overridden by SetNewUserLevel
-		dataPath: dataPath,                          // Store the data path
+		dataPath:     dataPath,                          // Store the data path
 		// LastLogins:  make([]LoginEvent, 0, MaxLastLogins), // Removed LastLogins initialization
 		callHistory:    make([]CallRecord, 0, callHistoryLimit), // Initialize call history
 		nextUserID:     1,                                       // Start user IDs from 1
@@ -70,19 +70,19 @@ func NewUserManager(dataPath string) (*UserMgr, error) { // Return renamed type
 	// Load call history using the stored dataPath
 	if err := um.loadCallHistory(); err != nil {
 		// Log warning but continue
-		log.Printf("WARN: Failed to load call history: %v", err)
+		slog.Warn("failed to load call history", "error", err)
 	}
 
 	// Load the next call number
 	if err := um.loadNextCallNumber(); err != nil {
 		// Log warning but continue, using the default start value of 1
-		log.Printf("WARN: Failed to load next call number: %v", err)
+		slog.Warn("failed to load next call number", "error", err)
 	}
 
 	if err := um.loadUsers(); err != nil {
 		// If loading fails (e.g., file not found), create default felonius user
 		if os.IsNotExist(err) {
-			log.Println("INFO: users.json not found, creating default felonius user.")
+			slog.Info("users.json not found; creating default felonius user")
 			// Build the fully-initialized bootstrap user and write exactly once,
 			// avoiding a partially-initialized entry on disk if a second save fails.
 			hashedPw, hashErr := bcrypt.GenerateFromPassword([]byte("password"), bcrypt.DefaultCost)
@@ -111,7 +111,7 @@ func NewUserManager(dataPath string) (*UserMgr, error) { // Return renamed type
 			if saveErr != nil {
 				return nil, fmt.Errorf("failed to save default felonius user: %w", saveErr)
 			}
-			log.Println("INFO: Default felonius user created (felonius/password).")
+			slog.Info("default felonius user created (felonius/password)")
 			// Determine next user ID after creating the default user
 			um.determineNextUserID()
 			return um, nil // Return successfully after creating default
@@ -155,19 +155,19 @@ func (um *UserMgr) loadUsers() error { // Receiver uses renamed type
 		// Migration: legacy records stored handle in "username"; if Handle is absent use it.
 		if strings.TrimSpace(user.Handle) == "" && user.LegacyUsername != "" {
 			user.Handle = user.LegacyUsername
-			log.Printf("INFO: Migrated legacy username %q to handle for user ID %d.", user.LegacyUsername, user.ID)
+			slog.Info("migrated legacy username to handle", "username", user.LegacyUsername, "id", user.ID)
 		}
 		if strings.TrimSpace(user.Handle) == "" {
-			log.Printf("WARN: Skipping user ID %d with no handle in users.json.", user.ID)
+			slog.Warn("skipping user with no handle", "id", user.ID)
 			continue
 		}
 		lowerHandle := strings.ToLower(user.Handle)
 		if _, exists := um.users[lowerHandle]; exists {
-			log.Printf("WARN: Duplicate handle found in users.json: %s. Skipping subsequent entry.", user.Handle)
+			slog.Warn("duplicate handle; skipping subsequent entry", "handle", user.Handle)
 			continue
 		}
 		um.users[lowerHandle] = user
-		log.Printf("TRACE: Loaded user %s (Group: %s) from JSON.", user.Handle, user.GroupLocation)
+		slog.Debug("loaded user", "handle", user.Handle, "group", user.GroupLocation)
 	}
 
 	// Note: determineNextUserID should be called *after* successful load
@@ -190,7 +190,7 @@ func (um *UserMgr) determineNextUserID() { // Receiver uses renamed type
 
 	um.mu.Lock() // Need write lock to set nextUserID
 	um.nextUserID = maxID + 1
-	log.Printf("DEBUG: Determined next User ID to be %d", um.nextUserID)
+	slog.Debug("determined next user ID", "id", um.nextUserID)
 	um.mu.Unlock()
 }
 
@@ -201,7 +201,7 @@ func (um *UserMgr) loadCallHistory() error {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("INFO: %s not found, starting with empty call history list.", callHistoryFile)
+			slog.Info("call history file not found; starting empty", "file", callHistoryFile)
 			return nil // Not an error if the file doesn't exist yet
 		}
 		return fmt.Errorf("failed to read %s: %w", callHistoryFile, err)
@@ -226,7 +226,7 @@ func (um *UserMgr) loadCallHistory() error {
 		startIdx := len(um.callHistory) - callHistoryLimit
 		um.callHistory = um.callHistory[startIdx:]
 	}
-	log.Printf("DEBUG: Loaded %d call history records from %s", len(um.callHistory), callHistoryFile)
+	slog.Debug("loaded call history records", "count", len(um.callHistory), "file", callHistoryFile)
 	return nil
 }
 
@@ -236,7 +236,7 @@ func (um *UserMgr) loadNextCallNumber() error {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("INFO: %s not found, starting call numbers from 1.", callNumberFile)
+			slog.Info("call number file not found; starting from 1", "file", callNumberFile)
 			// Keep the default um.nextCallNumber = 1
 			return nil // Not an error if the file doesn't exist
 		}
@@ -245,7 +245,7 @@ func (um *UserMgr) loadNextCallNumber() error {
 
 	data = StripUTF8BOM(data)
 	if len(data) == 0 {
-		log.Printf("WARN: %s is empty, starting call numbers from 1.", callNumberFile)
+		slog.Warn("call number file is empty; starting from 1", "file", callNumberFile)
 		return nil // Empty file, use default
 	}
 
@@ -253,12 +253,12 @@ func (um *UserMgr) loadNextCallNumber() error {
 	defer um.mu.Unlock()
 	if err := json.Unmarshal(data, &um.nextCallNumber); err != nil {
 		// If unmarshal fails, log and keep the default
-		log.Printf("WARN: Failed to unmarshal %s: %v. Starting call numbers from 1.", callNumberFile, err)
+		slog.Warn("failed to unmarshal call number file; starting from 1", "file", callNumberFile, "error", err)
 		um.nextCallNumber = 1
 		return nil // Don't return error, just use default
 	}
 
-	log.Printf("DEBUG: Loaded next call number %d from %s", um.nextCallNumber, callNumberFile)
+	slog.Debug("loaded next call number", "number", um.nextCallNumber, "file", callNumberFile)
 	return nil
 }
 
@@ -282,7 +282,7 @@ func (um *UserMgr) saveCallHistoryLocked() error {
 	// Also save the next call number (atomically with history? separate file is simpler for now)
 	if err := um.saveNextCallNumberLocked(); err != nil {
 		// Log error but don't fail the history save if number save fails
-		log.Printf("ERROR: Failed to save next call number: %v", err)
+		slog.Error("failed to save next call number", "error", err)
 	}
 
 	return nil
@@ -493,7 +493,7 @@ func (um *UserMgr) Authenticate(handle, password string) (*User, bool) {
 
 	// Save outside the write lock to avoid blocking other user operations
 	if err := um.SaveUsers(); err != nil {
-		log.Printf("ERROR: Failed to save user data after successful login for %s: %v", handle, err)
+		slog.Error("failed to save user data after login", "handle", handle, "error", err)
 	}
 
 	// Return a copy
@@ -580,13 +580,13 @@ func (um *UserMgr) AddUser(password, handle, realName, groupLocation string) (*U
 
 	// Save the updated user list *while still holding the lock*
 	if err := um.saveUsersLocked(); err != nil {
-		log.Printf("ERROR: Failed to save users after adding %s: %v", handle, err)
+		slog.Error("failed to save users after adding user", "handle", handle, "error", err)
 		delete(um.users, lowerHandle)
 		um.nextUserID--
 		return nil, err
 	}
 
-	log.Printf("INFO: Added user %s (ID: %d)", newUser.Handle, newUser.ID)
+	slog.Info("added user", "handle", newUser.Handle, "id", newUser.ID)
 	return newUser, nil
 }
 
@@ -615,7 +615,7 @@ func (um *UserMgr) AddCallRecord(record CallRecord) {
 
 	// Save the updated history *while still holding the lock*
 	if err := um.saveCallHistoryLocked(); err != nil {
-		log.Printf("ERROR: Failed to save call history after adding record for user %d: %v", record.UserID, err)
+		slog.Error("failed to save call history after adding record", "user_id", record.UserID, "error", err)
 		// Maybe try to rollback the append? Less critical than user add.
 	}
 }
@@ -671,10 +671,10 @@ func (um *UserMgr) SetNewUserLevel(level int) {
 
 	// Validate and clamp to 0-255 range
 	if level < 0 {
-		log.Printf("WARN: invalid newUserLevel %d; clamping to 0", level)
+		slog.Warn("invalid newUserLevel; clamping to 0", "level", level)
 		level = 0
 	} else if level > 255 {
-		log.Printf("WARN: invalid newUserLevel %d; clamping to 255", level)
+		slog.Warn("invalid newUserLevel; clamping to 255", "level", level)
 		level = 255
 	}
 
@@ -686,7 +686,7 @@ func (um *UserMgr) MarkUserOnline(userID int) {
 	um.mu.Lock()
 	defer um.mu.Unlock()
 	um.activeUserIDs[int32(userID)] = true
-	log.Printf("DEBUG: User ID %d marked as ONLINE", userID)
+	slog.Debug("user marked online", "id", userID)
 }
 
 // MarkUserOffline marks a user as offline/disconnected
@@ -694,7 +694,7 @@ func (um *UserMgr) MarkUserOffline(userID int) {
 	um.mu.Lock()
 	defer um.mu.Unlock()
 	delete(um.activeUserIDs, int32(userID))
-	log.Printf("DEBUG: User ID %d marked as OFFLINE", userID)
+	slog.Debug("user marked offline", "id", userID)
 }
 
 // IsUserOnline returns true if the user is currently connected
@@ -779,7 +779,6 @@ func (um *UserMgr) PurgeDeletedUsers(retentionDays int) ([]PurgeResult, error) {
 	for i, c := range candidates {
 		purged[i] = c.result
 	}
-	log.Printf("INFO: Purged %d soft-deleted user account(s)", len(purged))
+	slog.Info("purged soft-deleted user accounts", "count", len(purged))
 	return purged, nil
 }
-

--- a/internal/user/manager.go
+++ b/internal/user/manager.go
@@ -615,7 +615,7 @@ func (um *UserMgr) AddCallRecord(record CallRecord) {
 
 	// Save the updated history *while still holding the lock*
 	if err := um.saveCallHistoryLocked(); err != nil {
-		slog.Error("failed to save call history after adding record", "user_id", record.UserID, "error", err)
+		slog.Error("failed to save call history after adding record", "id", record.UserID, "error", err)
 		// Maybe try to rollback the append? Less critical than user add.
 	}
 }


### PR DESCRIPTION
Continues **Phase B** (slog migration) with three medium packages, applying the convention locked in by the merged pilots (#46, #47).

## Packages (49 sites)
| Package | Sites |
|---|---|
| user | 25 |
| message | 9 |
| telnetserver | 15 |

## Convention applied
- Level prefix → slog level (`TRACE→Debug`)
- Natural lowercase messages, **no `SUBSYSTEM:` colon prefixes**; acronyms (NAWS, CPR, MSGID, JSON) kept cased
- printf args → structured attributes with consistent keys (`id`, `handle`, `tag`, `file`, `count`, `remote`, `width`/`height`); trailing errors → `"error", err`

No behavior change beyond log format. `go build ./...`, `go vet`, and package tests pass.

_Independent per-package PR off `main`. ~1,377 sites remain (transfer/tosser/file/ziplab/config, then cmd/vision3 (202), then internal/menu (900) split across PRs)._