### PR TITLE
refactor: migrate tosser, transfer, ziplab, file, config to slog (Phase B)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1131,7 +1131,7 @@ func LoadFTNConfig(configPath string) (FTNConfig, error) {
 	for name, net := range config.Networks {
 		if net.InternalTosserEnabled {
 			enabledCount++
-			slog.Info("FTN network internal tosser enabled", "network", name, "address", net.OwnAddress)
+			slog.Info("ftn network internal tosser enabled", "network", name, "address", net.OwnAddress)
 		}
 	}
 	slog.Info("loaded FTN configuration", "networks", len(config.Networks), "tosserEnabled", enabledCount)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,7 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -521,22 +521,22 @@ type StringsConfig struct {
 // LoadStrings loads the string configuration from a JSON file.
 func LoadStrings(configPath string) (StringsConfig, error) { // Return the loaded config directly
 	filePath := filepath.Join(configPath, "strings.json")
-	log.Printf("INFO: Loading strings configuration from %s", filePath)
+	slog.Info("loading strings configuration", "path", filePath)
 	data, err := os.ReadFile(filePath)
 	if err != nil {
-		log.Printf("ERROR: Failed to read strings file %s: %v", filePath, err)
+		slog.Error("failed to read strings file", "path", filePath, "error", err)
 		return StringsConfig{}, fmt.Errorf("failed to read strings file %s: %w", filePath, err)
 	}
 
 	var loadedConfig StringsConfig // Load into a local variable
 	err = json.Unmarshal(data, &loadedConfig)
 	if err != nil {
-		log.Printf("ERROR: Failed to parse strings JSON from %s: %v", filePath, err)
+		slog.Error("failed to parse strings JSON", "path", filePath, "error", err)
 		return StringsConfig{}, fmt.Errorf("failed to parse strings JSON from %s: %w", filePath, err)
 	}
 
 	applyStringDefaults(&loadedConfig)
-	log.Printf("INFO: Successfully loaded strings configuration.")
+	slog.Info("successfully loaded strings configuration")
 	return loadedConfig, nil // Return the loaded struct
 }
 
@@ -666,12 +666,12 @@ type LoginItem struct {
 // If the file is missing, returns a default sequence matching legacy behavior.
 func LoadLoginSequence(configPath string) ([]LoginItem, error) {
 	filePath := filepath.Join(configPath, "login.json")
-	log.Printf("INFO: Loading login sequence from %s", filePath)
+	slog.Info("loading login sequence", "path", filePath)
 
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("INFO: login.json not found at %s, using default login sequence", filePath)
+			slog.Info("login.json not found, using default login sequence", "path", filePath)
 			return defaultLoginSequence(), nil
 		}
 		return nil, fmt.Errorf("failed to read login sequence file %s: %w", filePath, err)
@@ -687,7 +687,7 @@ func LoadLoginSequence(configPath string) ([]LoginItem, error) {
 		items[i].Command = strings.ToUpper(items[i].Command)
 	}
 
-	log.Printf("INFO: Loaded login sequence with %d items", len(items))
+	slog.Info("loaded login sequence", "count", len(items))
 	return items, nil
 }
 
@@ -703,15 +703,15 @@ func defaultLoginSequence() []LoginItem {
 // LoadOneLiners loads oneliner strings from a JSON file.
 func LoadOneLiners(dataPath string) ([]string, error) { // Changed configPath to dataPath for clarity
 	filePath := filepath.Join(dataPath, "oneliners.dat") // Assume loading .dat from data path
-	log.Printf("INFO: Loading oneliners from %s", filePath)
+	slog.Info("loading oneliners", "path", filePath)
 
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("WARN: oneliners.dat not found at %s. No oneliners loaded.", filePath)
+			slog.Warn("oneliners.dat not found, no oneliners loaded", "path", filePath)
 			return []string{}, nil // Return empty slice, not an error
 		}
-		log.Printf("ERROR: Failed to read oneliners file %s: %v", filePath, err)
+		slog.Error("failed to read oneliners file", "path", filePath, "error", err)
 		return nil, fmt.Errorf("failed to read oneliners file %s: %w", filePath, err)
 	}
 
@@ -725,7 +725,7 @@ func LoadOneLiners(dataPath string) ([]string, error) { // Changed configPath to
 		}
 	}
 
-	log.Printf("INFO: Successfully loaded %d oneliners.", len(oneLiners))
+	slog.Info("loaded oneliners", "count", len(oneLiners))
 	return oneLiners, nil
 }
 
