### PR TITLE
refactor: migrate ansi and syncjs to slog (Phase B)

### DIFF
--- a/internal/ansi/ansi.go
+++ b/internal/ansi/ansi.go
@@ -1017,7 +1017,7 @@ func ProcessAnsiAndExtractCoords(rawContent []byte, outputMode OutputMode) (Proc
 						break
 					} else {
 						// Invalid character in sequence, break parsing for this sequence
-						slog.Warn("invalid char in ANSI sequence", "char", char, "index", j)
+						slog.Warn("invalid char in ANSI sequence", "char", fmt.Sprintf("0x%X", char), "index", j)
 						terminatorIndex = j - 1 // Treat previous char as end? Or handle differently?
 						break
 					}
@@ -1270,16 +1270,18 @@ func ProcessAnsiAndExtractCoords(rawContent []byte, outputMode OutputMode) (Proc
 							// Double letter |XX placeholder
 							placeholderCode := string(content[i+1 : i+3])
 							result.FieldCoords[placeholderCode] = struct{ X, Y int }{X: currentX, Y: currentY}
-							result.FieldColors[placeholderCode] = buildColorSequence()
-							slog.Debug("recorded placeholder coord", "code", placeholderCode, "x", currentX, "y", currentY, "color", buildColorSequence())
+							color := buildColorSequence()
+							result.FieldColors[placeholderCode] = color
+							slog.Debug("recorded placeholder coord", "code", placeholderCode, "x", currentX, "y", currentY, "color", color)
 							consumed = 3
 							pipeCodeFound = true
 						} else {
 							// Single letter |X placeholder
 							placeholderCode := string(content[i+1 : i+2])
 							result.FieldCoords[placeholderCode] = struct{ X, Y int }{X: currentX, Y: currentY}
-							result.FieldColors[placeholderCode] = buildColorSequence()
-							slog.Debug("recorded placeholder coord", "code", placeholderCode, "x", currentX, "y", currentY, "color", buildColorSequence())
+							color := buildColorSequence()
+							result.FieldColors[placeholderCode] = color
+							slog.Debug("recorded placeholder coord", "code", placeholderCode, "x", currentX, "y", currentY, "color", color)
 							consumed = 2
 							pipeCodeFound = true
 						}
@@ -1333,8 +1335,9 @@ func ProcessAnsiAndExtractCoords(rawContent []byte, outputMode OutputMode) (Proc
 			if i+2 < len(content) && content[i+1] >= 'A' && content[i+1] <= 'Z' && content[i+2] >= 'A' && content[i+2] <= 'Z' {
 				code := string(content[i+1 : i+3])
 				result.FieldCoords[code] = struct{ X, Y int }{X: currentX, Y: currentY}
-				result.FieldColors[code] = buildColorSequence()
-				slog.Debug("found coord code", "code", code, "x", currentX, "y", currentY, "color", buildColorSequence())
+				color := buildColorSequence()
+				result.FieldColors[code] = color
+				slog.Debug("found coord code", "code", code, "x", currentX, "y", currentY, "color", color)
 				consumed = 3 // Consume ~XX, write nothing
 			} else {
 				// Invalid ~ sequence, write literally

--- a/internal/ansi/ansi.go
+++ b/internal/ansi/ansi.go
@@ -3,7 +3,7 @@ package ansi
 import (
 	"bytes"
 	"fmt"
-	"log"
+	"log/slog"
 	"os" // Needed for chcp command
 	"strings"
 	"time"
@@ -213,7 +213,7 @@ var pipeCodeReplacements = map[string]string{
 // It replaces the previous DisplayAnsiFile which incorrectly wrote directly.
 // SAUCE metadata (if present) is automatically stripped from the returned content.
 func GetAnsiFileContent(filename string) ([]byte, error) {
-	log.Printf("DEBUG: Reading ANSI file content for %s", filename)
+	slog.Debug("reading ANSI file content", "filename", filename)
 
 	// Read the file
 	data, err := os.ReadFile(filename)
@@ -250,7 +250,7 @@ func stripSAUCE(data []byte) []byte {
 		return data
 	}
 
-	log.Printf("DEBUG: SAUCE metadata detected, stripping from content")
+	slog.Debug("SAUCE metadata detected; stripping from content")
 
 	// Search backwards from the SAUCE record to find the EOF marker (0x1A)
 	// The EOF marker should be immediately before the SAUCE record,
@@ -269,13 +269,13 @@ func stripSAUCE(data []byte) []byte {
 
 	// If we found the EOF marker, return content up to (but not including) it
 	if eofPos >= 0 {
-		log.Printf("DEBUG: Found EOF marker at position %d, trimming content", eofPos)
+		slog.Debug("found EOF marker; trimming content", "position", eofPos)
 		return data[:eofPos]
 	}
 
 	// If no EOF marker found, just remove the SAUCE record itself
 	// This handles malformed SAUCE or files without the EOF marker
-	log.Printf("DEBUG: No EOF marker found, removing SAUCE record only")
+	slog.Debug("no EOF marker found; removing SAUCE record only")
 	return data[:sauceStart]
 }
 
@@ -902,9 +902,9 @@ func StripAnsi(str string) string {
 
 // ProcessAnsiResult holds the results of processing an ANSI file, including field coordinates.
 type ProcessAnsiResult struct {
-	DisplayBytes []byte                                     // The processed bytes with standard ANSI escapes, ready for display.
-	FieldCoords  map[string]struct{ X, Y int }              // Map of |XX or ~XX codes to their calculated coordinates.
-	FieldColors  map[string]string                          // Map of |XX or ~XX codes to their ANSI color escape sequence at that position.
+	DisplayBytes []byte                        // The processed bytes with standard ANSI escapes, ready for display.
+	FieldCoords  map[string]struct{ X, Y int } // Map of |XX or ~XX codes to their calculated coordinates.
+	FieldColors  map[string]string             // Map of |XX or ~XX codes to their ANSI color escape sequence at that position.
 }
 
 // ProcessAnsiAndExtractCoords processes raw CP437 byte content containing ViSiON/2 codes and ANSI escapes.
@@ -1017,7 +1017,7 @@ func ProcessAnsiAndExtractCoords(rawContent []byte, outputMode OutputMode) (Proc
 						break
 					} else {
 						// Invalid character in sequence, break parsing for this sequence
-						log.Printf("WARN: Invalid char 0x%X in ANSI sequence at index %d", char, j)
+						slog.Warn("invalid char in ANSI sequence", "char", char, "index", j)
 						terminatorIndex = j - 1 // Treat previous char as end? Or handle differently?
 						break
 					}
@@ -1127,18 +1127,18 @@ func ProcessAnsiAndExtractCoords(rawContent []byte, outputMode OutputMode) (Proc
 						}
 					case 's': // Save cursor position (DEC)
 						// We might need to store this if |P uses it, but handle simple cases first
-						log.Printf("TRACE: Ignoring ANSI Save Cursor (ESC[s)")
+						slog.Debug("ignoring ANSI save cursor (ESC[s)")
 					case 'u': // Restore cursor position (DEC)
 						// We might need to store this if |PP uses it, but handle simple cases first
-						log.Printf("TRACE: Ignoring ANSI Restore Cursor (ESC[u)")
+						slog.Debug("ignoring ANSI restore cursor (ESC[u)")
 						// Add other sequences like J (Erase), K (Erase Line) if needed,
 						// but they usually don't affect cursor position themselves.
 					}
 					// Log the coordinate change for debugging
-					// log.Printf("TRACE: ANSI Seq '%s', new coords (%d, %d)", string(content[start:terminatorIndex+1]), currentX, currentY)
+					// slog.Debug("ANSI seq", "seq", string(content[start:terminatorIndex+1]), "x", currentX, "y", currentY)
 
 				} else {
-					log.Printf("WARN: Incomplete or invalid ANSI CSI sequence starting at index %d", start)
+					slog.Warn("incomplete or invalid ANSI CSI sequence", "index", start)
 					displayBuf.WriteByte(b) // Write only ESC as fallback
 				}
 			} else {
@@ -1257,7 +1257,7 @@ func ProcessAnsiAndExtractCoords(rawContent []byte, outputMode OutputMode) (Proc
 							placeholderCode := string(content[i+1 : i+2])
 							result.FieldCoords[placeholderCode] = struct{ X, Y int }{X: currentX, Y: currentY}
 							result.FieldColors[placeholderCode] = buildColorSequence()
-							log.Printf("DEBUG: ProcessAnsi recorded dual-purpose coord '%s' at (%d, %d)", placeholderCode, currentX, currentY)
+							slog.Debug("recorded dual-purpose coord", "code", placeholderCode, "x", currentX, "y", currentY)
 						}
 					}
 				}
@@ -1271,7 +1271,7 @@ func ProcessAnsiAndExtractCoords(rawContent []byte, outputMode OutputMode) (Proc
 							placeholderCode := string(content[i+1 : i+3])
 							result.FieldCoords[placeholderCode] = struct{ X, Y int }{X: currentX, Y: currentY}
 							result.FieldColors[placeholderCode] = buildColorSequence()
-							log.Printf("DEBUG: ProcessAnsi recorded placeholder coord '%s' at (%d, %d) with color '%s'", placeholderCode, currentX, currentY, buildColorSequence())
+							slog.Debug("recorded placeholder coord", "code", placeholderCode, "x", currentX, "y", currentY, "color", buildColorSequence())
 							consumed = 3
 							pipeCodeFound = true
 						} else {
@@ -1279,7 +1279,7 @@ func ProcessAnsiAndExtractCoords(rawContent []byte, outputMode OutputMode) (Proc
 							placeholderCode := string(content[i+1 : i+2])
 							result.FieldCoords[placeholderCode] = struct{ X, Y int }{X: currentX, Y: currentY}
 							result.FieldColors[placeholderCode] = buildColorSequence()
-							log.Printf("DEBUG: ProcessAnsi recorded placeholder coord '%s' at (%d, %d) with color '%s'", placeholderCode, currentX, currentY, buildColorSequence())
+							slog.Debug("recorded placeholder coord", "code", placeholderCode, "x", currentX, "y", currentY, "color", buildColorSequence())
 							consumed = 2
 							pipeCodeFound = true
 						}
@@ -1334,7 +1334,7 @@ func ProcessAnsiAndExtractCoords(rawContent []byte, outputMode OutputMode) (Proc
 				code := string(content[i+1 : i+3])
 				result.FieldCoords[code] = struct{ X, Y int }{X: currentX, Y: currentY}
 				result.FieldColors[code] = buildColorSequence()
-				log.Printf("DEBUG: ProcessAnsi found coord code %s at (%d, %d) with color '%s'", code, currentX, currentY, buildColorSequence())
+				slog.Debug("found coord code", "code", code, "x", currentX, "y", currentY, "color", buildColorSequence())
 				consumed = 3 // Consume ~XX, write nothing
 			} else {
 				// Invalid ~ sequence, write literally

--- a/internal/syncjs/engine.go
+++ b/internal/syncjs/engine.go
@@ -115,7 +115,7 @@ func (eng *Engine) Close() {
 		func() {
 			defer func() {
 				if r := recover(); r != nil {
-					slog.Warn("SyncJS exit handler panic", "panic", r)
+					slog.Warn("exit handler panic", "panic", r)
 				}
 			}()
 			eng.exitHandlers[i](goja.Undefined())
@@ -126,7 +126,7 @@ func (eng *Engine) Close() {
 		func() {
 			defer func() {
 				if r := recover(); r != nil {
-					slog.Warn("SyncJS exit code eval panic", "panic", r)
+					slog.Warn("exit code eval panic", "panic", r)
 				}
 			}()
 			eng.vm.RunString(eng.exitCodes[i])
@@ -145,7 +145,7 @@ func (eng *Engine) Close() {
 		select {
 		case <-eng.copierDone:
 		case <-time.After(2 * time.Second):
-			slog.Warn("SyncJS copier goroutine did not exit within 2s; proceeding with cleanup")
+			slog.Warn("copier goroutine did not exit within 2s; proceeding with cleanup")
 		}
 	}
 	if eng.pipeReader != nil {

--- a/internal/syncjs/engine.go
+++ b/internal/syncjs/engine.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -93,7 +93,7 @@ func (eng *Engine) Run(scriptPath string) error {
 	// Set initial exec_dir to the script's directory
 	eng.pushExecDir(filepath.Dir(scriptPath) + string(filepath.Separator))
 
-	log.Printf("INFO: SyncJS: Running script %s for node %d", scriptPath, eng.session.NodeNumber)
+	slog.Info("running SyncJS script", "path", scriptPath, "node", eng.session.NodeNumber)
 
 	_, err = eng.vm.RunScript(scriptPath, stripUseStrict(string(data)))
 	if err != nil {
@@ -115,7 +115,7 @@ func (eng *Engine) Close() {
 		func() {
 			defer func() {
 				if r := recover(); r != nil {
-					log.Printf("WARN: SyncJS: exit handler panic: %v", r)
+					slog.Warn("SyncJS exit handler panic", "panic", r)
 				}
 			}()
 			eng.exitHandlers[i](goja.Undefined())
@@ -126,7 +126,7 @@ func (eng *Engine) Close() {
 		func() {
 			defer func() {
 				if r := recover(); r != nil {
-					log.Printf("WARN: SyncJS: exit code eval panic: %v", r)
+					slog.Warn("SyncJS exit code eval panic", "panic", r)
 				}
 			}()
 			eng.vm.RunString(eng.exitCodes[i])
@@ -145,7 +145,7 @@ func (eng *Engine) Close() {
 		select {
 		case <-eng.copierDone:
 		case <-time.After(2 * time.Second):
-			log.Printf("WARN: SyncJS: copier goroutine did not exit within 2s; proceeding with cleanup")
+			slog.Warn("SyncJS copier goroutine did not exit within 2s; proceeding with cleanup")
 		}
 	}
 	if eng.pipeReader != nil {
@@ -203,8 +203,8 @@ func (eng *Engine) writeRaw(s string) {
 
 // filterOutputResult holds the filtered output and flags for intercepted sequences.
 type filterOutputResult struct {
-	data    []byte
-	hasDSR  bool // true if \x1b[6n was intercepted (needs synthetic response)
+	data   []byte
+	hasDSR bool // true if \x1b[6n was intercepted (needs synthetic response)
 }
 
 // filterOutputSequences removes or intercepts problematic CSI sequences:

--- a/internal/syncjs/module_loader.go
+++ b/internal/syncjs/module_loader.go
@@ -2,7 +2,7 @@ package syncjs
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -129,7 +129,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 		// Synchronet runs the script in a separate thread. Since goja is
 		// single-threaded, we return an input Queue backed by session I/O.
 		if bg, ok := args[0].Export().(bool); ok && bg {
-			log.Printf("INFO: SyncJS: load(true, ...) background thread requested — returning input Queue bridge")
+			slog.Info("SyncJS load(true, ...) background thread requested; returning input Queue bridge")
 			return eng.createInputQueue()
 		}
 
@@ -180,7 +180,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 			// Set a stub on the scope so callers doing scope.X.method() get
 			// a callable stub instead of "cannot read property of undefined".
 			if scope != nil {
-				log.Printf("WARN: SyncJS: require(scope, %q) failed: %v", filename, err)
+				slog.Warn("SyncJS require failed", "filename", filename, "error", err)
 				if symbol != "" {
 					scope.Set(symbol, eng.newStubObject())
 				}
@@ -193,7 +193,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 			val := vm.Get(symbol)
 			if val == nil || goja.IsUndefined(val) {
 				if scope != nil {
-					log.Printf("WARN: SyncJS: require(scope, %q, %q): symbol not found", filename, symbol)
+					slog.Warn("SyncJS require: symbol not found", "filename", filename, "symbol", symbol)
 					scope.Set(symbol, eng.newStubObject())
 					return goja.Undefined()
 				}
@@ -283,7 +283,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 		} else {
 			msg = call.Arguments[0].String()
 		}
-		log.Printf("INFO: SyncJS: %s", msg)
+		slog.Info("SyncJS script log", "message", msg)
 		return goja.Undefined()
 	})
 
@@ -301,7 +301,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 	// alert(msg) — alias for log
 	vm.Set("alert", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) > 0 {
-			log.Printf("INFO: SyncJS alert: %s", call.Arguments[0].String())
+			slog.Info("SyncJS alert", "message", call.Arguments[0].String())
 		}
 		return goja.Undefined()
 	})
@@ -642,7 +642,7 @@ func (eng *Engine) resolveFilePath(path string) string {
 		}
 	}
 
-	log.Printf("WARN: SyncJS: resolved file path %q is outside all allowed directories", resolved)
+	slog.Warn("SyncJS resolved file path is outside all allowed directories", "path", resolved)
 	return resolved
 }
 

--- a/internal/syncjs/module_loader.go
+++ b/internal/syncjs/module_loader.go
@@ -129,7 +129,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 		// Synchronet runs the script in a separate thread. Since goja is
 		// single-threaded, we return an input Queue backed by session I/O.
 		if bg, ok := args[0].Export().(bool); ok && bg {
-			slog.Info("SyncJS load(true, ...) background thread requested; returning input Queue bridge")
+			slog.Info("load(true, ...) background thread requested; returning input Queue bridge")
 			return eng.createInputQueue()
 		}
 
@@ -180,7 +180,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 			// Set a stub on the scope so callers doing scope.X.method() get
 			// a callable stub instead of "cannot read property of undefined".
 			if scope != nil {
-				slog.Warn("SyncJS require failed", "filename", filename, "error", err)
+				slog.Warn("require failed", "filename", filename, "error", err)
 				if symbol != "" {
 					scope.Set(symbol, eng.newStubObject())
 				}
@@ -193,7 +193,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 			val := vm.Get(symbol)
 			if val == nil || goja.IsUndefined(val) {
 				if scope != nil {
-					slog.Warn("SyncJS require: symbol not found", "filename", filename, "symbol", symbol)
+					slog.Warn("require: symbol not found", "filename", filename, "symbol", symbol)
 					scope.Set(symbol, eng.newStubObject())
 					return goja.Undefined()
 				}
@@ -283,7 +283,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 		} else {
 			msg = call.Arguments[0].String()
 		}
-		slog.Info("SyncJS script log", "message", msg)
+		slog.Info("script log", "message", msg)
 		return goja.Undefined()
 	})
 
@@ -301,7 +301,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 	// alert(msg) — alias for log
 	vm.Set("alert", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) > 0 {
-			slog.Info("SyncJS alert", "message", call.Arguments[0].String())
+			slog.Info("script alert", "message", call.Arguments[0].String())
 		}
 		return goja.Undefined()
 	})
@@ -642,7 +642,7 @@ func (eng *Engine) resolveFilePath(path string) string {
 		}
 	}
 
-	slog.Warn("SyncJS resolved file path is outside all allowed directories", "path", resolved)
+	slog.Warn("resolved file path is outside all allowed directories", "path", resolved)
 	return resolved
 }
 


### PR DESCRIPTION
Continues **Phase B** (slog migration). `internal/ansi` (13 sites) and `internal/syncjs` (10 sites), per the locked convention (#46/#47).

- Level prefix → slog level (`TRACE→Debug`)
- Natural lowercase messages, no `SUBSYSTEM:` colon prefixes; acronyms/proper nouns (ANSI, SAUCE, CSI, SyncJS) kept cased
- printf args → structured attributes (`filename`, `char`, `index`, `x`/`y`, `code`, `color`, `path`, `node`, `message`); errors → `"error", err`
- Also updated a stale commented-out `log.Printf` in ansi.go to the slog form for consistency

No behavior change beyond log format. `go build ./...`, `go vet`, tests pass.

_The two remaining medium items (cmd/ansitest, cmd/v3net-bootstrap) use `log.Fatalf` → `logging.Fatal` and will be a separate small PR._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced diagnostics with structured logging across file processing and script/module execution, providing clearer `info`, `debug`, and `warning` messages.
  * Improved visibility into parsing anomalies (e.g., invalid sequences) and cursor/EOF handling with more consistent warning vs debug behavior.
  * Updated cleanup and exit-related warnings to be more informative while preserving the original error/panic details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->