@@ -740,7 +740,7 @@ type ThemeConfig struct {
 // LoadThemeConfig loads theme settings from theme.json within a specific menu set path.
 func LoadThemeConfig(menuSetPath string) (ThemeConfig, error) {
 	filePath := filepath.Join(menuSetPath, "theme.json")
-	log.Printf("INFO: Loading theme configuration from %s", filePath)
+	slog.Info("loading theme configuration", "path", filePath)
 
 	// Default theme settings
 	defaultTheme := ThemeConfig{
@@ -751,10 +751,10 @@ func LoadThemeConfig(menuSetPath string) (ThemeConfig, error) {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("WARN: theme.json not found at %s. Using default theme settings.", filePath)
+			slog.Warn("theme.json not found, using default theme settings", "path", filePath)
 			return defaultTheme, nil // Return defaults if file doesn't exist
 		}
-		log.Printf("ERROR: Failed to read theme file %s: %v", filePath, err)
+		slog.Error("failed to read theme file", "path", filePath, "error", err)
 		return defaultTheme, fmt.Errorf("failed to read theme file %s: %w", filePath, err)
 	}
 
@@ -763,11 +763,11 @@ func LoadThemeConfig(menuSetPath string) (ThemeConfig, error) {
 	theme = defaultTheme
 	err = json.Unmarshal(data, &theme)
 	if err != nil {
-		log.Printf("ERROR: Failed to parse theme JSON from %s: %v. Using default theme settings.", filePath, err)
+		slog.Error("failed to parse theme JSON, using default theme settings", "path", filePath, "error", err)
 		return defaultTheme, fmt.Errorf("failed to parse theme JSON from %s: %w", filePath, err)
 	}
 
-	log.Printf("INFO: Successfully loaded theme configuration from %s", filePath)
+	slog.Info("loaded theme configuration", "path", filePath)
 	return theme, nil
 }
 
@@ -1029,7 +1029,7 @@ type EventsConfig struct {
 // LoadServerConfig loads the server configuration from config.json
 func LoadServerConfig(configPath string) (ServerConfig, error) {
 	filePath := filepath.Join(configPath, "config.json")
-	log.Printf("INFO: Loading server configuration from %s", filePath)
+	slog.Info("loading server configuration", "path", filePath)
 
 	// Default config values
 	defaultConfig := ServerConfig{
@@ -1078,7 +1078,7 @@ func LoadServerConfig(configPath string) (ServerConfig, error) {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("WARN: config.json not found at %s. Using default settings.", filePath)
+			slog.Warn("config.json not found, using default settings", "path", filePath)
 			return defaultConfig, nil
 		}
 		return defaultConfig, fmt.Errorf("failed to read config file %s: %w", filePath, err)
@@ -1089,11 +1089,11 @@ func LoadServerConfig(configPath string) (ServerConfig, error) {
 	config = defaultConfig
 	err = json.Unmarshal(data, &config)
 	if err != nil {
-		log.Printf("ERROR: Failed to parse config JSON from %s: %v. Using default settings.", filePath, err)
+		slog.Error("failed to parse config JSON, using default settings", "path", filePath, "error", err)
 		return defaultConfig, fmt.Errorf("failed to parse config JSON from %s: %w", filePath, err)
 	}
 
-	log.Printf("INFO: Successfully loaded server configuration from %s", filePath)
+	slog.Info("loaded server configuration", "path", filePath)
 	return config, nil
 }
 
@@ -1101,7 +1101,7 @@ func LoadServerConfig(configPath string) (ServerConfig, error) {
 // Returns an empty config (no networks) if the file does not exist.
 func LoadFTNConfig(configPath string) (FTNConfig, error) {
 	filePath := filepath.Join(configPath, "ftn.json")
-	log.Printf("INFO: Loading FTN configuration from %s", filePath)
+	slog.Info("loading FTN configuration", "path", filePath)
 
 	defaultConfig := FTNConfig{
 		Networks: make(map[string]FTNNetworkConfig),
@@ -1110,7 +1110,7 @@ func LoadFTNConfig(configPath string) (FTNConfig, error) {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("INFO: ftn.json not found at %s. FTN disabled.", filePath)
+			slog.Info("ftn.json not found, FTN disabled", "path", filePath)
 			return defaultConfig, nil
 		}
 		return defaultConfig, fmt.Errorf("failed to read FTN config file %s: %w", filePath, err)
@@ -1119,7 +1119,7 @@ func LoadFTNConfig(configPath string) (FTNConfig, error) {
 	var config FTNConfig
 	err = json.Unmarshal(data, &config)
 	if err != nil {
-		log.Printf("ERROR: Failed to parse FTN config JSON from %s: %v", filePath, err)
+		slog.Error("failed to parse FTN config JSON", "path", filePath, "error", err)
 		return defaultConfig, fmt.Errorf("failed to parse FTN config JSON from %s: %w", filePath, err)
 	}
 
@@ -1131,10 +1131,10 @@ func LoadFTNConfig(configPath string) (FTNConfig, error) {
 	for name, net := range config.Networks {
 		if net.InternalTosserEnabled {
 			enabledCount++
-			log.Printf("INFO: FTN network %q internal tosser enabled: address=%s", name, net.OwnAddress)
+			slog.Info("FTN network internal tosser enabled", "network", name, "address", net.OwnAddress)
 		}
 	}
-	log.Printf("INFO: Loaded FTN configuration: %d network(s), %d with internal tosser enabled", len(config.Networks), enabledCount)
+	slog.Info("loaded FTN configuration", "networks", len(config.Networks), "tosserEnabled", enabledCount)
 
 	return config, nil
 }
@@ -1175,14 +1175,14 @@ func ValidateFTNConfig(cfg FTNConfig) error {
 // Returns a disabled config if the file does not exist.
 func LoadV3NetConfig(configPath string) (V3NetConfig, error) {
 	filePath := filepath.Join(configPath, "v3net.json")
-	log.Printf("INFO: Loading V3Net configuration from %s", filePath)
+	slog.Info("loading V3Net configuration", "path", filePath)
 
 	defaultConfig := V3NetConfig{}
 
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("INFO: v3net.json not found at %s. V3Net disabled.", filePath)
+			slog.Info("v3net.json not found, V3Net disabled", "path", filePath)
 			return defaultConfig, nil
 		}
 		return defaultConfig, fmt.Errorf("failed to read V3Net config file %s: %w", filePath, err)
@@ -1190,12 +1190,11 @@ func LoadV3NetConfig(configPath string) (V3NetConfig, error) {
 
 	var cfg V3NetConfig
 	if err := json.Unmarshal(data, &cfg); err != nil {
-		log.Printf("ERROR: Failed to parse V3Net config JSON from %s: %v", filePath, err)
+		slog.Error("failed to parse V3Net config JSON", "path", filePath, "error", err)
 		return defaultConfig, fmt.Errorf("failed to parse V3Net config JSON from %s: %w", filePath, err)
 	}
 
-	log.Printf("INFO: Loaded V3Net configuration: enabled=%v, hub=%v, leaves=%d",
-		cfg.Enabled, cfg.Hub.Enabled, len(cfg.Leaves))
+	slog.Info("loaded V3Net configuration", "enabled", cfg.Enabled, "hub", cfg.Hub.Enabled, "leaves", len(cfg.Leaves))
 
 	return cfg, nil
 }
@@ -1223,14 +1222,14 @@ func SaveServerConfig(configPath string, cfg ServerConfig) error {
 	if err := os.WriteFile(filePath, data, 0644); err != nil {
 		return fmt.Errorf("failed to write config file %s: %w", filePath, err)
 	}
-	log.Printf("INFO: Server configuration saved to %s", filePath)
+	slog.Info("server configuration saved", "path", filePath)
 	return nil
 }
 
 // LoadEventsConfig loads the event scheduler configuration from events.json
 func LoadEventsConfig(configPath string) (EventsConfig, error) {
 	filePath := filepath.Join(configPath, "events.json")
-	log.Printf("INFO: Loading event scheduler configuration from %s", filePath)
+	slog.Info("loading event scheduler configuration", "path", filePath)
 
 	defaultConfig := EventsConfig{
 		Enabled:             false,
@@ -1241,7 +1240,7 @@ func LoadEventsConfig(configPath string) (EventsConfig, error) {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("INFO: events.json not found at %s. Event scheduler disabled.", filePath)
+			slog.Info("events.json not found, event scheduler disabled", "path", filePath)
 			return defaultConfig, nil
 		}
 		return defaultConfig, fmt.Errorf("failed to read events config file %s: %w", filePath, err)
@@ -1250,7 +1249,7 @@ func LoadEventsConfig(configPath string) (EventsConfig, error) {
 	var config EventsConfig
 	err = json.Unmarshal(data, &config)
 	if err != nil {
-		log.Printf("ERROR: Failed to parse events config JSON from %s: %v", filePath, err)
+		slog.Error("failed to parse events config JSON", "path", filePath, "error", err)
 		return defaultConfig, fmt.Errorf("failed to parse events config JSON from %s: %w", filePath, err)
 	}
 
@@ -1266,7 +1265,7 @@ func LoadEventsConfig(configPath string) (EventsConfig, error) {
 		}
 	}
 
-	log.Printf("INFO: Loaded event scheduler configuration: %d event(s), %d enabled", len(config.Events), enabledCount)
+	slog.Info("loaded event scheduler configuration", "events", len(config.Events), "enabled", enabledCount)
 
 	return config, nil
 }
@@ -1287,7 +1286,7 @@ func LoadTimezone(configTZ string) *time.Location {
 		if loc, err := time.LoadLocation(tz); err == nil {
 			return loc
 		}
-		log.Printf("WARN: Invalid timezone '%s', trying next source.", tz)
+		slog.Warn("invalid timezone, trying next source", "timezone", tz)
 	}
 	return time.Local
 }

--- a/internal/file/manager.go
+++ b/internal/file/manager.go
@@ -3,7 +3,7 @@ package file
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/ViSiON-3/vision-3-bbs/internal/archiver"
+	"github.com/google/uuid"
 )
 
 // FileManager manages file areas and their associated file records.
@@ -36,15 +36,15 @@ func NewFileManager(baseDataPath, baseConfigPath string) (*FileManager, error) {
 		fileRecords: make(map[int][]FileRecord),
 	}
 
-	log.Printf("INFO: Loading file areas from: %s", fm.configPath)
+	slog.Info("loading file areas", "path", fm.configPath)
 	if err := fm.loadAreas(); err != nil {
 		return nil, fmt.Errorf("failed to load file areas: %w", err)
 	}
 
-	log.Printf("INFO: Loading file records from base path: %s", fm.basePath)
+	slog.Info("loading file records", "path", fm.basePath)
 	if err := fm.loadAllFileRecords(); err != nil {
 		// Log error but potentially continue if some areas loaded?
-		log.Printf("ERROR: Failed to load one or more file record sets: %v", err)
+		slog.Error("failed to load one or more file record sets", "error", err)
 		// Decide if this should be fatal. For now, let's allow startup.
 		// return nil, fmt.Errorf("failed to load file records: %w", err)
 	}
@@ -60,11 +60,11 @@ func (fm *FileManager) loadAreas() error {
 	data, err := os.ReadFile(fm.configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("WARN: File areas config %s not found. No file areas loaded.", fm.configPath)
+			slog.Warn("file areas config not found, no file areas loaded", "path", fm.configPath)
 			// Create an empty file?
 			emptyJSON := []byte("[]")
 			if writeErr := os.WriteFile(fm.configPath, emptyJSON, 0644); writeErr != nil {
-				log.Printf("ERROR: Failed to create empty file areas config %s: %v", fm.configPath, writeErr)
+				slog.Error("failed to create empty file areas config", "path", fm.configPath, "error", writeErr)
 			}
 			return nil // Not a fatal error if file doesn't exist initially
 		}
@@ -83,43 +83,43 @@ func (fm *FileManager) loadAreas() error {
 	for i := range areas {
 		area := &areas[i] // Take pointer to the element in the slice
 		if area.ID <= 0 {
-			log.Printf("WARN: Skipping file area with invalid ID <= 0: %+v", area)
+			slog.Warn("skipping file area with invalid ID <= 0", "area", fmt.Sprintf("%+v", area))
 			continue
 		}
 		if area.Tag == "" {
-			log.Printf("WARN: Skipping file area with empty Tag (ID: %d)", area.ID)
+			slog.Warn("skipping file area with empty tag", "id", area.ID)
 			continue
 		}
 		// Ensure path is clean and relative (security measure)
 		area.Path = filepath.Clean(area.Path)
 		if filepath.IsAbs(area.Path) || strings.HasPrefix(area.Path, "..") {
-			log.Printf("WARN: Skipping file area with invalid path (absolute or traversing up): %s (ID: %d)", area.Path, area.ID)
+			slog.Warn("skipping file area with invalid path (absolute or traversing up)", "path", area.Path, "id", area.ID)
 			continue
 		}
 
 		// Ensure area directory exists
 		fullAreaPath := filepath.Join(fm.basePath, area.Path)
 		if err := os.MkdirAll(fullAreaPath, 0755); err != nil {
-			log.Printf("ERROR: Failed to create directory for file area %s (%s): %v. Skipping area.", area.Tag, fullAreaPath, err)
+			slog.Error("failed to create directory for file area, skipping area", "area", area.Tag, "path", fullAreaPath, "error", err)
 			continue
 		}
 
 		ucTag := strings.ToUpper(area.Tag)
 		if _, exists := fm.fileTags[ucTag]; exists {
-			log.Printf("WARN: Duplicate file area Tag '%s' found. Skipping duplicate definition for ID %d.", area.Tag, area.ID)
+			slog.Warn("duplicate file area tag found, skipping duplicate definition", "area", area.Tag, "id", area.ID)
 			continue
 		}
 		if _, exists := fm.fileAreas[area.ID]; exists {
-			log.Printf("WARN: Duplicate file area ID '%d' found. Skipping duplicate definition for Tag %s.", area.ID, area.Tag)
+			slog.Warn("duplicate file area id found, skipping duplicate definition", "id", area.ID, "area", area.Tag)
 			continue
 		}
 
 		fm.fileAreas[area.ID] = area
 		fm.fileTags[ucTag] = area.ID
-		log.Printf("DEBUG: Loaded File Area: ID=%d, Tag=%s, Name=%s, Path=%s", area.ID, area.Tag, area.Name, area.Path)
+		slog.Debug("loaded file area", "id", area.ID, "area", area.Tag, "name", area.Name, "path", area.Path)
 	}
 
-	log.Printf("INFO: Successfully loaded %d file areas.", len(fm.fileAreas))
+	slog.Info("successfully loaded file areas", "count", len(fm.fileAreas))
 	return nil
 }
 
@@ -139,18 +139,18 @@ func (fm *FileManager) loadAllFileRecords() error {
 		data, err := os.ReadFile(metadataPath)
 		if err != nil {
 			if os.IsNotExist(err) {
-				log.Printf("DEBUG: Metadata file %s not found for area %s (ID: %d). Assuming no files.", metadataPath, area.Tag, areaID)
+				slog.Debug("metadata file not found for area, assuming no files", "path", metadataPath, "area", area.Tag, "id", areaID)
 				fm.fileRecords[areaID] = []FileRecord{} // Initialize empty slice
 				continue
 			}
-			log.Printf("ERROR: Failed to read metadata file %s for area %s: %v", metadataPath, area.Tag, err)
+			slog.Error("failed to read metadata file for area", "path", metadataPath, "area", area.Tag, "error", err)
 			errorsEncountered = true
 			continue // Skip this area on error
 		}
 
 		var records []FileRecord
 		if err := json.Unmarshal(data, &records); err != nil {
-			log.Printf("ERROR: Failed to parse metadata file %s for area %s: %v", metadataPath, area.Tag, err)
+			slog.Error("failed to parse metadata file for area", "path", metadataPath, "area", area.Tag, "error", err)
 			errorsEncountered = true
 			continue // Skip this area on error
 		}
@@ -158,10 +158,10 @@ func (fm *FileManager) loadAllFileRecords() error {
 		// TODO: Validate records? Ensure filenames exist?
 		fm.fileRecords[areaID] = records
 		totalFilesLoaded += len(records)
-		log.Printf("DEBUG: Loaded %d file records for area %s (ID: %d)", len(records), area.Tag, areaID)
+		slog.Debug("loaded file records for area", "count", len(records), "area", area.Tag, "id", areaID)
 	}
 
-	log.Printf("INFO: Loaded metadata for %d areas, total %d file records.", len(fm.fileAreas), totalFilesLoaded)
+	slog.Info("loaded metadata for areas", "areas", len(fm.fileAreas), "count", totalFilesLoaded)
 	if errorsEncountered {
 		return fmt.Errorf("encountered errors while loading file records")
 	}
@@ -186,7 +186,7 @@ func (fm *FileManager) saveFileRecords(areaID int) error {
 	if !exists {
 		// This might happen if an area was loaded but metadata failed initially
 		// Or if called for a newly created area before any records added.
-		log.Printf("DEBUG: No records found in memory for area ID %d during save. Saving empty list.", areaID)
+		slog.Debug("no records found in memory for area during save, saving empty list", "id", areaID)
 		records = []FileRecord{} // Ensure we save an empty list, not nil
 	}
 
@@ -199,7 +199,7 @@ func (fm *FileManager) saveFileRecords(areaID int) error {
 		return fmt.Errorf("failed to write metadata file %s: %w", metadataPath, err)
 	}
 
-	log.Printf("DEBUG: Saved %d file records for area %s (ID: %d) to %s", len(records), area.Tag, areaID, metadataPath)
+	slog.Debug("saved file records for area", "count", len(records), "area", area.Tag, "id", areaID, "path", metadataPath)
 	return nil
 }
 
@@ -337,7 +337,7 @@ func (fm *FileManager) GetFileCountForArea(areaID int) (int, error) {
 	if !exists {
 		// Area might not exist or simply hasn't had metadata loaded/saved yet.
 		// Returning 0 is appropriate for the caller (runListFiles).
-		log.Printf("DEBUG: GetFileCountForArea called for non-existent or unloaded area ID %d. Returning 0.", areaID)
+		slog.Debug("GetFileCountForArea called for non-existent or unloaded area, returning 0", "id", areaID)
 		return 0, nil
 	}
 
@@ -366,7 +366,7 @@ func (fm *FileManager) GetFilesForAreaPaginated(areaID int, page int, pageSize i
 	defer fm.muFiles.RUnlock()
 
 	if page <= 0 || pageSize <= 0 {
-		log.Printf("WARN: GetFilesForAreaPaginated called with invalid page (%d) or pageSize (%d)", page, pageSize)
+		slog.Warn("GetFilesForAreaPaginated called with invalid page or pageSize", "page", page, "pageSize", pageSize)
 		// Optionally return an error, but returning empty slice might be simpler for the caller
 		return []FileRecord{}, fmt.Errorf("invalid page number or page size")
 	}
@@ -382,7 +382,7 @@ func (fm *FileManager) GetFilesForAreaPaginated(areaID int, page int, pageSize i
 
 	// Check if start index is out of bounds
 	if startIndex >= totalFiles {
-		log.Printf("DEBUG: GetFilesForAreaPaginated requested page %d which is out of bounds (Total: %d, PageSize: %d)", page, totalFiles, pageSize)
+		slog.Debug("GetFilesForAreaPaginated requested page out of bounds", "page", page, "total", totalFiles, "pageSize", pageSize)
 		return []FileRecord{}, nil // Requested page is beyond the last file
 	}
 
@@ -431,7 +431,7 @@ func (fm *FileManager) AddFileRecord(record FileRecord) error {
 	existingRecords := fm.fileRecords[record.AreaID]
 	for _, existing := range existingRecords {
 		if strings.EqualFold(existing.Filename, record.Filename) {
-			log.Printf("WARN: Adding file record with duplicate filename '%s' in area ID %d", record.Filename, record.AreaID)
+			slog.Warn("adding file record with duplicate filename", "file", record.Filename, "area", record.AreaID)
 			break
 		}
 	}
@@ -445,13 +445,13 @@ func (fm *FileManager) AddFileRecord(record FileRecord) error {
 
 	if err != nil {
 		// Attempt to rollback the in-memory addition? Complex.
-		log.Printf("ERROR: Failed to save file records after adding %s to area %d: %v. In-memory state might be inconsistent!", record.Filename, record.AreaID, err)
+		slog.Error("failed to save file records after adding, in-memory state might be inconsistent", "file", record.Filename, "area", record.AreaID, "error", err)
 		// Maybe remove the last added record if save fails?
 		// fm.fileRecords[record.AreaID] = fm.fileRecords[record.AreaID][:len(fm.fileRecords[record.AreaID])-1]
 		return err // Propagate save error
 	}
 
-	log.Printf("INFO: Added file record '%s' (ID: %s) to area %d.", record.Filename, record.ID, record.AreaID)
+	slog.Info("added file record", "file", record.Filename, "id", record.ID, "area", record.AreaID)
 	return nil
 }
 
@@ -490,13 +490,13 @@ searchLoop:
 	fm.muFiles.Lock() // Re-acquire lock before returning
 
 	if err != nil {
-		log.Printf("ERROR: Failed to save file records after incrementing download count for %s (ID: %s): %v. In-memory state might be inconsistent!", filename, fileID, err)
+		slog.Error("failed to save file records after incrementing download count, in-memory state might be inconsistent", "file", filename, "id", fileID, "error", err)
 		// Attempt rollback?
 		// fm.fileRecords[foundAreaID][foundIndex].DownloadCount--
 		return err
 	}
 
-	log.Printf("DEBUG: Incremented download count for file '%s' (ID: %s) to %d.", filename, fileID, newCount)
+	slog.Debug("incremented download count for file", "file", filename, "id", fileID, "count", newCount)
 	return nil
 }
 
@@ -531,11 +531,11 @@ searchLoop:
 	fm.muFiles.Lock()
 
 	if err != nil {
-		log.Printf("ERROR: Failed to save file records after updating %s (ID: %s): %v", filename, fileID, err)
+		slog.Error("failed to save file records after updating", "file", filename, "id", fileID, "error", err)
 		return err
 	}
 
-	log.Printf("DEBUG: Updated file record '%s' (ID: %s).", filename, fileID)
+	slog.Debug("updated file record", "file", filename, "id", fileID)
 	return nil
 }
 
@@ -587,10 +587,10 @@ searchLoop:
 		}
 		fullPath := filepath.Join(absBasePath, area.Path, filepath.Base(foundFilename))
 		if err := os.Remove(fullPath); err != nil && !os.IsNotExist(err) {
-			log.Printf("WARN: Failed to delete file from disk at %s: %v", fullPath, err)
+			slog.Warn("failed to delete file from disk", "path", fullPath, "error", err)
 			return fmt.Errorf("failed to delete file from disk: %w", err)
 		}
-		log.Printf("INFO: Deleted file from disk: %s", fullPath)
+		slog.Info("deleted file from disk", "path", fullPath)
 	}
 
 	// Remove record from slice and persist.
@@ -602,11 +602,11 @@ searchLoop:
 	fm.muFiles.Lock()
 
 	if saveErr != nil {
-		log.Printf("ERROR: Failed to save file records after deleting %s (ID: %s): %v", foundFilename, fileID, saveErr)
+		slog.Error("failed to save file records after deleting", "file", foundFilename, "id", fileID, "error", saveErr)
 		return saveErr
 	}
 
-	log.Printf("INFO: Deleted file record '%s' (ID: %s) from area %d.", foundFilename, fileID, foundAreaID)
+	slog.Info("deleted file record", "file", foundFilename, "id", fileID, "area", foundAreaID)
 	return nil
 }
 
@@ -684,7 +684,7 @@ searchLoop:
 		// At least one metadata save failed. Roll back the filesystem rename so
 		// the file returns to the source directory and the operation is retryable.
 		if renameBackErr := os.Rename(dstPath, srcPath); renameBackErr != nil {
-			log.Printf("ERROR: Failed to roll back file rename after metadata save failure (%s -> %s): %v", dstPath, srcPath, renameBackErr)
+			slog.Error("failed to roll back file rename after metadata save failure", "from", dstPath, "to", srcPath, "error", renameBackErr)
 		} else {
 			// Restore in-memory state.
 			tgtRecords := fm.fileRecords[targetAreaID]
@@ -696,22 +696,22 @@ searchLoop:
 			// written one side; re-saving corrects any such divergence.
 			fm.muFiles.Unlock()
 			if resaveErr := fm.saveFileRecords(srcAreaID); resaveErr != nil {
-				log.Printf("ERROR: Failed to re-save source area %d during rollback: %v", srcAreaID, resaveErr)
+				slog.Error("failed to re-save source area during rollback", "area", srcAreaID, "error", resaveErr)
 			}
 			if resaveErr := fm.saveFileRecords(targetAreaID); resaveErr != nil {
-				log.Printf("ERROR: Failed to re-save target area %d during rollback: %v", targetAreaID, resaveErr)
+				slog.Error("failed to re-save target area during rollback", "area", targetAreaID, "error", resaveErr)
 			}
 			fm.muFiles.Lock()
 		}
 		if errSrc != nil {
-			log.Printf("ERROR: Failed to save source area %d after moving %s: %v", srcAreaID, safeFilename, errSrc)
+			slog.Error("failed to save source area after moving", "area", srcAreaID, "file", safeFilename, "error", errSrc)
 			return errSrc
 		}
-		log.Printf("ERROR: Failed to save target area %d after moving %s: %v", targetAreaID, safeFilename, errDst)
+		slog.Error("failed to save target area after moving", "area", targetAreaID, "file", safeFilename, "error", errDst)
 		return errDst
 	}
 
-	log.Printf("INFO: Moved file '%s' (ID: %s) from area %d to area %d.", safeFilename, fileID, srcAreaID, targetAreaID)
+	slog.Info("moved file", "file", safeFilename, "id", fileID, "from", srcAreaID, "to", targetAreaID)
 	return nil
 }
 
@@ -804,7 +804,7 @@ func (fm *FileManager) IsSupportedArchive(filename string) bool {
 	// Load the central archiver config. Defaults are used if archivers.json is missing.
 	arcCfg, err := archiver.LoadConfig("configs")
 	if err != nil {
-		log.Printf("WARN: Failed to load archivers config: %v, falling back to .zip only", err)
+		slog.Warn("failed to load archivers config, falling back to .zip only", "error", err)
 		return strings.HasSuffix(strings.ToLower(filename), ".zip")
 	}
 	return arcCfg.IsSupported(filename)

--- a/internal/file/manager.go
+++ b/internal/file/manager.go
@@ -337,7 +337,7 @@ func (fm *FileManager) GetFileCountForArea(areaID int) (int, error) {
 	if !exists {
 		// Area might not exist or simply hasn't had metadata loaded/saved yet.
 		// Returning 0 is appropriate for the caller (runListFiles).
-		slog.Debug("GetFileCountForArea called for non-existent or unloaded area, returning 0", "id", areaID)
+		slog.Debug("area not found or unloaded; returning file count 0", "id", areaID)
 		return 0, nil
 	}
 
@@ -366,7 +366,7 @@ func (fm *FileManager) GetFilesForAreaPaginated(areaID int, page int, pageSize i
 	defer fm.muFiles.RUnlock()
 
 	if page <= 0 || pageSize <= 0 {
-		slog.Warn("GetFilesForAreaPaginated called with invalid page or pageSize", "page", page, "pageSize", pageSize)
+		slog.Warn("invalid page or pageSize for paginated file listing", "page", page, "pageSize", pageSize)
 		// Optionally return an error, but returning empty slice might be simpler for the caller
 		return []FileRecord{}, fmt.Errorf("invalid page number or page size")
 	}
@@ -382,7 +382,7 @@ func (fm *FileManager) GetFilesForAreaPaginated(areaID int, page int, pageSize i
 
 	// Check if start index is out of bounds
 	if startIndex >= totalFiles {
-		slog.Debug("GetFilesForAreaPaginated requested page out of bounds", "page", page, "total", totalFiles, "pageSize", pageSize)
+		slog.Debug("requested page out of bounds for file listing", "page", page, "total", totalFiles, "pageSize", pageSize)
 		return []FileRecord{}, nil // Requested page is beyond the last file
 	}
 

--- a/internal/tosser/dupecheck.go
+++ b/internal/tosser/dupecheck.go
@@ -2,7 +2,7 @@ package tosser
 
 import (
 	"encoding/json"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -42,7 +42,7 @@ func NewDupeDB(path string, maxAge time.Duration) (*DupeDB, error) {
 	if len(data) > 0 {
 		var f dupeFile
 		if err := json.Unmarshal(data, &f); err != nil {
-			log.Printf("WARN: Corrupt dupe DB at %s, starting fresh: %v", path, err)
+			slog.Warn("corrupt dupe DB, starting fresh", "path", path, "error", err)
 			return db, nil
 		}
 		if f.Entries != nil {

--- a/internal/tosser/export.go
+++ b/internal/tosser/export.go
@@ -2,7 +2,7 @@ package tosser
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,7 +20,7 @@ func getBaseHWM(base *jam.Base) int {
 	lr, err := base.GetLastRead(ScannerUser)
 	if err != nil {
 		if err != jam.ErrNotFound {
-			log.Printf("WARN: Export: failed to read HWM from .jlr, resetting to 0 (area will be fully re-scanned): %v", err)
+			slog.Warn("failed to read HWM from .jlr, resetting to 0; area will be fully re-scanned", "error", err)
 		}
 		return 0
 	}
@@ -63,14 +63,14 @@ func (t *Tosser) ScanAndExport() TossResult {
 
 		base, err := t.msgMgr.GetBase(area.ID)
 		if err != nil {
-			log.Printf("WARN: Export: cannot get base for area %d (%s): %v", area.ID, area.Tag, err)
+			slog.Warn("cannot get base for area", "area", area.ID, "tag", area.Tag, "error", err)
 			continue
 		}
 		openBases = append(openBases, base)
 
 		count, err := base.GetMessageCount()
 		if err != nil {
-			log.Printf("WARN: Export: cannot get message count for area %d: %v", area.ID, err)
+			slog.Warn("cannot get message count for area", "area", area.ID, "error", err)
 			continue
 		}
 
@@ -91,7 +91,7 @@ func (t *Tosser) ScanAndExport() TossResult {
 				cur := getBaseHWM(base)
 				if msgNum == cur+1 {
 					if err := setBaseHWM(base, msgNum); err != nil {
-						log.Printf("WARN: Export: failed to advance HWM for area %d: %v", area.ID, err)
+						slog.Warn("failed to advance HWM for area", "area", area.ID, "error", err)
 					}
 				}
 				continue
@@ -104,7 +104,7 @@ func (t *Tosser) ScanAndExport() TossResult {
 
 			msg, err := base.ReadMessage(msgNum)
 			if err != nil {
-				log.Printf("WARN: Export: cannot read message %d in area %d: %v", msgNum, area.ID, err)
+				slog.Warn("cannot read message in area", "msg", msgNum, "area", area.ID, "error", err)
 				continue
 			}
 
@@ -142,14 +142,12 @@ func (t *Tosser) ScanAndExport() TossResult {
 		for _, pm := range msgs {
 			pm.hdr.DateProcessed = now
 			if err := pm.base.UpdateMessageHeader(pm.msgNum, pm.hdr); err != nil {
-				log.Printf("WARN: Export: failed to update DateProcessed for msg %d: %v",
-					pm.msgNum, err)
+				slog.Warn("failed to update DateProcessed for msg", "msg", pm.msgNum, "error", err)
 			}
 			// Advance HWM in the base's .jlr so the next scan skips this message
 			if pm.msgNum > getBaseHWM(pm.base) {
 				if err := setBaseHWM(pm.base, pm.msgNum); err != nil {
-					log.Printf("WARN: Export: failed to update HWM for area %d msg %d: %v",
-						pm.area.ID, pm.msgNum, err)
+					slog.Warn("failed to update HWM for area msg", "area", pm.area.ID, "msg", pm.msgNum, "error", err)
 				}
 			}
 		}
@@ -193,14 +191,14 @@ func (t *Tosser) scanAndExportNetmail(result *TossResult) {
 
 		base, err := t.msgMgr.GetBase(area.ID)
 		if err != nil {
-			log.Printf("WARN: NetmailExport: cannot get base for area %d (%s): %v", area.ID, area.Tag, err)
+			slog.Warn("netmail: cannot get base for area", "area", area.ID, "tag", area.Tag, "error", err)
 			continue
 		}
 		openBases = append(openBases, base)
 
 		count, err := base.GetMessageCount()
 		if err != nil {
-			log.Printf("WARN: NetmailExport: cannot get message count for area %d: %v", area.ID, err)
+			slog.Warn("netmail: cannot get message count for area", "area", area.ID, "error", err)
 			continue
 		}
 
@@ -215,7 +213,7 @@ func (t *Tosser) scanAndExportNetmail(result *TossResult) {
 
 			msg, err := base.ReadMessage(msgNum)
 			if err != nil {
-				log.Printf("WARN: NetmailExport: cannot read msg %d in area %s: %v", msgNum, area.Tag, err)
+				slog.Warn("netmail: cannot read msg in area", "msg", msgNum, "area", area.Tag, "error", err)
 				continue
 			}
 
@@ -223,21 +221,21 @@ func (t *Tosser) scanAndExportNetmail(result *TossResult) {
 			destAddrStr := msg.DestAddr
 			if destAddrStr == "" {
 				if len(t.config.Links) == 0 {
-					log.Printf("WARN: NetmailExport: no links for network %s, cannot route msg %d", t.networkName, msgNum)
+					slog.Warn("netmail: no links for network, cannot route msg", "network", t.networkName, "msg", msgNum)
 					continue
 				}
 				destAddrStr = t.config.Links[0].Address
 			}
 			destAddr, err := jam.ParseAddress(destAddrStr)
 			if err != nil {
-				log.Printf("WARN: NetmailExport: invalid dest addr %q for msg %d: %v", destAddrStr, msgNum, err)
+				slog.Warn("netmail: invalid dest addr for msg", "addr", destAddrStr, "msg", msgNum, "error", err)
 				continue
 			}
 
 			// Route to the best link (direct match or hub fallback).
 			link := t.findLinkForNetmail(destAddr)
 			if link == nil {
-				log.Printf("WARN: NetmailExport: no link available for %s, skipping msg %d", destAddrStr, msgNum)
+				slog.Warn("netmail: no link available, skipping msg", "addr", destAddrStr, "msg", msgNum)
 				continue
 			}
 
@@ -264,7 +262,7 @@ func (t *Tosser) scanAndExportNetmail(result *TossResult) {
 		for _, pm := range msgs {
 			pm.hdr.DateProcessed = now
 			if err := pm.base.UpdateMessageHeader(pm.msgNum, pm.hdr); err != nil {
-				log.Printf("WARN: NetmailExport: failed to mark msg %d as processed: %v", pm.msgNum, err)
+				slog.Warn("netmail: failed to mark msg as processed", "msg", pm.msgNum, "error", err)
 			}
 		}
 		result.MessagesExported += exported
@@ -384,11 +382,11 @@ func (t *Tosser) createOutboundNetmailPacket(link *linkConfig, msgs []pendingNet
 	finalName := fmt.Sprintf("%08x.pkt", time.Now().UnixNano()&0xFFFFFFFF)
 	finalPath := filepath.Join(t.paths.OutboundPath, finalName)
 	if err := os.Rename(pktPath, finalPath); err != nil {
-		log.Printf("WARN: NetmailExport: rename %s -> %s failed: %v (temp file kept)", pktPath, finalPath, err)
+		slog.Warn("netmail: rename pkt failed, temp file kept", "from", pktPath, "to", finalPath, "error", err)
 		finalName = filepath.Base(pktPath)
 	}
 
-	log.Printf("INFO: Exported %d netmail(s) to %s for link %s", len(packedMsgs), finalName, link.Address)
+	slog.Info("exported netmails", "count", len(packedMsgs), "file", finalName, "link", link.Address)
 	return len(packedMsgs), nil
 }
 
@@ -504,11 +502,11 @@ func (t *Tosser) createOutboundPacket(link *linkConfig, msgs []pendingMsg) (int,
 	finalPath := filepath.Join(t.paths.OutboundPath, finalName)
 	if err := os.Rename(pktPath, finalPath); err != nil {
 		// Temp file is already a valid .pkt, just log the rename failure
-		log.Printf("WARN: Export: rename %s -> %s failed: %v (temp file kept)", pktPath, finalPath, err)
+		slog.Warn("rename pkt failed, temp file kept", "from", pktPath, "to", finalPath, "error", err)
 		finalName = filepath.Base(pktPath)
 	}
 
-	log.Printf("INFO: Exported %d messages to %s for link %s", len(packedMsgs), finalName, link.Address)
+	slog.Info("exported messages", "count", len(packedMsgs), "file", finalName, "link", link.Address)
 	return len(packedMsgs), nil
 }
 

--- a/internal/tosser/import.go
+++ b/internal/tosser/import.go
@@ -2,7 +2,7 @@ package tosser
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -159,12 +159,12 @@ func (t *Tosser) processBundle(path, name string, result *TossResult) {
 		// Move bad bundle to temp for inspection
 		badPath := filepath.Join(t.paths.TempPath, name)
 		if renErr := os.Rename(path, badPath); renErr != nil {
-			log.Printf("WARN: Failed to move bad bundle %s: %v", path, renErr)
+			slog.Warn("failed to move bad bundle", "path", path, "error", renErr)
 		}
 		return
 	}
 
-	log.Printf("INFO: Unpacked bundle %s: %d .PKT files", name, len(pktPaths))
+	slog.Info("unpacked bundle", "bundle", name, "count", len(pktPaths))
 
 	// tossPktFile handles cleanup of each extracted .PKT (removes on success, moves to temp on error).
 	allSkipped := true
@@ -184,7 +184,7 @@ func (t *Tosser) processBundle(path, name string, result *TossResult) {
 		for _, pktPath := range pktPaths {
 			os.Remove(pktPath)
 		}
-		log.Printf("TRACE: tosser[%s]: skipping foreign bundle %s", t.networkName, name)
+		slog.Debug("skipping foreign bundle", "network", t.networkName, "bundle", name)
 		return
 	}
 
@@ -197,15 +197,15 @@ func (t *Tosser) processBundle(path, name string, result *TossResult) {
 		if err := os.Rename(pktPath, destPath); err != nil {
 			// Do not delete on rename failure — a stranded packet in unpack/ is
 			// recoverable; a deleted packet is not.
-			log.Printf("WARN: tosser[%s]: failed to re-queue skipped packet %s: %v — packet left in unpack dir for manual recovery", t.networkName, filepath.Base(pktPath), err)
+			slog.Warn("failed to re-queue skipped packet, left in unpack dir for manual recovery", "network", t.networkName, "packet", filepath.Base(pktPath), "error", err)
 		} else {
-			log.Printf("TRACE: tosser[%s]: re-queued skipped packet %s to inbound", t.networkName, filepath.Base(pktPath))
+			slog.Debug("re-queued skipped packet to inbound", "network", t.networkName, "packet", filepath.Base(pktPath))
 		}
 	}
 
 	// Remove the bundle itself after processing all packets.
 	if err := os.Remove(path); err != nil {
-		log.Printf("WARN: Failed to remove processed bundle %s: %v", path, err)
+		slog.Warn("failed to remove processed bundle", "path", path, "error", err)
 	}
 }
 
@@ -224,12 +224,12 @@ func (t *Tosser) tossPktFile(path, displayName string, result *TossResult) bool 
 
 	if len(errs) == 0 {
 		if err := os.Remove(path); err != nil {
-			log.Printf("WARN: Failed to remove processed packet %s: %v", path, err)
+			slog.Warn("failed to remove processed packet", "path", path, "error", err)
 		}
 	} else {
 		badPath := filepath.Join(t.paths.TempPath, displayName)
 		if err := os.Rename(path, badPath); err != nil {
-			log.Printf("WARN: Failed to move bad packet %s to %s: %v", path, badPath, err)
+			slog.Warn("failed to move bad packet", "path", path, "dest", badPath, "error", err)
 		}
 	}
 	return false
@@ -254,8 +254,7 @@ func (t *Tosser) tossPacket(path string) (imported, dupes int, errs []string, sk
 		}
 		// Partial parse: packet is truncated but some messages were read before the
 		// bad offset. Process what we have and treat the truncation as a warning.
-		log.Printf("WARN: tosser[%s]: truncated packet %s (%v) — processing %d message(s) before truncation",
-			t.networkName, filepath.Base(path), err, len(msgs))
+		slog.Warn("truncated packet, processing available messages", "network", t.networkName, "packet", filepath.Base(path), "error", err, "count", len(msgs))
 	}
 
 	// Check if this packet belongs to our network by matching the source address
@@ -266,8 +265,7 @@ func (t *Tosser) tossPacket(path string) (imported, dupes int, errs []string, sk
 		if pktZone == 0 {
 			pktZone = pktHdr.QOrigZone
 		}
-		log.Printf("TRACE: tosser[%s]: skipping packet %s from unknown link %d:%d/%d",
-			t.networkName, filepath.Base(path), pktZone, pktHdr.OrigNet, pktHdr.OrigNode)
+		slog.Debug("skipping packet from unknown link", "network", t.networkName, "packet", filepath.Base(path), "zone", pktZone, "net", pktHdr.OrigNet, "node", pktHdr.OrigNode)
 		return 0, 0, nil, true
 	}
 
@@ -301,7 +299,7 @@ func (t *Tosser) isPacketFromKnownLink(hdr *ftn.PacketHeader) bool {
 	for _, link := range t.config.Links {
 		addr, err := jam.ParseAddress(link.Address)
 		if err != nil {
-			log.Printf("WARN: tosser[%s]: invalid link address %q: %v", t.networkName, link.Address, err)
+			slog.Warn("invalid link address", "network", t.networkName, "link", link.Address, "error", err)
 			continue
 		}
 		hasValidLink = true
@@ -314,8 +312,7 @@ func (t *Tosser) isPacketFromKnownLink(hdr *ftn.PacketHeader) bool {
 	// If no configured link addresses could be parsed, accept the packet
 	// to avoid silently stalling all inbound processing.
 	if !hasValidLink {
-		log.Printf("WARN: tosser[%s]: no valid link addresses configured; accepting packet from %d:%d/%d",
-			t.networkName, pktZone, hdr.OrigNet, hdr.OrigNode)
+		slog.Warn("no valid link addresses configured, accepting packet", "network", t.networkName, "zone", pktZone, "net", hdr.OrigNet, "node", hdr.OrigNode)
 		return true
 	}
 	return false
@@ -347,19 +344,19 @@ func (t *Tosser) tossMessage(msg *ftn.PackedMessage, pktHdr *ftn.PacketHeader) e
 			if err := t.writeMsgToArea(t.netmailAreaTag, msg, pktHdr, parsed, msgID); err != nil {
 				return fmt.Errorf("netmail to area %q: %w", t.netmailAreaTag, err)
 			}
-			log.Printf("INFO: Tossed netmail from %s to %s (MSGID: %s)", msg.From, msg.To, msgID)
+			slog.Info("tossed netmail", "from", msg.From, "to", msg.To, "msgid", msgID)
 			return nil
 		}
-		log.Printf("TRACE: Skipping netmail from %s to %s (no netmail area configured for network %s)", msg.From, msg.To, t.networkName)
+		slog.Debug("skipping netmail, no netmail area configured", "from", msg.From, "to", msg.To, "network", t.networkName)
 		return nil
 	}
 
 	// Dupe check (only meaningful if message has a MSGID)
 	if msgID != "" && t.dupeDB.Add(msgID) {
-		log.Printf("TRACE: Dupe MSGID=%s area %s", msgID, parsed.Area)
+		slog.Debug("dupe message", "msgid", msgID, "area", parsed.Area)
 		if t.paths.DupeAreaTag != "" {
 			if err := t.writeMsgToArea(t.paths.DupeAreaTag, msg, pktHdr, parsed, msgID); err != nil {
-				log.Printf("WARN: Dupe area write failed: %v", err)
+				slog.Warn("dupe area write failed", "error", err)
 			}
 		}
 		return errDupe
@@ -377,13 +374,13 @@ func (t *Tosser) tossMessage(msg *ftn.PackedMessage, pktHdr *ftn.PacketHeader) e
 		}
 	}
 	if !found {
-		log.Printf("WARN: Unknown echo area %q from %s", parsed.Area, msg.From)
+		slog.Warn("unknown echo area", "area", parsed.Area, "from", msg.From)
 		if t.paths.BadAreaTag != "" {
 			if err := t.writeMsgToArea(t.paths.BadAreaTag, msg, pktHdr, parsed, msgID); err != nil {
-				log.Printf("WARN: Bad area write failed for area %q: %v", parsed.Area, err)
+				slog.Warn("bad area write failed", "area", parsed.Area, "error", err)
 				return fmt.Errorf("unknown area %q", parsed.Area)
 			}
-			log.Printf("INFO: Routed unknown area %q message from %s to bad area", parsed.Area, msg.From)
+			slog.Info("routed unknown area message to bad area", "area", parsed.Area, "from", msg.From)
 			return nil // counted as imported
 		}
 		return fmt.Errorf("unknown area %q", parsed.Area)
@@ -476,13 +473,13 @@ func (t *Tosser) tossMessage(msg *ftn.PackedMessage, pktHdr *ftn.PacketHeader) e
 	if hdr, herr := base.ReadMessageHeader(msgNum); herr == nil {
 		hdr.DateProcessed = uint32(time.Now().Unix())
 		if uerr := base.UpdateMessageHeader(msgNum, hdr); uerr != nil {
-			log.Printf("WARN: toss: failed to mark msg %d as processed in area %s: %v", msgNum, area.Tag, uerr)
+			slog.Warn("failed to mark msg as processed", "msg", msgNum, "area", area.Tag, "error", uerr)
 		}
 	} else {
-		log.Printf("WARN: toss: failed to read header for msg %d in area %s to mark as processed: %v", msgNum, area.Tag, herr)
+		slog.Warn("failed to read header to mark msg as processed", "msg", msgNum, "area", area.Tag, "error", herr)
 	}
 
-	log.Printf("INFO: Tossed message from %s to %s in %s (MSGID: %s)", msg.From, msg.To, parsed.Area, msgID)
+	slog.Info("tossed message", "from", msg.From, "to", msg.To, "area", parsed.Area, "msgid", msgID)
 	return nil
 }
 
@@ -557,10 +554,10 @@ func (t *Tosser) writeMsgToArea(areaTag string, msg *ftn.PackedMessage, pktHdr *
 	if hdr, herr := base.ReadMessageHeader(msgNum); herr == nil {
 		hdr.DateProcessed = uint32(time.Now().Unix())
 		if uerr := base.UpdateMessageHeader(msgNum, hdr); uerr != nil {
-			log.Printf("WARN: toss: failed to mark routed msg %d in %s as processed: %v", msgNum, areaTag, uerr)
+			slog.Warn("failed to mark routed msg as processed", "msg", msgNum, "area", areaTag, "error", uerr)
 		}
 	} else {
-		log.Printf("WARN: toss: failed to read header for routed msg %d in %s to mark as processed: %v", msgNum, areaTag, herr)
+		slog.Warn("failed to read header for routed msg to mark as processed", "msg", msgNum, "area", areaTag, "error", herr)
 	}
 	return nil
 }

--- a/internal/tosser/pack.go
+++ b/internal/tosser/pack.go
@@ -2,7 +2,7 @@ package tosser
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -118,8 +118,7 @@ func (t *Tosser) PackOutbound() PackResult {
 			continue
 		}
 
-		log.Printf("INFO: Pack: created bundle %s with %d packets for link %s",
-			filepath.Base(bundlePath), count, link.Address)
+		slog.Info("created bundle", "bundle", filepath.Base(bundlePath), "count", count, "link", link.Address)
 		result.BundlesCreated++
 		result.PacketsPacked += count
 
@@ -130,14 +129,14 @@ func (t *Tosser) PackOutbound() PackResult {
 
 		// Create BSO flow file (.clo/.hlo) for crash/hold delivery.
 		if err := writeFlowFile(binkdDir, destAddr, link.Flavour, bundlePath); err != nil {
-			log.Printf("WARN: Pack: failed to write flow file for %s: %v", link.Address, err)
+			slog.Warn("failed to write flow file", "link", link.Address, "error", err)
 		}
 	}
 
 	// Remove only the .pkt files that were successfully bundled.
 	for pktPath := range bundledPkts {
 		if err := os.Remove(pktPath); err != nil {
-			log.Printf("WARN: Pack: failed to remove staged pkt %s: %v", pktPath, err)
+			slog.Warn("failed to remove staged pkt", "path", pktPath, "error", err)
 		}
 	}
 

--- a/internal/tosser/runner.go
+++ b/internal/tosser/runner.go
@@ -2,7 +2,7 @@ package tosser
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"time"
 )
 
@@ -11,12 +11,12 @@ import (
 // Call cancel on the context to stop.
 func (t *Tosser) Start(ctx context.Context) {
 	if t.config.PollSeconds <= 0 {
-		log.Printf("INFO: Tosser[%s] polling disabled (poll_interval_seconds=0). Use RunOnce() for manual toss.", t.networkName)
+		slog.Info("polling disabled, use RunOnce for manual toss", "network", t.networkName)
 		return
 	}
 
 	interval := time.Duration(t.config.PollSeconds) * time.Second
-	log.Printf("INFO: Tosser[%s] started. Polling every %v.", t.networkName, interval)
+	slog.Info("tosser started", "network", t.networkName, "interval", interval)
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -24,22 +24,20 @@ func (t *Tosser) Start(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			log.Printf("INFO: Tosser[%s] stopping.", t.networkName)
+			slog.Info("tosser stopping", "network", t.networkName)
 			// Save dupe DB on shutdown
 			if err := t.dupeDB.Save(); err != nil {
-				log.Printf("WARN: Tosser[%s] failed to save dupe DB on shutdown: %v", t.networkName, err)
+				slog.Warn("failed to save dupe DB on shutdown", "network", t.networkName, "error", err)
 			}
 			return
 		case <-ticker.C:
 			result := t.RunOnce()
 			if result.PacketsProcessed > 0 || result.MessagesExported > 0 {
-				log.Printf("INFO: Tosser[%s] cycle: imported=%d, exported=%d, dupes=%d, packets=%d",
-					t.networkName, result.MessagesImported, result.MessagesExported,
-					result.DupesSkipped, result.PacketsProcessed)
+				slog.Info("toss cycle complete", "network", t.networkName, "imported", result.MessagesImported, "exported", result.MessagesExported, "dupes", result.DupesSkipped, "packets", result.PacketsProcessed)
 			}
 			if len(result.Errors) > 0 {
 				for _, e := range result.Errors {
-					log.Printf("ERROR: Tosser[%s] cycle: %s", t.networkName, e)
+					slog.Error("toss cycle error", "network", t.networkName, "msg", e)
 				}
 			}
 		}

--- a/internal/transfer/protocol.go
+++ b/internal/transfer/protocol.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -67,7 +67,7 @@ func LoadProtocols(path string) ([]ProtocolConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("INFO: protocols file not found, using built-in defaults")
+			slog.Info("protocols file not found, using built-in defaults")
 			return defaultProtocols(), nil
 		}
 		return nil, fmt.Errorf("failed to read protocols file %q: %w", path, err)
@@ -125,7 +125,7 @@ func (p *ProtocolConfig) ExecuteSend(ctx context.Context, s ssh.Session, filePat
 
 	cmdPath, err := exec.LookPath(p.SendCmd)
 	if err != nil {
-		log.Printf("ERROR: send command %q not found for protocol %q: %v", p.SendCmd, p.Name, err)
+		slog.Error("send command not found for protocol", "cmd", p.SendCmd, "protocol", p.Name, "error", err)
 		return fmt.Errorf("%w: send command %q not found for protocol %q — see docs/sysop/files/file-transfer.md", ErrBinaryNotFound, p.SendCmd, p.Name)
 	}
 	// Resolve to absolute path so relative binary paths survive any working-directory changes.
@@ -144,7 +144,7 @@ func (p *ProtocolConfig) ExecuteSend(ctx context.Context, s ssh.Session, filePat
 	}
 	cmd := exec.CommandContext(ctx, cmdPath, args...)
 
-	log.Printf("INFO: Protocol %q send: %s %v (pty=%v)", p.Name, cmdPath, args, p.UsePTY)
+	slog.Info("protocol send", "protocol", p.Name, "cmd", cmdPath, "args", args, "pty", p.UsePTY)
 	if p.UsePTY {
 		return RunCommandWithPTY(ctx, s, cmd, 0)
 	}
@@ -164,7 +164,7 @@ func (p *ProtocolConfig) ExecuteReceive(ctx context.Context, s ssh.Session, targ
 
 	cmdPath, err := exec.LookPath(p.RecvCmd)
 	if err != nil {
-		log.Printf("ERROR: recv command %q not found for protocol %q: %v", p.RecvCmd, p.Name, err)
+		slog.Error("recv command not found for protocol", "cmd", p.RecvCmd, "protocol", p.Name, "error", err)
 		return fmt.Errorf("%w: recv command %q not found for protocol %q — see docs/sysop/files/file-transfer.md", ErrBinaryNotFound, p.RecvCmd, p.Name)
 	}
 	// Resolve to absolute path so that cmd.Dir does not break relative binary paths.
@@ -196,7 +196,7 @@ func (p *ProtocolConfig) ExecuteReceive(ctx context.Context, s ssh.Session, targ
 		recvIdleTimeout = 10 * time.Second
 	}
 
-	log.Printf("INFO: Protocol %q receive in %s: %s %v (pty=%v)", p.Name, targetDir, cmdPath, args, p.UsePTY)
+	slog.Info("protocol receive", "protocol", p.Name, "dir", targetDir, "cmd", cmdPath, "args", args, "pty", p.UsePTY)
 	if p.UsePTY {
 		return RunCommandWithPTY(ctx, s, cmd, recvIdleTimeout)
 	}
@@ -274,7 +274,7 @@ func expandArgs(template []string, filePaths []string, targetDir string) ([]stri
 func writeFileList(paths []string) string {
 	f, err := os.CreateTemp("", "sexyz-filelist-*.txt")
 	if err != nil {
-		log.Printf("ERROR: failed to create file list temp file: %v", err)
+		slog.Error("failed to create file list temp file", "error", err)
 		return ""
 	}
 	for _, p := range paths {

--- a/internal/transfer/zmodem.go
+++ b/internal/transfer/zmodem.go
@@ -256,7 +256,7 @@ func RunCommandDirect(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinId
 						canRun++
 						if canRun >= 5 && !killed {
 							killed = true
-							slog.Debug("ZModem CAN abort detected in stdin, killing process", "cmd", cmd.Path)
+							slog.Debug("zmodem CAN abort detected in stdin, killing process", "cmd", cmd.Path)
 							if cmd.Process != nil {
 								_ = cmd.Process.Kill()
 							}
@@ -672,15 +672,15 @@ func ExecuteZmodemSend(ctx context.Context, s ssh.Session, filePaths ...string) 
 	}
 	cmd := exec.CommandContext(ctx, szPath, args...)
 
-	slog.Info("executing Zmodem send", "cmd", szPath, "args", args)
+	slog.Info("executing zmodem send", "cmd", szPath, "args", args)
 	// Execute using the PTY helper
 	err = RunCommandWithPTY(ctx, s, cmd, 0)
 	if err != nil {
-		slog.Error("Zmodem send command failed", "cmd", szPath, "error", err)
-		return fmt.Errorf("Zmodem send failed: %w", err)
+		slog.Error("zmodem send command failed", "cmd", szPath, "error", err)
+		return fmt.Errorf("zmodem send failed: %w", err)
 	}
 
-	slog.Info("Zmodem send completed", "files", filePaths)
+	slog.Info("zmodem send completed", "files", filePaths)
 	return nil
 }
 
@@ -721,14 +721,14 @@ func ExecuteZmodemReceive(ctx context.Context, s ssh.Session, targetDir string) 
 	cmd := exec.CommandContext(ctx, rzPath, args...)
 	cmd.Dir = absTargetDir // Run rz in the target directory
 
-	slog.Info("executing Zmodem receive", "dir", absTargetDir, "cmd", rzPath, "args", args)
+	slog.Info("executing zmodem receive", "dir", absTargetDir, "cmd", rzPath, "args", args)
 	// 4. Execute using the PTY helper
 	err = RunCommandWithPTY(ctx, s, cmd, 0)
 	if err != nil {
-		slog.Error("Zmodem receive command failed", "cmd", rzPath, "error", err)
-		return fmt.Errorf("Zmodem receive failed: %w", err)
+		slog.Error("zmodem receive command failed", "cmd", rzPath, "error", err)
+		return fmt.Errorf("zmodem receive failed: %w", err)
 	}
 
-	slog.Info("Zmodem receive completed", "dir", absTargetDir)
+	slog.Info("zmodem receive completed", "dir", absTargetDir)
 	return nil
 }

--- a/internal/transfer/zmodem.go
+++ b/internal/transfer/zmodem.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -87,8 +87,7 @@ func adaptiveCopy(dst io.Writer, src io.Reader, backoff *atomic.Int32) (int64, e
 					chunkSize = adaptiveMinChunk
 				}
 				writesAtLevel = 0
-				log.Printf("DEBUG: adaptiveCopy: ZRPOS backoff %d→%d bytes (signal #%d) at %d total bytes",
-					oldChunk, chunkSize, cur, total)
+				slog.Debug("adaptiveCopy ZRPOS backoff", "from", oldChunk, "to", chunkSize, "signal", cur, "total", total)
 			}
 		}
 
@@ -101,7 +100,7 @@ func adaptiveCopy(dst io.Writer, src io.Reader, backoff *atomic.Int32) (int64, e
 				chunkSize = adaptiveMaxChunk
 			}
 			writesAtLevel = 0
-			log.Printf("DEBUG: adaptiveCopy: ramp %d→%d bytes at %d total bytes", oldChunk, chunkSize, total)
+			slog.Debug("adaptiveCopy ramp", "from", oldChunk, "to", chunkSize, "total", total)
 		}
 
 		nr, rerr := src.Read(buf[:chunkSize])
@@ -110,21 +109,20 @@ func adaptiveCopy(dst io.Writer, src io.Reader, backoff *atomic.Int32) (int64, e
 			total += int64(nw)
 			hasher.Write(buf[:nr])
 			if werr != nil {
-				log.Printf("DEBUG: adaptiveCopy: write error after %d bytes: %v", total, werr)
+				slog.Debug("adaptiveCopy write error", "total", total, "error", werr)
 				return total, werr
 			}
 			if nw != nr {
-				log.Printf("DEBUG: adaptiveCopy: short write %d/%d after %d total bytes", nw, nr, total)
+				slog.Debug("adaptiveCopy short write", "wrote", nw, "expected", nr, "total", total)
 				return total, io.ErrShortWrite
 			}
 		}
 		if rerr != nil {
 			if rerr == io.EOF {
-				log.Printf("DEBUG: adaptiveCopy: finished. Bytes=%d ChunkSize=%d SHA256=%x",
-					total, chunkSize, hasher.Sum(nil))
+				slog.Debug("adaptiveCopy finished", "bytes", total, "chunk", chunkSize, "sha256", fmt.Sprintf("%x", hasher.Sum(nil)))
 				return total, nil
 			}
-			log.Printf("DEBUG: adaptiveCopy: read error after %d bytes: %v", total, rerr)
+			slog.Debug("adaptiveCopy read error", "total", total, "error", rerr)
 			return total, rerr
 		}
 	}
@@ -156,7 +154,7 @@ func RunCommandDirect(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinId
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	log.Printf("DEBUG: Starting command '%s' in DIRECT (no-PTY) mode", cmd.Path)
+	slog.Debug("starting command in direct (no-PTY) mode", "cmd", cmd.Path)
 
 	stdinPipe, err := cmd.StdinPipe()
 	if err != nil {
@@ -228,8 +226,7 @@ func RunCommandDirect(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinId
 							chunk := combined[i-3 : i+1]
 							if chunk[0] == 0x2a && chunk[1] == 0x18 && chunk[2] == 0x41 {
 								zrposBackoff.Add(1)
-								log.Printf("DEBUG: (%s) ZRPOS binary header detected across boundary at offset %d (backoff #%d)",
-									cmd.Path, total-int64(prevLen)+int64(i), zrposBackoff.Load())
+								slog.Debug("ZRPOS binary header detected across boundary", "cmd", cmd.Path, "offset", total-int64(prevLen)+int64(i), "backoff", zrposBackoff.Load())
 							}
 						}
 						if b == '9' && i >= 5 {
@@ -237,8 +234,7 @@ func RunCommandDirect(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinId
 							if chunk[0] == 0x2a && chunk[1] == 0x2a && chunk[2] == 0x18 &&
 								chunk[3] == 0x42 && chunk[4] == '0' {
 								zrposBackoff.Add(1)
-								log.Printf("DEBUG: (%s) ZRPOS hex header detected across boundary at offset %d (backoff #%d)",
-									cmd.Path, total-int64(prevLen)+int64(i), zrposBackoff.Load())
+								slog.Debug("ZRPOS hex header detected across boundary", "cmd", cmd.Path, "offset", total-int64(prevLen)+int64(i), "backoff", zrposBackoff.Load())
 							}
 						}
 					}
@@ -260,7 +256,7 @@ func RunCommandDirect(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinId
 						canRun++
 						if canRun >= 5 && !killed {
 							killed = true
-							log.Printf("DEBUG: (%s) ZModem CAN abort detected in stdin; killing process", cmd.Path)
+							slog.Debug("ZModem CAN abort detected in stdin, killing process", "cmd", cmd.Path)
 							if cmd.Process != nil {
 								_ = cmd.Process.Kill()
 							}
@@ -280,8 +276,7 @@ func RunCommandDirect(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinId
 						if chunk[0] == 0x2a && chunk[1] == 0x18 && chunk[2] == 0x41 {
 							// Binary ZRPOS header: * ZDLE A ZRPOS
 							zrposBackoff.Add(1)
-							log.Printf("DEBUG: (%s) ZRPOS binary header detected in stdin at offset %d (backoff #%d)",
-								cmd.Path, total+int64(i), zrposBackoff.Load())
+							slog.Debug("ZRPOS binary header detected in stdin", "cmd", cmd.Path, "offset", total+int64(i), "backoff", zrposBackoff.Load())
 						}
 					}
 					if b == '9' && i >= 5 {
@@ -290,8 +285,7 @@ func RunCommandDirect(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinId
 							chunk[3] == 0x42 && chunk[4] == '0' {
 							// Hex ZRPOS header: ** ZDLE B 0 9
 							zrposBackoff.Add(1)
-							log.Printf("DEBUG: (%s) ZRPOS hex header detected in stdin at offset %d (backoff #%d)",
-								cmd.Path, total+int64(i), zrposBackoff.Load())
+							slog.Debug("ZRPOS hex header detected in stdin", "cmd", cmd.Path, "offset", total+int64(i), "backoff", zrposBackoff.Load())
 						}
 					}
 				}
@@ -319,7 +313,7 @@ func RunCommandDirect(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinId
 				break
 			}
 		}
-		log.Printf("DEBUG: (%s) direct stdin copy finished. Bytes: %d, Error: %v", cmd.Path, total, cpErr)
+		slog.Debug("direct stdin copy finished", "cmd", cmd.Path, "bytes", total, "error", cpErr)
 		_ = stdinPipe.Close()
 	}()
 
@@ -334,7 +328,7 @@ func RunCommandDirect(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinId
 			for {
 				select {
 				case <-timer.C:
-					log.Printf("DEBUG: (%s) no client stdin activity for %v; killing process", cmd.Path, stdinIdleTimeout)
+					slog.Debug("no client stdin activity, killing process", "cmd", cmd.Path, "idle", stdinIdleTimeout)
 					if cmd.Process != nil {
 						_ = cmd.Process.Kill()
 					}
@@ -368,13 +362,13 @@ func RunCommandDirect(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinId
 	go func() {
 		dst := io.Writer(s)
 		if rw, ok := s.(rawBinaryWriter); ok {
-			log.Printf("DEBUG: (%s) using RawWrite for binary-safe output (type=%T)", cmd.Path, s)
+			slog.Debug("using RawWrite for binary-safe output", "cmd", cmd.Path, "type", fmt.Sprintf("%T", s))
 			dst = writeFunc(rw.RawWrite)
 		} else {
-			log.Printf("WARN: (%s) rawBinaryWriter assertion FAILED (type=%T), falling back to session.Write", cmd.Path, s)
+			slog.Warn("rawBinaryWriter assertion failed, falling back to session.Write", "cmd", cmd.Path, "type", fmt.Sprintf("%T", s))
 		}
 		n, cpErr := adaptiveCopy(dst, stdoutPipe, &zrposBackoff)
-		log.Printf("DEBUG: (%s) direct stdout copy finished. Bytes: %d, Error: %v", cmd.Path, n, cpErr)
+		slog.Debug("direct stdout copy finished", "cmd", cmd.Path, "bytes", n, "error", cpErr)
 		outputDone <- cpErr
 	}()
 
@@ -401,7 +395,7 @@ func RunCommandDirect(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinId
 		case err := <-waitDone:
 			cmdDone <- cmdResult{waitErr: err, copyErr: copyErr}
 		case <-time.After(postOutputGrace):
-			log.Printf("DEBUG: (%s) process still running %v after output closed; killing", cmd.Path, postOutputGrace)
+			slog.Debug("process still running after output closed, killing", "cmd", cmd.Path, "grace", postOutputGrace)
 			if cmd.Process != nil {
 				_ = cmd.Process.Kill()
 			}
@@ -412,7 +406,7 @@ func RunCommandDirect(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinId
 	var cmdErr error
 	select {
 	case <-ctx.Done():
-		log.Printf("DEBUG: (%s) transfer cancelled or timed out, killing process", cmd.Path)
+		slog.Debug("transfer cancelled or timed out, killing process", "cmd", cmd.Path)
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
 		}
@@ -422,7 +416,7 @@ func RunCommandDirect(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinId
 		select {
 		case <-cmdDone:
 		case <-time.After(5 * time.Second):
-			log.Printf("WARN: (%s) timed out waiting for command goroutine after cancel", cmd.Path)
+			slog.Warn("timed out waiting for command goroutine after cancel", "cmd", cmd.Path)
 		}
 		cmdErr = ctx.Err()
 	case res := <-cmdDone:
@@ -431,7 +425,7 @@ func RunCommandDirect(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinId
 			cmdErr = fmt.Errorf("stdout copy failed: %w", res.copyErr)
 		}
 	}
-	log.Printf("DEBUG: (%s) command finished (direct). Error: %v", cmd.Path, cmdErr)
+	slog.Debug("command finished (direct)", "cmd", cmd.Path, "error", cmdErr)
 
 	// When the transfer ended abnormally (killed or non-zero exit), send a
 	// ZModem abort sequence to the client. This is necessary because after
@@ -449,7 +443,7 @@ func RunCommandDirect(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinId
 	if stderrBuf.Len() > 0 {
 		for _, line := range strings.Split(strings.TrimSpace(stderrBuf.String()), "\n") {
 			if line = strings.TrimSpace(line); line != "" {
-				log.Printf("INFO: [%s stderr] %s", filepath.Base(cmd.Path), line)
+				slog.Info("external command stderr", "cmd", filepath.Base(cmd.Path), "line", line)
 			}
 		}
 	}
@@ -468,9 +462,9 @@ func RunCommandDirect(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinId
 	// Wait briefly for the stdin goroutine to notice the closed pipe / interrupt.
 	select {
 	case <-inputDone:
-		log.Printf("DEBUG: (%s) stdin goroutine finished cleanly", cmd.Path)
+		slog.Debug("stdin goroutine finished cleanly", "cmd", cmd.Path)
 	case <-time.After(2 * time.Second):
-		log.Printf("WARN: (%s) stdin goroutine did not finish within 2s, proceeding", cmd.Path)
+		slog.Warn("stdin goroutine did not finish within 2s, proceeding", "cmd", cmd.Path)
 	}
 
 	// CRITICAL: Clear the read interrupt and reset the connection deadline
@@ -526,7 +520,7 @@ func drainSessionInput(s ssh.Session, duration time.Duration) {
 	}
 
 	if totalDrained > 0 {
-		log.Printf("DEBUG: Drained %d leftover bytes from session after transfer", totalDrained)
+		slog.Debug("drained leftover bytes from session after transfer", "bytes", totalDrained)
 	}
 }
 
@@ -542,11 +536,11 @@ func RunCommandWithPTY(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinI
 	}
 	ptyReq, winCh, isPty := s.Pty()
 	if !isPty {
-		log.Printf("WARN: No PTY available for session. Falling back to direct mode for %s.", cmd.Path)
+		slog.Warn("no PTY available for session, falling back to direct mode", "cmd", cmd.Path)
 		return RunCommandDirect(ctx, s, cmd, stdinIdleTimeout)
 	}
 
-	log.Printf("DEBUG: Starting command '%s' with PTY", cmd.Path)
+	slog.Debug("starting command with PTY", "cmd", cmd.Path)
 	ptmx, err := pty.Start(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to start pty for command '%s': %w", cmd.Path, err)
@@ -558,13 +552,13 @@ func RunCommandWithPTY(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinI
 		if ptyReq.Window.Width > 0 || ptyReq.Window.Height > 0 {
 			wErr := pty.Setsize(ptmx, &pty.Winsize{Rows: uint16(ptyReq.Window.Height), Cols: uint16(ptyReq.Window.Width)})
 			if wErr != nil {
-				log.Printf("WARN: Failed to set initial pty size: %v", wErr)
+				slog.Warn("failed to set initial PTY size", "error", wErr)
 			}
 		}
 		for win := range winCh {
 			wErr := pty.Setsize(ptmx, &pty.Winsize{Rows: uint16(win.Height), Cols: uint16(win.Width)})
 			if wErr != nil {
-				log.Printf("WARN: Failed to resize pty: %v", wErr)
+				slog.Warn("failed to resize PTY", "error", wErr)
 			}
 		}
 	}()
@@ -574,11 +568,11 @@ func RunCommandWithPTY(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinI
 	var restoreTerminal func() = func() {}
 	originalState, err := term.MakeRaw(fd)
 	if err != nil {
-		log.Printf("WARN: Failed to put PTY (fd: %d) into raw mode for command '%s': %v.", fd, cmd.Path, err)
+		slog.Warn("failed to put PTY into raw mode", "fd", fd, "cmd", cmd.Path, "error", err)
 	} else {
 		restoreTerminal = func() {
 			if err := term.Restore(fd, originalState); err != nil {
-				log.Printf("ERROR: Failed to restore terminal state (fd: %d) after command '%s': %v", fd, cmd.Path, err)
+				slog.Error("failed to restore terminal state", "fd", fd, "cmd", cmd.Path, "error", err)
 			}
 		}
 	}
@@ -597,32 +591,32 @@ func RunCommandWithPTY(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinI
 	outputDone := make(chan struct{})
 	go func() {
 		defer close(inputDone)
-		log.Printf("DEBUG: (%s) Goroutine: Copying session stdin -> PTY starting...", cmd.Path)
+		slog.Debug("copying session stdin to PTY starting", "cmd", cmd.Path)
 		n, err := io.Copy(ptmx, s)
-		log.Printf("DEBUG: (%s) Goroutine: Copying session stdin -> PTY finished. Bytes: %d, Error: %v", cmd.Path, n, err)
+		slog.Debug("copying session stdin to PTY finished", "cmd", cmd.Path, "bytes", n, "error", err)
 		if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, os.ErrClosed) && !errors.Is(err, syscall.EIO) && !errors.Is(err, syscall.EINTR) {
-			log.Printf("WARN: (%s) Error copying session stdin to PTY: %v", cmd.Path, err)
+			slog.Warn("error copying session stdin to PTY", "cmd", cmd.Path, "error", err)
 		}
 	}()
 	go func() {
 		defer close(outputDone)
-		log.Printf("DEBUG: (%s) Goroutine: Copying PTY stdout -> session starting...", cmd.Path)
+		slog.Debug("copying PTY stdout to session starting", "cmd", cmd.Path)
 		n, err := io.Copy(s, ptmx)
-		log.Printf("DEBUG: (%s) Goroutine: Copying PTY stdout -> session finished. Bytes: %d, Error: %v", cmd.Path, n, err)
+		slog.Debug("copying PTY stdout to session finished", "cmd", cmd.Path, "bytes", n, "error", err)
 		if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, os.ErrClosed) && !errors.Is(err, syscall.EIO) {
-			log.Printf("WARN: (%s) Error copying PTY stdout to session stdout: %v", cmd.Path, err)
+			slog.Warn("error copying PTY stdout to session", "cmd", cmd.Path, "error", err)
 		}
 	}()
 
 	// Race: ctx cancellation vs normal completion
-	log.Printf("DEBUG: (%s) Waiting for command completion...", cmd.Path)
+	slog.Debug("waiting for command completion", "cmd", cmd.Path)
 	cmdDoneCh := make(chan error, 1)
 	go func() { cmdDoneCh <- cmd.Wait() }()
 
 	var cmdErr error
 	select {
 	case <-ctx.Done():
-		log.Printf("DEBUG: (%s) transfer cancelled or timed out, killing process", cmd.Path)
+		slog.Debug("transfer cancelled or timed out, killing process", "cmd", cmd.Path)
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
 		}
@@ -630,7 +624,7 @@ func RunCommandWithPTY(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinI
 		<-cmdDoneCh
 	case cmdErr = <-cmdDoneCh:
 	}
-	log.Printf("DEBUG: (%s) Command finished. Error: %v", cmd.Path, cmdErr)
+	slog.Debug("command finished", "cmd", cmd.Path, "error", cmdErr)
 
 	// Interrupt the input goroutine's blocked Read() so it exits without
 	// consuming the user's next keypress
@@ -657,7 +651,7 @@ func RunCommandWithPTY(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinI
 // filePaths should be absolute paths to the files being sent.
 // ctx controls cancellation and timeout; pass nil for no timeout.
 func ExecuteZmodemSend(ctx context.Context, s ssh.Session, filePaths ...string) error {
-	log.Printf("DEBUG: executeZmodemSend called with files: %v", filePaths)
+	slog.Debug("zmodem send called", "files", filePaths)
 
 	if len(filePaths) == 0 {
 		return fmt.Errorf("no files provided for Zmodem send")
@@ -666,10 +660,10 @@ func ExecuteZmodemSend(ctx context.Context, s ssh.Session, filePaths ...string) 
 	// Check if sz command exists
 	szPath, err := exec.LookPath("sz")
 	if err != nil {
-		log.Printf("ERROR: 'sz' command not found in PATH: %v", err)
+		slog.Error("sz command not found in PATH", "error", err)
 		return fmt.Errorf("'sz' command not found, Zmodem send unavailable")
 	}
-	log.Printf("DEBUG: Found 'sz' command at: %s", szPath)
+	slog.Debug("found sz command", "path", szPath)
 
 	// Construct command: sz [-b] <files...>
 	args := append([]string{"-b"}, filePaths...)
@@ -678,15 +672,15 @@ func ExecuteZmodemSend(ctx context.Context, s ssh.Session, filePaths ...string) 
 	}
 	cmd := exec.CommandContext(ctx, szPath, args...)
 
-	log.Printf("INFO: Executing Zmodem send: %s %v", szPath, args)
+	slog.Info("executing Zmodem send", "cmd", szPath, "args", args)
 	// Execute using the PTY helper
 	err = RunCommandWithPTY(ctx, s, cmd, 0)
 	if err != nil {
-		log.Printf("ERROR: Zmodem send command ('%s') failed: %v", szPath, err)
+		slog.Error("Zmodem send command failed", "cmd", szPath, "error", err)
 		return fmt.Errorf("Zmodem send failed: %w", err)
 	}
 
-	log.Printf("INFO: Zmodem send completed successfully for files: %v", filePaths)
+	slog.Info("Zmodem send completed", "files", filePaths)
 	return nil
 }
 
@@ -695,7 +689,7 @@ func ExecuteZmodemSend(ctx context.Context, s ssh.Session, filePaths ...string) 
 // targetDir should be the absolute path to the directory where received files will be stored.
 // ctx controls cancellation and timeout; pass nil for no timeout.
 func ExecuteZmodemReceive(ctx context.Context, s ssh.Session, targetDir string) error {
-	log.Printf("DEBUG: executeZmodemReceive called for target directory: %s", targetDir)
+	slog.Debug("zmodem receive called", "dir", targetDir)
 
 	// 1. Validate and ensure target directory exists
 	if targetDir == "" {
@@ -714,10 +708,10 @@ func ExecuteZmodemReceive(ctx context.Context, s ssh.Session, targetDir string) 
 	// 2. Check if rz command exists
 	rzPath, err := exec.LookPath("rz")
 	if err != nil {
-		log.Printf("ERROR: 'rz' command not found in PATH: %v", err)
+		slog.Error("rz command not found in PATH", "error", err)
 		return fmt.Errorf("'rz' command not found, Zmodem receive unavailable")
 	}
-	log.Printf("DEBUG: Found 'rz' command at: %s", rzPath)
+	slog.Debug("found rz command", "path", rzPath)
 
 	// 3. Construct command: rz -b -r
 	args := []string{"-b", "-r"} // Binary mode, Restricted mode (prevents path traversal)
@@ -727,14 +721,14 @@ func ExecuteZmodemReceive(ctx context.Context, s ssh.Session, targetDir string) 
 	cmd := exec.CommandContext(ctx, rzPath, args...)
 	cmd.Dir = absTargetDir // Run rz in the target directory
 
-	log.Printf("INFO: Executing Zmodem receive in directory '%s': %s %v", absTargetDir, rzPath, args)
+	slog.Info("executing Zmodem receive", "dir", absTargetDir, "cmd", rzPath, "args", args)
 	// 4. Execute using the PTY helper
 	err = RunCommandWithPTY(ctx, s, cmd, 0)
 	if err != nil {
-		log.Printf("ERROR: Zmodem receive command ('%s') failed: %v", rzPath, err)
+		slog.Error("Zmodem receive command failed", "cmd", rzPath, "error", err)
 		return fmt.Errorf("Zmodem receive failed: %w", err)
 	}
 
-	log.Printf("INFO: Zmodem receive completed successfully into directory: %s", absTargetDir)
+	slog.Info("Zmodem receive completed", "dir", absTargetDir)
 	return nil
 }

--- a/internal/ziplab/config.go
+++ b/internal/ziplab/config.go
@@ -3,7 +3,7 @@ package ziplab
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -97,14 +97,14 @@ func DefaultConfig() Config {
 // Returns defaults if the file doesn't exist.
 func LoadConfig(configPath string) (Config, error) {
 	filePath := filepath.Join(configPath, "ziplab.json")
-	log.Printf("INFO: Loading ZipLab config from %s", filePath)
+	slog.Info("loading ziplab config", "path", filePath)
 
 	cfg := DefaultConfig()
 
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("INFO: ziplab.json not found at %s, using defaults", filePath)
+			slog.Info("ziplab.json not found, using defaults", "path", filePath)
 		} else {
 			return cfg, fmt.Errorf("failed to read ziplab config %s: %w", filePath, err)
 		}
@@ -118,13 +118,12 @@ func LoadConfig(configPath string) (Config, error) {
 	// This ensures all enabled archivers are available to the ZipLab pipeline.
 	arcCfg, arcErr := archiver.LoadConfig(configPath)
 	if arcErr != nil {
-		log.Printf("WARN: Failed to load archivers.json: %v, using ZipLab defaults", arcErr)
+		slog.Warn("failed to load archivers.json, using ziplab defaults", "error", arcErr)
 	} else {
 		cfg.ArchiveTypes = archiverTypesFromConfig(arcCfg)
 	}
 
-	log.Printf("INFO: Loaded ZipLab config: enabled=%v, runOnUpload=%v, scanFailBehavior=%s, archiveTypes=%d",
-		cfg.Enabled, cfg.RunOnUpload, cfg.ScanFailBehavior, len(cfg.ArchiveTypes))
+	slog.Info("loaded ziplab config", "enabled", cfg.Enabled, "runOnUpload", cfg.RunOnUpload, "scanFailBehavior", cfg.ScanFailBehavior, "archiveTypes", len(cfg.ArchiveTypes))
 	return cfg, nil
 }
 

--- a/internal/ziplab/display.go
+++ b/internal/ziplab/display.go
@@ -3,7 +3,7 @@ package ziplab
 import (
 	"bufio"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -111,7 +111,7 @@ func ParseNFO(filePath string) (*NFOConfig, error) {
 		// Parse: "1D = 45,10,112,116,███"
 		parts := strings.SplitN(line, "=", 2)
 		if len(parts) != 2 {
-			log.Printf("WARN: NFO line %d: invalid format (no '='): %s", lineNum, line)
+			slog.Warn("nfo invalid format (no '=')", "line", lineNum, "content", line)
 			continue
 		}
 
@@ -119,7 +119,7 @@ func ParseNFO(filePath string) (*NFOConfig, error) {
 		value := strings.TrimSpace(parts[1])
 
 		if len(key) < 2 {
-			log.Printf("WARN: NFO line %d: key too short: %s", lineNum, key)
+			slog.Warn("nfo key too short", "line", lineNum, "key", key)
 			continue
 		}
 
@@ -129,7 +129,7 @@ func ParseNFO(filePath string) (*NFOConfig, error) {
 
 		step, err := strconv.Atoi(stepStr)
 		if err != nil {
-			log.Printf("WARN: NFO line %d: invalid step number: %s", lineNum, stepStr)
+			slog.Warn("nfo invalid step number", "line", lineNum, "step", stepStr)
 			continue
 		}
 
@@ -142,35 +142,35 @@ func ParseNFO(filePath string) (*NFOConfig, error) {
 		case "F":
 			status = StatusFail
 		default:
-			log.Printf("WARN: NFO line %d: unknown status '%s'", lineNum, statusChar)
+			slog.Warn("nfo unknown status", "line", lineNum, "status", statusChar)
 			continue
 		}
 
 		// Parse value: X,Y,NormalColor,HiColor,DisplayChars
 		valueParts := strings.SplitN(value, ",", 5)
 		if len(valueParts) < 5 {
-			log.Printf("WARN: NFO line %d: expected 5 comma-separated values, got %d", lineNum, len(valueParts))
+			slog.Warn("nfo expected 5 comma-separated values", "line", lineNum, "count", len(valueParts))
 			continue
 		}
 
 		col, err := strconv.Atoi(strings.TrimSpace(valueParts[0]))
 		if err != nil {
-			log.Printf("WARN: NFO line %d: invalid X coordinate: %s", lineNum, valueParts[0])
+			slog.Warn("nfo invalid X coordinate", "line", lineNum, "value", valueParts[0])
 			continue
 		}
 		row, err := strconv.Atoi(strings.TrimSpace(valueParts[1]))
 		if err != nil {
-			log.Printf("WARN: NFO line %d: invalid Y coordinate: %s", lineNum, valueParts[1])
+			slog.Warn("nfo invalid Y coordinate", "line", lineNum, "value", valueParts[1])
 			continue
 		}
 		normalColor, err := strconv.Atoi(strings.TrimSpace(valueParts[2]))
 		if err != nil {
-			log.Printf("WARN: NFO line %d: invalid normal color: %s", lineNum, valueParts[2])
+			slog.Warn("nfo invalid normal color", "line", lineNum, "value", valueParts[2])
 			continue
 		}
 		hiColor, err := strconv.Atoi(strings.TrimSpace(valueParts[3]))
 		if err != nil {
-			log.Printf("WARN: NFO line %d: invalid hi color: %s", lineNum, valueParts[3])
+			slog.Warn("nfo invalid hi color", "line", lineNum, "value", valueParts[3])
 			continue
 		}
 		displayChars := strings.TrimSpace(valueParts[4])
@@ -190,7 +190,7 @@ func ParseNFO(filePath string) (*NFOConfig, error) {
 		return nil, fmt.Errorf("error reading NFO file %s: %w", filePath, err)
 	}
 
-	log.Printf("DEBUG: Parsed %d NFO entries from %s", len(nfo.Entries), filePath)
+	slog.Debug("parsed nfo entries", "count", len(nfo.Entries), "path", filePath)
 	return nfo, nil
 }
 
@@ -208,8 +208,8 @@ func (n *NFOConfig) MaxRow() int {
 // DOSColorToANSI converts a DOS color attribute (bg*16 + fg) to ANSI components.
 // Returns foreground color (0-15), background color (0-7), and whether bold is needed.
 func DOSColorToANSI(dosAttr int) (fg int, bg int, bold bool) {
-	fg = dosAttr & 0x0F   // Lower 4 bits = foreground (0-15)
+	fg = dosAttr & 0x0F        // Lower 4 bits = foreground (0-15)
 	bg = (dosAttr >> 4) & 0x07 // Bits 4-6 = background (0-7)
-	bold = fg >= 8         // High bit of foreground = bold/bright
+	bold = fg >= 8             // High bit of foreground = bold/bright
 	return fg, bg, bold
 }

--- a/internal/ziplab/pipeline.go
+++ b/internal/ziplab/pipeline.go
@@ -3,7 +3,7 @@ package ziplab
 import (
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"time"
@@ -52,7 +52,7 @@ func (p *Processor) RunPipeline(archivePath string, statusFn StatusCallback) Pip
 		statusFn = func(StepNumber, Status) {}
 	}
 
-	log.Printf("INFO: ZipLab pipeline starting for %s", archivePath)
+	slog.Info("pipeline starting", "path", archivePath)
 
 	// Step 1: Test Integrity
 	if p.config.Steps.TestIntegrity.Enabled {
@@ -114,7 +114,7 @@ func (p *Processor) RunPipeline(archivePath string, statusFn StatusCallback) Pip
 		result.StepResults = append(result.StepResults, sr)
 		if sr.Error != nil {
 			// Non-fatal — log but continue
-			log.Printf("WARN: ZipLab step 5 had errors: %v", sr.Error)
+			slog.Warn("step 5 had errors", "error", sr.Error)
 		}
 		if diz != "" {
 			result.Description = diz
@@ -129,7 +129,7 @@ func (p *Processor) RunPipeline(archivePath string, statusFn StatusCallback) Pip
 		result.StepResults = append(result.StepResults, sr)
 		if sr.Error != nil {
 			// Non-fatal
-			log.Printf("WARN: ZipLab step 6 had errors: %v", sr.Error)
+			slog.Warn("step 6 had errors", "error", sr.Error)
 		}
 	}
 
@@ -141,12 +141,11 @@ func (p *Processor) RunPipeline(archivePath string, statusFn StatusCallback) Pip
 		result.StepResults = append(result.StepResults, sr)
 		if sr.Error != nil {
 			// Non-fatal
-			log.Printf("WARN: ZipLab step 7 had errors: %v", sr.Error)
+			slog.Warn("step 7 had errors", "error", sr.Error)
 		}
 	}
 
-	log.Printf("INFO: ZipLab pipeline completed for %s: success=%v, description=%q",
-		archivePath, result.Success, result.Description)
+	slog.Info("pipeline completed", "path", archivePath, "success", result.Success, "description", result.Description)
 	return result
 }
 
@@ -180,31 +179,31 @@ func (p *Processor) handleScanFailure(archivePath string) {
 	case "quarantine":
 		if p.config.QuarantinePath != "" {
 			if err := os.MkdirAll(p.config.QuarantinePath, 0755); err != nil {
-				log.Printf("ERROR: Failed to create quarantine directory %s: %v", p.config.QuarantinePath, err)
+				slog.Error("failed to create quarantine directory", "path", p.config.QuarantinePath, "error", err)
 				if rmErr := os.Remove(archivePath); rmErr != nil {
-					log.Printf("ERROR: Failed to remove infected file %s after quarantine dir failure: %v", archivePath, rmErr)
+					slog.Error("failed to remove infected file after quarantine dir failure", "path", archivePath, "error", rmErr)
 				}
 				return
 			}
 			dest := filepath.Join(p.config.QuarantinePath, filepath.Base(archivePath))
 			if err := os.Rename(archivePath, dest); err != nil {
-				log.Printf("ERROR: Failed to quarantine %s: %v", archivePath, err)
+				slog.Error("failed to quarantine file", "path", archivePath, "error", err)
 				if rmErr := os.Remove(archivePath); rmErr != nil {
-					log.Printf("ERROR: Failed to remove infected file %s after quarantine failure: %v", archivePath, rmErr)
+					slog.Error("failed to remove infected file after quarantine failure", "path", archivePath, "error", rmErr)
 				}
 			} else {
-				log.Printf("INFO: Quarantined infected file: %s -> %s", archivePath, dest)
+				slog.Info("quarantined infected file", "path", archivePath, "dest", dest)
 			}
 		} else {
-			log.Printf("WARN: Quarantine path not configured, deleting %s", archivePath)
+			slog.Warn("quarantine path not configured, deleting", "path", archivePath)
 			if rmErr := os.Remove(archivePath); rmErr != nil {
-				log.Printf("ERROR: Failed to remove infected file %s: %v", archivePath, rmErr)
+				slog.Error("failed to remove infected file", "path", archivePath, "error", rmErr)
 			}
 		}
 	default: // "delete"
-		log.Printf("INFO: Deleting infected file: %s", archivePath)
+		slog.Info("deleting infected file", "path", archivePath)
 		if rmErr := os.Remove(archivePath); rmErr != nil {
-			log.Printf("ERROR: Failed to remove infected file %s: %v", archivePath, rmErr)
+			slog.Error("failed to remove infected file", "path", archivePath, "error", rmErr)
 		}
 	}
 }

--- a/internal/ziplab/processor.go
+++ b/internal/ziplab/processor.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -41,7 +41,7 @@ func (p *Processor) resolvePath(path string) string {
 // For external formats, it runs the configured test command.
 func (p *Processor) StepTestIntegrity(archivePath string) error {
 	if !p.config.Steps.TestIntegrity.Enabled {
-		log.Printf("INFO: ZipLab step 1 (test integrity) skipped — disabled")
+		slog.Info("step 1 (test integrity) skipped — disabled")
 		return nil
 	}
 
@@ -82,7 +82,7 @@ func (p *Processor) testZipIntegrity(zipPath string) error {
 // Returns the path to the work directory.
 func (p *Processor) StepExtract(archivePath string) (string, error) {
 	if !p.config.Steps.ExtractToTemp.Enabled {
-		log.Printf("INFO: ZipLab step 2 (extract) skipped — disabled")
+		slog.Info("step 2 (extract) skipped — disabled")
 		return "", nil
 	}
 
@@ -165,7 +165,7 @@ func (p *Processor) extractZip(zipPath, destDir string) error {
 // StepVirusScan (Step 3) runs a configurable external virus scanner.
 func (p *Processor) StepVirusScan(workDir string) error {
 	if !p.config.Steps.VirusScan.Enabled {
-		log.Printf("INFO: ZipLab step 3 (virus scan) skipped — disabled")
+		slog.Info("step 3 (virus scan) skipped — disabled")
 		return nil
 	}
 
@@ -178,7 +178,7 @@ func (p *Processor) StepVirusScan(workDir string) error {
 // workDir is used to find FILE_ID.DIZ; archivePath is the ZIP to strip ad files from.
 func (p *Processor) StepRemoveAdsAndDIZ(workDir, archivePath string) (string, error) {
 	if !p.config.Steps.RemoveAds.Enabled {
-		log.Printf("INFO: ZipLab step 5 (remove ads/DIZ) skipped — disabled")
+		slog.Info("step 5 (remove ads/DIZ) skipped — disabled")
 		return "", nil
 	}
 
@@ -198,7 +198,7 @@ func (p *Processor) StepRemoveAdsAndDIZ(workDir, archivePath string) (string, er
 		at, ok := p.config.GetArchiveType(archivePath)
 		if ok && at.Native {
 			if err := p.removeFilesFromZip(archivePath, patterns); err != nil {
-				log.Printf("WARN: failed to remove ad files from archive: %v", err)
+				slog.Warn("failed to remove ad files from archive", "error", err)
 			}
 		}
 	}
@@ -252,7 +252,7 @@ func (p *Processor) removeFilesFromZip(zipPath string, patterns []string) (retEr
 	seen := make(map[string]bool)
 	for _, f := range r.File {
 		if shouldRemoveFile(f.Name, patterns) {
-			log.Printf("INFO: removing ad file from archive: %s", f.Name)
+			slog.Info("removing ad file from archive", "file", f.Name)
 			removed++
 			continue
 		}
@@ -324,7 +324,7 @@ func (p *Processor) findAndReadDIZ(workDir string) string {
 
 	data, readErr := os.ReadFile(target)
 	if readErr != nil {
-		log.Printf("WARN: found %s but failed to read: %v", filepath.Base(target), readErr)
+		slog.Warn("found diz file but failed to read", "file", filepath.Base(target), "error", readErr)
 		return ""
 	}
 	return cleanDIZ(string(stripSauceMetadata(data)))
@@ -339,7 +339,7 @@ func (p *Processor) loadRemovePatterns() []string {
 
 	f, err := os.Open(patternsPath)
 	if err != nil {
-		log.Printf("WARN: could not open patterns file %s: %v", patternsPath, err)
+		slog.Warn("could not open patterns file", "path", patternsPath, "error", err)
 		return nil
 	}
 	defer f.Close()
@@ -365,9 +365,9 @@ func (p *Processor) removeMatchingFiles(dir, pattern string) {
 		if !entry.IsDir() && strings.EqualFold(entry.Name(), pattern) {
 			target := filepath.Join(dir, entry.Name())
 			if err := os.Remove(target); err != nil {
-				log.Printf("WARN: failed to remove %s: %v", target, err)
+				slog.Warn("failed to remove ad file", "path", target, "error", err)
 			} else {
-				log.Printf("INFO: removed ad file: %s", entry.Name())
+				slog.Info("removed ad file", "file", entry.Name())
 			}
 		}
 	}
@@ -376,7 +376,7 @@ func (p *Processor) removeMatchingFiles(dir, pattern string) {
 // StepAddComment (Step 6) adds a ZIP comment from the configured comment file.
 func (p *Processor) StepAddComment(archivePath string) error {
 	if !p.config.Steps.AddComment.Enabled {
-		log.Printf("INFO: ZipLab step 6 (add comment) skipped — disabled")
+		slog.Info("step 6 (add comment) skipped — disabled")
 		return nil
 	}
 
@@ -438,7 +438,7 @@ func (p *Processor) setZipComment(zipPath, comment string) (retErr error) {
 // StepIncludeFile (Step 7) adds a file (e.g., BBS.AD) into the archive.
 func (p *Processor) StepIncludeFile(archivePath string) error {
 	if !p.config.Steps.IncludeFile.Enabled {
-		log.Printf("INFO: ZipLab step 7 (include file) skipped — disabled")
+		slog.Info("step 7 (include file) skipped — disabled")
 		return nil
 	}
 

--- a/internal/ziplab/viewer.go
+++ b/internal/ziplab/viewer.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -44,7 +44,6 @@ func sanitizeEntryName(s string) string {
 		return r
 	}, s)
 }
-
 
 // formatArchiveListing opens a ZIP file and writes a numbered, pipe-code-formatted
 // listing to w. Returns the file count and any error opening the archive.
@@ -199,7 +198,7 @@ func RunZipLabView(ctx context.Context, s ssh.Session, terminal *term.Terminal, 
 
 		extractedPath, cleanup, err := extractSingleEntry(filePath, num)
 		if err != nil {
-			log.Printf("ziplab: extraction failed: %v", err)
+			slog.Error("extraction failed", "error", err)
 			msg := "\r\n|01Extraction failed.|07\r\n"
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 			continue
@@ -222,7 +221,7 @@ func RunZipLabView(ctx context.Context, s ssh.Session, terminal *term.Terminal, 
 			cancel()
 		}
 		if sendErr != nil {
-			log.Printf("ziplab: zmodem send failed: %v", sendErr)
+			slog.Error("zmodem send failed", "error", sendErr)
 			msg := "\r\n|01Transfer failed.|07\r\n"
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		} else {


### PR DESCRIPTION
Phase B slog migration across:
- internal/tosser (5 files)
- internal/transfer (2 files)
- internal/ziplab (5 files)
- internal/file (1 file)
- internal/config (1 file)

All `log.Printf("LEVEL: ...")` calls converted to structured `slog.{Info,Warn,Error,Debug}` with lowercased messages, subsystem prefixes removed, and interpolated values moved to key/value attrs (`error`, `path`, `file`, `id`, `count`, etc.). No SECURITY/FATAL/log.Fatal calls were present, so the logging package import was not needed.

`go build ./...`, `go vet`, and `go test` (201 tests across the 5 affected packages) all pass.

Part of the logging overhaul described in docs-internal/plans/2026-06-28-logging-overhaul-design.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated logging across configuration, transfer, toss, and ZIP processing workflows to use structured messages.
  * Improved error and status reporting with more consistent context when loading configs, processing files, and running transfers.
  * No user-facing behavior, data handling, or workflow logic was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->