### PR TITLE
refactor: migrate menu package to slog (Phase B)

### DIFF
--- a/internal/menu/acs_checker.go
+++ b/internal/menu/acs_checker.go
@@ -2,7 +2,7 @@ package menu
 
 import (
 	"fmt" // Added for errors
-	"log"
+	"log/slog"
 	"strconv"
 	"strings"
 	"time"
@@ -78,7 +78,7 @@ func tokenizeACS(acsString string) ([]token, error) {
 				flushCondition() // Flush the completed condition
 			} else {
 				// If it doesn't start with a letter/number/allowed symbol, but isn't whitespace or an operator/paren, it's unexpected.
-				log.Printf("WARN: Ignoring unexpected character '%c' during ACS tokenization", r)
+				slog.Warn("ignoring unexpected character during ACS tokenization", "char", string(r))
 				// Consider returning an error instead? For now, just ignore.
 				// return nil, fmt.Errorf("unexpected character '%c' in ACS string", r)
 			}
@@ -86,7 +86,7 @@ func tokenizeACS(acsString string) ([]token, error) {
 	}
 	flushCondition() // Add any trailing condition
 
-	log.Printf("DEBUG: Tokenized ACS '%s' -> %v", acsString, tokens) // Log tokens
+	slog.Debug("tokenized ACS", "acs", acsString, "tokens", tokens) // Log tokens
 	return tokens, nil
 }
 
@@ -149,7 +149,7 @@ func infixToRPN(tokens []token) ([]token, error) {
 		outputQueue = append(outputQueue, op)
 		operatorStack = operatorStack[:len(operatorStack)-1]
 	}
-	log.Printf("DEBUG: RPN Output Queue: %v", outputQueue) // Log RPN
+	slog.Debug("RPN output queue", "queue", outputQueue) // Log RPN
 	return outputQueue, nil
 }
 
@@ -213,49 +213,49 @@ func CheckUserACS(acsString string, u *user.User) bool {
 // checkACS evaluates a ViSiON/2 Access Control String (ACS) against user credentials.
 // Returns true if the user meets the ACS requirements, false otherwise.
 func checkACS(acsString string, u *user.User, s ssh.Session, terminal *term.Terminal, startTime time.Time) bool {
-	// log.Printf("DEBUG: [checkACS] Received ACS: '%s' (Length: %d)", acsString, len(acsString))
+	// slog.Debug("checkACS received ACS", "acs", acsString, "length", len(acsString))
 
 	if acsString == "" {
-		// log.Printf("DEBUG: [checkACS] Empty ACS string. Allowing access.")
+		// slog.Debug("checkACS empty ACS string, allowing access")
 		return true // No ACS defined, always allow
 	}
 
 	// Handle '*' wildcard explicitly *before* tokenization
 	if acsString == "*" { // <--- Check 2: Wildcard allows
-		// log.Printf("DEBUG: [checkACS] Wildcard '*' matched. Allowing access.")
+		// slog.Debug("checkACS wildcard '*' matched, allowing access")
 		return true
 	}
 
 	// Check if user is authenticated
 	if u == nil {
-		// log.Printf("DEBUG: [checkACS] Unauthenticated user ('%s'). Denying access.", acsString)
+		// slog.Debug("checkACS unauthenticated user, denying access", "acs", acsString)
 		return false // Unauthenticated users cannot pass non-empty, non-wildcard ACS
 	}
 
-	log.Printf("DEBUG: Checking ACS: '%s' for user '%s' (Level: %d, Flags: '%s', ID: %d, Validated: %t)", acsString, u.Handle, u.AccessLevel, u.Flags, u.ID, u.Validated)
+	slog.Debug("checking ACS", "acs", acsString, "handle", u.Handle, "level", u.AccessLevel, "flags", u.Flags, "id", u.ID, "validated", u.Validated)
 
 	// 1. Tokenize
 	tokens, err := tokenizeACS(acsString)
 	if err != nil {
-		log.Printf("ERROR: Failed to tokenize ACS string '%s': %v", acsString, err)
+		slog.Error("failed to tokenize ACS string", "acs", acsString, "error", err)
 		return false // Fail on tokenization error
 	}
 
 	// 2. Convert to RPN
 	rpnQueue, err := infixToRPN(tokens)
 	if err != nil {
-		log.Printf("ERROR: Failed to convert ACS string '%s' to RPN: %v", acsString, err)
+		slog.Error("failed to convert ACS string to RPN", "acs", acsString, "error", err)
 		return false // Fail on RPN conversion error
 	}
 
 	// 3. Evaluate RPN
 	result, err := evaluateRPN(rpnQueue, u, s, terminal, startTime)
 	if err != nil {
-		log.Printf("ERROR: Failed to evaluate RPN for ACS string '%s': %v", acsString, err)
+		slog.Error("failed to evaluate RPN for ACS string", "acs", acsString, "error", err)
 		return false // Fail on evaluation error
 	}
 
-	log.Printf("DEBUG: ACS Check Result for '%s': %t", acsString, result)
+	slog.Debug("ACS check result", "acs", acsString, "result", result)
 	return result
 }
 
@@ -266,7 +266,7 @@ func evaluateCondition(condition string, u *user.User, s ssh.Session, _ *term.Te
 	// Negation handling removed - done in evaluateRPN
 
 	if len(condition) == 0 {
-		log.Printf("WARN: Empty condition encountered in ACS string after tokenization")
+		slog.Warn("empty condition encountered in ACS string after tokenization")
 		return false // Treat empty condition as failing
 	}
 
@@ -290,7 +290,7 @@ func evaluateCondition(condition string, u *user.User, s ssh.Session, _ *term.Te
 	case "S": // Security Level >= value
 		level, err := strconv.Atoi(value)
 		if err != nil {
-			log.Printf("WARN: Invalid level value in ACS condition '%s': %v", condition, err)
+			slog.Warn("invalid level value in ACS condition", "condition", condition, "error", err)
 			result = false
 		} else {
 			result = u.AccessLevel >= level
@@ -303,7 +303,7 @@ func evaluateCondition(condition string, u *user.User, s ssh.Session, _ *term.Te
 			addr := s.RemoteAddr().String()
 			isLoopback := strings.HasPrefix(addr, "127.") || strings.HasPrefix(addr, "[::1]")
 			result = (network == "pipe" || network == "unix" || isLoopback)
-			log.Printf("DEBUG: ACS 'L' check: Network='%s', Addr='%s', IsLoopback=%t -> %t", network, addr, isLoopback, result)
+			slog.Debug("ACS 'L' check", "network", network, "addr", addr, "isLoopback", isLoopback, "result", result)
 		}
 	case "A": // ANSI graphics supported
 		if s == nil {
@@ -311,11 +311,11 @@ func evaluateCondition(condition string, u *user.User, s ssh.Session, _ *term.Te
 		} else {
 			_, _, isPty := s.Pty()
 			result = isPty
-			log.Printf("DEBUG: ACS 'A' check: isPty=%t -> %t", isPty, result)
+			slog.Debug("ACS 'A' check", "isPty", isPty, "result", result)
 		}
 	case "F": // Flag is set
 		if len(value) != 1 {
-			log.Printf("WARN: Invalid flag value in ACS condition '%s': Flag must be single character", condition)
+			slog.Warn("invalid flag value in ACS condition: flag must be single character", "condition", condition)
 			result = false
 		} else {
 			result = strings.Contains(strings.ToUpper(u.Flags), strings.ToUpper(value))
@@ -323,7 +323,7 @@ func evaluateCondition(condition string, u *user.User, s ssh.Session, _ *term.Te
 	case "U": // User ID == value
 		id, err := strconv.Atoi(value)
 		if err != nil {
-			log.Printf("WARN: Invalid user ID value in ACS condition '%s': %v", condition, err)
+			slog.Warn("invalid user ID value in ACS condition", "condition", condition, "error", err)
 			result = false
 		} else {
 			result = u.ID == id
@@ -333,7 +333,7 @@ func evaluateCondition(condition string, u *user.User, s ssh.Session, _ *term.Te
 	case "D": // File download level >= value (Using AccessLevel for now)
 		level, err := strconv.Atoi(value)
 		if err != nil {
-			log.Printf("WARN: Invalid level value in ACS condition '%s': %v", condition, err)
+			slog.Warn("invalid level value in ACS condition", "condition", condition, "error", err)
 			result = false
 		} else {
 			// TODO: Confirm if this should be AccessLevel or a separate FileLevel
@@ -342,7 +342,7 @@ func evaluateCondition(condition string, u *user.User, s ssh.Session, _ *term.Te
 	case "E": // Post/Call Ratio >= value (Uploads / Calls)
 		pcrThreshold, err := strconv.Atoi(value)
 		if err != nil {
-			log.Printf("WARN: Invalid PCR value in ACS condition '%s': %v", condition, err)
+			slog.Warn("invalid PCR value in ACS condition", "condition", condition, "error", err)
 			result = false
 		} else {
 			numLogons := u.TimesCalled
@@ -351,13 +351,13 @@ func evaluateCondition(condition string, u *user.User, s ssh.Session, _ *term.Te
 			} else {
 				userPCR := (float64(u.NumUploads) / float64(numLogons)) * 100
 				result = int(userPCR) >= pcrThreshold
-				log.Printf("DEBUG: ACS 'E' check: Uploads=%d, Calls=%d, PCR=%f, Threshold=%d -> %t", u.NumUploads, numLogons, userPCR, pcrThreshold, result)
+				slog.Debug("ACS 'E' check", "uploads", u.NumUploads, "calls", numLogons, "pcr", userPCR, "threshold", pcrThreshold, "result", result)
 			}
 		}
 	case "H": // Current Hour == value
 		hour, err := strconv.Atoi(value)
 		if err != nil || hour < 0 || hour > 23 {
-			log.Printf("WARN: Invalid hour value in ACS condition '%s': %v", condition, err)
+			slog.Warn("invalid hour value in ACS condition", "condition", condition, "error", err)
 			result = false
 		} else {
 			result = time.Now().Hour() == hour
@@ -365,7 +365,7 @@ func evaluateCondition(condition string, u *user.User, s ssh.Session, _ *term.Te
 	case "P": // File Points >= value
 		points, err := strconv.Atoi(value)
 		if err != nil {
-			log.Printf("WARN: Invalid points value in ACS condition '%s': %v", condition, err)
+			slog.Warn("invalid points value in ACS condition", "condition", condition, "error", err)
 			result = false
 		} else {
 			result = u.FilePoints >= points
@@ -373,24 +373,24 @@ func evaluateCondition(condition string, u *user.User, s ssh.Session, _ *term.Te
 	case "T": // Time Left >= value (minutes)
 		minutesLeftThreshold, err := strconv.Atoi(value)
 		if err != nil {
-			log.Printf("WARN: Invalid time left value in ACS condition '%s': %v", condition, err)
+			slog.Warn("invalid time left value in ACS condition", "condition", condition, "error", err)
 			result = false
 		} else {
 			if u.TimeLimit <= 0 {
-				log.Printf("DEBUG: ACS 'T' check: User has no time limit (TimeLimit=%d), passing.", u.TimeLimit)
+				slog.Debug("ACS 'T' check: user has no time limit, passing", "timeLimit", u.TimeLimit)
 				result = true
 			} else {
 				elapsedSeconds := time.Since(startTime).Seconds()
 				timeLeftSeconds := float64(u.TimeLimit*60) - elapsedSeconds
 				thresholdSeconds := float64(minutesLeftThreshold * 60)
 				result = timeLeftSeconds >= thresholdSeconds
-				log.Printf("DEBUG: ACS 'T' check: Limit=%dm, Elapsed=%.fs, Left=%.fs, Threshold=%ds -> %t", u.TimeLimit, elapsedSeconds, timeLeftSeconds, int(thresholdSeconds), result)
+				slog.Debug("ACS 'T' check", "limitMin", u.TimeLimit, "elapsedSec", elapsedSeconds, "leftSec", timeLeftSeconds, "thresholdSec", int(thresholdSeconds), "result", result)
 			}
 		}
 	case "W": // Day of Week == value (0=Sun, 1=Mon, ... 6=Sat)
 		day, err := strconv.Atoi(value)
 		if err != nil || day < 0 || day > 6 {
-			log.Printf("WARN: Invalid day of week value in ACS condition '%s': %v", condition, err)
+			slog.Warn("invalid day of week value in ACS condition", "condition", condition, "error", err)
 			result = false
 		} else {
 			result = int(time.Now().Weekday()) == day
@@ -400,7 +400,7 @@ func evaluateCondition(condition string, u *user.User, s ssh.Session, _ *term.Te
 	case "Y": // Within Time Range hh:mm/hh:mm
 		parts := strings.Split(value, "/")
 		if len(parts) != 2 {
-			log.Printf("WARN: Invalid time range format in ACS condition '%s': Expected hh:mm/hh:mm", condition)
+			slog.Warn("invalid time range format in ACS condition: expected hh:mm/hh:mm", "condition", condition)
 			result = false
 		} else {
 			startTimeStr := parts[0]
@@ -411,7 +411,7 @@ func evaluateCondition(condition string, u *user.User, s ssh.Session, _ *term.Te
 			endTime, errEnd := time.Parse(layout, endTimeStr)
 
 			if errStart != nil || errEnd != nil {
-				log.Printf("WARN: Invalid time format in ACS time range '%s': %v / %v", value, errStart, errEnd)
+				slog.Warn("invalid time format in ACS time range", "value", value, "startError", errStart, "endError", errEnd)
 				result = false
 			} else {
 				startDateTime := time.Date(now.Year(), now.Month(), now.Day(), startTime.Hour(), startTime.Minute(), 0, 0, now.Location())
@@ -421,13 +421,13 @@ func evaluateCondition(condition string, u *user.User, s ssh.Session, _ *term.Te
 				} else {
 					result = (now.After(startDateTime) || now.Equal(startDateTime)) && (now.Before(endDateTime) || now.Equal(endDateTime))
 				}
-				log.Printf("DEBUG: ACS 'Y' check: Range='%s' Start=%s End=%s Now=%s -> %t", value, startDateTime, endDateTime, now, result)
+				slog.Debug("ACS 'Y' check", "range", value, "start", startDateTime, "end", endDateTime, "now", now, "result", result)
 			}
 		}
 	case "B": // Upload/Download ratio >= value (as percentage)
 		ratioThreshold, err := strconv.Atoi(value)
 		if err != nil {
-			log.Printf("WARN: Invalid ratio value in ACS condition '%s': %v", condition, err)
+			slog.Warn("invalid ratio value in ACS condition", "condition", condition, "error", err)
 			result = false
 		} else {
 			if u.NumDownloads <= 0 {
@@ -437,29 +437,29 @@ func evaluateCondition(condition string, u *user.User, s ssh.Session, _ *term.Te
 				ratio := (float64(u.NumUploads) / float64(u.NumDownloads)) * 100
 				result = int(ratio) >= ratioThreshold
 			}
-			log.Printf("DEBUG: ACS 'B' check: Uploads=%d, Downloads=%d, Threshold=%d%% -> %t", u.NumUploads, u.NumDownloads, ratioThreshold, result)
+			slog.Debug("ACS 'B' check", "uploads", u.NumUploads, "downloads", u.NumDownloads, "threshold", ratioThreshold, "result", result)
 		}
 	case "C": // Message Conference == value
 		confID, err := strconv.Atoi(value)
 		if err != nil {
-			log.Printf("WARN: Invalid conference ID in ACS condition '%s': %v", condition, err)
+			slog.Warn("invalid conference ID in ACS condition", "condition", condition, "error", err)
 			result = false
 		} else {
 			result = u.CurrentMsgConferenceID == confID
 		}
 	case "I": // Internet access flag — user has flag "I" set
 		result = strings.Contains(strings.ToUpper(u.Flags), "I")
-		log.Printf("DEBUG: ACS 'I' check: Flags=%q -> %t", u.Flags, result)
+		slog.Debug("ACS 'I' check", "flags", u.Flags, "result", result)
 	case "X": // File Conference == value
 		confID, err := strconv.Atoi(value)
 		if err != nil {
-			log.Printf("WARN: Invalid conference ID in ACS condition '%s': %v", condition, err)
+			slog.Warn("invalid conference ID in ACS condition", "condition", condition, "error", err)
 			result = false
 		} else {
 			result = u.CurrentFileConferenceID == confID
 		}
 	default:
-		log.Printf("WARN: Unknown ACS code '%s' in condition '%s'", code, condition)
+		slog.Warn("unknown ACS code in condition", "code", code, "condition", condition)
 		result = false
 	}
 

--- a/internal/menu/area_lightbar_conf.go
+++ b/internal/menu/area_lightbar_conf.go
@@ -3,7 +3,7 @@ package menu
 import (
 	"errors"
 	"io"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -28,7 +28,7 @@ func runChangeMsgConferenceLightbar(c *cmdCtx, args string) (*user.User, string,
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running CHANGEMSGCONF (lightbar)", nodeNumber)
+	slog.Debug("running CHANGEMSGCONF (lightbar)", "node", nodeNumber)
 
 	// Resolve terminal dimensions: prefer passed values, then user prefs, then defaults.
 	if termWidth <= 0 && currentUser != nil {
@@ -61,7 +61,7 @@ func runChangeMsgConferenceLightbar(c *cmdCtx, args string) (*user.User, string,
 	midBytes, errMid := readTemplateFile(filepath.Join(templateDir, "MSGCONF.MID"))
 
 	if errTop != nil || errMid != nil {
-		log.Printf("WARN: Node %d: MSGCONF templates unavailable (%v/%v), using text mode", nodeNumber, errTop, errMid)
+		slog.Warn("MSGCONF templates unavailable, using text mode", "node", nodeNumber, "topError", errTop, "midError", errMid)
 		return runChangeMsgConference(&cmdCtx{e: e, s: s, terminal: terminal, userManager: userManager, currentUser: currentUser, nodeNumber: nodeNumber, sessionStartTime: sessionStartTime, outputMode: outputMode, termWidth: termWidth, termHeight: termHeight}, args)
 	}
 
@@ -103,7 +103,7 @@ func runChangeMsgConferenceLightbar(c *cmdCtx, args string) (*user.User, string,
 	// Load optional highlight BAR file (MSGCONFHI.BAR) — same pattern as FILELISTHI.BAR.
 	hiBarOptions, hiBarErr := loadBarFile("MSGCONFHI", e)
 	if hiBarErr != nil {
-		log.Printf("WARN: Node %d: Failed to load MSGCONFHI.BAR: %v", nodeNumber, hiBarErr)
+		slog.Warn("failed to load MSGCONFHI.BAR", "node", nodeNumber, "error", hiBarErr)
 	}
 
 	// Measure header rows using the same pipeline as renderTop.
@@ -349,7 +349,7 @@ func runChangeMsgConferenceLightbar(c *cmdCtx, args string) (*user.User, string,
 			}
 
 			if err := userManager.UpdateUser(currentUser); err != nil {
-				log.Printf("ERROR: Node %d: Failed to save user after conference change: %v", nodeNumber, err)
+				slog.Error("failed to save user after conference change", "node", nodeNumber, "error", err)
 			}
 
 			confName := chosen.name
@@ -364,8 +364,8 @@ func runChangeMsgConferenceLightbar(c *cmdCtx, args string) (*user.User, string,
 			_ = terminalio.WriteProcessedBytes(terminal, []byte(hintLine), outputMode)
 			time.Sleep(1 * time.Second)
 
-			log.Printf("INFO: Node %d: User %s changed to conference %d (%s), area: %s",
-				nodeNumber, currentUser.Handle, chosen.id, confTag, currentUser.CurrentMessageAreaTag)
+			slog.Info("user changed conference",
+				"node", nodeNumber, "handle", currentUser.Handle, "id", chosen.id, "tag", confTag, "area", currentUser.CurrentMessageAreaTag)
 			return currentUser, "", nil
 
 		case editor.KeyEsc:

--- a/internal/menu/area_lightbar_select.go
+++ b/internal/menu/area_lightbar_select.go
@@ -3,7 +3,7 @@ package menu
 import (
 	"errors"
 	"io"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -31,7 +31,7 @@ func runSelectMessageAreaLightbar(c *cmdCtx, args string) (*user.User, string, e
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running SELECTMSGAREA (lightbar)", nodeNumber)
+	slog.Debug("running SELECTMSGAREA (lightbar)", "node", nodeNumber)
 
 	// Resolve terminal dimensions: prefer passed values, then user prefs, then defaults.
 	if termWidth <= 0 && currentUser != nil {
@@ -59,7 +59,7 @@ func runSelectMessageAreaLightbar(c *cmdCtx, args string) (*user.User, string, e
 	midBytes, errMid := readTemplateFile(filepath.Join(templateDir, "MSGAREA.MID"))
 
 	if errTop != nil || errMid != nil {
-		log.Printf("WARN: Node %d: MSGAREA templates unavailable (%v/%v), using text mode", nodeNumber, errTop, errMid)
+		slog.Warn("MSGAREA templates unavailable, using text mode", "node", nodeNumber, "topError", errTop, "midError", errMid)
 		return runSelectMessageArea(&cmdCtx{e: e, s: s, terminal: terminal, userManager: userManager, currentUser: currentUser, nodeNumber: nodeNumber, sessionStartTime: sessionStartTime, outputMode: outputMode, termWidth: termWidth, termHeight: termHeight}, args)
 	}
 
@@ -116,7 +116,7 @@ func runSelectMessageAreaLightbar(c *cmdCtx, args string) (*user.User, string, e
 	// Load optional highlight BAR file (MSGAREAHI.BAR) — same pattern as FILELISTHI.BAR.
 	hiBarOptions, hiBarErr := loadBarFile("MSGAREAHI", e)
 	if hiBarErr != nil {
-		log.Printf("WARN: Node %d: Failed to load MSGAREAHI.BAR: %v", nodeNumber, hiBarErr)
+		slog.Warn("failed to load MSGAREAHI.BAR", "node", nodeNumber, "error", hiBarErr)
 	}
 
 	// Measure header rows using the same pipeline as renderTop so the count
@@ -370,7 +370,7 @@ func runSelectMessageAreaLightbar(c *cmdCtx, args string) (*user.User, string, e
 			currentUser.CurrentMessageAreaTag = area.Tag
 			e.setUserMsgConference(currentUser, area.ConferenceID)
 			if err := userManager.UpdateUser(currentUser); err != nil {
-				log.Printf("ERROR: Node %d: Failed to save user after area change: %v", nodeNumber, err)
+				slog.Error("failed to save user after area change", "node", nodeNumber, "error", err)
 			}
 
 			confirmMsg := "|08[ |15" + area.Name + " |08] |15Area Joined!|07"
@@ -378,8 +378,8 @@ func runSelectMessageAreaLightbar(c *cmdCtx, args string) (*user.User, string, e
 			_ = terminalio.WriteProcessedBytes(terminal, []byte(hintLine), outputMode)
 			time.Sleep(1 * time.Second)
 
-			log.Printf("INFO: Node %d: User %s changed message area to ID %d ('%s')",
-				nodeNumber, currentUser.Handle, area.ID, area.Tag)
+			slog.Info("user changed message area",
+				"node", nodeNumber, "handle", currentUser.Handle, "id", area.ID, "tag", area.Tag)
 			return currentUser, "", nil
 
 		case editor.KeyEsc:

--- a/internal/menu/bbslist.go
+++ b/internal/menu/bbslist.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -138,7 +138,7 @@ func runBBSList(c *cmdCtx, args string) (*user.User, string, error) {
 		return currentUser, "", nil
 	}
 
-	log.Printf("DEBUG: Node %d: Running BBSLIST for user %s", nodeNumber, currentUser.Handle)
+	slog.Debug("running BBSLIST", "node", nodeNumber, "handle", currentUser.Handle)
 
 	// Resolve terminal dimensions.
 	if termWidth <= 0 && currentUser != nil {
@@ -486,7 +486,7 @@ func runBBSList(c *cmdCtx, args string) (*user.User, string, error) {
 								edited.ID = entryID
 								freshBld.Listings[fi] = edited
 								if saveErr := saveBBSListData(e.RootConfigPath, freshBld); saveErr != nil {
-									log.Printf("ERROR: Node %d: failed to save BBS list after edit: %v", nodeNumber, saveErr)
+									slog.Error("failed to save BBS list after edit", "node", nodeNumber, "error", saveErr)
 								} else {
 									bld = freshBld
 									selectedIndex = fi
@@ -513,11 +513,11 @@ func runBBSList(c *cmdCtx, args string) (*user.User, string, error) {
 							if fi := findListingIndexByID(freshBld, entryID); fi >= 0 {
 								freshBld.Listings = append(freshBld.Listings[:fi], freshBld.Listings[fi+1:]...)
 								if saveErr := saveBBSListData(e.RootConfigPath, freshBld); saveErr != nil {
-									log.Printf("ERROR: Node %d: failed to save BBS list after delete: %v", nodeNumber, saveErr)
+									slog.Error("failed to save BBS list after delete", "node", nodeNumber, "error", saveErr)
 								} else {
 									bld = freshBld
-									log.Printf("INFO: Node %d: User %s deleted BBS listing: %s",
-										nodeNumber, currentUser.Handle, entryName)
+									slog.Info("user deleted BBS listing",
+										"node", nodeNumber, "handle", currentUser.Handle, "name", entryName)
 								}
 							}
 						}
@@ -543,12 +543,12 @@ func runBBSList(c *cmdCtx, args string) (*user.User, string, error) {
 								status = "verified"
 							}
 							if saveErr := saveBBSListData(e.RootConfigPath, freshBld); saveErr != nil {
-								log.Printf("ERROR: Node %d: failed to save BBS list after verify toggle: %v", nodeNumber, saveErr)
+								slog.Error("failed to save BBS list after verify toggle", "node", nodeNumber, "error", saveErr)
 							} else {
 								bld = freshBld
 								selectedIndex = fi
-								log.Printf("INFO: Node %d: User %s toggled BBS listing #%d (%s) to %s",
-									nodeNumber, currentUser.Handle, fi+1, freshBld.Listings[fi].Name, status)
+								slog.Info("user toggled BBS listing verification",
+									"node", nodeNumber, "handle", currentUser.Handle, "id", fi+1, "name", freshBld.Listings[fi].Name, "status", status)
 							}
 						}
 					}
@@ -574,7 +574,7 @@ func runBBSListAdd(c *cmdCtx, args string) (*user.User, string, error) {
 		return currentUser, "", nil
 	}
 
-	log.Printf("DEBUG: Node %d: Running BBSLISTADD for user %s", nodeNumber, currentUser.Handle)
+	slog.Debug("running BBSLISTADD", "node", nodeNumber, "handle", currentUser.Handle)
 
 	wv(terminal, ansi.ClearScreen()+"|15Add BBS Listing\r\n", outputMode)
 	wv(terminal, "|08"+strings.Repeat("\xc4", 40)+"\r\n", outputMode)
@@ -706,7 +706,7 @@ func runBBSListAdd(c *cmdCtx, args string) (*user.User, string, error) {
 	bbsListMu.Unlock()
 
 	wv(terminal, "\r\n|10Your entry has been added!\r\n", outputMode)
-	log.Printf("INFO: Node %d: User %s added BBS listing: %s", nodeNumber, currentUser.Handle, name)
+	slog.Info("user added BBS listing", "node", nodeNumber, "handle", currentUser.Handle, "name", name)
 	return currentUser, "", nil
 }
 
@@ -822,7 +822,7 @@ func bbsListEditEntry(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 	}
 
 	wv(terminal, "\r\n|10Entry updated!\r\n", outputMode)
-	log.Printf("INFO: Node %d: User %s edited BBS listing #%d (%s)", nodeNumber, currentUser.Handle, idx+1, entry.Name)
+	slog.Info("user edited BBS listing", "node", nodeNumber, "handle", currentUser.Handle, "id", idx+1, "name", entry.Name)
 	return entry, true
 }
 
@@ -992,7 +992,7 @@ func runBBSListDelete(c *cmdCtx, args string) (*user.User, string, error) {
 	bbsListMu.Unlock()
 
 	wv(terminal, "\r\n|10Entry deleted.\r\n", outputMode)
-	log.Printf("INFO: Node %d: User %s deleted BBS listing: %s", nodeNumber, currentUser.Handle, entry.Name)
+	slog.Info("user deleted BBS listing", "node", nodeNumber, "handle", currentUser.Handle, "name", entry.Name)
 	return currentUser, "", nil
 }
 

--- a/internal/menu/chat.go
+++ b/internal/menu/chat.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -249,7 +249,7 @@ func runChat(c *cmdCtx, args string) (*user.User, string, error) {
 	// Network and room selection — runs in normal terminal mode before full-screen UI.
 	svc, selectedRoom, selectedNetwork, err := chatSelectService(e, s, terminal, handle, outputMode)
 	if err != nil {
-		log.Printf("ERROR: Node %d: chat setup failed: %v", nodeNumber, err)
+		slog.Error("chat setup failed", "node", nodeNumber, "error", err)
 		return nil, "", nil
 	}
 	if svc == nil {
@@ -378,18 +378,18 @@ func runChat(c *cmdCtx, args string) (*user.User, string, error) {
 
 	_, history, err := svc.Join(currentRoom)
 	if err != nil {
-		log.Printf("INFO: Node %d: chat join failed (%v), falling back to local chat", nodeNumber, err)
+		slog.Info("chat join failed, falling back to local chat", "node", nodeNumber, "error", err)
 		svc.Close() //nolint:errcheck
 		dbPath := e.ServerCfg.DataDir + "/chat.db"
 		var localErr error
 		svc, localErr = chat.NewLocalChatService(handle, dbPath)
 		if localErr != nil {
-			log.Printf("ERROR: Node %d: local chat fallback failed: %v", nodeNumber, localErr)
+			slog.Error("local chat fallback failed", "node", nodeNumber, "error", localErr)
 			return nil, "", nil
 		}
 		_, history, err = svc.Join(currentRoom)
 		if err != nil {
-			log.Printf("ERROR: Node %d: local chat join failed: %v", nodeNumber, err)
+			slog.Error("local chat join failed", "node", nodeNumber, "error", err)
 			svc.Close() //nolint:errcheck
 			return nil, "", nil
 		}
@@ -477,7 +477,7 @@ func runChat(c *cmdCtx, args string) (*user.User, string, error) {
 				terminal.SetPrompt("")
 				return nil, "LOGOFF", io.EOF
 			}
-			log.Printf("ERROR: Node %d: Chat input error: %v", nodeNumber, err)
+			slog.Error("chat input error", "node", nodeNumber, "error", err)
 			break
 		}
 
@@ -607,7 +607,7 @@ func runChat(c *cmdCtx, args string) (*user.User, string, error) {
 				}
 			}
 			if err != nil || newSvc == nil {
-				log.Printf("ERROR: Node %d: /network reconnect failed: %v", nodeNumber, err)
+				slog.Error("/network reconnect failed", "node", nodeNumber, "error", err)
 				rawWrite([]byte("\x1B[r"))
 				return nil, "", nil
 			}

--- a/internal/menu/conference_menu.go
+++ b/internal/menu/conference_menu.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -33,7 +33,7 @@ func runChangeMsgConference(c *cmdCtx, args string) (*user.User, string, error) 
 	sessionStartTime := c.sessionStartTime
 	outputMode := c.outputMode
 
-	log.Printf("DEBUG: Node %d: Running CHANGEMSGCONF", nodeNumber)
+	slog.Debug("running CHANGEMSGCONF", "node", nodeNumber)
 
 	if currentUser == nil {
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ConfLoginRequired)), outputMode)
@@ -139,7 +139,7 @@ func runChangeMsgConference(c *cmdCtx, args string) (*user.User, string, error) 
 		}
 
 		if err := userManager.UpdateUser(currentUser); err != nil {
-			log.Printf("ERROR: Node %d: Failed to save user after conference change: %v", nodeNumber, err)
+			slog.Error("failed to save user after conference change", "node", nodeNumber, "error", err)
 		}
 
 		// Display confirmation
@@ -153,8 +153,8 @@ func runChangeMsgConference(c *cmdCtx, args string) (*user.User, string, error) 
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(joinedMsg)), outputMode)
 		time.Sleep(1 * time.Second)
 
-		log.Printf("INFO: Node %d: User %s changed to conference %d (%s), area: %s",
-			nodeNumber, currentUser.Handle, confID, conf.Tag, currentUser.CurrentMessageAreaTag)
+		slog.Info("user changed conference",
+			"node", nodeNumber, "handle", currentUser.Handle, "id", confID, "tag", conf.Tag, "area", currentUser.CurrentMessageAreaTag)
 
 		return currentUser, "", nil
 	}
@@ -194,7 +194,7 @@ func navigateMsgArea(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, us
 	if !forward {
 		direction = "PREVMSGAREA"
 	}
-	log.Printf("DEBUG: Node %d: Running %s", nodeNumber, direction)
+	slog.Debug("running menu command", "node", nodeNumber, "command", direction)
 
 	if currentUser == nil {
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ConfNavLoginRequired)), outputMode)
@@ -235,13 +235,13 @@ func navigateMsgArea(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, us
 	currentUser.CurrentMessageAreaTag = newArea.Tag
 
 	if err := userManager.UpdateUser(currentUser); err != nil {
-		log.Printf("ERROR: Node %d: Failed to save user after area change: %v", nodeNumber, err)
+		slog.Error("failed to save user after area change", "node", nodeNumber, "error", err)
 	}
 
 	msg := fmt.Sprintf(e.LoadedStrings.ConfCurrentAreaFormat, newArea.Name, newArea.Tag)
 	terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 
-	log.Printf("INFO: Node %d: User %s navigated to area %d (%s)", nodeNumber, currentUser.Handle, newArea.ID, newArea.Tag)
+	slog.Info("user navigated to area", "node", nodeNumber, "handle", currentUser.Handle, "id", newArea.ID, "tag", newArea.Tag)
 
 	return currentUser, "", nil
 }
@@ -255,7 +255,7 @@ func displayConferenceList(e *MenuExecutor, s ssh.Session, terminal *term.Termin
 	botBytes, errBot := readTemplateFile(filepath.Join(templateDir, "MSGCONF.BOT"))
 
 	if errTop != nil || errMid != nil || errBot != nil {
-		log.Printf("ERROR: Node %d: Failed to load MSGCONF templates: TOP(%v), MID(%v), BOT(%v)", nodeNumber, errTop, errMid, errBot)
+		slog.Error("failed to load MSGCONF templates", "node", nodeNumber, "topError", errTop, "midError", errMid, "botError", errBot)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ConfTemplateError)), outputMode)
 		return nil, fmt.Errorf("failed loading MSGCONF templates")
 	}
@@ -304,7 +304,7 @@ func displayConferenceList(e *MenuExecutor, s ssh.Session, terminal *term.Termin
 // displayMessageAreaListFiltered is like displayMessageAreaList but filters to a single conference.
 // If filterConfID is -1, all conferences are shown (same as unfiltered behavior).
 func displayMessageAreaListFiltered(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, currentUser *user.User, outputMode ansi.OutputMode, nodeNumber int, sessionStartTime time.Time, filterConfID int) ([]*message.MessageArea, error) {
-	log.Printf("DEBUG: Node %d: Displaying message area list (filtered, confID=%d)", nodeNumber, filterConfID)
+	slog.Debug("displaying message area list (filtered)", "node", nodeNumber, "confID", filterConfID)
 
 	templateDir := filepath.Join(e.MenuSetPath, "templates")
 	topTemplateBytes, errTop := readTemplateFile(filepath.Join(templateDir, "MSGAREA.TOP"))
@@ -312,7 +312,7 @@ func displayMessageAreaListFiltered(e *MenuExecutor, s ssh.Session, terminal *te
 	botTemplateBytes, errBot := readTemplateFile(filepath.Join(templateDir, "MSGAREA.BOT"))
 
 	if errTop != nil || errMid != nil || errBot != nil {
-		log.Printf("ERROR: Node %d: Failed to load MSGAREA template files: TOP(%v), MID(%v), BOT(%v)", nodeNumber, errTop, errMid, errBot)
+		slog.Error("failed to load MSGAREA template files", "node", nodeNumber, "topError", errTop, "midError", errMid, "botError", errBot)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ConfAreaTemplateError)), outputMode)
 		time.Sleep(1 * time.Second)
 		return nil, fmt.Errorf("failed loading MSGAREA templates")
@@ -473,7 +473,7 @@ func navigateMsgConf(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, us
 	if !forward {
 		direction = "PREVMSGCONF"
 	}
-	log.Printf("DEBUG: Node %d: Running %s", nodeNumber, direction)
+	slog.Debug("running menu command", "node", nodeNumber, "command", direction)
 
 	if currentUser == nil {
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ConfNavLoginRequired)), outputMode)
@@ -533,7 +533,7 @@ func navigateMsgConf(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, us
 	}
 
 	if err := userManager.UpdateUser(currentUser); err != nil {
-		log.Printf("ERROR: Node %d: Failed to save user after conference change: %v", nodeNumber, err)
+		slog.Error("failed to save user after conference change", "node", nodeNumber, "error", err)
 	}
 
 	msg := e.LoadedStrings.ConfCurrentConfFormat
@@ -543,7 +543,7 @@ func navigateMsgConf(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, us
 	formatted := fmt.Sprintf(msg, newConf.Name, newConf.Tag)
 	terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(formatted)), outputMode)
 
-	log.Printf("INFO: Node %d: User %s navigated to conference %d (%s)", nodeNumber, currentUser.Handle, newConf.ID, newConf.Tag)
+	slog.Info("user navigated to conference", "node", nodeNumber, "handle", currentUser.Handle, "id", newConf.ID, "tag", newConf.Tag)
 
 	return currentUser, "", nil
 }

--- a/internal/menu/door_handler.go
+++ b/internal/menu/door_handler.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -49,8 +49,8 @@ func executeCleanup(ctx *DoorCtx) {
 		substitutedArgs[i] = newArg
 	}
 
-	log.Printf("INFO: Node %d: Running cleanup command for door '%s': %s %v",
-		ctx.NodeNumber, ctx.DoorName, ctx.Config.CleanupCommand, substitutedArgs)
+	slog.Info("running cleanup command for door",
+		"node", ctx.NodeNumber, "door", ctx.DoorName, "command", ctx.Config.CleanupCommand, "args", substitutedArgs)
 
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
 	defer cancel()
@@ -63,14 +63,14 @@ func executeCleanup(ctx *DoorCtx) {
 
 	if output, err := cmd.CombinedOutput(); err != nil {
 		if cleanupCtx.Err() == context.DeadlineExceeded {
-			log.Printf("WARN: Node %d: Cleanup command for door '%s' timed out after %v",
-				ctx.NodeNumber, ctx.DoorName, cleanupTimeout)
+			slog.Warn("cleanup command for door timed out",
+				"node", ctx.NodeNumber, "door", ctx.DoorName, "timeout", cleanupTimeout)
 		} else {
-			log.Printf("WARN: Node %d: Cleanup command for door '%s' failed: %v (output: %s)",
-				ctx.NodeNumber, ctx.DoorName, err, string(output))
+			slog.Warn("cleanup command for door failed",
+				"node", ctx.NodeNumber, "door", ctx.DoorName, "error", err, "output", string(output))
 		}
 	} else {
-		log.Printf("DEBUG: Node %d: Cleanup command for door '%s' completed successfully", ctx.NodeNumber, ctx.DoorName)
+		slog.Debug("cleanup command for door completed successfully", "node", ctx.NodeNumber, "door", ctx.DoorName)
 	}
 }
 
@@ -84,10 +84,10 @@ func executeDoor(ctx *DoorCtx) error {
 	if ctx.Config.SingleInstance {
 		if err := acquireDoorLock(ctx.DoorName, ctx.NodeNumber); err != nil {
 			if errors.Is(err, ErrDoorBusy) {
-				log.Printf("WARN: Node %d: Door '%s' is already in use by another node", ctx.NodeNumber, ctx.DoorName)
+				slog.Warn("door already in use by another node", "node", ctx.NodeNumber, "door", ctx.DoorName)
 				return fmt.Errorf("%w: %s", ErrDoorBusy, ctx.DoorName)
 			}
-			log.Printf("ERROR: Node %d: Failed to acquire lock for door '%s': %v", ctx.NodeNumber, ctx.DoorName, err)
+			slog.Error("failed to acquire lock for door", "node", ctx.NodeNumber, "door", ctx.DoorName, "error", err)
 			return fmt.Errorf("failed to acquire door lock: %w", err)
 		}
 		defer releaseDoorLock(ctx.DoorName, ctx.NodeNumber)
@@ -112,7 +112,7 @@ func doorErrorMessage(ctx *DoorCtx, msg string) {
 	errMsg := fmt.Sprintf(ctx.Executor.LoadedStrings.DoorErrorFormat, msg)
 	wErr := terminalio.WriteProcessedBytes(ctx.Session.Stderr(), ansi.ReplacePipeCodes([]byte(errMsg)), ctx.OutputMode)
 	if wErr != nil {
-		log.Printf("ERROR: Failed writing door error message: %v", wErr)
+		slog.Error("failed writing door error message", "error", wErr)
 	}
 }
 
@@ -126,7 +126,7 @@ func runListDoors(c *cmdCtx, args string) (*user.User, string, error) {
 	nodeNumber := c.nodeNumber
 	outputMode := c.outputMode
 
-	log.Printf("DEBUG: Node %d: Running LISTDOORS", nodeNumber)
+	slog.Debug("running LISTDOORS", "node", nodeNumber)
 
 	if currentUser == nil {
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.DoorLoginRequired)), outputMode)
@@ -144,7 +144,7 @@ func runListDoors(c *cmdCtx, args string) (*user.User, string, error) {
 	botBytes, errBot := readTemplateFile(botPath)
 
 	if errTop != nil || errMid != nil || errBot != nil {
-		log.Printf("ERROR: Node %d: Failed to load DOORLIST templates: TOP(%v), MID(%v), BOT(%v)", nodeNumber, errTop, errMid, errBot)
+		slog.Error("failed to load DOORLIST templates", "node", nodeNumber, "topError", errTop, "midError", errMid, "botError", errBot)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.DoorTemplateError)), outputMode)
 		time.Sleep(1 * time.Second)
 		return currentUser, "", nil
@@ -232,7 +232,7 @@ func runOpenDoor(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running OPENDOOR", nodeNumber)
+	slog.Debug("running OPENDOOR", "node", nodeNumber)
 
 	if currentUser == nil {
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.DoorLoginRequired)), outputMode)
@@ -252,7 +252,7 @@ func runOpenDoor(c *cmdCtx, args string) (*user.User, string, error) {
 			if errors.Is(err, io.EOF) {
 				return nil, "LOGOFF", io.EOF
 			}
-			log.Printf("ERROR: Node %d: Error reading OPENDOOR input: %v", nodeNumber, err)
+			slog.Error("error reading OPENDOOR input", "node", nodeNumber, "error", err)
 			return currentUser, "", err
 		}
 
@@ -288,8 +288,8 @@ func runOpenDoor(c *cmdCtx, args string) (*user.User, string, error) {
 
 		// Check per-door access level
 		if doorConfig.MinAccessLevel > 0 && currentUser.AccessLevel < doorConfig.MinAccessLevel {
-			log.Printf("WARN: Node %d: User %s (level %d) denied access to door %s (requires %d)",
-				nodeNumber, currentUser.Handle, currentUser.AccessLevel, upperInput, doorConfig.MinAccessLevel)
+			slog.Warn("user denied access to door",
+				"node", nodeNumber, "handle", currentUser.Handle, "level", currentUser.AccessLevel, "door", upperInput, "required", doorConfig.MinAccessLevel)
 			msg := fmt.Sprintf(e.LoadedStrings.DoorAccessDenied, upperInput)
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 			time.Sleep(1 * time.Second)
@@ -312,7 +312,7 @@ func runOpenDoor(c *cmdCtx, args string) (*user.User, string, error) {
 
 		if cmdErr != nil {
 			if errors.Is(cmdErr, ErrDoorBusy) {
-				log.Printf("INFO: Node %d: Door %s is busy for user %s", nodeNumber, upperInput, currentUser.Handle)
+				slog.Info("door is busy for user", "node", nodeNumber, "door", upperInput, "handle", currentUser.Handle)
 				busyFmt := e.LoadedStrings.DoorBusyFormat
 				if strings.TrimSpace(busyFmt) == "" {
 					busyFmt = "\r\n|14Door is currently in use: |11%s|07\r\n"
@@ -321,11 +321,11 @@ func runOpenDoor(c *cmdCtx, args string) (*user.User, string, error) {
 				terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(busyMsg)), outputMode)
 				time.Sleep(1 * time.Second)
 			} else {
-				log.Printf("ERROR: Node %d: Door execution failed for user %s, door %s: %v", nodeNumber, currentUser.Handle, upperInput, cmdErr)
+				slog.Error("door execution failed", "node", nodeNumber, "handle", currentUser.Handle, "door", upperInput, "error", cmdErr)
 				doorErrorMessage(ctx, fmt.Sprintf("Error running door '%s': %v", upperInput, cmdErr))
 			}
 		} else {
-			log.Printf("INFO: Node %d: Door completed for user %s, door %s", nodeNumber, currentUser.Handle, upperInput)
+			slog.Info("door completed", "node", nodeNumber, "handle", currentUser.Handle, "door", upperInput)
 		}
 
 		return currentUser, "", nil
@@ -345,7 +345,7 @@ func runDoorInfo(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running DOORINFO", nodeNumber)
+	slog.Debug("running DOORINFO", "node", nodeNumber)
 
 	if currentUser == nil {
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.DoorInfoLoginRequired)), outputMode)
@@ -365,7 +365,7 @@ func runDoorInfo(c *cmdCtx, args string) (*user.User, string, error) {
 			if errors.Is(err, io.EOF) {
 				return nil, "LOGOFF", io.EOF
 			}
-			log.Printf("ERROR: Node %d: Error reading DOORINFO input: %v", nodeNumber, err)
+			slog.Error("error reading DOORINFO input", "node", nodeNumber, "error", err)
 			return currentUser, "", err
 		}
 
@@ -401,8 +401,8 @@ func runDoorInfo(c *cmdCtx, args string) (*user.User, string, error) {
 
 		// Check per-door access level
 		if doorConfig.MinAccessLevel > 0 && currentUser.AccessLevel < doorConfig.MinAccessLevel {
-			log.Printf("WARN: Node %d: User %s (level %d) denied access to door info %s (requires %d)",
-				nodeNumber, currentUser.Handle, currentUser.AccessLevel, upperInput, doorConfig.MinAccessLevel)
+			slog.Warn("user denied access to door info",
+				"node", nodeNumber, "handle", currentUser.Handle, "level", currentUser.AccessLevel, "door", upperInput, "required", doorConfig.MinAccessLevel)
 			msg := fmt.Sprintf(e.LoadedStrings.DoorAccessDenied, upperInput)
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 			time.Sleep(1 * time.Second)

--- a/internal/menu/door_handler_dos.go
+++ b/internal/menu/door_handler_dos.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -33,7 +33,7 @@ func dosDropfileName(dropfileType string) string {
 
 // writeBatchFile generates EXTERNAL.BAT for dosemu2 execution.
 func writeBatchFile(ctx *DoorCtx, batchPath string) error {
-	log.Printf("INFO: Writing batch file: %s", batchPath)
+	slog.Info("writing batch file", "path", batchPath)
 	crlf := "\r\n"
 
 	var b strings.Builder
@@ -87,7 +87,7 @@ func writeBatchFile(ctx *DoorCtx, batchPath string) error {
 // writeDosemurc generates a per-node dosemurc config file that points
 // $_hdimage at the correct drive_c path and allows lredir to the node dir.
 func writeDosemurc(ctx *DoorCtx, rcPath, driveCPath, nodePath string) error {
-	log.Printf("INFO: Writing dosemurc: %s (drive_c=%s)", rcPath, driveCPath)
+	slog.Info("writing dosemurc", "path", rcPath, "driveC", driveCPath)
 
 	// Start from the user's custom config if one exists, otherwise use defaults
 	baseConfig := ctx.Config.DosemuConfig
@@ -227,7 +227,7 @@ func executeDOSDoor(ctx *DoorCtx) error {
 		"-o", logPath,
 	)
 
-	log.Printf("INFO: Node %d: Launching DOS door '%s' via dosemu2: %s %v", ctx.NodeNumber, ctx.DoorName, dosemuPath, args)
+	slog.Info("launching DOS door via dosemu2", "node", ctx.NodeNumber, "door", ctx.DoorName, "path", dosemuPath, "args", args)
 
 	cmd := exec.Command(dosemuPath, args...)
 	cmd.Dir = driveCPath
@@ -282,7 +282,7 @@ func executeDOSDoor(ctx *DoorCtx) error {
 		defer close(inputDone)
 		_, err := io.Copy(ptmx, ctx.Session)
 		if err != nil && err != io.EOF && !errors.Is(err, os.ErrClosed) {
-			log.Printf("WARN: Node %d: Error copying session stdin to dosemu PTY: %v", ctx.NodeNumber, err)
+			slog.Warn("error copying session stdin to dosemu PTY", "node", ctx.NodeNumber, "error", err)
 		}
 	}()
 	go func() {
@@ -294,7 +294,7 @@ func executeDOSDoor(ctx *DoorCtx) error {
 			// the door starts. Door output (via FOSSIL → COM1 → PTY) contains
 			// ANSI escape codes. Gate on the first ESC (0x1B) byte to suppress
 			// boot text while forwarding all door output.
-			log.Printf("DEBUG: Node %d: FOSSIL mode — gating boot text until first ESC byte", ctx.NodeNumber)
+			slog.Debug("FOSSIL mode — gating boot text until first ESC byte", "node", ctx.NodeNumber)
 			var accum []byte
 			gated := true
 			for {
@@ -306,10 +306,10 @@ func executeDOSDoor(ctx *DoorCtx) error {
 							gated = false
 							ctx.Session.Write(accum[idx:])
 							accum = nil
-							log.Printf("DEBUG: Node %d: FOSSIL boot text gate opened (ESC byte at offset %d)", ctx.NodeNumber, idx)
+							slog.Debug("FOSSIL boot text gate opened", "node", ctx.NodeNumber, "offset", idx)
 						}
 						if gated && len(accum) > 32768 {
-							log.Printf("WARN: Node %d: FOSSIL gate: no ESC after 32KB, flushing", ctx.NodeNumber)
+							slog.Warn("FOSSIL gate: no ESC after 32KB, flushing", "node", ctx.NodeNumber)
 							gated = false
 							ctx.Session.Write(accum)
 							accum = nil
@@ -320,10 +320,10 @@ func executeDOSDoor(ctx *DoorCtx) error {
 				}
 				if err != nil {
 					if gated && len(accum) > 0 {
-						log.Printf("WARN: Node %d: FOSSIL boot text gate never opened. Accumulated %d bytes", ctx.NodeNumber, len(accum))
+						slog.Warn("FOSSIL boot text gate never opened", "node", ctx.NodeNumber, "bytes", len(accum))
 					}
 					if err != io.EOF && !errors.Is(err, os.ErrClosed) {
-						log.Printf("WARN: Node %d: Error copying dosemu PTY to session: %v", ctx.NodeNumber, err)
+						slog.Warn("error copying dosemu PTY to session", "node", ctx.NodeNumber, "error", err)
 					}
 					return
 				}
@@ -345,11 +345,11 @@ func executeDOSDoor(ctx *DoorCtx) error {
 						gated = false
 						ctx.Session.Write(accum[idx:])
 						accum = nil
-						log.Printf("DEBUG: Node %d: DOS boot text gate opened (clear screen detected)", ctx.NodeNumber)
+						slog.Debug("DOS boot text gate opened (clear screen detected)", "node", ctx.NodeNumber)
 					}
 					// Safety: if we've accumulated too much without finding cls, flush it
 					if gated && len(accum) > 32768 {
-						log.Printf("WARN: Node %d: Clear screen not found after 32KB, flushing", ctx.NodeNumber)
+						slog.Warn("clear screen not found after 32KB, flushing", "node", ctx.NodeNumber)
 						gated = false
 						ctx.Session.Write(accum)
 						accum = nil
@@ -360,10 +360,10 @@ func executeDOSDoor(ctx *DoorCtx) error {
 			}
 			if err != nil {
 				if gated && len(accum) > 0 {
-					log.Printf("WARN: Node %d: DOS boot text gate never opened. Accumulated %d bytes. First 200: %q", ctx.NodeNumber, len(accum), accum[:min(200, len(accum))])
+					slog.Warn("DOS boot text gate never opened", "node", ctx.NodeNumber, "bytes", len(accum), "first200", accum[:min(200, len(accum))])
 				}
 				if err != io.EOF && !errors.Is(err, os.ErrClosed) {
-					log.Printf("WARN: Node %d: Error copying dosemu PTY to session: %v", ctx.NodeNumber, err)
+					slog.Warn("error copying dosemu PTY to session", "node", ctx.NodeNumber, "error", err)
 				}
 				return
 			}
@@ -372,7 +372,7 @@ func executeDOSDoor(ctx *DoorCtx) error {
 
 	// Wait for dosemu to exit, then cleanly shut down I/O goroutines
 	cmdErr := cmd.Wait()
-	log.Printf("DEBUG: Node %d: dosemu2 process exited for door '%s'", ctx.NodeNumber, ctx.DoorName)
+	slog.Debug("dosemu2 process exited", "node", ctx.NodeNumber, "door", ctx.DoorName)
 
 	// Interrupt the input goroutine's blocked Read() so it exits without
 	// consuming the user's next keypress, then close the PTY.
@@ -384,9 +384,9 @@ func executeDOSDoor(ctx *DoorCtx) error {
 	<-outputDone
 
 	if cmdErr != nil {
-		log.Printf("ERROR: Node %d: DOS door '%s' failed: %v", ctx.NodeNumber, ctx.DoorName, cmdErr)
+		slog.Error("DOS door failed", "node", ctx.NodeNumber, "door", ctx.DoorName, "error", cmdErr)
 	} else {
-		log.Printf("INFO: Node %d: DOS door '%s' completed successfully", ctx.NodeNumber, ctx.DoorName)
+		slog.Info("DOS door completed successfully", "node", ctx.NodeNumber, "door", ctx.DoorName)
 	}
 
 	// Run cleanup while dropfiles/node dirs still exist (before deferred cleanup fires)

--- a/internal/menu/door_handler_dropfiles.go
+++ b/internal/menu/door_handler_dropfiles.go
@@ -2,7 +2,7 @@ package menu
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -88,7 +88,7 @@ func buildDoorCtx(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 // generateDoorSys writes a full 52-line PCBoard DOOR.SYS file.
 func generateDoorSys(ctx *DoorCtx, dir string) error {
 	path := filepath.Join(dir, "DOOR.SYS")
-	log.Printf("INFO: Generating DOOR.SYS at: %s", path)
+	slog.Info("generating DOOR.SYS", "path", path)
 
 	bbsName := ctx.Executor.ServerCfg.BoardName
 	timeLeftSecs := ctx.TimeLeftMin * 60
@@ -161,7 +161,7 @@ func generateDoorSys(ctx *DoorCtx, dir string) error {
 // generateDoor32Sys writes an 11-line DOOR32.SYS file.
 func generateDoor32Sys(ctx *DoorCtx, dir string) error {
 	path := filepath.Join(dir, "DOOR32.SYS")
-	log.Printf("INFO: Generating DOOR32.SYS at: %s", path)
+	slog.Info("generating DOOR32.SYS", "path", path)
 
 	bbsName := ctx.Executor.ServerCfg.BoardName
 	crlf := "\r\n"
@@ -185,7 +185,7 @@ func generateDoor32Sys(ctx *DoorCtx, dir string) error {
 // generateDorInfo writes a 13-line DORINFO1.DEF file.
 func generateDorInfo(ctx *DoorCtx, dir string) error {
 	path := filepath.Join(dir, "DORINFO1.DEF")
-	log.Printf("INFO: Generating DORINFO1.DEF at: %s", path)
+	slog.Info("generating DORINFO1.DEF", "path", path)
 
 	bbsName := ctx.Executor.ServerCfg.BoardName
 	crlf := "\r\n"
@@ -226,7 +226,7 @@ func generateDorInfo(ctx *DoorCtx, dir string) error {
 // generateChainTxt writes a CHAIN.TXT file (WWIV format).
 func generateChainTxt(ctx *DoorCtx, dir string) error {
 	path := filepath.Join(dir, "CHAIN.TXT")
-	log.Printf("INFO: Generating CHAIN.TXT at: %s", path)
+	slog.Info("generating CHAIN.TXT", "path", path)
 
 	bbsName := ctx.Executor.ServerCfg.BoardName
 	timeLeftSecs := ctx.TimeLeftMin * 60
@@ -296,7 +296,7 @@ func generateAllDropfiles(ctx *DoorCtx, dir string) error {
 		return fmt.Errorf("failed to generate CHAIN.TXT: %w", err)
 	}
 
-	log.Printf("INFO: All dropfiles generated in %s", dir)
+	slog.Info("all dropfiles generated", "dir", dir)
 	return nil
 }
 
@@ -306,8 +306,8 @@ func cleanupDropfiles(dir string) {
 	for _, f := range files {
 		path := filepath.Join(dir, f)
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-			log.Printf("WARN: Failed to remove %s: %v", path, err)
+			slog.Warn("failed to remove dropfile", "path", path, "error", err)
 		}
 	}
-	log.Printf("DEBUG: Cleaned up dropfiles in %s", dir)
+	slog.Debug("cleaned up dropfiles", "dir", dir)
 }

--- a/internal/menu/door_handler_native.go
+++ b/internal/menu/door_handler_native.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -44,7 +44,7 @@ func executeNativeDoor(ctx *DoorCtx) error {
 		}
 		defer func() {
 			if err := os.RemoveAll(nodeDir); err != nil {
-				log.Printf("WARN: Failed to remove node dropfile dir %s: %v", nodeDir, err)
+				slog.Warn("failed to remove node dropfile dir", "dir", nodeDir, "error", err)
 			}
 		}()
 		dropfileDir = nodeDir
@@ -54,7 +54,7 @@ func executeNativeDoor(ctx *DoorCtx) error {
 
 	if dropfileTypeUpper == "DOOR.SYS" || dropfileTypeUpper == "CHAIN.TXT" || dropfileTypeUpper == "DOOR32.SYS" || dropfileTypeUpper == "DORINFO1.DEF" {
 		dropfilePath = filepath.Join(dropfileDir, dropfileTypeUpper)
-		log.Printf("INFO: Generating %s dropfile at: %s", dropfileTypeUpper, dropfilePath)
+		slog.Info("generating dropfile", "type", dropfileTypeUpper, "path", dropfilePath)
 
 		// Use full-format dropfile generators (standard BBS formats)
 		var genErr error
@@ -70,18 +70,18 @@ func executeNativeDoor(ctx *DoorCtx) error {
 		}
 
 		if genErr != nil {
-			log.Printf("ERROR: Failed to write dropfile %s: %v", dropfilePath, genErr)
+			slog.Error("failed to write dropfile", "path", dropfilePath, "error", genErr)
 			errMsg := fmt.Sprintf(ctx.Executor.LoadedStrings.DoorDropfileError, ctx.DoorName)
 			if wErr := terminalio.WriteProcessedBytes(ctx.Session.Stderr(), ansi.ReplacePipeCodes([]byte(errMsg)), ctx.OutputMode); wErr != nil {
-				log.Printf("ERROR: Failed writing dropfile creation error message: %v", wErr)
+				slog.Error("failed writing dropfile creation error message", "error", wErr)
 			}
 			return genErr
 		}
 
 		defer func() {
-			log.Printf("DEBUG: Cleaning up dropfile: %s", dropfilePath)
+			slog.Debug("cleaning up dropfile", "path", dropfilePath)
 			if err := os.Remove(dropfilePath); err != nil {
-				log.Printf("WARN: Failed to remove dropfile %s: %v", dropfilePath, err)
+				slog.Warn("failed to remove dropfile", "path", dropfilePath, "error", err)
 			}
 		}()
 	}
@@ -128,14 +128,14 @@ func executeNativeDoor(ctx *DoorCtx) error {
 		// Use exec "$0" "$@" to preserve argument boundaries and prevent injection
 		shellArgs := append([]string{"-c", `exec "$0" "$@"`, doorCommand}, substitutedArgs...)
 		cmd = exec.Command("/bin/sh", shellArgs...)
-		log.Printf("DEBUG: Node %d: Using shell execution for %q with %d arg(s)", ctx.NodeNumber, doorCommand, len(substitutedArgs))
+		slog.Debug("using shell execution", "node", ctx.NodeNumber, "command", doorCommand, "argCount", len(substitutedArgs))
 	} else {
 		cmd = exec.Command(doorCommand, substitutedArgs...)
 	}
 
 	if doorConfig.WorkingDirectory != "" {
 		cmd.Dir = doorConfig.WorkingDirectory
-		log.Printf("DEBUG: Setting working directory for door '%s' to '%s'", ctx.DoorName, cmd.Dir)
+		slog.Debug("setting working directory for door", "door", ctx.DoorName, "dir", cmd.Dir)
 	}
 
 	// Set environment variables
@@ -181,14 +181,14 @@ func executeNativeDoor(ctx *DoorCtx) error {
 		}
 	}
 	cmd.Env = append(filteredEnv, fmt.Sprintf("LINES=%d", screenHeight), fmt.Sprintf("COLUMNS=%d", screenWidth))
-	log.Printf("DEBUG: Node %d: Set door env LINES=%d COLUMNS=%d", ctx.NodeNumber, screenHeight, screenWidth)
+	slog.Debug("set door env LINES/COLUMNS", "node", ctx.NodeNumber, "lines", screenHeight, "columns", screenWidth)
 
 	// Execute command
 	_, winChOrig, isPty := ctx.Session.Pty()
 	var cmdErr error
 
 	if doorConfig.RequiresRawTerminal && isPty {
-		log.Printf("INFO: Node %d: Starting door '%s' with PTY/Raw mode", ctx.NodeNumber, ctx.DoorName)
+		slog.Info("starting door with PTY/Raw mode", "node", ctx.NodeNumber, "door", ctx.DoorName)
 
 		// Set PTY size from user's saved preferences - BEFORE starting the command
 		doorScreenHeight := uint16(25) // default
@@ -200,7 +200,7 @@ func executeNativeDoor(ctx *DoorCtx) error {
 			doorScreenWidth = uint16(ctx.User.ScreenWidth)
 		}
 		doorSize := &pty.Winsize{Rows: doorScreenHeight, Cols: doorScreenWidth}
-		log.Printf("DEBUG: Node %d: Starting door with PTY size %dx%d (from user preferences)", ctx.NodeNumber, doorScreenWidth, doorScreenHeight)
+		slog.Debug("starting door with PTY size from user preferences", "node", ctx.NodeNumber, "width", doorScreenWidth, "height", doorScreenHeight)
 
 		ptmx, err := pty.StartWithSize(cmd, doorSize)
 		if err != nil {
@@ -219,8 +219,8 @@ func executeNativeDoor(ctx *DoorCtx) error {
 						if !ok {
 							return
 						}
-						log.Printf("DEBUG: Node %d: Ignoring SSH resize event %dx%d (keeping user preference %dx%d)",
-							ctx.NodeNumber, win.Width, win.Height, doorScreenWidth, doorScreenHeight)
+						slog.Debug("ignoring SSH resize event, keeping user preference",
+							"node", ctx.NodeNumber, "width", win.Width, "height", win.Height, "prefWidth", doorScreenWidth, "prefHeight", doorScreenHeight)
 					case <-resizeStop:
 						return
 					}
@@ -230,9 +230,9 @@ func executeNativeDoor(ctx *DoorCtx) error {
 			fd := int(ptmx.Fd())
 			originalState, err := term.MakeRaw(fd)
 			if err != nil {
-				log.Printf("WARN: Node %d: Failed to put PTY into raw mode for door '%s': %v.", ctx.NodeNumber, ctx.DoorName, err)
+				slog.Warn("failed to put PTY into raw mode for door", "node", ctx.NodeNumber, "door", ctx.DoorName, "error", err)
 			} else {
-				log.Printf("DEBUG: Node %d: PTY set to raw mode for door '%s'.", ctx.NodeNumber, ctx.DoorName)
+				slog.Debug("PTY set to raw mode for door", "node", ctx.NodeNumber, "door", ctx.DoorName)
 			}
 			needsRestore := (err == nil)
 
@@ -257,9 +257,9 @@ func executeNativeDoor(ctx *DoorCtx) error {
 				if err != nil && err != io.EOF && !errors.Is(err, os.ErrClosed) {
 					// "read interrupted" is expected when we close readInterrupt during shutdown
 					if strings.Contains(err.Error(), "read interrupted") {
-						log.Printf("DEBUG: Node %d: Input goroutine interrupted for door '%s' (expected during shutdown)", ctx.NodeNumber, ctx.DoorName)
+						slog.Debug("input goroutine interrupted for door (expected during shutdown)", "node", ctx.NodeNumber, "door", ctx.DoorName)
 					} else {
-						log.Printf("WARN: Node %d: Error copying session stdin to PTY for door '%s': %v", ctx.NodeNumber, ctx.DoorName, err)
+						slog.Warn("error copying session stdin to PTY for door", "node", ctx.NodeNumber, "door", ctx.DoorName, "error", err)
 					}
 				}
 			}()
@@ -269,9 +269,9 @@ func executeNativeDoor(ctx *DoorCtx) error {
 				if err != nil && err != io.EOF && !errors.Is(err, os.ErrClosed) {
 					// "input/output error" on PTY is expected when closing during active read
 					if strings.Contains(err.Error(), "input/output error") {
-						log.Printf("DEBUG: Node %d: Output goroutine I/O error for door '%s' (expected during shutdown)", ctx.NodeNumber, ctx.DoorName)
+						slog.Debug("output goroutine I/O error for door (expected during shutdown)", "node", ctx.NodeNumber, "door", ctx.DoorName)
 					} else {
-						log.Printf("WARN: Node %d: Error copying PTY stdout to session for door '%s': %v", ctx.NodeNumber, ctx.DoorName, err)
+						slog.Warn("error copying PTY stdout to session for door", "node", ctx.NodeNumber, "door", ctx.DoorName, "error", err)
 					}
 				}
 			}()
@@ -279,7 +279,7 @@ func executeNativeDoor(ctx *DoorCtx) error {
 			// Wait for door to exit, then cleanly shut down I/O goroutines
 			cmdErr = cmd.Wait()
 			close(resizeStop)
-			log.Printf("DEBUG: Node %d: Door '%s' process exited", ctx.NodeNumber, ctx.DoorName)
+			slog.Debug("door process exited", "node", ctx.NodeNumber, "door", ctx.DoorName)
 
 			// Interrupt the input goroutine's blocked Read() so it exits without
 			// consuming the user's next keypress, then restore PTY state and close.
@@ -290,9 +290,9 @@ func executeNativeDoor(ctx *DoorCtx) error {
 
 			// Restore PTY state before closing the file descriptor
 			if needsRestore {
-				log.Printf("DEBUG: Node %d: Restoring PTY mode after door '%s'.", ctx.NodeNumber, ctx.DoorName)
+				slog.Debug("restoring PTY mode after door", "node", ctx.NodeNumber, "door", ctx.DoorName)
 				if err := term.Restore(fd, originalState); err != nil {
-					log.Printf("ERROR: Node %d: Failed to restore PTY state after door '%s': %v", ctx.NodeNumber, ctx.DoorName, err)
+					slog.Error("failed to restore PTY state after door", "node", ctx.NodeNumber, "door", ctx.DoorName, "error", err)
 				}
 			}
 
@@ -302,7 +302,7 @@ func executeNativeDoor(ctx *DoorCtx) error {
 	} else if strings.ToUpper(doorConfig.IOMode) == "SOCKET" {
 		// Socket I/O: create a Unix socketpair and pass one end to the door as FD 3.
 		// The other end is bridged bidirectionally to the BBS session.
-		log.Printf("INFO: Node %d: Starting door '%s' with Socket I/O mode", ctx.NodeNumber, ctx.DoorName)
+		slog.Info("starting door with Socket I/O mode", "node", ctx.NodeNumber, "door", ctx.DoorName)
 
 		fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
 		if err != nil {
@@ -340,7 +340,7 @@ func executeNativeDoor(ctx *DoorCtx) error {
 					_, err := io.Copy(bbsSock, ctx.Session)
 					if err != nil && err != io.EOF && !errors.Is(err, os.ErrClosed) {
 						if !strings.Contains(err.Error(), "read interrupted") {
-							log.Printf("WARN: Node %d: Socket I/O input error for door '%s': %v", ctx.NodeNumber, ctx.DoorName, err)
+							slog.Warn("socket I/O input error for door", "node", ctx.NodeNumber, "door", ctx.DoorName, "error", err)
 						}
 					}
 				}()
@@ -348,12 +348,12 @@ func executeNativeDoor(ctx *DoorCtx) error {
 					defer close(outputDone)
 					_, err := io.Copy(ctx.Session, bbsSock)
 					if err != nil && err != io.EOF && !errors.Is(err, os.ErrClosed) {
-						log.Printf("WARN: Node %d: Socket I/O output error for door '%s': %v", ctx.NodeNumber, ctx.DoorName, err)
+						slog.Warn("socket I/O output error for door", "node", ctx.NodeNumber, "door", ctx.DoorName, "error", err)
 					}
 				}()
 
 				cmdErr = cmd.Wait()
-				log.Printf("DEBUG: Node %d: Door '%s' (socket I/O) process exited", ctx.NodeNumber, ctx.DoorName)
+				slog.Debug("door (socket I/O) process exited", "node", ctx.NodeNumber, "door", ctx.DoorName)
 
 				close(readInterrupt)
 				if hasInterrupt {
@@ -365,9 +365,9 @@ func executeNativeDoor(ctx *DoorCtx) error {
 		}
 	} else {
 		if doorConfig.RequiresRawTerminal && !isPty {
-			log.Printf("WARN: Node %d: Door '%s' requires raw terminal, but no PTY was allocated.", ctx.NodeNumber, ctx.DoorName)
+			slog.Warn("door requires raw terminal, but no PTY was allocated", "node", ctx.NodeNumber, "door", ctx.DoorName)
 		}
-		log.Printf("INFO: Node %d: Starting door '%s' with standard I/O redirection", ctx.NodeNumber, ctx.DoorName)
+		slog.Info("starting door with standard I/O redirection", "node", ctx.NodeNumber, "door", ctx.DoorName)
 
 		cmd.Stdout = ctx.Session
 		cmd.Stderr = ctx.Session

--- a/internal/menu/door_handler_windows.go
+++ b/internal/menu/door_handler_windows.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -45,7 +45,7 @@ func executeNativeDoorWindows(ctx *DoorCtx) error {
 		}
 		defer func() {
 			if err := os.RemoveAll(nodeDir); err != nil {
-				log.Printf("WARN: Failed to remove node dropfile dir %s: %v", nodeDir, err)
+				slog.Warn("failed to remove node dropfile dir", "dir", nodeDir, "error", err)
 			}
 		}()
 		dropfileDir = nodeDir
@@ -55,7 +55,7 @@ func executeNativeDoorWindows(ctx *DoorCtx) error {
 
 	if dropfileTypeUpper == "DOOR.SYS" || dropfileTypeUpper == "CHAIN.TXT" || dropfileTypeUpper == "DOOR32.SYS" || dropfileTypeUpper == "DORINFO1.DEF" {
 		dropfilePath = filepath.Join(dropfileDir, dropfileTypeUpper)
-		log.Printf("INFO: Generating %s dropfile at: %s", dropfileTypeUpper, dropfilePath)
+		slog.Info("generating dropfile", "type", dropfileTypeUpper, "path", dropfilePath)
 
 		var genErr error
 		switch dropfileTypeUpper {
@@ -70,18 +70,18 @@ func executeNativeDoorWindows(ctx *DoorCtx) error {
 		}
 
 		if genErr != nil {
-			log.Printf("ERROR: Failed to write dropfile %s: %v", dropfilePath, genErr)
+			slog.Error("failed to write dropfile", "path", dropfilePath, "error", genErr)
 			errMsg := fmt.Sprintf(ctx.Executor.LoadedStrings.DoorDropfileError, ctx.DoorName)
 			if wErr := terminalio.WriteProcessedBytes(ctx.Session.Stderr(), ansi.ReplacePipeCodes([]byte(errMsg)), ctx.OutputMode); wErr != nil {
-				log.Printf("ERROR: Failed writing dropfile creation error message: %v", wErr)
+				slog.Error("failed writing dropfile creation error message", "error", wErr)
 			}
 			return genErr
 		}
 
 		defer func() {
-			log.Printf("DEBUG: Cleaning up dropfile: %s", dropfilePath)
+			slog.Debug("cleaning up dropfile", "path", dropfilePath)
 			if err := os.Remove(dropfilePath); err != nil {
-				log.Printf("WARN: Failed to remove dropfile %s: %v", dropfilePath, err)
+				slog.Warn("failed to remove dropfile", "path", dropfilePath, "error", err)
 			}
 		}()
 	}
@@ -134,7 +134,7 @@ func executeNativeDoorWindows(ctx *DoorCtx) error {
 			cmdLine += " " + syscall.EscapeArg(arg)
 		}
 		cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: cmdLine}
-		log.Printf("DEBUG: Node %d: Using shell execution for %q with %d arg(s)", ctx.NodeNumber, doorCommand, len(substitutedArgs))
+		slog.Debug("using shell execution", "node", ctx.NodeNumber, "command", doorCommand, "argCount", len(substitutedArgs))
 	} else {
 		cmd = exec.Command(doorCommand, substitutedArgs...)
 	}
@@ -174,10 +174,10 @@ func executeNativeDoorWindows(ctx *DoorCtx) error {
 	}
 
 	if doorConfig.RequiresRawTerminal {
-		log.Printf("WARN: Node %d: Door '%s' requires raw terminal, but PTY is not supported on Windows. Falling back to STDIO.", ctx.NodeNumber, ctx.DoorName)
+		slog.Warn("door requires raw terminal, but PTY is not supported on Windows, falling back to STDIO", "node", ctx.NodeNumber, "door", ctx.DoorName)
 	}
 
-	log.Printf("INFO: Node %d: Starting door '%s' with standard I/O redirection (Windows)", ctx.NodeNumber, ctx.DoorName)
+	slog.Info("starting door with standard I/O redirection (Windows)", "node", ctx.NodeNumber, "door", ctx.DoorName)
 	cmd.Stdout = ctx.Session
 	cmd.Stderr = ctx.Session
 	cmd.Stdin = ctx.Session
@@ -199,10 +199,10 @@ func executeDoor(ctx *DoorCtx) error {
 	if ctx.Config.SingleInstance {
 		if err := acquireDoorLock(ctx.DoorName, ctx.NodeNumber); err != nil {
 			if errors.Is(err, ErrDoorBusy) {
-				log.Printf("WARN: Node %d: Door '%s' is already in use by another node", ctx.NodeNumber, ctx.DoorName)
+				slog.Warn("door already in use by another node", "node", ctx.NodeNumber, "door", ctx.DoorName)
 				return fmt.Errorf("%w: %s", ErrDoorBusy, ctx.DoorName)
 			}
-			log.Printf("ERROR: Node %d: Failed to acquire lock for door '%s': %v", ctx.NodeNumber, ctx.DoorName, err)
+			slog.Error("failed to acquire lock for door", "node", ctx.NodeNumber, "door", ctx.DoorName, "error", err)
 			return fmt.Errorf("failed to acquire door lock: %w", err)
 		}
 		defer releaseDoorLock(ctx.DoorName, ctx.NodeNumber)
@@ -240,8 +240,8 @@ func executeCleanupWindows(ctx *DoorCtx) {
 		substitutedArgs[i] = newArg
 	}
 
-	log.Printf("INFO: Node %d: Running cleanup command for door '%s': %s %v",
-		ctx.NodeNumber, ctx.DoorName, ctx.Config.CleanupCommand, substitutedArgs)
+	slog.Info("running cleanup command for door",
+		"node", ctx.NodeNumber, "door", ctx.DoorName, "command", ctx.Config.CleanupCommand, "args", substitutedArgs)
 
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
 	defer cancel()
@@ -261,14 +261,14 @@ func executeCleanupWindows(ctx *DoorCtx) {
 
 	if output, err := cmd.CombinedOutput(); err != nil {
 		if cleanupCtx.Err() == context.DeadlineExceeded {
-			log.Printf("WARN: Node %d: Cleanup command for door '%s' timed out after %v",
-				ctx.NodeNumber, ctx.DoorName, cleanupTimeout)
+			slog.Warn("cleanup command for door timed out",
+				"node", ctx.NodeNumber, "door", ctx.DoorName, "timeout", cleanupTimeout)
 		} else {
-			log.Printf("WARN: Node %d: Cleanup command for door '%s' failed: %v (output: %s)",
-				ctx.NodeNumber, ctx.DoorName, err, string(output))
+			slog.Warn("cleanup command for door failed",
+				"node", ctx.NodeNumber, "door", ctx.DoorName, "error", err, "output", string(output))
 		}
 	} else {
-		log.Printf("DEBUG: Node %d: Cleanup command for door '%s' completed successfully", ctx.NodeNumber, ctx.DoorName)
+		slog.Debug("cleanup command for door completed successfully", "node", ctx.NodeNumber, "door", ctx.DoorName)
 	}
 }
 
@@ -277,7 +277,7 @@ func doorErrorMessage(ctx *DoorCtx, msg string) {
 	errMsg := fmt.Sprintf(ctx.Executor.LoadedStrings.DoorErrorFormat, msg)
 	wErr := terminalio.WriteProcessedBytes(ctx.Session.Stderr(), ansi.ReplacePipeCodes([]byte(errMsg)), ctx.OutputMode)
 	if wErr != nil {
-		log.Printf("ERROR: Failed writing door error message: %v", wErr)
+		slog.Error("failed writing door error message", "error", wErr)
 	}
 }
 
@@ -289,7 +289,7 @@ func runListDoors(c *cmdCtx, args string) (*user.User, string, error) {
 	nodeNumber := c.nodeNumber
 	outputMode := c.outputMode
 
-	log.Printf("DEBUG: Node %d: runListDoors (Windows)", nodeNumber)
+	slog.Debug("running LISTDOORS (Windows)", "node", nodeNumber)
 
 	if currentUser == nil {
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.DoorLoginRequired)), outputMode)
@@ -307,7 +307,7 @@ func runListDoors(c *cmdCtx, args string) (*user.User, string, error) {
 	botBytes, errBot := readTemplateFile(botPath)
 
 	if errTop != nil || errMid != nil || errBot != nil {
-		log.Printf("ERROR: Node %d: Failed to load DOORLIST templates: TOP(%v), MID(%v), BOT(%v)", nodeNumber, errTop, errMid, errBot)
+		slog.Error("failed to load DOORLIST templates", "node", nodeNumber, "topError", errTop, "midError", errMid, "botError", errBot)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.DoorTemplateError)), outputMode)
 		time.Sleep(1 * time.Second)
 		return currentUser, "", nil
@@ -391,7 +391,7 @@ func runOpenDoor(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: runOpenDoor (Windows)", nodeNumber)
+	slog.Debug("running OPENDOOR (Windows)", "node", nodeNumber)
 
 	if currentUser == nil {
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.DoorLoginRequired)), outputMode)
@@ -410,7 +410,7 @@ func runOpenDoor(c *cmdCtx, args string) (*user.User, string, error) {
 			if errors.Is(err, io.EOF) {
 				return nil, "LOGOFF", io.EOF
 			}
-			log.Printf("ERROR: Node %d: Error reading OPENDOOR input: %v", nodeNumber, err)
+			slog.Error("error reading OPENDOOR input", "node", nodeNumber, "error", err)
 			return currentUser, "", err
 		}
 
@@ -445,8 +445,8 @@ func runOpenDoor(c *cmdCtx, args string) (*user.User, string, error) {
 
 		// Check per-door access level
 		if doorConfig.MinAccessLevel > 0 && currentUser.AccessLevel < doorConfig.MinAccessLevel {
-			log.Printf("WARN: Node %d: User %s (level %d) denied access to door %s (requires %d)",
-				nodeNumber, currentUser.Handle, currentUser.AccessLevel, upperInput, doorConfig.MinAccessLevel)
+			slog.Warn("user denied access to door",
+				"node", nodeNumber, "handle", currentUser.Handle, "level", currentUser.AccessLevel, "door", upperInput, "required", doorConfig.MinAccessLevel)
 			msg := fmt.Sprintf(e.LoadedStrings.DoorAccessDenied, upperInput)
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 			time.Sleep(1 * time.Second)
@@ -468,7 +468,7 @@ func runOpenDoor(c *cmdCtx, args string) (*user.User, string, error) {
 
 		if cmdErr != nil {
 			if errors.Is(cmdErr, ErrDoorBusy) {
-				log.Printf("INFO: Node %d: Door %s is busy for user %s", nodeNumber, upperInput, currentUser.Handle)
+				slog.Info("door is busy for user", "node", nodeNumber, "door", upperInput, "handle", currentUser.Handle)
 				busyFmt := e.LoadedStrings.DoorBusyFormat
 				if strings.TrimSpace(busyFmt) == "" {
 					busyFmt = "\r\n|14Door is currently in use: |11%s|07\r\n"
@@ -501,7 +501,7 @@ func runDoorInfo(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: runDoorInfo (Windows)", nodeNumber)
+	slog.Debug("running DOORINFO (Windows)", "node", nodeNumber)
 
 	if currentUser == nil {
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.DoorInfoLoginRequired)), outputMode)
@@ -554,8 +554,8 @@ func runDoorInfo(c *cmdCtx, args string) (*user.User, string, error) {
 
 		// Check per-door access level
 		if doorConfig.MinAccessLevel > 0 && currentUser.AccessLevel < doorConfig.MinAccessLevel {
-			log.Printf("WARN: Node %d: User %s (level %d) denied access to door info %s (requires %d)",
-				nodeNumber, currentUser.Handle, currentUser.AccessLevel, upperInput, doorConfig.MinAccessLevel)
+			slog.Warn("user denied access to door info",
+				"node", nodeNumber, "handle", currentUser.Handle, "level", currentUser.AccessLevel, "door", upperInput, "required", doorConfig.MinAccessLevel)
 			msg := fmt.Sprintf(e.LoadedStrings.DoorAccessDenied, upperInput)
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 			time.Sleep(1 * time.Second)

--- a/internal/menu/door_handler_windows.go
+++ b/internal/menu/door_handler_windows.go
@@ -477,11 +477,11 @@ func runOpenDoor(c *cmdCtx, args string) (*user.User, string, error) {
 				terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(busyMsg)), outputMode)
 				time.Sleep(1 * time.Second)
 			} else {
-				log.Printf("ERROR: Node %d: Door execution failed for user %s, door %s: %v", nodeNumber, currentUser.Handle, upperInput, cmdErr)
+				slog.Error("door execution failed", "node", nodeNumber, "user", currentUser.Handle, "door", upperInput, "error", cmdErr)
 				doorErrorMessage(ctx, fmt.Sprintf("Error running door '%s': %v", upperInput, cmdErr))
 			}
 		} else {
-			log.Printf("INFO: Node %d: Door completed for user %s, door %s", nodeNumber, currentUser.Handle, upperInput)
+			slog.Info("door completed", "node", nodeNumber, "user", currentUser.Handle, "door", upperInput)
 		}
 
 		return currentUser, "", nil

--- a/internal/menu/door_lock.go
+++ b/internal/menu/door_lock.go
@@ -3,7 +3,7 @@ package menu
 import (
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -66,7 +66,7 @@ func acquireDoorLock(doorName string, nodeNumber int) error {
 
 	doorLockFiles[key] = f
 	doorLockNodes[key] = nodeNumber
-	log.Printf("DEBUG: Acquired file lock for door %s (node %d, pid %d)", key, nodeNumber, os.Getpid())
+	slog.Debug("acquired file lock for door", "door", key, "node", nodeNumber, "pid", os.Getpid())
 	return nil
 }
 
@@ -87,6 +87,6 @@ func releaseDoorLock(doorName string, nodeNumber int) {
 			delete(doorLockFiles, key)
 		}
 		delete(doorLockNodes, key)
-		log.Printf("DEBUG: Released file lock for door %s (node %d)", key, nodeNumber)
+		slog.Debug("released file lock for door", "door", key, "node", nodeNumber)
 	}
 }

--- a/internal/menu/executor.go
+++ b/internal/menu/executor.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -397,7 +397,7 @@ func (e *MenuExecutor) handleIdleTimeout(terminal *term.Terminal, outputMode ans
 		terminalio.WriteProcessedBytes(terminal, []byte(fmt.Sprintf("\x1b[%d;1H", row)), outputMode)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 	}
-	log.Printf("INFO: Node %d: Idle timeout after %d minutes, disconnecting", nodeNumber, e.GetServerConfig().SessionIdleTimeoutMinutes)
+	slog.Info("idle timeout, disconnecting", "node", nodeNumber, "minutes", e.GetServerConfig().SessionIdleTimeoutMinutes)
 }
 
 // remoteIPFromSession extracts the IP address from an SSH session's remote address,
@@ -416,7 +416,7 @@ func (e *MenuExecutor) showUndefinedMenuInput(terminal *term.Terminal, outputMod
 	errMsg := e.LoadedStrings.ExecUnknownCommand
 	processedErrMsg := ansi.ReplacePipeCodes([]byte(errMsg))
 	if wErr := terminalio.WriteProcessedBytes(terminal, processedErrMsg, outputMode); wErr != nil {
-		log.Printf("ERROR: Node %d: Failed writing unknown command message: %v", nodeNumber, wErr)
+		slog.Error("failed writing unknown command message", "node", nodeNumber, "error", wErr)
 	}
 	time.Sleep(500 * time.Millisecond)
 }
@@ -454,11 +454,11 @@ func registerPlaceholderRunnables(registry map[string]RunnableFunc) { // Use loc
 		outputMode := c.outputMode
 
 		if currentUser == nil {
-			log.Printf("WARN: Node %d: READMAIL called without logged in user.", nodeNumber)
+			slog.Warn("readmail called without logged in user", "node", nodeNumber)
 			msg := e.LoadedStrings.ExecReadmailLogin
 			wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 			if wErr != nil {
-				log.Printf("ERROR: Failed writing READMAIL error message: %v", wErr)
+				slog.Error("failed writing readmail error message", "error", wErr)
 			}
 			time.Sleep(1 * time.Second)
 			return nil, "", nil // No user change, no next action, no error
@@ -466,7 +466,7 @@ func registerPlaceholderRunnables(registry map[string]RunnableFunc) { // Use loc
 		msg := fmt.Sprintf(e.LoadedStrings.ExecReadmailPlaceholder, currentUser.Handle)
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		if wErr != nil {
-			log.Printf("ERROR: Failed writing READMAIL placeholder message: %v", wErr)
+			slog.Error("failed writing readmail placeholder message", "error", wErr)
 		}
 		time.Sleep(500 * time.Millisecond)
 		return nil, "", nil // No user change, no next action, no error
@@ -486,32 +486,31 @@ func registerPlaceholderRunnables(registry map[string]RunnableFunc) { // Use loc
 		termHeight := c.termHeight
 
 		if currentUser == nil {
-			log.Printf("WARN: Node %d: DOOR:%s called without logged in user.", nodeNumber, doorName)
+			slog.Warn("door called without logged in user", "node", nodeNumber, "door", doorName)
 			msg := e.LoadedStrings.ExecDoorLogin
 			wErr := terminalio.WriteProcessedBytes(s.Stderr(), ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 			if wErr != nil {
-				log.Printf("ERROR: Failed writing DOOR error message (not logged in): %v", wErr)
+				slog.Error("failed writing door error message (not logged in)", "error", wErr)
 			}
 			return nil, "", nil
 		}
-		log.Printf("INFO: Node %d: User %s attempting to run door: %s", nodeNumber, currentUser.Handle, doorName)
+		slog.Info("user attempting to run door", "node", nodeNumber, "handle", currentUser.Handle, "door", doorName)
 
 		// Look up door configuration
 		doorConfig, exists := e.GetDoorConfig(strings.ToUpper(doorName))
 		if !exists {
-			log.Printf("WARN: Door configuration not found for '%s'", doorName)
+			slog.Warn("door configuration not found", "door", doorName)
 			errMsg := fmt.Sprintf(e.LoadedStrings.ExecDoorNotConfigured, doorName)
 			wErr := terminalio.WriteProcessedBytes(s.Stderr(), ansi.ReplacePipeCodes([]byte(errMsg)), outputMode)
 			if wErr != nil {
-				log.Printf("ERROR: Failed writing DOOR error message (not configured) to stderr: %v", wErr)
+				slog.Error("failed writing door error message (not configured) to stderr", "error", wErr)
 			}
 			return nil, "", nil
 		}
 
 		// Check per-door access level
 		if doorConfig.MinAccessLevel > 0 && currentUser.AccessLevel < doorConfig.MinAccessLevel {
-			log.Printf("WARN: Node %d: User %s (level %d) denied access to door %s (requires %d)",
-				nodeNumber, currentUser.Handle, currentUser.AccessLevel, doorName, doorConfig.MinAccessLevel)
+			slog.Warn("user denied access to door", "node", nodeNumber, "handle", currentUser.Handle, "level", currentUser.AccessLevel, "door", doorName, "requires", doorConfig.MinAccessLevel)
 			errFmt := e.LoadedStrings.DoorAccessDenied
 			if strings.TrimSpace(errFmt) == "" {
 				errFmt = "\r\n|14Access denied to door: |11%s|07\r\n"
@@ -519,7 +518,7 @@ func registerPlaceholderRunnables(registry map[string]RunnableFunc) { // Use loc
 			errMsg := fmt.Sprintf(errFmt, doorName)
 			wErr := terminalio.WriteProcessedBytes(s.Stderr(), ansi.ReplacePipeCodes([]byte(errMsg)), outputMode)
 			if wErr != nil {
-				log.Printf("ERROR: Failed writing door access denied message: %v", wErr)
+				slog.Error("failed writing door access denied message", "error", wErr)
 			}
 			time.Sleep(1 * time.Second)
 			return nil, "", nil
@@ -545,7 +544,7 @@ func registerPlaceholderRunnables(registry map[string]RunnableFunc) { // Use loc
 
 		if cmdErr != nil {
 			if errors.Is(cmdErr, ErrDoorBusy) {
-				log.Printf("INFO: Node %d: Door %s is busy for user %s", nodeNumber, doorName, currentUser.Handle)
+				slog.Info("door is busy", "node", nodeNumber, "door", doorName, "handle", currentUser.Handle)
 				busyFmt := e.LoadedStrings.DoorBusyFormat
 				if strings.TrimSpace(busyFmt) == "" {
 					busyFmt = "\r\n|14Door is currently in use: |11%s|07\r\n"
@@ -554,12 +553,12 @@ func registerPlaceholderRunnables(registry map[string]RunnableFunc) { // Use loc
 				terminalio.WriteProcessedBytes(s.Stderr(), ansi.ReplacePipeCodes([]byte(busyMsg)), outputMode)
 				time.Sleep(1 * time.Second)
 			} else {
-				log.Printf("ERROR: Node %d: Door execution failed for user %s, door %s: %v", nodeNumber, currentUser.Handle, doorName, cmdErr)
+				slog.Error("door execution failed", "node", nodeNumber, "handle", currentUser.Handle, "door", doorName, "error", cmdErr)
 				doorErrorMessage(ctx, fmt.Sprintf("Error running external program '%s': %v", doorName, cmdErr))
 				time.Sleep(2 * time.Second)
 			}
 		} else {
-			log.Printf("INFO: Node %d: Door completed for user %s, door %s", nodeNumber, currentUser.Handle, doorName)
+			slog.Info("door completed", "node", nodeNumber, "handle", currentUser.Handle, "door", doorName)
 		}
 
 		return nil, "", nil
@@ -733,7 +732,7 @@ func runImmediateLogoffCommand(c *cmdCtx, args string) (*user.User, string, erro
 	outputMode := c.outputMode
 
 	if displayErr := e.displayFile(terminal, "GOODBYE.ANS", outputMode); displayErr != nil {
-		log.Printf("WARN: Node %d: Failed to display GOODBYE.ANS before logoff: %v", nodeNumber, displayErr)
+		slog.Warn("failed to display GOODBYE.ANS before logoff", "node", nodeNumber, "error", displayErr)
 		_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ExecGoodbye)), outputMode)
 	}
 
@@ -754,11 +753,11 @@ func runShowStats(c *cmdCtx, args string) (*user.User, string, error) {
 	termHeight := c.termHeight
 
 	if currentUser == nil {
-		log.Printf("WARN: Node %d: SHOWSTATS called without logged in user.", nodeNumber)
+		slog.Warn("showstats called without logged in user", "node", nodeNumber)
 		msg := e.LoadedStrings.ExecStatsLogin
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		if wErr != nil {
-			log.Printf("ERROR: Failed writing SHOWSTATS error message: %v", wErr)
+			slog.Error("failed writing showstats error message", "error", wErr)
 		}
 		time.Sleep(1 * time.Second)
 		return nil, "", nil // Updated return
@@ -769,11 +768,11 @@ func runShowStats(c *cmdCtx, args string) (*user.User, string, error) {
 	fullAnsPath := filepath.Join(e.MenuSetPath, "ansi", ansFilename)
 	rawAnsiContent, readErr := ansi.GetAnsiFileContent(fullAnsPath)
 	if readErr != nil {
-		log.Printf("ERROR: Node %d: Failed to read %s for SHOWSTATS: %v", nodeNumber, fullAnsPath, readErr)
+		slog.Error("failed to read file for showstats", "node", nodeNumber, "path", fullAnsPath, "error", readErr)
 		msg := fmt.Sprintf(e.LoadedStrings.ExecStatsError, ansFilename)
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		if wErr != nil {
-			log.Printf("ERROR: Failed writing SHOWSTATS file read error message: %v", wErr)
+			slog.Error("failed writing showstats file read error message", "error", wErr)
 		}
 		time.Sleep(1 * time.Second)
 		return nil, "", fmt.Errorf("failed to read %s: %w", ansFilename, readErr) // Updated return
@@ -801,7 +800,7 @@ func runShowStats(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	// Branch based on output mode to preserve encoding correctness
-	log.Printf("DEBUG: Node %d: SHOWSTATS outputMode = %v", nodeNumber, outputMode)
+	slog.Debug("showstats output mode", "node", nodeNumber, "outputMode", outputMode)
 	var statsDisplayBytes []byte
 	if outputMode == ansi.OutputModeUTF8 {
 		// UTF-8 mode: Convert CP437→UTF-8 first, then substitute placeholders
@@ -823,7 +822,7 @@ func runShowStats(c *cmdCtx, args string) (*user.User, string, error) {
 	wErr := terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 	if wErr != nil {
 		// Log error but continue if possible
-		log.Printf("ERROR: Node %d: Failed clearing screen for SHOWSTATS: %v", nodeNumber, wErr)
+		slog.Error("failed clearing screen for showstats", "node", nodeNumber, "error", wErr)
 	}
 	// For CP437 mode with raw ANSI content, write bytes directly to avoid UTF-8 decode artifacts
 	if outputMode == ansi.OutputModeCP437 {
@@ -832,7 +831,7 @@ func runShowStats(c *cmdCtx, args string) (*user.User, string, error) {
 		wErr = terminalio.WriteProcessedBytes(terminal, statsDisplayBytes, outputMode)
 	}
 	if wErr != nil {
-		log.Printf("ERROR: Node %d: Failed writing processed YOURSTAT.ANS: %v", nodeNumber, wErr)
+		slog.Error("failed writing processed YOURSTAT.ANS", "node", nodeNumber, "error", wErr)
 		return nil, "", wErr // Updated return
 	}
 
@@ -842,14 +841,14 @@ func runShowStats(c *cmdCtx, args string) (*user.User, string, error) {
 		pausePrompt = "\r\n|07Press |15[ENTER]|07 to continue... " // Fallback
 	}
 
-	log.Printf("DEBUG: Node %d: Displaying SHOWSTATS pause prompt (centered)", nodeNumber)
+	slog.Debug("displaying showstats pause prompt (centered)", "node", nodeNumber)
 	err := writeCenteredPausePrompt(s, terminal, pausePrompt, outputMode, termWidth, termHeight)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
-			log.Printf("INFO: Node %d: User disconnected during SHOWSTATS pause.", nodeNumber)
+			slog.Info("user disconnected during showstats pause", "node", nodeNumber)
 			return nil, "LOGOFF", io.EOF
 		}
-		log.Printf("ERROR: Failed during SHOWSTATS pause: %v", err)
+		slog.Error("failed during showstats pause", "error", err)
 		return nil, "", err
 	}
 	return nil, "", nil // Updated return (Success)
@@ -897,9 +896,9 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 	defer resetSessionIH(s)
 
 	if currentUser != nil {
-		log.Printf("DEBUG: Running menu for user %s (Level: %d)", currentUser.Handle, currentUser.AccessLevel)
+		slog.Debug("running menu for user", "handle", currentUser.Handle, "level", currentUser.AccessLevel)
 	} else {
-		log.Printf("DEBUG: Running menu for potentially unauthenticated user (login phase)")
+		slog.Debug("running menu for potentially unauthenticated user (login phase)")
 	}
 
 	// Apply the session-level idle timeout to the shared InputHandler.
@@ -909,7 +908,7 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 	getSessionIH(s).SetSessionIdleTimeout(e.idleTimeout(currentUser))
 
 	for {
-		log.Printf("INFO: Running menu: %s (Previous: %s) for Node %d", currentMenuName, previousMenuName, nodeNumber)
+		slog.Info("running menu", "menu", currentMenuName, "previous", previousMenuName, "node", nodeNumber)
 
 		var userInput string // Declare userInput here (Keep this one)
 		// Removed authenticatedUserResult declaration from here
@@ -954,12 +953,12 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 		var ansiProcessResult ansi.ProcessAnsiResult
 		var processErr error
 		if readErr != nil {
-			log.Printf("ERROR: Failed to read ANSI file %s: %v", ansFilename, readErr)
+			slog.Error("failed to read ANSI file", "file", ansFilename, "error", readErr)
 			// Display error message to user (using new helper)
 			errMsg := fmt.Sprintf("\r\n|01Error reading screen file: %s|07\r\n", ansFilename)
 			wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(errMsg)), outputMode)
 			if wErr != nil {
-				log.Printf("ERROR: Failed writing screen read error: %v", wErr)
+				slog.Error("failed writing screen read error", "error", wErr)
 			}
 			// Reading the screen file is critical, return error
 			return "", nil, fmt.Errorf("failed to read screen file %s: %w", ansFilename, readErr)
@@ -969,7 +968,7 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 		// Use CP437 mode to keep raw bytes for coordinate tracking, then convert based on outputMode
 		ansiProcessResult, processErr = ansi.ProcessAnsiAndExtractCoords(rawAnsiContent, ansi.OutputModeCP437)
 		if processErr != nil {
-			log.Printf("ERROR: Failed to process ANSI file %s: %v. Display may be incorrect.", ansFilename, processErr)
+			slog.Error("failed to process ANSI file, display may be incorrect", "file", ansFilename, "error", processErr)
 			// Processing error is also critical, return error
 			return "", nil, fmt.Errorf("failed to process screen file %s: %w", ansFilename, processErr)
 		}
@@ -984,7 +983,7 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 		// --- SPECIAL HANDLING FOR LOGIN MENU INTERACTION ---
 		if currentMenuName == "LOGIN" {
 			if currentUser != nil {
-				log.Printf("WARN: Attempting to run LOGIN menu for already authenticated user %s. Skipping login, going to MAIN.", currentUser.Handle)
+				slog.Warn("attempting to run LOGIN menu for already authenticated user, skipping login, going to MAIN", "handle", currentUser.Handle)
 
 				// Set default message area if not already set (e.g., SSH auto-login)
 				if currentUser.CurrentMessageAreaID == 0 && e.MessageMgr != nil {
@@ -1013,7 +1012,7 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 				// Persist defaults
 				if userManager != nil {
 					if saveErr := userManager.UpdateUser(currentUser); saveErr != nil {
-						log.Printf("ERROR: Failed to save user default area selections: %v", saveErr)
+						slog.Error("failed to save user default area selections", "error", saveErr)
 					}
 				}
 
@@ -1031,8 +1030,7 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 				lines := bytes.Split(displayBytes, []byte("\n"))
 				if len(lines) > termHeight {
 					displayBytes = bytes.Join(lines[:termHeight], []byte("\n"))
-					log.Printf("DEBUG: Truncated LOGIN.ANS from %d to %d lines for %d-row terminal",
-						len(lines), termHeight, termHeight)
+					slog.Debug("truncated LOGIN.ANS to fit terminal", "from", len(lines), "to", termHeight, "rows", termHeight)
 				}
 			}
 			// For CP437 mode, write raw bytes directly to avoid UTF-8 false positives
@@ -1045,7 +1043,7 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 				wErr = terminalio.WriteProcessedBytes(terminal, displayBytes, outputMode)
 			}
 			if wErr != nil {
-				log.Printf("ERROR: Failed to write processed LOGIN.ANS bytes to terminal: %v", wErr)
+				slog.Error("failed to write processed LOGIN.ANS bytes to terminal", "error", wErr)
 				return "", nil, fmt.Errorf("failed to display LOGIN.ANS: %w", wErr)
 			}
 
@@ -1055,25 +1053,25 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 			// Process result of login attempt
 			if loginErr != nil {
 				if errors.Is(loginErr, io.EOF) {
-					log.Printf("INFO: User disconnected during login prompt.")
+					slog.Info("user disconnected during login prompt")
 					return "LOGOFF", nil, nil // Signal logoff
 				}
-				log.Printf("ERROR: Error during login prompt handling: %v", loginErr)
+				slog.Error("error during login prompt handling", "error", loginErr)
 				return "", nil, loginErr // Propagate critical error
 			}
 
 			if authenticatedUserResult != nil {
-				log.Printf("INFO: Login successful for user %s. Proceeding based on LOGIN menu config.", authenticatedUserResult.Handle)
+				slog.Info("login successful, proceeding based on LOGIN menu config", "handle", authenticatedUserResult.Handle)
 				currentUser = authenticatedUserResult // Update the user for this Run context
 
 				// --- Update user's terminal dimensions from detected size ---
 				if termWidth > 0 && termHeight > 0 {
 					currentUser.ScreenWidth = termWidth
 					currentUser.ScreenHeight = termHeight
-					log.Printf("INFO: Updated user %s screen preferences to %dx%d", currentUser.Handle, termWidth, termHeight)
+					slog.Info("updated user screen preferences", "handle", currentUser.Handle, "width", termWidth, "height", termHeight)
 					if userManager != nil {
 						if saveErr := userManager.UpdateUser(currentUser); saveErr != nil {
-							log.Printf("ERROR: Failed to save user screen preferences: %v", saveErr)
+							slog.Error("failed to save user screen preferences", "error", saveErr)
 						}
 					}
 				}
@@ -1081,67 +1079,63 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 				// --- BEGIN Set Default Message Area (only if not already set from saved prefs) ---
 				if currentUser.CurrentMessageAreaID == 0 && e.MessageMgr != nil {
 					allAreas := e.MessageMgr.ListAreas() // Already sorted by Position
-					log.Printf("DEBUG: Found %d message areas for user %s.", len(allAreas), currentUser.Handle)
+					slog.Debug("found message areas for user", "count", len(allAreas), "handle", currentUser.Handle)
 					foundDefaultArea := false
 					for _, area := range allAreas {
 						// Check if user has read access to this area
 						if checkACS(area.ACSRead, currentUser, s, terminal, sessionStartTime) {
-							log.Printf("INFO: Setting default message area for user %s to Area ID %d (%s)", currentUser.Handle, area.ID, area.Tag)
+							slog.Info("setting default message area for user", "handle", currentUser.Handle, "id", area.ID, "tag", area.Tag)
 							currentUser.CurrentMessageAreaID = area.ID
 							currentUser.CurrentMessageAreaTag = area.Tag
 							e.setUserMsgConference(currentUser, area.ConferenceID)
 							foundDefaultArea = true
 							break // Found the first accessible area
 						} else {
-							log.Printf("TRACE: User %s denied read access to Area ID %d (%s) based on ACS '%s'", currentUser.Handle, area.ID, area.Tag, area.ACSRead)
+							slog.Debug("user denied read access to message area", "handle", currentUser.Handle, "id", area.ID, "tag", area.Tag, "acs", area.ACSRead)
 						}
 					}
 					if !foundDefaultArea {
-						log.Printf("WARN: User %s has no access to any message areas.", currentUser.Handle)
+						slog.Warn("user has no access to any message areas", "handle", currentUser.Handle)
 						currentUser.CurrentMessageAreaID = 0
 						currentUser.CurrentMessageAreaTag = ""
 					}
 				} else if currentUser.CurrentMessageAreaID != 0 {
-					log.Printf("INFO: User %s has saved message area %d (%s), conference %d (%s)",
-						currentUser.Handle, currentUser.CurrentMessageAreaID, currentUser.CurrentMessageAreaTag,
-						currentUser.CurrentMsgConferenceID, currentUser.CurrentMsgConferenceTag)
+					slog.Info("user has saved message area", "handle", currentUser.Handle, "id", currentUser.CurrentMessageAreaID, "tag", currentUser.CurrentMessageAreaTag, "conferenceID", currentUser.CurrentMsgConferenceID, "conferenceTag", currentUser.CurrentMsgConferenceTag)
 				}
 				// --- END Set Default Message Area ---
 
 				// --- BEGIN Set Default File Area (only if not already set from saved prefs) ---
 				if currentUser.CurrentFileAreaID == 0 && e.FileMgr != nil {
 					allFileAreas := e.FileMgr.ListAreas() // Assumes ListAreas is sorted by ID
-					log.Printf("DEBUG: Found %d file areas for user %s.", len(allFileAreas), currentUser.Handle)
+					slog.Debug("found file areas for user", "count", len(allFileAreas), "handle", currentUser.Handle)
 					foundDefaultFileArea := false
 					for _, area := range allFileAreas {
 						// Check if user has list access to this area
 						if checkACS(area.ACSList, currentUser, s, terminal, sessionStartTime) { // Use ACSList
-							log.Printf("INFO: Setting default file area for user %s to Area ID %d (%s)", currentUser.Handle, area.ID, area.Tag)
+							slog.Info("setting default file area for user", "handle", currentUser.Handle, "id", area.ID, "tag", area.Tag)
 							currentUser.CurrentFileAreaID = area.ID
 							currentUser.CurrentFileAreaTag = area.Tag
 							e.setUserFileConference(currentUser, area.ConferenceID)
 							foundDefaultFileArea = true
 							break // Found the first accessible area
 						} else {
-							log.Printf("TRACE: User %s denied list access to File Area ID %d (%s) based on ACS '%s'", currentUser.Handle, area.ID, area.Tag, area.ACSList)
+							slog.Debug("user denied list access to file area", "handle", currentUser.Handle, "id", area.ID, "tag", area.Tag, "acs", area.ACSList)
 						}
 					}
 					if !foundDefaultFileArea {
-						log.Printf("WARN: User %s has no access to any file areas.", currentUser.Handle)
+						slog.Warn("user has no access to any file areas", "handle", currentUser.Handle)
 						currentUser.CurrentFileAreaID = 0
 						currentUser.CurrentFileAreaTag = ""
 					}
 				} else if currentUser.CurrentFileAreaID != 0 {
-					log.Printf("INFO: User %s has saved file area %d (%s), conference %d (%s)",
-						currentUser.Handle, currentUser.CurrentFileAreaID, currentUser.CurrentFileAreaTag,
-						currentUser.CurrentFileConferenceID, currentUser.CurrentFileConferenceTag)
+					slog.Info("user has saved file area", "handle", currentUser.Handle, "id", currentUser.CurrentFileAreaID, "tag", currentUser.CurrentFileAreaTag, "conferenceID", currentUser.CurrentFileConferenceID, "conferenceTag", currentUser.CurrentFileConferenceTag)
 				}
 				// --- END Set Default File Area ---
 
 				// Persist default area/conference selections to disk
 				if userManager != nil {
 					if saveErr := userManager.UpdateUser(currentUser); saveErr != nil {
-						log.Printf("ERROR: Failed to save user default area selections: %v", saveErr)
+						slog.Error("failed to save user default area selections", "error", saveErr)
 					}
 				}
 
@@ -1150,7 +1144,7 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 				loginCfgPath := filepath.Join(e.MenuSetPath, "cfg") // Use correct path structure
 				loginCommands, loadCmdErr := LoadCommands("LOGIN", loginCfgPath)
 				if loadCmdErr != nil {
-					log.Printf("CRITICAL: Failed to load LOGIN.CFG (%s) after successful authentication: %v", filepath.Join(loginCfgPath, "LOGIN.CFG"), loadCmdErr)
+					slog.Error("failed to load LOGIN.CFG after successful authentication", "path", filepath.Join(loginCfgPath, "LOGIN.CFG"), "error", loadCmdErr)
 					// Return an error? Or try to default to MAIN?
 					return "LOGOFF", currentUser, fmt.Errorf("failed loading LOGIN.CFG post-auth") // Logoff user on critical error
 				}
@@ -1166,22 +1160,22 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 						if checkACS(cmd.ACS, currentUser, s, terminal, sessionStartTime) { // Use ssh.Session 's'
 							nextAction = cmd.Command
 							foundDefault = true
-							log.Printf("DEBUG: Found default command in LOGIN.CFG after auth: %s", nextAction)
+							slog.Debug("found default command in LOGIN.CFG after auth", "command", nextAction)
 							break // Found the relevant default command (e.g., GOTO:MAIN)
 						} else {
-							log.Printf("WARN: User %s denied default command '%s' in LOGIN.CFG due to ACS '%s'", currentUser.Handle, cmd.Command, cmd.ACS)
+							slog.Warn("user denied default command in LOGIN.CFG", "handle", currentUser.Handle, "command", cmd.Command, "acs", cmd.ACS)
 						}
 					}
 				}
 
 				if !foundDefault {
-					log.Printf("CRITICAL: No accessible default command ('') found in LOGIN.CFG for user %s. Logging off.", currentUser.Handle)
+					slog.Error("no accessible default command found in LOGIN.CFG, logging off", "handle", currentUser.Handle)
 					return "LOGOFF", currentUser, fmt.Errorf("no accessible default command found in LOGIN.CFG")
 				}
 				// -- Return the next action AND the authenticated user --
 				return nextAction, currentUser, nil
 			} else { // authenticatedUserResult == nil
-				log.Printf("INFO: Login failed. Redisplaying LOGIN menu.")
+				slog.Info("login failed, redisplaying LOGIN menu")
 				continue // Restart loop for LOGIN
 			}
 		} // --- END SPECIAL LOGIN INTERACTION BLOCK ---
@@ -1196,9 +1190,9 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 			// Use new helper for error message
 			wErr := terminalio.WriteProcessedBytes(terminal, processedErrMsg, outputMode)
 			if wErr != nil {
-				log.Printf("ERROR: Failed writing menu load error message: %v", wErr)
+				slog.Error("failed writing menu load error message", "error", wErr)
 			}
-			log.Printf("ERROR: %s", errMsg)
+			slog.Error(errMsg)
 			return "", nil, fmt.Errorf("failed to load menu %s: %w", currentMenuName, err)
 		}
 
@@ -1206,7 +1200,7 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 		menuCfgPath := filepath.Join(e.MenuSetPath, "cfg") // Use correct path structure for CFG
 		commands, err := LoadCommands(currentMenuName, menuCfgPath)
 		if err != nil {
-			log.Printf("WARN: Failed to load commands for menu %s: %v", currentMenuName, err)
+			slog.Warn("failed to load commands for menu", "menu", currentMenuName, "error", err)
 			commands = []CommandRecord{} // Use empty slice
 		}
 
@@ -1228,28 +1222,28 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 		// Check Menu Password if required
 		menuPassword := menuRec.Password
 		if menuPassword != "" {
-			log.Printf("DEBUG: Menu '%s' requires password.", currentMenuName)
+			slog.Debug("menu requires password", "menu", currentMenuName)
 			passwordOk := false
 			for i := 0; i < 3; i++ { // Allow 3 attempts
 				prompt := fmt.Sprintf(e.LoadedStrings.ExecMenuPasswordPrompt, currentMenuName, i+1)
 				processedPrompt := ansi.ReplacePipeCodes([]byte(prompt))
 				wErr := terminalio.WriteProcessedBytes(terminal, processedPrompt, outputMode)
 				if wErr != nil {
-					log.Printf("ERROR: Node %d: Failed writing menu password prompt: %v", nodeNumber, wErr)
+					slog.Error("failed writing menu password prompt", "node", nodeNumber, "error", wErr)
 				}
 
 				// Use our helper for secure input reading (using ssh.Session 's')
 				inputPassword, err := readPasswordSecurely(s, terminal, outputMode)
 				if err != nil {
 					if errors.Is(err, io.EOF) {
-						log.Printf("INFO: User disconnected during menu password entry for '%s'", currentMenuName)
+						slog.Info("user disconnected during menu password entry", "menu", currentMenuName)
 						return "LOGOFF", nil, nil // Signal logoff
 					}
 					if errors.Is(err, errInputAborted) { // Check for specific error
-						log.Printf("INFO: User interrupted password entry for menu '%s'", currentMenuName)
+						slog.Info("user interrupted password entry for menu", "menu", currentMenuName)
 						return "LOGOFF", nil, nil // Signal logoff
 					}
-					log.Printf("ERROR: Failed to read password input securely: %v", err)
+					slog.Error("failed to read password input securely", "error", err)
 					return "", nil, fmt.Errorf("failed reading password: %w", err)
 				}
 				if inputPassword == menuPassword {
@@ -1257,23 +1251,23 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 					// Use new helper for feedback message
 					wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ExecPasswordAccepted)), outputMode)
 					if wErr != nil {
-						log.Printf("ERROR: Failed writing password accepted message: %v", wErr)
+						slog.Error("failed writing password accepted message", "error", wErr)
 					}
 					break
 				} else {
 					// Use new helper for feedback message
 					wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ExecIncorrectPassword)), outputMode)
 					if wErr != nil {
-						log.Printf("ERROR: Failed writing incorrect password message: %v", wErr)
+						slog.Error("failed writing incorrect password message", "error", wErr)
 					}
 				}
 			}
 			if !passwordOk {
-				log.Printf("WARN: User failed password entry for menu '%s' (User: %v)", currentMenuName, currentUser)
+				slog.Warn("user failed password entry for menu", "menu", currentMenuName, "user", currentUser)
 				// Use new helper for feedback message
 				wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ExecTooManyAttempts)), outputMode)
 				if wErr != nil {
-					log.Printf("ERROR: Failed writing too many attempts message: %v", wErr)
+					slog.Error("failed writing too many attempts message", "error", wErr)
 				}
 				time.Sleep(1 * time.Second)
 				return "LOGOFF", nil, nil // Signal logoff after too many failures
@@ -1283,13 +1277,13 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 		// Check Menu ACS before proceeding
 		menuACS := menuRec.ACS
 		if !checkACS(menuACS, currentUser, s, terminal, sessionStartTime) { // Use ssh.Session 's'
-			log.Printf("INFO: User denied access to menu '%s' due to ACS: %s (User: %v)", currentMenuName, menuACS, currentUser)
+			slog.Info("user denied access to menu", "menu", currentMenuName, "acs", menuACS, "user", currentUser)
 			errMsg := e.LoadedStrings.ExecAccessDenied
 			processedErrMsg := ansi.ReplacePipeCodes([]byte(errMsg))
 			// Use new helper for error message
 			wErr := terminalio.WriteProcessedBytes(terminal, processedErrMsg, outputMode)
 			if wErr != nil {
-				log.Printf("ERROR: Failed writing ACS denied message: %v", wErr)
+				slog.Error("failed writing ACS denied message", "error", wErr)
 			}
 			time.Sleep(1 * time.Second) // Brief pause
 			return "LOGOFF", nil, nil   // Signal logoff
@@ -1302,11 +1296,11 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 				autoRunKey := fmt.Sprintf("%s:%s", currentMenuName, cmd.Command) // Unique key per menu/command
 
 				if cmd.Keys == "//" && autoRunLog[autoRunKey] {
-					log.Printf("DEBUG: Skipping already executed run-once command: %s", autoRunKey)
+					slog.Debug("skipping already executed run-once command", "command", autoRunKey)
 					continue // Skip if already run
 				}
 				if checkACS(cmd.ACS, currentUser, s, terminal, sessionStartTime) { // Use ssh.Session 's'
-					log.Printf("INFO: Executing AutoRun command (%s): %s (ACS: %s)", cmd.Keys, cmd.Command, cmd.ACS)
+					slog.Info("executing autorun command", "keys", cmd.Keys, "command", cmd.Command, "acs", cmd.ACS)
 
 					if cmd.Keys == "//" {
 						autoRunLog[autoRunKey] = true
@@ -1328,7 +1322,7 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 						}
 					}
 				} else {
-					log.Printf("DEBUG: AutoRun command (%s) %s denied by ACS: %s", cmd.Keys, cmd.Command, cmd.ACS)
+					slog.Debug("autorun command denied by ACS", "keys", cmd.Keys, "command", cmd.Command, "acs", cmd.ACS)
 				}
 			}
 		}
@@ -1353,8 +1347,7 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 				lines := bytes.Split(displayBytes, []byte("\n"))
 				if len(lines) > termHeight {
 					displayBytes = bytes.Join(lines[:termHeight], []byte("\n"))
-					log.Printf("DEBUG: Truncated %s.ANS from %d to %d lines for %d-row terminal",
-						currentMenuName, len(lines), termHeight, termHeight)
+					slog.Debug("truncated menu ANSI to fit terminal", "menu", currentMenuName, "from", len(lines), "to", termHeight, "rows", termHeight)
 				}
 			}
 			// For CP437 mode, write raw bytes directly to avoid UTF-8 false positives
@@ -1365,7 +1358,7 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 				wErr = terminalio.WriteProcessedBytes(terminal, displayBytes, outputMode)
 			}
 			if wErr != nil {
-				log.Printf("ERROR: Failed writing ANSI screen for %s: %v", currentMenuName, wErr)
+				slog.Error("failed writing ANSI screen", "menu", currentMenuName, "error", wErr)
 				return "", nil, fmt.Errorf("failed displaying screen: %w", wErr)
 			}
 		}
@@ -1380,15 +1373,15 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 
 		// 4. Determine Input Mode / Method
 		if isLightbarMenu {
-			log.Printf("DEBUG: Entering Lightbar input mode for %s", currentMenuName)
+			slog.Debug("entering lightbar input mode", "menu", currentMenuName)
 
 			// Load lightbar options from the config directory
 			lightbarOptions, loadErr := loadLightbarOptions(currentMenuName, e)
 			if loadErr != nil {
-				log.Printf("ERROR: Failed to load lightbar options for %s: %v", currentMenuName, loadErr)
+				slog.Error("failed to load lightbar options", "menu", currentMenuName, "error", loadErr)
 				isLightbarMenu = false
 			} else if len(lightbarOptions) == 0 {
-				log.Printf("WARN: No valid lightbar options loaded for %s", currentMenuName)
+				slog.Warn("no valid lightbar options loaded", "menu", currentMenuName)
 				isLightbarMenu = false
 			}
 
@@ -1400,7 +1393,7 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 				selectedIndex := 0
 				drawErr := drawLightbarMenu(terminal, ansBackgroundBytes, lightbarOptions, selectedIndex, outputMode, false)
 				if drawErr != nil {
-					log.Printf("ERROR: Failed to draw lightbar menu for %s: %v", currentMenuName, drawErr)
+					slog.Error("failed to draw lightbar menu", "menu", currentMenuName, "error", drawErr)
 					e.showCursorIfHidden(terminal, outputMode, cursorHidden)
 					isLightbarMenu = false
 				} else {
@@ -1418,17 +1411,17 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 						if err != nil {
 							e.showCursorIfHidden(terminal, outputMode, cursorHidden)
 							if errors.Is(err, io.EOF) {
-								log.Printf("INFO: User disconnected during lightbar input for %s", currentMenuName)
+								slog.Info("user disconnected during lightbar input", "menu", currentMenuName)
 								return "LOGOFF", nil, nil
 							}
 							if errors.Is(err, editor.ErrIdleTimeout) {
 								e.handleIdleTimeout(terminal, outputMode, nodeNumber, termHeight)
 								return "LOGOFF", nil, nil
 							}
-							log.Printf("ERROR: Failed to read lightbar input for menu %s: %v", currentMenuName, err)
+							slog.Error("failed to read lightbar input", "menu", currentMenuName, "error", err)
 							return "", nil, fmt.Errorf("failed reading lightbar input: %w", err)
 						}
-						log.Printf("DEBUG: Lightbar input key: %d", key)
+						slog.Debug("lightbar input key", "key", key)
 
 						switch key {
 						case editor.KeyArrowUp:
@@ -1501,7 +1494,7 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 							// Control chars and other special codes are ignored
 						}
 					}
-					log.Printf("DEBUG: Processed Lightbar input as: '%s'", lightbarResult)
+					slog.Debug("processed lightbar input", "result", lightbarResult)
 					e.showCursorIfHidden(terminal, outputMode, cursorHidden)
 					// Set userInput to lightbar result if a selection was made
 					if lightbarResult != "" {
@@ -1521,66 +1514,66 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 					}
 				} else {
 					// Log message remains the same, but the condition causing it is now just UsePrompt==false
-					log.Printf("DEBUG: Skipping prompt display for %s (UsePrompt: %t, Prompt1 empty: %t)", currentMenuName, menuRec.GetUsePrompt(), menuRec.Prompt1 == "")
+					slog.Debug("skipping prompt display", "menu", currentMenuName, "usePrompt", menuRec.GetUsePrompt(), "prompt1Empty", menuRec.Prompt1 == "")
 				}
 
 				// Read User Input Line via shared InputHandler to avoid reader races.
 				input, err := readLineFromSessionIH(s, terminal)
 				if err != nil {
 					if err == io.EOF {
-						log.Printf("INFO: User disconnected during menu input for %s", currentMenuName)
+						slog.Info("user disconnected during menu input", "menu", currentMenuName)
 						return "LOGOFF", nil, nil // Signal logoff
 					}
-					log.Printf("ERROR: Failed to read input for menu %s: %v", currentMenuName, err)
+					slog.Error("failed to read input for menu", "menu", currentMenuName, "error", err)
 					return "", nil, fmt.Errorf("failed reading input: %w", err)
 				}
 				userInput = strings.ToUpper(strings.TrimSpace(input))
-				log.Printf("DEBUG: User input: '%s'", userInput)
+				slog.Debug("user input", "input", userInput)
 			}
 		} else {
 			// --- Standard Menu Input Handling ---
 			e.deliverPendingPages(terminal, nodeNumber, outputMode)
 			// Display Prompt (Skip if USEPROMPT is false)
-			log.Printf("DEBUG: Checking prompt display for menu: %s. UsePrompt=%t", currentMenuName, menuRec.GetUsePrompt())
+			slog.Debug("checking prompt display for menu", "menu", currentMenuName, "usePrompt", menuRec.GetUsePrompt())
 			if menuRec.GetUsePrompt() { // Condition changed: Only check UsePrompt
-				log.Printf("DEBUG: Calling displayPrompt for menu: %s", currentMenuName)
+				slog.Debug("calling displayPrompt for menu", "menu", currentMenuName)
 				err = e.displayPrompt(terminal, menuRec, currentUser, userManager, nodeNumber, currentMenuName, sessionStartTime, outputMode, currentAreaName) // Pass currentAreaName
-				log.Printf("DEBUG: Returned from displayPrompt for menu: %s. Error: %v", currentMenuName, err)
+				slog.Debug("returned from displayPrompt for menu", "menu", currentMenuName, "error", err)
 				if err != nil {
 					return "", nil, err // Propagate the error
 				}
 			} else {
 				// Log message remains the same, but the condition causing it is now just UsePrompt==false
-				log.Printf("DEBUG: Skipping prompt display for %s (UsePrompt: %t, Prompt1 empty: %t)", currentMenuName, menuRec.GetUsePrompt(), menuRec.Prompt1 == "")
+				slog.Debug("skipping prompt display", "menu", currentMenuName, "usePrompt", menuRec.GetUsePrompt(), "prompt1Empty", menuRec.Prompt1 == "")
 			}
 
 			// Read User Input Line via shared InputHandler to avoid reader races.
 			input, err := readLineFromSessionIH(s, terminal)
 			if err != nil {
 				if errors.Is(err, io.EOF) {
-					log.Printf("INFO: User disconnected during menu input for %s", currentMenuName)
+					slog.Info("user disconnected during menu input", "menu", currentMenuName)
 					return "LOGOFF", nil, nil
 				}
 				if errors.Is(err, editor.ErrIdleTimeout) {
 					e.handleIdleTimeout(terminal, outputMode, nodeNumber, termHeight)
 					return "LOGOFF", nil, nil
 				}
-				log.Printf("ERROR: Failed to read input for menu %s: %v", currentMenuName, err)
+				slog.Error("failed to read input for menu", "menu", currentMenuName, "error", err)
 				return "", nil, fmt.Errorf("failed reading input: %w", err)
 			}
 			userInput = strings.ToUpper(strings.TrimSpace(input))
-			log.Printf("DEBUG: User input: '%s'", userInput)
+			slog.Debug("user input", "input", userInput)
 
 			// --- Special Input Handling (^P, ##) ---
 			if userInput == "\x10" || userInput == "^P" { // Ctrl+P is ASCII 16 (\x10)
 				if previousMenuName != "" {
-					log.Printf("DEBUG: User entered ^P, going back to previous menu: %s", previousMenuName)
+					slog.Debug("user entered ^P, going back to previous menu", "previous", previousMenuName)
 					temp := currentMenuName
 					currentMenuName = previousMenuName
 					previousMenuName = temp // Update previous in case they go back again
 					continue                // Go directly to the previous menu loop iteration
 				} else {
-					log.Printf("DEBUG: User entered ^P, but no previous menu recorded.")
+					slog.Debug("user entered ^P, but no previous menu recorded")
 					continue // Re-display current menu prompt
 				}
 			}
@@ -1606,9 +1599,9 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 				cmdACS := cmdRec.ACS
 				if !checkACS(cmdACS, currentUser, s, terminal, sessionStartTime) { // Use ssh.Session 's'
 					if currentUser != nil {
-						log.Printf("DEBUG: User '%s' does not meet ACS '%s' for command key(s) '%s'", currentUser.Handle, cmdACS, cmdRec.Keys)
+						slog.Debug("user does not meet ACS for command keys", "handle", currentUser.Handle, "acs", cmdACS, "keys", cmdRec.Keys)
 					} else {
-						log.Printf("DEBUG: Unauthenticated user does not meet ACS '%s' for command key(s) '%s'", cmdACS, cmdRec.Keys)
+						slog.Debug("unauthenticated user does not meet ACS for command keys", "acs", cmdACS, "keys", cmdRec.Keys)
 					}
 					continue // Skip this command if ACS check fails
 				}
@@ -1619,7 +1612,7 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 					if key == "^M" && userInput == "" {
 						nextAction = cmdRec.Command
 						matchedNodeActivity = cmdRec.NodeActivity
-						log.Printf("DEBUG: Matched ^M (Enter/default) to command action: '%s'", nextAction)
+						slog.Debug("matched ^M (enter/default) to command action", "command", nextAction)
 						matched = true
 						break
 					}
@@ -1627,7 +1620,7 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 					if key != "" && userInput != "" && userInput == key {
 						nextAction = cmdRec.Command
 						matchedNodeActivity = cmdRec.NodeActivity
-						log.Printf("DEBUG: Matched key '%s' to command action: '%s'", key, nextAction)
+						slog.Debug("matched key to command action", "key", key, "command", nextAction)
 						matched = true
 						break
 					}
@@ -1645,7 +1638,7 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 							// forwards it to the RUN: handler via runArgs.
 							nextAction = cmdRec.Command + " " + userInput
 							matchedNodeActivity = cmdRec.NodeActivity
-							log.Printf("DEBUG: Matched ## (numeric wildcard, input='%s') to command action: '%s'", userInput, nextAction)
+							slog.Debug("matched ## numeric wildcard to command action", "input", userInput, "command", nextAction)
 							matched = true
 							break
 						}
@@ -1691,10 +1684,10 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 				}
 				continue // Re-display current menu prompt
 			}
-			log.Printf("WARN: Unhandled action type '%s' after executing command '%s'", nextActionType, nextAction)
+			slog.Warn("unhandled action type after executing command", "actionType", nextActionType, "command", nextAction)
 			continue
 		} else {
-			log.Printf("DEBUG: Input '%s' did not match any commands in menu %s", userInput, currentMenuName)
+			slog.Debug("input did not match any commands in menu", "input", userInput, "menu", currentMenuName)
 
 			// If it was a lightbar menu and input was ignored (userInput == ""), just loop again
 			if isLightbarMenu {
@@ -1708,7 +1701,7 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 
 			fallbackMenu := menuRec.Fallback
 			if fallbackMenu != "" {
-				log.Printf("INFO: No command match, using fallback menu: %s", fallbackMenu)
+				slog.Info("no command match, using fallback menu", "menu", fallbackMenu)
 				previousMenuName = currentMenuName // Store current before going to fallback
 				currentMenuName = strings.ToUpper(fallbackMenu)
 				continue
@@ -1734,72 +1727,72 @@ func (e *MenuExecutor) executeCommandAction(action string, s ssh.Session, termin
 		if len(parts) > 1 {
 			runArgs = parts[1]
 		}
-		log.Printf("INFO: Executing RUN action: Target='%s' Args='%s'", runTarget, runArgs)
+		slog.Info("executing RUN action", "target", runTarget, "args", runArgs)
 
 		if runnableFunc, exists := e.RunRegistry[runTarget]; exists {
-			log.Printf("DEBUG: Node %d: Calling registered function for RUN:%s", nodeNumber, runTarget)
+			slog.Debug("calling registered function for RUN", "node", nodeNumber, "target", runTarget)
 			// RunnableFunc now returns user, nextActionString, error
 			authUser, nextActionStr, runErr := runnableFunc(&cmdCtx{e: e, s: s, terminal: terminal, userManager: userManager, currentUser: currentUser, nodeNumber: nodeNumber, sessionStartTime: sessionStartTime, outputMode: outputMode, termWidth: termWidth, termHeight: termHeight}, runArgs)
 			if runErr != nil {
 				if errors.Is(runErr, io.EOF) {
-					log.Printf("INFO: Node %d: User disconnected during RUN:%s execution.", nodeNumber, runTarget)
+					slog.Info("user disconnected during RUN execution", "node", nodeNumber, "target", runTarget)
 					return "LOGOFF", "", nil, nil
 				}
 				if errors.Is(runErr, editor.ErrIdleTimeout) {
 					e.handleIdleTimeout(terminal, outputMode, nodeNumber, termHeight)
 					return "LOGOFF", "", nil, nil
 				}
-				log.Printf("ERROR: RUN:%s function failed: %v", runTarget, runErr)
+				slog.Error("RUN function failed", "target", runTarget, "error", runErr)
 				errMsg := fmt.Sprintf(e.LoadedStrings.ExecRunCommandError, runTarget, runErr)
 				wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(errMsg)), outputMode)
 				if wErr != nil {
-					log.Printf("ERROR: Failed writing RUN command error message: %v", wErr)
+					slog.Error("failed writing RUN command error message", "error", wErr)
 				}
 				time.Sleep(1 * time.Second)
 				// Assign the potentially updated user before returning
 				userResult = authUser                     // Capture potential user changes (like from AUTHENTICATE)
 				return "CONTINUE", "", userResult, runErr // Continue but report error?
 			}
-			log.Printf("DEBUG: RUN:%s function completed.", runTarget)
+			slog.Debug("RUN function completed", "target", runTarget)
 
 			// Check if the runnable function returned a specific next action
 			if strings.HasPrefix(nextActionStr, "GOTO:") {
 				nextMenu = strings.ToUpper(strings.TrimPrefix(nextActionStr, "GOTO:"))
-				log.Printf("DEBUG: RUN:%s requested GOTO:%s", runTarget, nextMenu)
+				slog.Debug("RUN requested GOTO", "target", runTarget, "menu", nextMenu)
 				return "GOTO", nextMenu, authUser, nil
 			} else if nextActionStr == "LOGOFF" {
-				log.Printf("DEBUG: RUN:%s requested LOGOFF", runTarget)
+				slog.Debug("RUN requested LOGOFF", "target", runTarget)
 				return "LOGOFF", "", authUser, nil
 			}
 
 			// Default action for RUN is CONTINUE
 			return "CONTINUE", "", authUser, nil
 		} else {
-			log.Printf("WARN: No internal function registered for RUN:%s", runTarget)
+			slog.Warn("no internal function registered for RUN", "target", runTarget)
 			msg := fmt.Sprintf(e.LoadedStrings.ExecRunCommandNotFound, runTarget)
 			wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 			if wErr != nil {
-				log.Printf("ERROR: Failed writing missing RUN command message: %v", wErr)
+				slog.Error("failed writing missing RUN command message", "error", wErr)
 			}
 			time.Sleep(1 * time.Second)
 			return "CONTINUE", "", currentUser, nil
 		}
 	} else if strings.HasPrefix(action, "DOOR:") {
 		doorTarget := strings.TrimPrefix(action, "DOOR:")
-		log.Printf("INFO: Executing DOOR action: '%s'", doorTarget)
+		slog.Info("executing DOOR action", "door", doorTarget)
 		if doorFunc, exists := e.RunRegistry["DOOR:"]; exists {
 			// DOOR runnable returns user, "", error
 			userResultDoor, nextActionStrDoor, doorErr := doorFunc(&cmdCtx{e: e, s: s, terminal: terminal, userManager: userManager, currentUser: currentUser, nodeNumber: nodeNumber, sessionStartTime: sessionStartTime, outputMode: outputMode, termWidth: termWidth, termHeight: termHeight}, doorTarget)
 			if doorErr != nil {
 				if errors.Is(doorErr, io.EOF) {
-					log.Printf("INFO: Node %d: User disconnected during DOOR:%s execution.", nodeNumber, doorTarget)
+					slog.Info("user disconnected during DOOR execution", "node", nodeNumber, "door", doorTarget)
 					return "LOGOFF", "", nil, nil
 				}
-				log.Printf("ERROR: DOOR:%s execution failed: %v", doorTarget, doorErr)
+				slog.Error("DOOR execution failed", "door", doorTarget, "error", doorErr)
 				errMsg := fmt.Sprintf(e.LoadedStrings.ExecRunDoorError, doorTarget, doorErr)
 				wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(errMsg)), outputMode)
 				if wErr != nil {
-					log.Printf("ERROR: Failed writing DOOR command error message: %v", wErr)
+					slog.Error("failed writing DOOR command error message", "error", wErr)
 				}
 				time.Sleep(1 * time.Second)
 				// Assign potential user result before returning
@@ -1808,17 +1801,17 @@ func (e *MenuExecutor) executeCommandAction(action string, s ssh.Session, termin
 			}
 			// Handle potential LOGOFF request from DOOR runnable (though currently returns "")
 			if nextActionStrDoor == "LOGOFF" {
-				log.Printf("DEBUG: DOOR:%s requested LOGOFF", doorTarget)
+				slog.Debug("DOOR requested LOGOFF", "door", doorTarget)
 				return "LOGOFF", "", userResultDoor, nil
 			}
-			log.Printf("DEBUG: DOOR:%s completed.", doorTarget)
+			slog.Debug("DOOR completed", "door", doorTarget)
 			return "CONTINUE", "", userResultDoor, nil // Default CONTINUE after door
 		} else {
-			log.Printf("CRITICAL: DOOR: function not registered!")
+			slog.Error("DOOR function not registered")
 			return "CONTINUE", "", currentUser, nil
 		}
 	} else {
-		log.Printf("WARN: Unhandled command action type in executeCommandAction: %s", action)
+		slog.Warn("unhandled command action type in executeCommandAction", "action", action)
 		return "CONTINUE", "", currentUser, nil
 	}
 }
@@ -1986,11 +1979,11 @@ func (e *MenuExecutor) displayFile(terminal *term.Terminal, filename string, out
 	// Read ANSI content via helper (strips SAUCE metadata)
 	data, err := ansi.GetAnsiFileContent(filePath)
 	if err != nil {
-		log.Printf("ERROR: Failed to read ANSI file %s: %v", filePath, err)
+		slog.Error("failed to read ANSI file", "path", filePath, "error", err)
 		errMsg := fmt.Sprintf(e.LoadedStrings.ExecFileLoadError, filename)
 		writeErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(errMsg)), outputMode)
 		if writeErr != nil {
-			log.Printf("ERROR: Failed writing displayFile error message: %v", writeErr)
+			slog.Error("failed writing displayFile error message", "error", writeErr)
 			return fmt.Errorf("read: %w; write error: %w", err, writeErr)
 		}
 		return err
@@ -2015,7 +2008,7 @@ func (e *MenuExecutor) displayFile(terminal *term.Terminal, filename string, out
 		writeErr = terminalio.WriteProcessedBytes(terminal, data, outputMode)
 	}
 	if writeErr != nil {
-		log.Printf("ERROR: Failed to write ANSI file %s: %v", filePath, writeErr)
+		slog.Error("failed to write ANSI file", "path", filePath, "error", writeErr)
 		return writeErr
 	}
 
@@ -2034,7 +2027,7 @@ func (e *MenuExecutor) deliverPendingPages(terminal *term.Terminal, nodeNumber i
 	pages := sess.DrainPages()
 	for _, page := range pages {
 		if err := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n"+page+"\r\n")), outputMode); err != nil {
-			log.Printf("ERROR: Node %d: failed to deliver page: %v", nodeNumber, err)
+			slog.Error("failed to deliver page", "node", nodeNumber, "error", err)
 			return
 		}
 	}
@@ -2073,12 +2066,12 @@ func (e *MenuExecutor) displayPrompt(terminal *term.Terminal, menu *MenuRecord, 
 		if e.LoadedStrings.DefPrompt != "" { // Use loaded strings
 			promptString = e.LoadedStrings.DefPrompt
 		} else {
-			log.Printf("WARN: Default prompt (DefPrompt) is empty in config/strings.json and menu prompt fields are empty for menu %s. No prompt will be displayed.", currentMenuName)
+			slog.Warn("default prompt empty and menu prompt fields empty, no prompt will be displayed", "menu", currentMenuName)
 			return nil // Explicitly return nil if no prompt string can be determined
 		}
 	}
 
-	log.Printf("DEBUG: Displaying menu prompt for: %s", currentMenuName)
+	slog.Debug("displaying menu prompt", "menu", currentMenuName)
 
 	newUsersStatus := "NO"
 	if e.GetServerConfig().AllowNewUsers {
@@ -2194,7 +2187,7 @@ func (e *MenuExecutor) displayPrompt(terminal *term.Terminal, menu *MenuRecord, 
 
 	processedPrompt, err := e.processFileIncludes(substitutedPrompt, 0) // Pass 'e'
 	if err != nil {
-		log.Printf("ERROR: Failed processing file includes in prompt for menu %s: %v", currentMenuName, err)
+		slog.Error("failed processing file includes in prompt", "menu", currentMenuName, "error", err)
 
 		// Use RootAssetsPath for global assets if needed, or MenuSetPath for set-specific
 		// pausePrompt := e.LoadedStrings.PauseString // This comes from global strings
@@ -2235,7 +2228,7 @@ func (e *MenuExecutor) displayPrompt(terminal *term.Terminal, menu *MenuRecord, 
 	// 5. Write the final processed bytes using the terminal's standard Write (Reverted)
 	err = terminalio.WriteProcessedBytes(terminal, finalBuf.Bytes(), outputMode)
 	if err != nil {
-		log.Printf("ERROR: Failed writing processed prompt for menu %s: %v", currentMenuName, err)
+		slog.Error("failed writing processed prompt", "menu", currentMenuName, "error", err)
 		return err
 	}
 
@@ -2247,7 +2240,7 @@ func (e *MenuExecutor) displayPrompt(terminal *term.Terminal, menu *MenuRecord, 
 func (e *MenuExecutor) processFileIncludes(prompt string, depth int) (string, error) {
 	const maxDepth = 5 // Limit recursion depth
 	if depth > maxDepth {
-		log.Printf("WARN: Exceeded maximum file inclusion depth (%d). Stopping processing.", maxDepth)
+		slog.Warn("exceeded maximum file inclusion depth, stopping processing", "maxDepth", maxDepth)
 		return prompt, nil
 	}
 
@@ -2259,10 +2252,10 @@ func (e *MenuExecutor) processFileIncludes(prompt string, depth int) (string, er
 		// Look for included file in MenuSetPath/ansi
 		filePath := filepath.Join(e.MenuSetPath, "ansi", fileName)
 
-		log.Printf("DEBUG: Including file in prompt: %s (Depth: %d)", filePath, depth)
+		slog.Debug("including file in prompt", "path", filePath, "depth", depth)
 		data, err := os.ReadFile(filePath)
 		if err != nil {
-			log.Printf("WARN: Failed to read included file '%s': %v. Skipping inclusion.", filePath, err)
+			slog.Warn("failed to read included file, skipping inclusion", "path", filePath, "error", err)
 			return ""
 		}
 		return string(data)
@@ -2314,7 +2307,7 @@ func runShowVersion(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running SHOWVERSION", nodeNumber)
+	slog.Debug("running showversion", "node", nodeNumber)
 
 	versionTemplate := e.LoadedStrings.ExecVersionString
 	versionString := versionTemplate
@@ -2327,25 +2320,25 @@ func runShowVersion(c *cmdCtx, args string) (*user.User, string, error) {
 	terminalio.WriteProcessedBytes(terminal, []byte("\r\n\r\n"), outputMode)         // Add some spacing
 	wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(versionString)), outputMode)
 	if wErr != nil {
-		log.Printf("ERROR: Node %d: Failed writing SHOWVERSION output: %v", nodeNumber, wErr)
+		slog.Error("failed writing showversion output", "node", nodeNumber, "error", wErr)
 		// Don't return error, just log it
 	}
 
 	// Wait for Enter
 	pausePrompt := e.LoadedStrings.PauseString // Use configured pause string
 	if pausePrompt == "" {
-		log.Printf("WARN: Node %d: PauseString is empty in config/strings.json. No pause prompt will be shown for SHOWVERSION.", nodeNumber)
+		slog.Warn("pausestring empty, no pause prompt will be shown for showversion", "node", nodeNumber)
 		// Don't use a hardcoded fallback. If it's empty, it's empty.
 	} else {
 		terminalio.WriteProcessedBytes(terminal, []byte("\r\n"), outputMode) // Add newline before pause
-		log.Printf("DEBUG: Node %d: Displaying SHOWVERSION pause prompt (centered)", nodeNumber)
+		slog.Debug("displaying showversion pause prompt (centered)", "node", nodeNumber)
 		err := writeCenteredPausePrompt(s, terminal, pausePrompt, outputMode, termWidth, termHeight)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				log.Printf("INFO: Node %d: User disconnected during SHOWVERSION pause.", nodeNumber)
+				slog.Info("user disconnected during showversion pause", "node", nodeNumber)
 				return nil, "LOGOFF", io.EOF
 			}
-			log.Printf("ERROR: Node %d: Failed during SHOWVERSION pause: %v", nodeNumber, err)
+			slog.Error("failed during showversion pause", "node", nodeNumber, "error", err)
 			return nil, "", err
 		}
 	}

--- a/internal/menu/executor_admin_users.go
+++ b/internal/menu/executor_admin_users.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -33,7 +33,7 @@ func runListUsers(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running LISTUSERS", nodeNumber)
+	slog.Debug("running LISTUSERS", "node", nodeNumber)
 
 	// 1. Load Templates (Corrected filenames)
 	topTemplatePath := filepath.Join(e.MenuSetPath, "templates", "USERLIST.TOP")
@@ -45,7 +45,7 @@ func runListUsers(c *cmdCtx, args string) (*user.User, string, error) {
 	botTemplateBytes, errBot := readTemplateFile(botTemplatePath)
 
 	if errTop != nil || errMid != nil || errBot != nil {
-		log.Printf("ERROR: Node %d: Failed to load one or more USERLIST template files: TOP(%v), MID(%v), BOT(%v)", nodeNumber, errTop, errMid, errBot)
+		slog.Error("failed to load USERLIST template files", "node", nodeNumber, "top", errTop, "mid", errMid, "bot", errBot)
 		msg := e.LoadedStrings.ExecUserlistTemplateErr
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		if wErr != nil { /* Log? */
@@ -77,7 +77,7 @@ func runListUsers(c *cmdCtx, args string) (*user.User, string, error) {
 
 	if len(users) == 0 {
 		// Optional: Handle empty state. The template might handle this.
-		log.Printf("DEBUG: Node %d: No users to display.", nodeNumber)
+		slog.Debug("no users to display", "node", nodeNumber)
 		// If templates don't handle empty, add a message here.
 	} else {
 		// Iterate through user records and format using processed USERLIST.MID
@@ -109,20 +109,20 @@ func runListUsers(c *cmdCtx, args string) (*user.User, string, error) {
 			line = strings.ReplaceAll(line, "|GL", groupLocation) // Use |GL for Group/Location (Replaces |UN)
 			line = strings.ReplaceAll(line, "|LV", level)         // Use |LV for Level
 
-			log.Printf("DEBUG: About to write line for user %s: %q", handle, line)
+			slog.Debug("about to write line for user", "handle", handle, "line", line)
 			outputBuffer.WriteString(line) // Add the fully substituted and processed line
-			log.Printf("DEBUG: Wrote line. Buffer size now: %d", outputBuffer.Len())
+			slog.Debug("wrote line", "bufferSize", outputBuffer.Len())
 		}
 	}
 
-	log.Printf("DEBUG: Finished user loop. Total buffer size before BOT: %d", outputBuffer.Len())
+	slog.Debug("finished user loop", "bufferSize", outputBuffer.Len())
 	outputBuffer.Write(processedBotTemplate) // Write processed bottom template
-	log.Printf("DEBUG: Added BOT template. Final buffer size: %d", outputBuffer.Len())
+	slog.Debug("added BOT template", "bufferSize", outputBuffer.Len())
 
 	// 4. Clear screen and display the assembled content
 	writeErr := terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 	if writeErr != nil {
-		log.Printf("ERROR: Node %d: Failed clearing screen for USERLIST: %v", nodeNumber, writeErr)
+		slog.Error("failed clearing screen for USERLIST", "node", nodeNumber, "error", writeErr)
 		return nil, "", writeErr
 	}
 
@@ -135,7 +135,7 @@ func runListUsers(c *cmdCtx, args string) (*user.User, string, error) {
 		wErr = terminalio.WriteProcessedBytes(terminal, processedContent, outputMode)
 	}
 	if wErr != nil {
-		log.Printf("ERROR: Node %d: Failed writing USERLIST output: %v", nodeNumber, wErr)
+		slog.Error("failed writing USERLIST output", "node", nodeNumber, "error", wErr)
 		return nil, "", wErr
 	}
 
@@ -145,14 +145,14 @@ func runListUsers(c *cmdCtx, args string) (*user.User, string, error) {
 		pausePrompt = "\r\n|07Press |15[ENTER]|07 to continue... " // Fallback
 	}
 
-	log.Printf("DEBUG: Node %d: Displaying USERLIST pause prompt (centered)", nodeNumber)
+	slog.Debug("displaying USERLIST pause prompt", "node", nodeNumber)
 	err := writeCenteredPausePrompt(s, terminal, pausePrompt, outputMode, termWidth, termHeight)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
-			log.Printf("INFO: Node %d: User disconnected during USERLIST pause.", nodeNumber)
+			slog.Info("user disconnected during USERLIST pause", "node", nodeNumber)
 			return nil, "LOGOFF", io.EOF
 		}
-		log.Printf("ERROR: Node %d: Failed during USERLIST pause: %v", nodeNumber, err)
+		slog.Error("failed during USERLIST pause", "node", nodeNumber, "error", err)
 		return nil, "", err
 	}
 
@@ -467,7 +467,7 @@ func (e *MenuExecutor) applyPendingUserChanges(userManager *user.UserMgr, adminU
 		)
 		if logErr := userManager.LogAdminActivity(logEntry); logErr != nil {
 			// Don't fail the save, but make the audit gap observable.
-			log.Printf("ERROR: admin audit log write failed for user %d field %s: %v", target.ID, fieldName, logErr)
+			slog.Error("admin audit log write failed", "id", target.ID, "field", fieldName, "error", logErr)
 		}
 	}
 
@@ -500,7 +500,7 @@ func runUserEditor(c *cmdCtx, cfg userEditorConfig) (*user.User, string, error) 
 	termHeight := c.termHeight
 
 	if cfg.logLabel != "" {
-		log.Printf("DEBUG: Node %d: Running %s", nodeNumber, cfg.logLabel)
+		slog.Debug("running command", "node", nodeNumber, "label", cfg.logLabel)
 	}
 
 	adminCursorHidden := e.hideCursorIfNeeded(terminal, outputMode, cursorHideContextDefault)
@@ -1301,7 +1301,7 @@ func runAdminToggleAllowNewUsers(c *cmdCtx, args string) (*user.User, string, er
 	cfg.AllowNewUsers = !cfg.AllowNewUsers
 
 	if err := config.SaveServerConfig(e.RootConfigPath, cfg); err != nil {
-		log.Printf("ERROR: Node %d: Failed to save config after toggling allowNewUsers: %v", nodeNumber, err)
+		slog.Error("failed to save config after toggling allowNewUsers", "node", nodeNumber, "error", err)
 		_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Error saving config.|07\r\n")), outputMode)
 		time.Sleep(1 * time.Second)
 		return nil, "", nil
@@ -1344,7 +1344,7 @@ func runNewUserValidation(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running NEWUSERVAL", nodeNumber)
+	slog.Debug("running NEWUSERVAL", "node", nodeNumber)
 
 	if currentUser == nil {
 		return nil, "", nil
@@ -1414,7 +1414,7 @@ func runUnvalidateUser(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running UNVALIDATEUSER", nodeNumber)
+	slog.Debug("running UNVALIDATEUSER", "node", nodeNumber)
 
 	if currentUser == nil {
 		msg := "\r\n|01Error: You must be logged in to modify users.|07\r\n"
@@ -1523,7 +1523,7 @@ func runBanUser(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running BANUSER", nodeNumber)
+	slog.Debug("running BANUSER", "node", nodeNumber)
 
 	if currentUser == nil {
 		msg := "\r\n|01Error: You must be logged in to modify users.|07\r\n"
@@ -1644,7 +1644,7 @@ func runDeleteUser(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running DELETEUSER", nodeNumber)
+	slog.Debug("running DELETEUSER", "node", nodeNumber)
 
 	if currentUser == nil {
 		msg := "\r\n|01Error: You must be logged in to delete users.|07\r\n"
@@ -1767,7 +1767,7 @@ func runPurgeUsers(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running PURGEUSERS", nodeNumber)
+	slog.Debug("running PURGEUSERS", "node", nodeNumber)
 
 	if currentUser == nil || userManager == nil {
 		msg := "\r\n|01Error: You must be logged in to purge users.|07\r\n"

--- a/internal/menu/executor_files.go
+++ b/internal/menu/executor_files.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -38,16 +38,16 @@ func scanDirectoryFiles(dir string) (map[string]int64, error) {
 			continue
 		}
 		if entry.Type()&os.ModeSymlink != 0 {
-			log.Printf("WARN: Skipping symlink %s", entry.Name())
+			slog.Warn("skipping symlink", "name", entry.Name())
 			continue
 		}
 		info, err := entry.Info()
 		if err != nil {
-			log.Printf("WARN: Failed to get info for file %s: %v", entry.Name(), err)
+			slog.Warn("failed to get file info", "name", entry.Name(), "error", err)
 			continue
 		}
 		if !info.Mode().IsRegular() {
-			log.Printf("WARN: Skipping non-regular file %s", entry.Name())
+			slog.Warn("skipping non-regular file", "name", entry.Name())
 			continue
 		}
 		files[entry.Name()] = info.Size()
@@ -151,7 +151,7 @@ func (e *MenuExecutor) runTransferSend(s ssh.Session, terminal *term.Terminal, p
 
 	if proto.BatchSend && len(paths) > 1 {
 		// Batch: single transfer session
-		log.Printf("INFO: Node %d: Batch sending %d file(s) via %q: %v", nodeNumber, len(paths), proto.Name, names)
+		slog.Info("batch sending files", "node", nodeNumber, "count", len(paths), "protocol", proto.Name, "names", names)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(fmt.Sprintf("\r\n|15Initiating %s batch transfer (%d files)...|07\r\n", proto.Name, len(paths)))), outputMode)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("|07Please start the receive function in your terminal.\r\n")), outputMode)
 
@@ -159,7 +159,7 @@ func (e *MenuExecutor) runTransferSend(s ssh.Session, terminal *term.Terminal, p
 		defer cancel()
 		transferErr := proto.ExecuteSend(ctx, s, paths...)
 		if transferErr != nil {
-			log.Printf("ERROR: Node %d: %q batch send failed: %v", nodeNumber, proto.Name, transferErr)
+			slog.Error("batch send failed", "node", nodeNumber, "protocol", proto.Name, "error", transferErr)
 			terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 			if errors.Is(transferErr, transfer.ErrBinaryNotFound) {
 				terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|01File transfer program not found!|07\r\n|07The SysOp needs to install the transfer binary (sexyz).\r\n|07See docs/sysop/files/file-transfer.md for setup instructions.\r\n")), outputMode)
@@ -168,13 +168,13 @@ func (e *MenuExecutor) runTransferSend(s ssh.Session, terminal *term.Terminal, p
 			}
 			return 0, len(paths)
 		}
-		log.Printf("INFO: Node %d: %q batch send completed successfully.", nodeNumber, proto.Name)
+		slog.Info("batch send completed", "node", nodeNumber, "protocol", proto.Name)
 		terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("|07Transfer complete.\r\n")), outputMode)
 		for _, id := range fileIDs {
 			if id != uuid.Nil {
 				if err := e.FileMgr.IncrementDownloadCount(id); err != nil {
-					log.Printf("WARN: Node %d: Failed to increment download count for %s: %v", nodeNumber, id, err)
+					slog.Warn("failed to increment download count", "node", nodeNumber, "fileID", id, "error", err)
 				}
 			}
 		}
@@ -182,7 +182,7 @@ func (e *MenuExecutor) runTransferSend(s ssh.Session, terminal *term.Terminal, p
 	}
 
 	// One-at-a-time
-	log.Printf("INFO: Node %d: Sending %d file(s) one-at-a-time via %q", nodeNumber, len(paths), proto.Name)
+	slog.Info("sending files one-at-a-time", "node", nodeNumber, "count", len(paths), "protocol", proto.Name)
 	terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(fmt.Sprintf("\r\n|15Initiating %s transfer (%d file(s), one at a time)...|07\r\n", proto.Name, len(paths)))), outputMode)
 	terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("|07Prepare your terminal to receive each file.\r\n")), outputMode)
 
@@ -192,7 +192,7 @@ func (e *MenuExecutor) runTransferSend(s ssh.Session, terminal *term.Terminal, p
 		sendErr := proto.ExecuteSend(ctx, s, p)
 		cancel()
 		if sendErr != nil {
-			log.Printf("ERROR: Node %d: %q send failed for %s: %v", nodeNumber, proto.Name, names[i], sendErr)
+			slog.Error("send failed", "node", nodeNumber, "protocol", proto.Name, "name", names[i], "error", sendErr)
 			if errors.Is(sendErr, transfer.ErrBinaryNotFound) {
 				terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 				terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|01File transfer program not found!|07\r\n|07The SysOp needs to install the transfer binary (sexyz).\r\n|07See docs/sysop/files/file-transfer.md for setup instructions.\r\n")), outputMode)
@@ -203,13 +203,13 @@ func (e *MenuExecutor) runTransferSend(s ssh.Session, terminal *term.Terminal, p
 			failCount++
 			continue
 		}
-		log.Printf("INFO: Node %d: %q sent %s OK", nodeNumber, proto.Name, names[i])
+		slog.Info("file sent", "node", nodeNumber, "protocol", proto.Name, "name", names[i])
 		terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(fmt.Sprintf("|15[%d/%d]|07 |14%s|07: |02OK|07\r\n", i+1, len(paths), names[i]))), outputMode)
 		successCount++
 		if i < len(fileIDs) && fileIDs[i] != uuid.Nil {
 			if err := e.FileMgr.IncrementDownloadCount(fileIDs[i]); err != nil {
-				log.Printf("WARN: Node %d: Failed to increment download count for %s: %v", nodeNumber, fileIDs[i], err)
+				slog.Warn("failed to increment download count", "node", nodeNumber, "fileID", fileIDs[i], "error", err)
 			}
 		}
 	}
@@ -247,7 +247,7 @@ func runUploadFile(c *cmdCtx, args string) (*user.User, string, error) {
 		if errors.Is(err, io.EOF) {
 			return nil, "LOGOFF", err
 		}
-		log.Printf("ERROR: Node %d: Upload failed: %v", nodeNumber, err)
+		slog.Error("upload failed", "node", nodeNumber, "error", err)
 	}
 
 	// Reload user to get updated NumUploads
@@ -269,7 +269,7 @@ func (e *MenuExecutor) runUploadFiles(
 	nodeNumber int,
 	sessionStartTime time.Time,
 ) error {
-	log.Printf("INFO: Node %d: User %s starting upload to area %d (%s)", nodeNumber, currentUser.Handle, currentAreaID, currentAreaTag)
+	slog.Info("user starting upload", "node", nodeNumber, "handle", currentUser.Handle, "area", currentAreaID, "tag", currentAreaTag)
 
 	// 1. Check upload ACS
 	area, areaExists := e.FileMgr.GetAreaByID(currentAreaID)
@@ -278,7 +278,7 @@ func (e *MenuExecutor) runUploadFiles(
 	}
 
 	if area.ACSUpload != "" && !checkACS(area.ACSUpload, currentUser, s, terminal, sessionStartTime) {
-		log.Printf("WARN: Node %d: User %s denied upload access to area %s (ACS: %s)", nodeNumber, currentUser.Handle, currentAreaTag, area.ACSUpload)
+		slog.Warn("user denied upload access", "node", nodeNumber, "handle", currentUser.Handle, "tag", currentAreaTag, "acs", area.ACSUpload)
 		msg := "\r\n|01You do not have permission to upload to this area.|07\r\n"
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(2 * time.Second)
@@ -305,7 +305,7 @@ func (e *MenuExecutor) runUploadFiles(
 		if errors.Is(protoErr, io.EOF) {
 			return protoErr
 		}
-		log.Printf("ERROR: Node %d: Protocol selection error: %v", nodeNumber, protoErr)
+		slog.Error("protocol selection error", "node", nodeNumber, "error", protoErr)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Error: No transfer protocols configured on this system.|07\r\n")), outputMode)
 		time.Sleep(2 * time.Second)
 		return nil
@@ -332,7 +332,7 @@ func (e *MenuExecutor) runUploadFiles(
 	// 7. Create temp directory for receiving uploads
 	incomingDir, err := os.MkdirTemp(targetDir, ".incoming-*")
 	if err != nil {
-		log.Printf("ERROR: Node %d: Failed to create incoming directory: %v", nodeNumber, err)
+		slog.Error("failed to create incoming directory", "node", nodeNumber, "error", err)
 		return fmt.Errorf("failed to create incoming directory: %w", err)
 	}
 	defer os.RemoveAll(incomingDir)
@@ -350,11 +350,11 @@ func (e *MenuExecutor) runUploadFiles(
 	terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 	if transferErr != nil {
 		if errors.Is(transferErr, transfer.ErrBinaryNotFound) {
-			log.Printf("ERROR: Node %d: Transfer binary not found: %v", nodeNumber, transferErr)
+			slog.Error("transfer binary not found", "node", nodeNumber, "error", transferErr)
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|01File transfer program not found!|07\r\n|07The SysOp needs to install the transfer binary (sexyz).\r\n|07See docs/sysop/files/file-transfer.md for setup instructions.\r\n")), outputMode)
 			return nil
 		}
-		log.Printf("WARN: Node %d: %q receive returned error: %v (checking for partial receives)", nodeNumber, proto.Name, transferErr)
+		slog.Warn("receive returned error, checking for partial receives", "node", nodeNumber, "protocol", proto.Name, "error", transferErr)
 	}
 
 	// 9. Scan received files from temp directory.
@@ -362,7 +362,7 @@ func (e *MenuExecutor) runUploadFiles(
 	// waiting for ZFIN, but may have already received files successfully.
 	receivedFiles, err := scanDirectoryFiles(incomingDir)
 	if err != nil {
-		log.Printf("ERROR: Node %d: Failed to scan incoming directory: %v", nodeNumber, err)
+		slog.Error("failed to scan incoming directory", "node", nodeNumber, "error", err)
 		return nil
 	}
 
@@ -392,7 +392,7 @@ func (e *MenuExecutor) runUploadFiles(
 		return newFiles[i].name < newFiles[j].name
 	})
 
-	log.Printf("INFO: Node %d: Detected %d new file(s) after upload", nodeNumber, len(newFiles))
+	slog.Info("detected new files after upload", "node", nodeNumber, "count", len(newFiles))
 
 	// 9. Process each new file
 	successCount := 0
@@ -401,7 +401,7 @@ func (e *MenuExecutor) runUploadFiles(
 	// Load ZipLab config once for all files
 	zlCfg, zlErr := ziplab.LoadConfig(e.RootConfigPath)
 	if zlErr != nil {
-		log.Printf("WARN: Node %d: Failed to load ZipLab config: %v", nodeNumber, zlErr)
+		slog.Warn("failed to load ziplab config", "node", nodeNumber, "error", zlErr)
 	}
 
 	for _, nf := range newFiles {
@@ -410,7 +410,7 @@ func (e *MenuExecutor) runUploadFiles(
 		// Validate filename (defense in depth — rz -r should prevent this, but be safe)
 		safeName := filepath.Base(nf.name)
 		if safeName != nf.name || safeName == "." || safeName == ".." || strings.Contains(nf.name, "..") || filepath.IsAbs(nf.name) {
-			log.Printf("ERROR: Node %d: Rejected unsafe filename: %s", nodeNumber, nf.name)
+			slog.Error("rejected unsafe filename", "node", nodeNumber, "name", nf.name)
 			os.Remove(incomingPath)
 			errMsg := fmt.Sprintf("\r\n|01'%s' rejected: invalid filename.|07\r\n", nf.name)
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(errMsg)), outputMode)
@@ -419,7 +419,7 @@ func (e *MenuExecutor) runUploadFiles(
 
 		// Check for duplicate in metadata
 		if existingNames[strings.ToLower(nf.name)] {
-			log.Printf("WARN: Node %d: Duplicate file rejected: %s", nodeNumber, nf.name)
+			slog.Warn("duplicate file rejected", "node", nodeNumber, "name", nf.name)
 			duplicateCount++
 			os.Remove(incomingPath)
 
@@ -433,7 +433,7 @@ func (e *MenuExecutor) runUploadFiles(
 		filePath := incomingPath
 
 		if zlErr == nil && zlCfg.Enabled && zlCfg.RunOnUpload && zlCfg.IsArchiveSupported(nf.name) {
-			log.Printf("INFO: Node %d: Running ZipLab pipeline on %s", nodeNumber, nf.name)
+			slog.Info("running ziplab pipeline", "node", nodeNumber, "name", nf.name)
 
 			zlBaseDir := filepath.Join(filepath.Dir(e.RootConfigPath), "ziplab")
 			proc := ziplab.NewProcessor(zlCfg, zlBaseDir)
@@ -453,7 +453,7 @@ func (e *MenuExecutor) runUploadFiles(
 			}
 
 			if !result.Success {
-				log.Printf("ERROR: Node %d: ZipLab pipeline failed for %s: %v", nodeNumber, nf.name, result.Error)
+				slog.Error("ziplab pipeline failed", "node", nodeNumber, "name", nf.name, "error", result.Error)
 				errMsg := fmt.Sprintf("\r\n|01ZipLab processing failed for '%s'.|07\r\n", nf.name)
 				terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(errMsg)), outputMode)
 				time.Sleep(2 * time.Second)
@@ -462,7 +462,7 @@ func (e *MenuExecutor) runUploadFiles(
 
 			if result.Description != "" {
 				description = sanitizeControlChars(strings.TrimRight(result.Description, " \t\r\n"))
-				log.Printf("INFO: Node %d: Using FILE_ID.DIZ description for %s: %q", nodeNumber, nf.name, description)
+				slog.Info("using FILE_ID.DIZ description", "node", nodeNumber, "name", nf.name, "description", description)
 			}
 		}
 
@@ -478,7 +478,7 @@ func (e *MenuExecutor) runUploadFiles(
 				// If the session died (e.g. SSH client disconnected during the
 				// transfer wait), preserve the upload with a default description
 				// rather than LOGOFFing the user mid-file-processing.
-				log.Printf("WARN: Node %d: Session lost during description prompt for %s (%v); using default description", nodeNumber, nf.name, err)
+				slog.Warn("session lost during description prompt, using default description", "node", nodeNumber, "name", nf.name, "error", err)
 				description = "No description"
 			} else {
 				description = sanitizeControlChars(strings.TrimSpace(descInput))
@@ -493,7 +493,7 @@ func (e *MenuExecutor) runUploadFiles(
 
 		// Re-stat file to get post-pipeline size (ZipLab may have modified it)
 		if fi, statErr := os.Stat(incomingPath); statErr != nil {
-			log.Printf("WARN: Node %d: Failed to stat %s after pipeline: %v (using original size)", nodeNumber, nf.name, statErr)
+			slog.Warn("failed to stat file after pipeline, using original size", "node", nodeNumber, "name", nf.name, "error", statErr)
 		} else {
 			nf.size = fi.Size()
 		}
@@ -515,7 +515,7 @@ func (e *MenuExecutor) runUploadFiles(
 		// Guard against clobbering a file that exists on disk but is absent from
 		// the metadata duplicate check above: os.Rename would overwrite it.
 		if _, statErr := os.Stat(finalPath); statErr == nil {
-			log.Printf("WARN: Node %d: Upload rejected, '%s' already exists on disk (not in metadata)", nodeNumber, nf.name)
+			slog.Warn("upload rejected, file already exists on disk", "node", nodeNumber, "name", nf.name)
 			duplicateCount++
 			os.Remove(incomingPath)
 			dupMsg := fmt.Sprintf("\r\n|09'%s' already exists in this area. Rejected.|07\r\n", nf.name)
@@ -523,23 +523,23 @@ func (e *MenuExecutor) runUploadFiles(
 			continue
 		}
 		if moveErr := os.Rename(incomingPath, finalPath); moveErr != nil {
-			log.Printf("ERROR: Node %d: Failed to move %s to area: %v", nodeNumber, nf.name, moveErr)
+			slog.Error("failed to move file to area", "node", nodeNumber, "name", nf.name, "error", moveErr)
 			errMsg := fmt.Sprintf("\r\n|01Failed to accept '%s'.|07\r\n", nf.name)
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(errMsg)), outputMode)
 			continue
 		}
 
 		if addErr := e.FileMgr.AddFileRecord(record); addErr != nil {
-			log.Printf("ERROR: Node %d: Failed to add file record for %s: %v", nodeNumber, nf.name, addErr)
+			slog.Error("failed to add file record", "node", nodeNumber, "name", nf.name, "error", addErr)
 			errMsg := fmt.Sprintf("\r\n|01Failed to register '%s'.|07\r\n", nf.name)
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(errMsg)), outputMode)
 			if removeErr := os.Remove(finalPath); removeErr != nil {
-				log.Printf("ERROR: Node %d: Failed to clean up orphaned file %s: %v", nodeNumber, nf.name, removeErr)
+				slog.Error("failed to clean up orphaned file", "node", nodeNumber, "name", nf.name, "error", removeErr)
 			}
 			continue
 		}
 
-		log.Printf("INFO: Node %d: Added file record for %s (ID: %s)", nodeNumber, nf.name, record.ID)
+		slog.Info("added file record", "node", nodeNumber, "name", nf.name, "fileID", record.ID)
 		successCount++
 		existingNames[strings.ToLower(nf.name)] = true
 	}
@@ -548,7 +548,7 @@ func (e *MenuExecutor) runUploadFiles(
 	if successCount > 0 {
 		currentUser.NumUploads += successCount
 		if updateErr := userManager.UpdateUser(currentUser); updateErr != nil {
-			log.Printf("ERROR: Node %d: Failed to update user upload count: %v", nodeNumber, updateErr)
+			slog.Error("failed to update user upload count", "node", nodeNumber, "error", updateErr)
 		}
 	}
 
@@ -629,11 +629,11 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 			break
 		}
 	}
-	log.Printf("DEBUG: Node %d: Running LISTFILES (extended=%v)", nodeNumber, extendedMode)
+	slog.Debug("running LISTFILES", "node", nodeNumber, "extended", extendedMode)
 
 	// 1. Check User and Current File Area
 	if currentUser == nil {
-		log.Printf("WARN: Node %d: LISTFILES called without logged in user.", nodeNumber)
+		slog.Warn("LISTFILES called without logged in user", "node", nodeNumber)
 		msg := "\r\n|01Error: You must be logged in to list files.|07\r\n"
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		if wErr != nil { /* Log? */
@@ -647,7 +647,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 	currentAreaTag := currentUser.CurrentFileAreaTag
 
 	if currentAreaID <= 0 {
-		log.Printf("WARN: Node %d: User %s has no current file area selected.", nodeNumber, currentUser.Handle)
+		slog.Warn("user has no current file area selected", "node", nodeNumber, "handle", currentUser.Handle)
 		msg := "\r\n|01Error: No file area selected.|07\r\n"
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		if wErr != nil { /* Log? */
@@ -656,16 +656,16 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 		return nil, "", nil // Return to menu
 	}
 
-	log.Printf("INFO: Node %d: User %s listing files for Area ID %d (%s)", nodeNumber, currentUser.Handle, currentAreaID, currentAreaTag)
+	slog.Info("user listing files", "node", nodeNumber, "handle", currentUser.Handle, "area", currentAreaID, "tag", currentAreaTag)
 
 	// Check Read ACS for the file area
 	area, exists := e.FileMgr.GetAreaByID(currentAreaID)
 	if !exists {
-		log.Printf("WARN: Node %d: User %s: current file area %d (%s) not found (stale/invalid area id)", nodeNumber, currentUser.Handle, currentAreaID, currentAreaTag)
+		slog.Warn("current file area not found (stale/invalid area id)", "node", nodeNumber, "handle", currentUser.Handle, "area", currentAreaID, "tag", currentAreaTag)
 		return nil, "", nil // Return to menu
 	}
 	if !checkACS(area.ACSList, currentUser, s, terminal, sessionStartTime) {
-		log.Printf("WARN: Node %d: User %s denied read access to file area %d (%s) due to ACS '%s'", nodeNumber, currentUser.Handle, currentAreaID, currentAreaTag, area.ACSList)
+		slog.Warn("user denied read access to file area", "node", nodeNumber, "handle", currentUser.Handle, "area", currentAreaID, "tag", currentAreaTag, "acs", area.ACSList)
 		// Display error message
 		return nil, "", nil // Return to menu
 	}
@@ -682,7 +682,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 		if os.IsNotExist(errBot) {
 			botTemplateBytes = nil
 		} else {
-			log.Printf("ERROR: Node %d: Failed to load FILELIST.BOT template: %v", nodeNumber, errBot)
+			slog.Error("failed to load FILELIST.BOT template", "node", nodeNumber, "error", errBot)
 			msg := "\r\n|01Error loading File List screen templates.|07\r\n"
 			wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 			if wErr != nil { /* Log? */
@@ -693,7 +693,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	if errTop != nil || errMid != nil {
-		log.Printf("ERROR: Node %d: Failed to load FILELIST template files: TOP(%v), MID(%v)", nodeNumber, errTop, errMid)
+		slog.Error("failed to load FILELIST template files", "node", nodeNumber, "topError", errTop, "midError", errMid)
 		msg := "\r\n|01Error loading File List screen templates.|07\r\n"
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		if wErr != nil { /* Log? */
@@ -741,13 +741,13 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 	if filesPerPage < 1 {
 		filesPerPage = 1 // Ensure at least 1 file can be shown
 	}
-	log.Printf("DEBUG: Node %d: TermHeight=%d, FixedLines=%d, FilesPerPage=%d", nodeNumber, termHeight, fixedLines, filesPerPage)
+	slog.Debug("file list pagination", "node", nodeNumber, "termHeight", termHeight, "fixedLines", fixedLines, "filesPerPage", filesPerPage)
 
 	// --- Get Total File Count ---
 	// TODO: Implement GetFileCountForArea in FileManager
 	totalFiles, err := e.FileMgr.GetFileCountForArea(currentAreaID)
 	if err != nil {
-		log.Printf("ERROR: Node %d: Failed to get file count for area %d: %v", nodeNumber, currentAreaID, err)
+		slog.Error("failed to get file count for area", "node", nodeNumber, "area", currentAreaID, "error", err)
 		msg := fmt.Sprintf("\r\n|01Error retrieving file list for area '%s'.|07\r\n", currentAreaTag)
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		if wErr != nil { /* Log? */
@@ -772,7 +772,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 		// TODO: Implement GetFilesForAreaPaginated in FileManager
 		filesOnPage, err = e.FileMgr.GetFilesForAreaPaginated(currentAreaID, currentPage, filesPerPage)
 		if err != nil {
-			log.Printf("ERROR: Node %d: Failed to get files for area %d, page %d: %v", nodeNumber, currentAreaID, currentPage, err)
+			slog.Error("failed to get files for area page", "node", nodeNumber, "area", currentAreaID, "page", currentPage, "error", err)
 			msg := fmt.Sprintf("\r\n|01Error retrieving file list page for area '%s'.|07\r\n", currentAreaTag)
 			wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 			if wErr != nil { /* Log? */
@@ -787,11 +787,11 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 	// Load optional BAR files for file listing lightbar.
 	cmdBarOptions, cmdBarErr := loadBarFile("FILELISTCMD", e)
 	if cmdBarErr != nil {
-		log.Printf("WARN: Node %d: Failed to load FILELISTCMD.BAR: %v", nodeNumber, cmdBarErr)
+		slog.Warn("failed to load FILELISTCMD.BAR", "node", nodeNumber, "error", cmdBarErr)
 	}
 	hiBarOptions, hiBarErr := loadBarFile("FILELISTHI", e)
 	if hiBarErr != nil {
-		log.Printf("WARN: Node %d: Failed to load FILELISTHI.BAR: %v", nodeNumber, hiBarErr)
+		slog.Warn("failed to load FILELISTHI.BAR", "node", nodeNumber, "error", hiBarErr)
 	}
 
 	// 4. Dispatch based on file listing mode (user pref overrides server default)
@@ -813,18 +813,18 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 		// 4.1 Clear Screen
 		writeErr := terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 		if writeErr != nil {
-			log.Printf("ERROR: Node %d: Failed clearing screen for LISTFILES: %v", nodeNumber, writeErr)
+			slog.Error("failed clearing screen for LISTFILES", "node", nodeNumber, "error", writeErr)
 		}
 
 		// 4.2 Display Top Template (process @FCONFPATH@, @FTOTAL@, @FPAGE@ placeholders per page)
 		topRendered := ansi.ReplacePipeCodes(processFileListPlaceholders(topTemplateBytes, currentPage, totalPages, totalFiles, fconfpath))
 		wErr := terminalio.WriteProcessedBytes(terminal, topRendered, outputMode)
 		if wErr != nil {
-			log.Printf("ERROR: Node %d: Failed writing LISTFILES top template: %v", nodeNumber, wErr)
+			slog.Error("failed writing LISTFILES top template", "node", nodeNumber, "error", wErr)
 		}
 		wErr = terminalio.WriteProcessedBytes(terminal, []byte("\r\n"), outputMode)
 		if wErr != nil {
-			log.Printf("ERROR: Node %d: Failed writing CRLF after LISTFILES top template: %v", nodeNumber, wErr)
+			slog.Error("failed writing CRLF after LISTFILES top template", "node", nodeNumber, "error", wErr)
 		}
 
 		// 4.3 Display Files on Current Page (using MID template)
@@ -892,11 +892,11 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 
 				wErr = writeProcessedStringWithManualEncoding(terminal, []byte(line), outputMode)
 				if wErr != nil {
-					log.Printf("ERROR: Node %d: Failed writing file list line %d: %v", nodeNumber, i, wErr)
+					slog.Error("failed writing file list line", "node", nodeNumber, "line", i, "error", wErr)
 				}
 				wErr = terminalio.WriteProcessedBytes(terminal, []byte("\r\n"), outputMode)
 				if wErr != nil {
-					log.Printf("ERROR: Node %d: Failed writing CRLF after file list line %d: %v", nodeNumber, i, wErr)
+					slog.Error("failed writing CRLF after file list line", "node", nodeNumber, "line", i, "error", wErr)
 				}
 
 				prefixLine := processedMidTemplate
@@ -928,7 +928,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 		bottomLine = strings.ReplaceAll(bottomLine, "^TOTALPAGES", strconv.Itoa(totalPages))
 		wErr = terminalio.WriteProcessedBytes(terminal, []byte(bottomLine), outputMode)
 		if wErr != nil {
-			log.Printf("ERROR: Node %d: Failed writing LISTFILES bottom template: %v", nodeNumber, wErr)
+			slog.Error("failed writing LISTFILES bottom template", "node", nodeNumber, "error", wErr)
 			// Handle error
 		}
 
@@ -944,10 +944,10 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 		input, err := readLineFromSessionIH(s, terminal)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				log.Printf("INFO: Node %d: User disconnected during LISTFILES.", nodeNumber)
+				slog.Info("user disconnected during LISTFILES", "node", nodeNumber)
 				return nil, "LOGOFF", io.EOF
 			}
-			log.Printf("ERROR: Node %d: Failed reading LISTFILES input: %v", nodeNumber, err)
+			slog.Error("failed reading LISTFILES input", "node", nodeNumber, "error", err)
 			// Consider retry or exit
 			return nil, "", err
 		}
@@ -963,7 +963,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 				filesOnPage, err = e.FileMgr.GetFilesForAreaPaginated(currentAreaID, currentPage, filesPerPage)
 				if err != nil {
 					// Log error and potentially return or break the loop
-					log.Printf("ERROR: Node %d: Failed to get files for page %d: %v", nodeNumber, currentPage, err)
+					slog.Error("failed to get files for page", "node", nodeNumber, "page", currentPage, "error", err)
 					// Display error message to user?
 					time.Sleep(1 * time.Second)
 				}
@@ -980,7 +980,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 				filesOnPage, err = e.FileMgr.GetFilesForAreaPaginated(currentAreaID, currentPage, filesPerPage)
 				if err != nil {
 					// Log error and potentially return or break the loop
-					log.Printf("ERROR: Node %d: Failed to get files for page %d: %v", nodeNumber, currentPage, err)
+					slog.Error("failed to get files for page", "node", nodeNumber, "page", currentPage, "error", err)
 					// Display error message to user?
 					time.Sleep(1 * time.Second)
 				}
@@ -991,10 +991,10 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 			}
 			continue // Redraw loop
 		case "Q": // Quit
-			log.Printf("DEBUG: Node %d: User quit LISTFILES.", nodeNumber)
+			slog.Debug("user quit LISTFILES", "node", nodeNumber)
 			return nil, "", nil // Return to FILEM menu
 		case "D": // Download marked files
-			log.Printf("DEBUG: Node %d: User %s initiated Download command in area %d.", nodeNumber, currentUser.Handle, currentAreaID)
+			slog.Debug("user initiated download command", "node", nodeNumber, "handle", currentUser.Handle, "area", currentAreaID)
 
 			// 1. Check if any files are marked
 			if len(currentUser.TaggedFileIDs) == 0 {
@@ -1019,10 +1019,10 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 
 			if err != nil {
 				if errors.Is(err, io.EOF) {
-					log.Printf("INFO: Node %d: User disconnected during download confirmation.", nodeNumber)
+					slog.Info("user disconnected during download confirmation", "node", nodeNumber)
 					return nil, "LOGOFF", io.EOF
 				}
-				log.Printf("ERROR: Node %d: Error getting download confirmation: %v", nodeNumber, err)
+				slog.Error("error getting download confirmation", "node", nodeNumber, "error", err)
 				msg := "\r\n|01Error during confirmation.|07\r\n"
 				terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 				time.Sleep(1 * time.Second)
@@ -1030,7 +1030,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 			}
 
 			if !proceed {
-				log.Printf("DEBUG: Node %d: User cancelled download.", nodeNumber)
+				slog.Debug("user cancelled download", "node", nodeNumber)
 				terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|07Download cancelled.|07")), outputMode)
 				time.Sleep(500 * time.Millisecond)
 				continue // Back to file list
@@ -1042,7 +1042,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 				if errors.Is(protoErr, io.EOF) {
 					return nil, "LOGOFF", protoErr
 				}
-				log.Printf("ERROR: Node %d: Protocol selection error: %v", nodeNumber, protoErr)
+				slog.Error("protocol selection error", "node", nodeNumber, "error", protoErr)
 				terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Error: No transfer protocols configured on this system.|07\r\n")), outputMode)
 				time.Sleep(2 * time.Second)
 				continue
@@ -1064,12 +1064,12 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 			for _, fileID := range currentUser.TaggedFileIDs {
 				filePath, pathErr := e.FileMgr.GetFilePath(fileID)
 				if pathErr != nil {
-					log.Printf("ERROR: Node %d: Failed to get path for file ID %s: %v", nodeNumber, fileID, pathErr)
+					slog.Error("failed to get path for file", "node", nodeNumber, "fileID", fileID, "error", pathErr)
 					failCount++
 					continue
 				}
 				if _, statErr := os.Stat(filePath); statErr != nil {
-					log.Printf("ERROR: Node %d: File %s (ID %s) not on disk: %v", nodeNumber, filePath, fileID, statErr)
+					slog.Error("file not on disk", "node", nodeNumber, "path", filePath, "fileID", fileID, "error", statErr)
 					failCount++
 					continue
 				}
@@ -1077,7 +1077,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 			}
 
 			if len(resolved) == 0 {
-				log.Printf("WARN: Node %d: No valid file paths found for tagged files.", nodeNumber)
+				slog.Warn("no valid file paths found for tagged files", "node", nodeNumber)
 				terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Could not find any of the marked files on the server.|07\r\n")), outputMode)
 				failCount = len(currentUser.TaggedFileIDs)
 			} else {
@@ -1094,11 +1094,11 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 			}
 
 			// 4. Clear tags, update download count, and save user state
-			log.Printf("DEBUG: Node %d: Clearing %d tagged file IDs for user %s.", nodeNumber, len(currentUser.TaggedFileIDs), currentUser.Handle)
+			slog.Debug("clearing tagged file IDs", "node", nodeNumber, "count", len(currentUser.TaggedFileIDs), "handle", currentUser.Handle)
 			currentUser.TaggedFileIDs = nil // Clear the list
 			currentUser.NumDownloads += successCount
 			if err := userManager.UpdateUser(currentUser); err != nil {
-				log.Printf("ERROR: Node %d: Failed to save user data after download attempt: %v", nodeNumber, err)
+				slog.Error("failed to save user data after download attempt", "node", nodeNumber, "error", err)
 				// Inform user? State might be inconsistent.
 				terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Error saving user state after download.|07")), outputMode)
 			}
@@ -1111,13 +1111,13 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 			// Go back to the file list (will redraw with cleared marks)
 			continue
 		case "U": // Upload Files
-			log.Printf("DEBUG: Node %d: Upload command entered for area %d (%s)", nodeNumber, currentAreaID, currentAreaTag)
+			slog.Debug("upload command entered", "node", nodeNumber, "area", currentAreaID, "tag", currentAreaTag)
 			uploadErr := e.runUploadFiles(s, terminal, currentUser, userManager, currentAreaID, currentAreaTag, outputMode, nodeNumber, sessionStartTime)
 			if uploadErr != nil {
 				if errors.Is(uploadErr, io.EOF) {
 					return nil, "LOGOFF", uploadErr
 				}
-				log.Printf("ERROR: Node %d: Upload failed: %v", nodeNumber, uploadErr)
+				slog.Error("upload failed", "node", nodeNumber, "error", uploadErr)
 			}
 			// Reload user to get updated NumUploads
 			if reloaded, exists := userManager.GetUser(currentUser.Handle); exists {
@@ -1137,7 +1137,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 			filesOnPage, _ = e.FileMgr.GetFilesForAreaPaginated(currentAreaID, currentPage, filesPerPage)
 			continue
 		case "V": // View file
-			log.Printf("DEBUG: Node %d: View command entered in file list", nodeNumber)
+			slog.Debug("view command entered in file list", "node", nodeNumber)
 			viewPrompt := "\r\n|07Enter file # to view (or |15ENTER|07 to cancel): |15"
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(viewPrompt)), outputMode)
 			viewInput, viewErr := readLineFromSessionIH(s, terminal)
@@ -1167,7 +1167,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 			if e.FileMgr.IsSupportedArchive(fileToView.Filename) {
 				viewFilePath, pathErr := e.FileMgr.GetFilePath(fileToView.ID)
 				if pathErr != nil {
-					log.Printf("ERROR: Node %d: Failed to get path for file %s: %v", nodeNumber, fileToView.ID, pathErr)
+					slog.Error("failed to get path for file", "node", nodeNumber, "fileID", fileToView.ID, "error", pathErr)
 					terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Error locating file.|07\r\n")), outputMode)
 					time.Sleep(1 * time.Second)
 				} else {
@@ -1180,7 +1180,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 			}
 			continue
 		case "A": // Area Change (Placeholder/Not implemented here, handled by menu?)
-			log.Printf("DEBUG: Node %d: Area Change command entered (Handled by menu)", nodeNumber)
+			slog.Debug("area change command entered (handled by menu)", "node", nodeNumber)
 			msg := "\r\n|01Use menu options to change area.|07\r\n"
 			wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 			if wErr != nil { /* Log? */
@@ -1208,21 +1208,21 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 					if !found {
 						// File was not tagged, so add it
 						newTaggedIDs = append(newTaggedIDs, fileToToggle.ID)
-						log.Printf("DEBUG: Node %d: User %s tagged file #%d (ID: %s)", nodeNumber, currentUser.Handle, fileNumToTag, fileToToggle.ID)
+						slog.Debug("user tagged file", "node", nodeNumber, "handle", currentUser.Handle, "fileNum", fileNumToTag, "fileID", fileToToggle.ID)
 					} else {
 						// File was tagged, so we removed it (untagged)
-						log.Printf("DEBUG: Node %d: User %s untagged file #%d (ID: %s)", nodeNumber, currentUser.Handle, fileNumToTag, fileToToggle.ID)
+						slog.Debug("user untagged file", "node", nodeNumber, "handle", currentUser.Handle, "file_num", fileNumToTag, "id", fileToToggle.ID)
 					}
 					currentUser.TaggedFileIDs = newTaggedIDs
 					// No page change needed, loop will redraw with updated marks
 				} else {
 					// Invalid file number for current page
-					log.Printf("DEBUG: Node %d: Invalid file number entered: %d", nodeNumber, fileNumToTag)
+					slog.Debug("invalid file number entered", "node", nodeNumber, "file_num", fileNumToTag)
 					// Optional: Add user feedback message
 				}
 			} else {
 				// Input was not N, P, Q, D, U, V, A, or a valid number - Invalid command
-				log.Printf("DEBUG: Node %d: Invalid command entered in LISTFILES: %s", nodeNumber, upperInput)
+				slog.Debug("invalid command entered in LISTFILES", "node", nodeNumber, "input", upperInput)
 				// Optional: Add user feedback message
 			}
 		} // end switch
@@ -1235,7 +1235,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 // displayFileAreaList is an internal helper to display the list of accessible file areas.
 // It does not include a pause prompt.
 func displayFileAreaList(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, currentUser *user.User, outputMode ansi.OutputMode, nodeNumber int, sessionStartTime time.Time) error {
-	log.Printf("DEBUG: Node %d: Displaying file area list (helper)", nodeNumber)
+	slog.Debug("displaying file area list", "node", nodeNumber)
 
 	// 1. Define Template filenames and paths
 	topTemplateFilename := "FILEAREA.TOP"
@@ -1252,7 +1252,7 @@ func displayFileAreaList(e *MenuExecutor, s ssh.Session, terminal *term.Terminal
 	botTemplateBytes, errBot := readTemplateFile(botTemplatePath)
 
 	if errTop != nil || errMid != nil || errBot != nil {
-		log.Printf("ERROR: Node %d: Failed to load one or more FILEAREA template files: TOP(%v), MID(%v), BOT(%v)", nodeNumber, errTop, errMid, errBot)
+		slog.Error("failed to load FILEAREA template files", "node", nodeNumber, "top_error", errTop, "mid_error", errMid, "bot_error", errBot)
 		// Display error message to terminal
 		msg := "\r\n|01Error loading File Area screen templates.|07\r\n"
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
@@ -1282,7 +1282,7 @@ func displayFileAreaList(e *MenuExecutor, s ssh.Session, terminal *term.Terminal
 	confIDs := make(map[int]bool)
 	for _, area := range areas {
 		if !checkACS(area.ACSList, currentUser, s, terminal, sessionStartTime) {
-			log.Printf("TRACE: Node %d: User %s denied list access to file area %d (%s) due to ACS '%s'", nodeNumber, currentUser.Handle, area.ID, area.Tag, area.ACSList)
+			slog.Debug("user denied list access to file area due to ACS", "node", nodeNumber, "handle", currentUser.Handle, "area", area.Tag, "acs", area.ACSList)
 			continue
 		}
 		groups[area.ConferenceID] = append(groups[area.ConferenceID], area)
@@ -1335,7 +1335,7 @@ func displayFileAreaList(e *MenuExecutor, s ssh.Session, terminal *term.Terminal
 			tag := string(ansi.ReplacePipeCodes([]byte(area.Tag)))
 			fileCount, countErr := e.FileMgr.GetFileCountForArea(area.ID)
 			if countErr != nil {
-				log.Printf("WARN: Node %d: Failed getting file count for area %d (%s): %v", nodeNumber, area.ID, area.Tag, countErr)
+				slog.Warn("failed getting file count for area", "node", nodeNumber, "area", area.Tag, "id", area.ID, "error", countErr)
 				fileCount = 0
 			}
 			fileCountStr := strconv.Itoa(fileCount)
@@ -1352,7 +1352,7 @@ func displayFileAreaList(e *MenuExecutor, s ssh.Session, terminal *term.Terminal
 	}
 
 	if areasDisplayed == 0 {
-		log.Printf("DEBUG: Node %d: No accessible file areas to display for user %s.", nodeNumber, currentUser.Handle)
+		slog.Debug("no accessible file areas to display", "node", nodeNumber, "handle", currentUser.Handle)
 		outputBuffer.WriteString("\r\n|07   No accessible file areas found.   \r\n")
 	}
 
@@ -1361,7 +1361,7 @@ func displayFileAreaList(e *MenuExecutor, s ssh.Session, terminal *term.Terminal
 	// 6. Clear screen and display the assembled content
 	writeErr := terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 	if writeErr != nil {
-		log.Printf("ERROR: Node %d: Failed clearing screen for file area list: %v", nodeNumber, writeErr)
+		slog.Error("failed clearing screen for file area list", "node", nodeNumber, "error", writeErr)
 		// Try to continue anyway?
 	}
 
@@ -1374,7 +1374,7 @@ func displayFileAreaList(e *MenuExecutor, s ssh.Session, terminal *term.Terminal
 		wErr = terminalio.WriteProcessedBytes(terminal, processedContent, outputMode)
 	}
 	if wErr != nil {
-		log.Printf("ERROR: Node %d: Failed writing file area list output: %v", nodeNumber, wErr)
+		slog.Error("failed writing file area list output", "node", nodeNumber, "error", wErr)
 		return wErr // Return the error from writing
 	}
 
@@ -1393,10 +1393,10 @@ func runListFileAreas(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running LISTFILEAR", nodeNumber)
+	slog.Debug("running LISTFILEAR", "node", nodeNumber)
 
 	if currentUser == nil {
-		log.Printf("WARN: Node %d: LISTFILEAR called without logged in user.", nodeNumber)
+		slog.Warn("LISTFILEAR called without logged in user", "node", nodeNumber)
 		msg := "\r\n|01Error: You must be logged in to list file areas.|07\r\n"
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		if wErr != nil { /* Log? */
@@ -1408,7 +1408,7 @@ func runListFileAreas(c *cmdCtx, args string) (*user.User, string, error) {
 	// Call the helper to display the list
 	if err := displayFileAreaList(e, s, terminal, currentUser, outputMode, nodeNumber, sessionStartTime); err != nil {
 		// Error already logged by helper, maybe add context?
-		log.Printf("ERROR: Node %d: Error occurred during displayFileAreaList from runListFileAreas: %v", nodeNumber, err)
+		slog.Error("error occurred during displayFileAreaList", "node", nodeNumber, "error", err)
 		// Need to decide if we still pause or just return.
 		// For now, return the error to prevent pause on failed display.
 		return nil, "", err
@@ -1420,14 +1420,14 @@ func runListFileAreas(c *cmdCtx, args string) (*user.User, string, error) {
 		pausePrompt = "\r\n|07Press |15[ENTER]|07 to continue... " // Fallback
 	}
 
-	log.Printf("DEBUG: Node %d: Displaying LISTFILEAR pause prompt (centered)", nodeNumber)
+	slog.Debug("displaying LISTFILEAR pause prompt", "node", nodeNumber)
 	err := writeCenteredPausePrompt(s, terminal, pausePrompt, outputMode, termWidth, termHeight)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
-			log.Printf("INFO: Node %d: User disconnected during LISTFILEAR pause.", nodeNumber)
+			slog.Info("user disconnected during LISTFILEAR pause", "node", nodeNumber)
 			return nil, "LOGOFF", io.EOF
 		}
-		log.Printf("ERROR: Node %d: Failed during LISTFILEAR pause: %v", nodeNumber, err)
+		slog.Error("failed during LISTFILEAR pause", "node", nodeNumber, "error", err)
 		return nil, "", err
 	}
 
@@ -1473,10 +1473,10 @@ func runSelectFileArea(c *cmdCtx, args string) (*user.User, string, error) {
 	sessionStartTime := c.sessionStartTime
 	outputMode := c.outputMode
 
-	log.Printf("DEBUG: Node %d: Running SELECTFILEAREA", nodeNumber)
+	slog.Debug("running SELECTFILEAREA", "node", nodeNumber)
 
 	if currentUser == nil {
-		log.Printf("WARN: Node %d: SELECTFILEAREA called without logged in user.", nodeNumber)
+		slog.Warn("SELECTFILEAREA called without logged in user", "node", nodeNumber)
 		msg := "\r\n|01Error: You must be logged in to select a file area.|07\r\n"
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		if wErr != nil { /* Log? */
@@ -1487,7 +1487,7 @@ func runSelectFileArea(c *cmdCtx, args string) (*user.User, string, error) {
 
 	// --- Display the list first --- <--- MODIFIED
 	if err := displayFileAreaList(e, s, terminal, currentUser, outputMode, nodeNumber, sessionStartTime); err != nil {
-		log.Printf("ERROR: Node %d: Failed displaying file area list in SELECTFILEAREA: %v", nodeNumber, err)
+		slog.Error("failed displaying file area list in SELECTFILEAREA", "node", nodeNumber, "error", err)
 		// Don't proceed if the list couldn't be displayed
 		return currentUser, "", err // Return error
 	}
@@ -1509,10 +1509,10 @@ func runSelectFileArea(c *cmdCtx, args string) (*user.User, string, error) {
 		inputTag, err := readLineFromSessionIH(s, terminal)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				log.Printf("INFO: Node %d: User disconnected during SELECTFILEAREA prompt.", nodeNumber)
+				slog.Info("user disconnected during SELECTFILEAREA prompt", "node", nodeNumber)
 				return nil, "LOGOFF", io.EOF
 			}
-			log.Printf("ERROR: Node %d: Error reading input for SELECTFILEAREA: %v", nodeNumber, err)
+			slog.Error("error reading input for SELECTFILEAREA", "node", nodeNumber, "error", err)
 			return currentUser, "", err
 		}
 
@@ -1520,7 +1520,7 @@ func runSelectFileArea(c *cmdCtx, args string) (*user.User, string, error) {
 		upperInput := strings.ToUpper(inputClean)
 
 		if upperInput == "Q" {
-			log.Printf("DEBUG: Node %d: SELECTFILEAREA aborted by user.", nodeNumber)
+			slog.Debug("SELECTFILEAREA aborted by user", "node", nodeNumber)
 			terminalio.WriteProcessedBytes(terminal, []byte("\r\n"), outputMode)
 			return currentUser, "", nil
 		}
@@ -1530,9 +1530,9 @@ func runSelectFileArea(c *cmdCtx, args string) (*user.User, string, error) {
 		}
 
 		if upperInput == "?" {
-			log.Printf("DEBUG: Node %d: User requested file area list again from SELECTFILEAREA.", nodeNumber)
+			slog.Debug("user requested file area list again from SELECTFILEAREA", "node", nodeNumber)
 			if listErr := displayFileAreaList(e, s, terminal, currentUser, outputMode, nodeNumber, sessionStartTime); listErr != nil {
-				log.Printf("ERROR: Node %d: Failed redisplaying file area list: %v", nodeNumber, listErr)
+				slog.Error("failed redisplaying file area list", "node", nodeNumber, "error", listErr)
 			}
 			terminalio.WriteProcessedBytes(terminal, []byte("\r\n"), outputMode)
 			terminalio.WriteProcessedBytes(terminal, renderedPrompt, outputMode)
@@ -1545,14 +1545,14 @@ func runSelectFileArea(c *cmdCtx, args string) (*user.User, string, error) {
 		matched := false
 
 		if inputID, parseErr := strconv.Atoi(inputClean); parseErr == nil {
-			log.Printf("DEBUG: Node %d: User input '%s' parsed as ID %d. Looking up by ID.", nodeNumber, inputClean, inputID)
+			slog.Debug("user input parsed as file area ID", "node", nodeNumber, "input", inputClean, "id", inputID)
 			area, exists = e.FileMgr.GetAreaByID(inputID)
 			if exists {
 				matched = true
 			}
 		}
 		if !matched {
-			log.Printf("DEBUG: Node %d: User input '%s' not an ID. Looking up by Tag '%s'.", nodeNumber, inputClean, upperInput)
+			slog.Debug("user input not an ID, looking up by tag", "node", nodeNumber, "input", inputClean, "tag", upperInput)
 			area, exists = e.FileMgr.GetAreaByTag(upperInput)
 			if exists {
 				matched = true
@@ -1571,7 +1571,7 @@ func runSelectFileArea(c *cmdCtx, args string) (*user.User, string, error) {
 
 		// Check ACSList permission
 		if !checkACS(area.ACSList, currentUser, s, terminal, sessionStartTime) {
-			log.Printf("WARN: Node %d: User %s denied access to file area %d ('%s') due to ACS '%s'", nodeNumber, currentUser.Handle, area.ID, area.Tag, area.ACSList)
+			slog.Warn("user denied access to file area due to ACS", "node", nodeNumber, "handle", currentUser.Handle, "area", area.Tag, "acs", area.ACSList)
 			terminalio.WriteProcessedBytes(terminal, []byte(curUpClear), outputMode)
 			msg := fmt.Sprintf("|01Access denied to file area '%s'!|07", area.Tag)
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
@@ -1588,7 +1588,7 @@ func runSelectFileArea(c *cmdCtx, args string) (*user.User, string, error) {
 
 		// Save the user state
 		if saveErr := userManager.UpdateUser(currentUser); saveErr != nil {
-			log.Printf("ERROR: Node %d: Failed to save user data after updating file area: %v", nodeNumber, saveErr)
+			slog.Error("failed to save user data after updating file area", "node", nodeNumber, "error", saveErr)
 			currentUser.CurrentFileAreaID = area.ID // revert not needed, just don't show success
 			msg := "\r\n|01Error: Could not save area selection.|07\r\n"
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
@@ -1597,7 +1597,7 @@ func runSelectFileArea(c *cmdCtx, args string) (*user.User, string, error) {
 			continue
 		}
 
-		log.Printf("INFO: Node %d: User %s changed file area to ID %d ('%s')", nodeNumber, currentUser.Handle, area.ID, area.Tag)
+		slog.Info("user changed file area", "node", nodeNumber, "handle", currentUser.Handle, "area", area.Tag, "id", area.ID)
 		msg := fmt.Sprintf("\r\n|07Current file area set to: |15%s|07\r\n", area.Name)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)

--- a/internal/menu/executor_lastcallers.go
+++ b/internal/menu/executor_lastcallers.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -32,7 +32,7 @@ func runLastCallers(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running LASTCALLERS", nodeNumber)
+	slog.Debug("running LASTCALLERS", "node", nodeNumber)
 
 	// Parse optional caller count argument (e.g., RUN:LASTCALLERS 10)
 	callerLimit := 10
@@ -52,7 +52,7 @@ func runLastCallers(c *cmdCtx, args string) (*user.User, string, error) {
 	botTemplateBytes, errBot := readTemplateFile(botTemplatePath)
 
 	if errTop != nil || errMid != nil || errBot != nil {
-		log.Printf("ERROR: Node %d: Failed to load one or more LASTCALL template files: TOP(%v), MID(%v), BOT(%v)", nodeNumber, errTop, errMid, errBot)
+		slog.Error("failed to load LASTCALL template files", "node", nodeNumber, "top", errTop, "mid", errMid, "bot", errBot)
 		msg := e.LoadedStrings.ExecLastcallTemplateErr
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		if wErr != nil { /* Log? */
@@ -118,7 +118,7 @@ func runLastCallers(c *cmdCtx, args string) (*user.User, string, error) {
 
 	if len(lastCallers) == 0 {
 		// Optional: Handle empty state. The template might handle this.
-		log.Printf("DEBUG: Node %d: No last callers to display.", nodeNumber)
+		slog.Debug("no last callers to display", "node", nodeNumber)
 		// If templates don't handle empty, add a message here.
 	} else {
 		// Iterate through call records and format using processed LASTCALL.MID
@@ -167,7 +167,7 @@ func runLastCallers(c *cmdCtx, args string) (*user.User, string, error) {
 	// 4. Clear screen and display the assembled content
 	writeErr := terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 	if writeErr != nil {
-		log.Printf("ERROR: Node %d: Failed clearing screen for LASTCALLERS: %v", nodeNumber, writeErr)
+		slog.Error("failed clearing screen for LASTCALLERS", "node", nodeNumber, "error", writeErr)
 		return nil, "", writeErr
 	}
 
@@ -181,7 +181,7 @@ func runLastCallers(c *cmdCtx, args string) (*user.User, string, error) {
 		wErr = terminalio.WriteProcessedBytes(terminal, processedContent, outputMode)
 	}
 	if wErr != nil {
-		log.Printf("ERROR: Node %d: Failed writing LASTCALLERS output: %v", nodeNumber, wErr)
+		slog.Error("failed writing LASTCALLERS output", "node", nodeNumber, "error", wErr)
 		return nil, "", wErr
 	}
 
@@ -191,14 +191,14 @@ func runLastCallers(c *cmdCtx, args string) (*user.User, string, error) {
 		pausePrompt = "\r\n|07Press |15[ENTER]|07 to continue... " // Fallback
 	}
 
-	log.Printf("DEBUG: Node %d: Displaying LASTCALLERS pause prompt (centered)", nodeNumber)
+	slog.Debug("displaying LASTCALLERS pause prompt (centered)", "node", nodeNumber)
 	err := writeCenteredPausePrompt(s, terminal, pausePrompt, outputMode, termWidth, termHeight)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
-			log.Printf("INFO: Node %d: User disconnected during LASTCALLERS pause.", nodeNumber)
+			slog.Info("user disconnected during LASTCALLERS pause", "node", nodeNumber)
 			return nil, "LOGOFF", io.EOF
 		}
-		log.Printf("ERROR: Node %d: Failed during LASTCALLERS pause: %v", nodeNumber, err)
+		slog.Error("failed during LASTCALLERS pause", "node", nodeNumber, "error", err)
 		return nil, "", err
 	}
 

--- a/internal/menu/executor_lightbar.go
+++ b/internal/menu/executor_lightbar.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -109,7 +109,7 @@ func writeCenteredPausePrompt(s ssh.Session, terminal *term.Terminal, pausePromp
 				centerPosBytes := []byte(fmt.Sprintf("\r\x1b[%dC", leftPadding))
 				wErr := terminalio.WriteProcessedBytes(terminal, centerPosBytes, outputMode)
 				if wErr != nil {
-					log.Printf("WARN: Failed positioning for centered pause: %v", wErr)
+					slog.Warn("failed positioning for centered pause", "error", wErr)
 				}
 			}
 		}
@@ -159,15 +159,15 @@ func loadLightbarOptions(menuName string, e *MenuExecutor) ([]LightbarOption, er
 	cfgPath := filepath.Join(e.MenuSetPath, "cfg", cfgFilename)
 	barPath := filepath.Join(e.MenuSetPath, "bar", barFilename)
 
-	log.Printf("DEBUG: Loading CFG: %s", cfgPath)
-	log.Printf("DEBUG: Loading BAR: %s", barPath)
+	slog.Debug("loading CFG", "path", cfgPath)
+	slog.Debug("loading BAR", "path", barPath)
 
 	// Load commands from CFG file using the proper JSON loader
 	commandsByHotkey := make(map[string]string)
 	configPath := filepath.Join(e.MenuSetPath, "cfg")
 	commands, err := LoadCommands(menuName, configPath)
 	if err != nil {
-		log.Printf("WARN: Failed to load CFG file %s: %v", cfgPath, err)
+		slog.Warn("failed to load CFG file", "path", cfgPath, "error", err)
 	} else {
 		// Build hotkey -> command mapping for validation
 		for _, cmd := range commands {
@@ -195,14 +195,14 @@ func loadLightbarOptions(menuName string, e *MenuExecutor) ([]LightbarOption, er
 		// Parse record in format: X,Y,HiLitedColor,RegularColor,HotKey,ReturnValue,HiLitedString // NEW Format
 		parts := strings.SplitN(line, ",", 7) // Split into 7 parts
 		if len(parts) != 7 {                  // Check for 7 parts
-			log.Printf("WARN: Malformed BAR line (expected 7 fields): %s", line)
+			slog.Warn("malformed BAR line (expected 7 fields)", "line", line)
 			continue
 		}
 
 		x, xerr := strconv.Atoi(strings.TrimSpace(parts[0]))
 		y, yerr := strconv.Atoi(strings.TrimSpace(parts[1]))
 		if xerr != nil || yerr != nil {
-			log.Printf("WARN: Invalid coordinates in BAR line: %s", line)
+			slog.Warn("invalid coordinates in BAR line", "line", line)
 			continue
 		}
 
@@ -210,7 +210,7 @@ func loadLightbarOptions(menuName string, e *MenuExecutor) ([]LightbarOption, er
 		highlightColor, hcErr := strconv.Atoi(strings.TrimSpace(parts[2]))
 		regularColor, rcErr := strconv.Atoi(strings.TrimSpace(parts[3]))
 		if hcErr != nil || rcErr != nil {
-			log.Printf("WARN: Invalid color codes in BAR line: %s", line)
+			slog.Warn("invalid color codes in BAR line", "line", line)
 			// Default colors? Or skip?
 			highlightColor = 7 // Default: White on Black (inverse)
 			regularColor = 15  // Default: Bright White on Black
@@ -222,7 +222,7 @@ func loadLightbarOptions(menuName string, e *MenuExecutor) ([]LightbarOption, er
 
 		// Verify the hotkey maps to a command
 		if _, exists := commandsByHotkey[hotkey]; !exists {
-			log.Printf("WARN: Hotkey '%s' in BAR file has no matching command in CFG", hotkey)
+			slog.Warn("hotkey in BAR file has no matching command in CFG", "hotkey", hotkey)
 		}
 
 		options = append(options, LightbarOption{
@@ -263,21 +263,21 @@ func loadBarFile(barName string, e *MenuExecutor) ([]LightbarOption, error) {
 
 		parts := strings.SplitN(line, ",", 7)
 		if len(parts) != 7 {
-			log.Printf("WARN: Malformed BAR line in %s (expected 7 fields): %s", barName, line)
+			slog.Warn("malformed BAR line (expected 7 fields)", "bar", barName, "line", line)
 			continue
 		}
 
 		x, xerr := strconv.Atoi(strings.TrimSpace(parts[0]))
 		y, yerr := strconv.Atoi(strings.TrimSpace(parts[1]))
 		if xerr != nil || yerr != nil {
-			log.Printf("WARN: Invalid coordinates in BAR line (%s): %s", barName, line)
+			slog.Warn("invalid coordinates in BAR line", "bar", barName, "line", line)
 			continue
 		}
 
 		highlightColor, hcErr := strconv.Atoi(strings.TrimSpace(parts[2]))
 		regularColor, rcErr := strconv.Atoi(strings.TrimSpace(parts[3]))
 		if hcErr != nil || rcErr != nil {
-			log.Printf("WARN: Invalid color codes in BAR line (%s): %s", barName, line)
+			slog.Warn("invalid color codes in BAR line", "bar", barName, "line", line)
 			highlightColor = 7
 			regularColor = 15
 		}
@@ -373,7 +373,7 @@ func (e *MenuExecutor) promptYesNoLightbar(s ssh.Session, terminal *term.Termina
 	// Use termHeight from user preferences instead of reading from PTY
 	if termHeight > 0 {
 		// --- Inline Lightbar Logic (prints at current cursor position) ---
-		log.Printf("DEBUG: Terminal height known (%d) from user preferences, using inline lightbar prompt.", termHeight)
+		slog.Debug("terminal height known from user preferences, using inline lightbar prompt", "height", termHeight)
 
 		// NOTE: We intentionally do NOT hide the cursor (\x1b[?25l) here.
 		// On iOS, MuffinTerm ties the software keyboard to cursor visibility —
@@ -397,10 +397,10 @@ func (e *MenuExecutor) promptYesNoLightbar(s ssh.Session, terminal *term.Termina
 
 		// Write the prompt text inline
 		promptDisplayBytes := ansi.ReplacePipeCodes([]byte(promptText))
-		log.Printf("DEBUG: Node %d: Writing prompt text bytes (hex): %x", nodeNumber, promptDisplayBytes)
+		slog.Debug("writing prompt text bytes", "node", nodeNumber, "bytes", promptDisplayBytes)
 		err := terminalio.WriteStringCP437(terminal, promptDisplayBytes, outputMode)
 		if err != nil {
-			log.Printf("ERROR: Node %d: Failed writing Yes/No prompt text (lightbar mode): %v", nodeNumber, err)
+			slog.Error("failed writing Yes/No prompt text (lightbar mode)", "node", nodeNumber, "error", err)
 			return false, fmt.Errorf("failed writing prompt text: %w", err)
 		}
 
@@ -408,7 +408,7 @@ func (e *MenuExecutor) promptYesNoLightbar(s ssh.Session, terminal *term.Termina
 		spacingBytes := []byte(strings.Repeat(" ", yesNoSpacing))
 		wErr := terminalio.WriteProcessedBytes(terminal, spacingBytes, outputMode)
 		if wErr != nil {
-			log.Printf("WARN: Failed writing spacing: %v", wErr)
+			slog.Warn("failed writing spacing", "error", wErr)
 		}
 
 		// Total visible width of the options area (used for cursor-backward repositioning).
@@ -430,7 +430,7 @@ func (e *MenuExecutor) promptYesNoLightbar(s ssh.Session, terminal *term.Termina
 				// Move cursor back to the start of the options area
 				wErr := terminalio.WriteProcessedBytes(terminal, []byte(ansi.CursorBackward(optionsWidth)), outputMode)
 				if wErr != nil {
-					log.Printf("WARN: Failed moving cursor backward: %v", wErr)
+					slog.Warn("failed moving cursor backward", "error", wErr)
 				}
 			}
 			firstDraw = false
@@ -438,7 +438,7 @@ func (e *MenuExecutor) promptYesNoLightbar(s ssh.Session, terminal *term.Termina
 			// Clear from cursor to end of line to remove old options
 			wErr := terminalio.WriteProcessedBytes(terminal, []byte("\x1b[K"), outputMode)
 			if wErr != nil {
-				log.Printf("WARN: Failed clearing old options: %v", wErr)
+				slog.Warn("failed clearing old options", "error", wErr)
 			}
 
 			// Draw No option
@@ -449,21 +449,21 @@ func (e *MenuExecutor) promptYesNoLightbar(s ssh.Session, terminal *term.Termina
 			noColorBytes := []byte(colorCodeToAnsi(noColorCode))
 			wErr = terminalio.WriteProcessedBytes(terminal, noColorBytes, outputMode)
 			if wErr != nil {
-				log.Printf("WARN: Failed setting No color: %v", wErr)
+				slog.Warn("failed setting No color", "error", wErr)
 			}
 			wErr = terminalio.WriteProcessedBytes(terminal, []byte(noOptionText), outputMode)
 			if wErr != nil {
-				log.Printf("WARN: Failed writing No option: %v", wErr)
+				slog.Warn("failed writing No option", "error", wErr)
 			}
 			wErr = terminalio.WriteProcessedBytes(terminal, []byte("\x1b[0m"), outputMode)
 			if wErr != nil {
-				log.Printf("WARN: Failed resetting attributes: %v", wErr)
+				slog.Warn("failed resetting attributes", "error", wErr)
 			}
 
 			// Add spacing between options
 			wErr = terminalio.WriteProcessedBytes(terminal, []byte(strings.Repeat(" ", optionSpacing)), outputMode)
 			if wErr != nil {
-				log.Printf("WARN: Failed writing option spacing: %v", wErr)
+				slog.Warn("failed writing option spacing", "error", wErr)
 			}
 
 			// Draw Yes option
@@ -474,15 +474,15 @@ func (e *MenuExecutor) promptYesNoLightbar(s ssh.Session, terminal *term.Termina
 			yesColorBytes := []byte(colorCodeToAnsi(yesColorCode))
 			wErr = terminalio.WriteProcessedBytes(terminal, yesColorBytes, outputMode)
 			if wErr != nil {
-				log.Printf("WARN: Failed setting Yes color: %v", wErr)
+				slog.Warn("failed setting Yes color", "error", wErr)
 			}
 			wErr = terminalio.WriteProcessedBytes(terminal, []byte(yesOptionText), outputMode)
 			if wErr != nil {
-				log.Printf("WARN: Failed writing Yes option: %v", wErr)
+				slog.Warn("failed writing Yes option", "error", wErr)
 			}
 			wErr = terminalio.WriteProcessedBytes(terminal, []byte("\x1b[0m"), outputMode)
 			if wErr != nil {
-				log.Printf("WARN: Failed resetting attributes: %v", wErr)
+				slog.Warn("failed resetting attributes", "error", wErr)
 			}
 		}
 
@@ -531,7 +531,7 @@ func (e *MenuExecutor) promptYesNoLightbar(s ssh.Session, terminal *term.Termina
 				}
 				wErr := terminalio.WriteProcessedBytes(terminal, []byte(ansi.CursorBackward(optionsWidth)+"\x1b[K"+selectedLabel+"\r\n"), outputMode)
 				if wErr != nil {
-					log.Printf("WARN: Failed writing selection result: %v", wErr)
+					slog.Warn("failed writing selection result", "error", wErr)
 				}
 				return result, nil
 			}
@@ -545,7 +545,7 @@ func (e *MenuExecutor) promptYesNoLightbar(s ssh.Session, terminal *term.Termina
 
 	} else {
 		// --- Text Input Fallback (if terminal height is unknown) ---
-		log.Printf("DEBUG: Terminal height unknown, using text fallback for Yes/No prompt.")
+		slog.Debug("terminal height unknown, using text fallback for Yes/No prompt")
 
 		// Construct the simple text prompt
 		yesNoHint := "[y/N]"
@@ -557,13 +557,13 @@ func (e *MenuExecutor) promptYesNoLightbar(s ssh.Session, terminal *term.Termina
 		// Write the prompt after one blank row: newline + blank line, then prompt.
 		wErr := terminalio.WriteProcessedBytes(terminal, []byte("\r\n\r\n"), outputMode)
 		if wErr != nil {
-			log.Printf("WARN: Failed writing fallback pre-prompt spacing: %v", wErr)
+			slog.Warn("failed writing fallback pre-prompt spacing", "error", wErr)
 		}
 
 		processedPromptBytes := ansi.ReplacePipeCodes([]byte(fullPrompt))
 		err := terminalio.WriteStringCP437(terminal, processedPromptBytes, outputMode)
 		if err != nil {
-			log.Printf("ERROR: Node %d: Failed writing Yes/No prompt text (fallback mode): %v", nodeNumber, err) // Use nodeNumber
+			slog.Error("failed writing Yes/No prompt text (fallback mode)", "node", nodeNumber, "error", err) // Use nodeNumber
 			return false, fmt.Errorf("failed writing fallback prompt text: %w", err)
 		}
 
@@ -573,7 +573,7 @@ func (e *MenuExecutor) promptYesNoLightbar(s ssh.Session, terminal *term.Termina
 			// Clean up line on error using WriteProcessedBytes
 			wErr := terminalio.WriteProcessedBytes(terminal, []byte("\r\n"), outputMode) // Assuming CRLF is enough cleanup here
 			if wErr != nil {
-				log.Printf("WARN: Failed writing CRLF on read error: %v", wErr)
+				slog.Warn("failed writing CRLF on read error", "error", wErr)
 			}
 
 			if errors.Is(err, io.EOF) {
@@ -729,7 +729,7 @@ func writeProcessedStringWithManualEncoding(terminal *term.Terminal, processedBy
 					i++
 					// Basic protection
 					if i-start > 30 {
-						log.Printf("WARN: [writeProcessedString] Potential runaway ANSI sequence encountered.")
+						slog.Warn("potential runaway ANSI sequence encountered")
 						break
 					}
 				}

--- a/internal/menu/executor_login.go
+++ b/internal/menu/executor_login.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/editor"
+	"github.com/ViSiON-3/vision-3-bbs/internal/logging"
 	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 	"github.com/gliderlabs/ssh"
@@ -34,12 +35,12 @@ func runAuthenticate(c *cmdCtx, args string) (*user.User, string, error) {
 
 	// If already logged in, maybe show an error or just return?
 	if currentUser != nil {
-		log.Printf("WARN: Node %d: User %s tried to run AUTHENTICATE while already logged in.", nodeNumber, currentUser.Handle)
+		slog.Warn("user tried to run AUTHENTICATE while already logged in", "node", nodeNumber, "handle", currentUser.Handle)
 		msg := e.LoadedStrings.ExecAlreadyLoggedIn
 		// Use WriteProcessedBytes
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		if wErr != nil {
-			log.Printf("ERROR: Failed writing already logged in message: %v", wErr)
+			slog.Error("failed writing already logged in message", "error", wErr)
 		}
 		time.Sleep(1 * time.Second) // Pause after failed attempt
 		return nil, "", nil         // No user change, no error
@@ -56,13 +57,13 @@ func runAuthenticate(c *cmdCtx, args string) (*user.User, string, error) {
 	// Use WriteProcessedBytes for prompt
 	wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(usernamePrompt)), outputMode)
 	if wErr != nil {
-		log.Printf("ERROR: Node %d: Failed writing username prompt: %v", nodeNumber, wErr)
+		slog.Error("failed writing username prompt", "node", nodeNumber, "error", wErr)
 		// Continue anyway?
 	}
 	usernameInput, err := readLineFromSessionIHAllowAbort(s, terminal)
 	if err != nil {
 		if err == io.EOF {
-			log.Printf("INFO: Node %d: User disconnected during username input.", nodeNumber)
+			slog.Info("user disconnected during username input", "node", nodeNumber)
 			// Return an error that signals disconnection to the main loop
 			return nil, "LOGOFF", io.EOF // Signal logoff
 		}
@@ -76,7 +77,7 @@ func runAuthenticate(c *cmdCtx, args string) (*user.User, string, error) {
 			}
 			return nil, "", nil
 		}
-		log.Printf("ERROR: Node %d: Failed to read username input: %v", nodeNumber, err)
+		slog.Error("failed to read username input", "node", nodeNumber, "error", err)
 		return nil, "", fmt.Errorf("failed reading username: %w", err) // Critical error
 	}
 	username := strings.TrimSpace(usernameInput)
@@ -86,13 +87,13 @@ func runAuthenticate(c *cmdCtx, args string) (*user.User, string, error) {
 
 	// Check if user wants to apply as a new user
 	if strings.EqualFold(username, "new") {
-		log.Printf("INFO: Node %d: User typed 'new' in AUTHENTICATE - starting new user application", nodeNumber)
+		slog.Info("user typed 'new' in AUTHENTICATE - starting new user application", "node", nodeNumber)
 		newUserErr := e.handleNewUserApplication(s, terminal, userManager, nodeNumber, outputMode, termWidth, termHeight)
 		if newUserErr != nil {
 			if errors.Is(newUserErr, io.EOF) {
 				return nil, "LOGOFF", io.EOF
 			}
-			log.Printf("ERROR: Node %d: New user application error: %v", nodeNumber, newUserErr)
+			slog.Error("new user application error", "node", nodeNumber, "error", newUserErr)
 		}
 		return nil, "", nil // Return to LOGIN screen after signup
 	}
@@ -102,16 +103,16 @@ func runAuthenticate(c *cmdCtx, args string) (*user.User, string, error) {
 	passwordPrompt := e.LoadedStrings.ExecPasswordPrompt
 	wErr = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(passwordPrompt)), outputMode)
 	if wErr != nil {
-		log.Printf("ERROR: Node %d: Failed writing password prompt: %v", nodeNumber, wErr)
+		slog.Error("failed writing password prompt", "node", nodeNumber, "error", wErr)
 	}
 	password, err := readPasswordSecurely(s, terminal, outputMode)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
-			log.Printf("INFO: Node %d: User disconnected during password input.", nodeNumber)
+			slog.Info("user disconnected during password input", "node", nodeNumber)
 			return nil, "LOGOFF", io.EOF // Signal logoff
 		}
 		if errors.Is(err, errInputAborted) {
-			log.Printf("INFO: Node %d: User pressed ESC during password entry.", nodeNumber)
+			slog.Info("user pressed ESC during password entry", "node", nodeNumber)
 			abort, confirmErr := e.confirmAbortLogin(s, terminal, outputMode, nodeNumber, termWidth, termHeight)
 			if confirmErr != nil {
 				return nil, "", confirmErr
@@ -121,7 +122,7 @@ func runAuthenticate(c *cmdCtx, args string) (*user.User, string, error) {
 			}
 			return nil, "", nil
 		}
-		log.Printf("ERROR: Node %d: Failed to read password securely: %v", nodeNumber, err)
+		slog.Error("failed to read password securely", "node", nodeNumber, "error", err)
 		return nil, "", fmt.Errorf("failed reading password: %w", err) // Critical error
 	}
 
@@ -132,14 +133,14 @@ func runAuthenticate(c *cmdCtx, args string) (*user.User, string, error) {
 	if e.IPLockoutCheck != nil {
 		isLocked, lockedUntil, attempts := e.IPLockoutCheck.IsIPLockedOut(remoteIP)
 		if isLocked {
-			log.Printf("SECURITY: Node %d: Login attempt from locked IP %s (locked until %s, %d attempts)",
-				nodeNumber, remoteIP, lockedUntil.Format("2006-01-02 15:04:05"), attempts)
+			logging.Security("login attempt from locked IP",
+				"node", nodeNumber, "ip", remoteIP, "locked_until", lockedUntil.Format("2006-01-02 15:04:05"), "attempts", attempts)
 			terminalio.WriteProcessedBytes(terminal, []byte(ansi.MoveCursor(errorRow, 1)), outputMode)
 			minutesLeft := int(time.Until(lockedUntil).Minutes()) + 1
 			errMsg := fmt.Sprintf(e.LoadedStrings.ExecIPLockout, minutesLeft)
 			wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(errMsg)), outputMode)
 			if wErr != nil {
-				log.Printf("ERROR: Failed writing IP lockout message: %v", wErr)
+				slog.Error("failed writing IP lockout message", "error", wErr)
 			}
 			time.Sleep(2 * time.Second)
 			return nil, "", nil
@@ -147,16 +148,16 @@ func runAuthenticate(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	// Attempt Authentication via UserManager
-	log.Printf("DEBUG: Node %d: Attempting authentication for user: %s from IP: %s", nodeNumber, username, remoteIP)
+	slog.Debug("attempting authentication", "node", nodeNumber, "handle", username, "ip", remoteIP)
 	authUser, authenticated := userManager.Authenticate(username, password)
 	if !authenticated {
-		log.Printf("WARN: Node %d: Failed authentication attempt for user: %s from IP: %s", nodeNumber, username, remoteIP)
+		slog.Warn("failed authentication attempt", "node", nodeNumber, "handle", username, "ip", remoteIP)
 
 		// Record failed login attempt for this IP
 		if e.IPLockoutCheck != nil {
 			wasLocked := e.IPLockoutCheck.RecordFailedLoginAttempt(remoteIP)
 			if wasLocked {
-				log.Printf("SECURITY: Node %d: IP %s has been locked out after too many failed attempts", nodeNumber, remoteIP)
+				logging.Security("IP locked out after too many failed attempts", "node", nodeNumber, "ip", remoteIP)
 			}
 		}
 
@@ -166,7 +167,7 @@ func runAuthenticate(c *cmdCtx, args string) (*user.User, string, error) {
 		// Use WriteProcessedBytes
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(errMsg)), outputMode)
 		if wErr != nil {
-			log.Printf("ERROR: Failed writing login incorrect message: %v", wErr)
+			slog.Error("failed writing login incorrect message", "error", wErr)
 		}
 		time.Sleep(1 * time.Second) // Pause after failed attempt
 		return nil, "", nil         // Failed auth, but not a critical error. Let LOGIN menu handle retries.
@@ -178,25 +179,24 @@ func runAuthenticate(c *cmdCtx, args string) (*user.User, string, error) {
 	// Get thread-safe config snapshot
 	cfg := e.GetServerConfig()
 	if cfg.LogonLevel > 0 && authUser.AccessLevel < cfg.LogonLevel {
-		log.Printf("INFO: Node %d: Login denied for user '%s' - insufficient access level (has %d, needs %d)",
-			nodeNumber, username, authUser.AccessLevel, cfg.LogonLevel)
+		slog.Info("login denied - insufficient access level", "node", nodeNumber, "handle", username, "has", authUser.AccessLevel, "needs", cfg.LogonLevel)
 		terminalio.WriteProcessedBytes(terminal, []byte(ansi.MoveCursor(errorRow, 1)), outputMode)
 		errMsg := e.LoadedStrings.ExecAccessDenied
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(errMsg)), outputMode)
 		if wErr != nil {
-			log.Printf("ERROR: Failed writing access denied message: %v", wErr)
+			slog.Error("failed writing access denied message", "error", wErr)
 		}
 		time.Sleep(1 * time.Second)
 		return nil, "", nil // Insufficient level, treat as failed login
 	}
 
 	// Authentication Successful!
-	log.Printf("INFO: Node %d: User '%s' authenticated successfully via RUN:AUTHENTICATE", nodeNumber, authUser.Handle)
+	slog.Info("user authenticated successfully via RUN:AUTHENTICATE", "node", nodeNumber, "handle", authUser.Handle)
 
 	// Clear failed login attempts for this IP
 	if e.IPLockoutCheck != nil {
 		e.IPLockoutCheck.ClearFailedLoginAttempts(remoteIP)
-		log.Printf("DEBUG: Node %d: Cleared failed login attempts for IP %s", nodeNumber, remoteIP)
+		slog.Debug("cleared failed login attempts", "node", nodeNumber, "ip", remoteIP)
 	}
 
 	// Display success message (optional) - Move cursor first
@@ -216,12 +216,12 @@ func (e *MenuExecutor) handleLoginPrompt(s ssh.Session, terminal *term.Terminal,
 	userCoord, userOk := coords["P"] // Use 'P' for Handle/Name field based on LOGIN.ANS
 	passCoord, passOk := coords["O"] // Use 'O' for Password field based on LOGIN.ANS
 
-	log.Printf("DEBUG: LOGIN Coords Received - P: %+v (Ok: %t), O: %+v (Ok: %t)", userCoord, userOk, passCoord, passOk)
+	slog.Debug("login coords received", "p", userCoord, "pOk", userOk, "o", passCoord, "oOk", passOk)
 
 	if !userOk || !passOk {
-		log.Printf("CRITICAL: LOGIN.ANS is missing required coordinate codes P or O.")
+		slog.Error("LOGIN.ANS is missing required coordinate codes P or O")
 		if wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ExecLoginCriticalError)), outputMode); wErr != nil {
-			log.Printf("ERROR: Failed writing critical login configuration message: %v", wErr)
+			slog.Error("failed writing critical login configuration message", "error", wErr)
 		}
 		time.Sleep(2 * time.Second)
 		return nil, fmt.Errorf("missing login coordinates P/O in LOGIN.ANS")
@@ -229,7 +229,7 @@ func (e *MenuExecutor) handleLoginPrompt(s ssh.Session, terminal *term.Terminal,
 
 	// No Y offset needed — ANSI display is truncated to termHeight rows,
 	// preventing scrolling, so extracted coordinates are accurate as-is
-	log.Printf("DEBUG: Node %d: Login prompt coords P=(%d,%d) O=(%d,%d) termHeight=%d", nodeNumber, userCoord.X, userCoord.Y, passCoord.X, passCoord.Y, termHeight)
+	slog.Debug("login prompt coords", "node", nodeNumber, "pX", userCoord.X, "pY", userCoord.Y, "oX", passCoord.X, "oY", passCoord.Y, "termHeight", termHeight)
 
 	errorRow := passCoord.Y + 2 // Error message row below password
 	if errorRow <= userCoord.Y || errorRow <= passCoord.Y {
@@ -259,24 +259,24 @@ func (e *MenuExecutor) handleLoginPrompt(s ssh.Session, terminal *term.Terminal,
 			}
 			return nil, nil
 		}
-		log.Printf("ERROR: Node %d: Failed to read username input: %v", nodeNumber, err)
+		slog.Error("failed to read username input", "node", nodeNumber, "error", err)
 		return nil, fmt.Errorf("failed reading username: %w", err)
 	}
 	username := strings.TrimSpace(usernameInput)
 	if username == "" {
-		log.Printf("DEBUG: Node %d: Empty username entered.", nodeNumber)
+		slog.Debug("empty username entered", "node", nodeNumber)
 		return nil, nil // Return nil user, nil error to signal retry LOGIN
 	}
 
 	// Check if user wants to apply as a new user
 	if strings.EqualFold(username, "new") {
-		log.Printf("INFO: Node %d: User typed 'new' - starting new user application", nodeNumber)
+		slog.Info("user typed 'new' - starting new user application", "node", nodeNumber)
 		err := e.handleNewUserApplication(s, terminal, userManager, nodeNumber, outputMode, termWidth, termHeight)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				return nil, io.EOF
 			}
-			log.Printf("ERROR: Node %d: New user application error: %v", nodeNumber, err)
+			slog.Error("new user application error", "node", nodeNumber, "error", err)
 		}
 		return nil, nil // Return to LOGIN screen after signup
 	}
@@ -295,7 +295,7 @@ func (e *MenuExecutor) handleLoginPrompt(s ssh.Session, terminal *term.Terminal,
 			return nil, io.EOF // Signal disconnection
 		}
 		if errors.Is(err, errInputAborted) { // ESC/Ctrl+C
-			log.Printf("INFO: Node %d: User pressed ESC during password entry.", nodeNumber)
+			slog.Info("user pressed ESC during password entry", "node", nodeNumber)
 			abort, confirmErr := e.confirmAbortLogin(s, terminal, outputMode, nodeNumber, termWidth, termHeight)
 			if confirmErr != nil {
 				return nil, confirmErr
@@ -305,7 +305,7 @@ func (e *MenuExecutor) handleLoginPrompt(s ssh.Session, terminal *term.Terminal,
 			}
 			return nil, nil
 		}
-		log.Printf("ERROR: Node %d: Failed to read password securely: %v", nodeNumber, err)
+		slog.Error("failed to read password securely", "node", nodeNumber, "error", err)
 		return nil, fmt.Errorf("failed reading password: %w", err)
 	}
 
@@ -316,14 +316,14 @@ func (e *MenuExecutor) handleLoginPrompt(s ssh.Session, terminal *term.Terminal,
 	if e.IPLockoutCheck != nil {
 		isLocked, lockedUntil, attempts := e.IPLockoutCheck.IsIPLockedOut(remoteIP)
 		if isLocked {
-			log.Printf("SECURITY: Node %d: Login attempt from locked IP %s (locked until %s, %d attempts)",
-				nodeNumber, remoteIP, lockedUntil.Format("2006-01-02 15:04:05"), attempts)
+			logging.Security("login attempt from locked IP",
+				"node", nodeNumber, "ip", remoteIP, "locked_until", lockedUntil.Format("2006-01-02 15:04:05"), "attempts", attempts)
 			terminalio.WriteProcessedBytes(terminal, []byte(ansi.MoveCursor(errorRow, 1)), outputMode)
 			minutesLeft := int(time.Until(lockedUntil).Minutes()) + 1
 			errMsg := fmt.Sprintf(e.LoadedStrings.ExecIPLockout, minutesLeft)
 			wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(errMsg)), outputMode)
 			if wErr != nil {
-				log.Printf("ERROR: Failed writing IP lockout message: %v", wErr)
+				slog.Error("failed writing IP lockout message", "error", wErr)
 			}
 			time.Sleep(2 * time.Second)
 			return nil, nil
@@ -331,16 +331,16 @@ func (e *MenuExecutor) handleLoginPrompt(s ssh.Session, terminal *term.Terminal,
 	}
 
 	// Attempt Authentication via UserManager
-	log.Printf("DEBUG: Node %d: Attempting authentication for user: %s from IP: %s", nodeNumber, username, remoteIP)
+	slog.Debug("attempting authentication", "node", nodeNumber, "handle", username, "ip", remoteIP)
 	authUser, authenticated := userManager.Authenticate(username, password)
 	if !authenticated {
-		log.Printf("WARN: Node %d: Failed authentication attempt for user: %s from IP: %s", nodeNumber, username, remoteIP)
+		slog.Warn("failed authentication attempt", "node", nodeNumber, "handle", username, "ip", remoteIP)
 
 		// Record failed login attempt for this IP
 		if e.IPLockoutCheck != nil {
 			wasLocked := e.IPLockoutCheck.RecordFailedLoginAttempt(remoteIP)
 			if wasLocked {
-				log.Printf("SECURITY: Node %d: IP %s has been locked out after too many failed attempts", nodeNumber, remoteIP)
+				logging.Security("IP locked out after too many failed attempts", "node", nodeNumber, "ip", remoteIP)
 			}
 		}
 
@@ -349,7 +349,7 @@ func (e *MenuExecutor) handleLoginPrompt(s ssh.Session, terminal *term.Terminal,
 		// Use WriteProcessedBytes with the passed outputMode
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(errMsg)), outputMode)
 		if wErr != nil {
-			log.Printf("ERROR: Failed writing login incorrect message: %v", wErr)
+			slog.Error("failed writing login incorrect message", "error", wErr)
 		}
 		time.Sleep(1 * time.Second) // Pause after failed attempt
 		return nil, nil             // Failed auth, but not a critical error. Let LOGIN menu handle retries.
@@ -361,24 +361,23 @@ func (e *MenuExecutor) handleLoginPrompt(s ssh.Session, terminal *term.Terminal,
 	// Get thread-safe config snapshot
 	cfg := e.GetServerConfig()
 	if cfg.LogonLevel > 0 && authUser.AccessLevel < cfg.LogonLevel {
-		log.Printf("INFO: Node %d: Login denied for user '%s' - insufficient access level (has %d, needs %d)",
-			nodeNumber, username, authUser.AccessLevel, cfg.LogonLevel)
+		slog.Info("login denied - insufficient access level", "node", nodeNumber, "handle", username, "has", authUser.AccessLevel, "needs", cfg.LogonLevel)
 		terminalio.WriteProcessedBytes(terminal, []byte(ansi.MoveCursor(errorRow, 1)), outputMode)
 		errMsg := e.LoadedStrings.ExecAccessDenied
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(errMsg)), outputMode)
 		if wErr != nil {
-			log.Printf("ERROR: Failed writing access denied message: %v", wErr)
+			slog.Error("failed writing access denied message", "error", wErr)
 		}
 		time.Sleep(1 * time.Second)
 		return nil, nil // Insufficient level, treat as failed login
 	}
 
-	log.Printf("INFO: Node %d: User '%s' authenticated successfully via LOGIN prompt", nodeNumber, authUser.Handle)
+	slog.Info("user authenticated successfully via LOGIN prompt", "node", nodeNumber, "handle", authUser.Handle)
 
 	// Clear failed login attempts for this IP
 	if e.IPLockoutCheck != nil {
 		e.IPLockoutCheck.ClearFailedLoginAttempts(remoteIP)
-		log.Printf("DEBUG: Node %d: Cleared failed login attempts for IP %s", nodeNumber, remoteIP)
+		slog.Debug("cleared failed login attempts", "node", nodeNumber, "ip", remoteIP)
 	}
 
 	return authUser, nil // Success!
@@ -396,7 +395,7 @@ func readPasswordSecurely(s ssh.Session, terminal *term.Terminal, outputMode ans
 		key, err := ih.ReadKey()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				log.Println("DEBUG: EOF received during secure password read.")
+				slog.Debug("EOF received during secure password read")
 			}
 			return "", err
 		}
@@ -409,7 +408,7 @@ func readPasswordSecurely(s ssh.Session, terminal *term.Terminal, outputMode ans
 			if len(password) > 0 {
 				password = password[:len(password)-1]
 				if err := terminalio.WriteProcessedBytes(terminal, []byte("\b \b"), outputMode); err != nil {
-					log.Printf("WARN: Failed to write backspace sequence: %v", err)
+					slog.Warn("failed to write backspace sequence", "error", err)
 				}
 			}
 		case 3: // Ctrl+C
@@ -423,7 +422,7 @@ func readPasswordSecurely(s ssh.Session, terminal *term.Terminal, outputMode ans
 				password = append(password, rune(key))
 				byteBuf[0] = '*'
 				if err := terminalio.WriteProcessedBytes(terminal, byteBuf[:], outputMode); err != nil {
-					log.Printf("WARN: Failed to write asterisk: %v", err)
+					slog.Warn("failed to write asterisk", "error", err)
 				}
 			}
 		}
@@ -442,24 +441,24 @@ func runNewMailScan(c *cmdCtx, args string) (*user.User, string, error) {
 		return nil, "", nil
 	}
 
-	log.Printf("DEBUG: Node %d: Running NMAILSCAN for user %s", nodeNumber, currentUser.Handle)
+	slog.Debug("running NMAILSCAN", "node", nodeNumber, "handle", currentUser.Handle)
 
 	if e.MessageMgr == nil {
-		log.Printf("WARN: Node %d: MessageMgr not available for NMAILSCAN", nodeNumber)
+		slog.Warn("MessageMgr not available for NMAILSCAN", "node", nodeNumber)
 		return currentUser, "", nil
 	}
 
 	// Get PRIVMAIL area
 	privmailArea, exists := e.MessageMgr.GetAreaByTag("PRIVMAIL")
 	if !exists {
-		log.Printf("DEBUG: Node %d: PRIVMAIL area not configured, skipping mail scan", nodeNumber)
+		slog.Debug("PRIVMAIL area not configured, skipping mail scan", "node", nodeNumber)
 		return currentUser, "", nil
 	}
 
 	// Get JAM base for PRIVMAIL area
 	base, err := e.MessageMgr.GetBase(privmailArea.ID)
 	if err != nil {
-		log.Printf("WARN: Node %d: JAM base not open for PRIVMAIL area: %v", nodeNumber, err)
+		slog.Warn("JAM base not open for PRIVMAIL area", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
 	defer base.Close()
@@ -467,7 +466,7 @@ func runNewMailScan(c *cmdCtx, args string) (*user.User, string, error) {
 	// Get total message count
 	totalMessages, err := e.MessageMgr.GetMessageCountForArea(privmailArea.ID)
 	if err != nil {
-		log.Printf("WARN: Node %d: Failed to get message count for PRIVMAIL: %v", nodeNumber, err)
+		slog.Warn("failed to get message count for PRIVMAIL", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
 
@@ -480,7 +479,7 @@ func runNewMailScan(c *cmdCtx, args string) (*user.User, string, error) {
 	// Get lastread pointer for this user
 	lastRead, err := e.MessageMgr.GetLastRead(privmailArea.ID, currentUser.Handle)
 	if err != nil {
-		log.Printf("WARN: Node %d: Failed to get lastread for PRIVMAIL: %v", nodeNumber, err)
+		slog.Warn("failed to get lastread for PRIVMAIL", "node", nodeNumber, "error", err)
 		lastRead = 0
 	}
 
@@ -521,15 +520,15 @@ func runLoginDisplayFile(c *cmdCtx, args string) (*user.User, string, error) {
 
 	filename := strings.TrimSpace(args)
 	if filename == "" {
-		log.Printf("WARN: Node %d: DISPLAYFILE called with no filename", nodeNumber)
+		slog.Warn("DISPLAYFILE called with no filename", "node", nodeNumber)
 		return currentUser, "", nil
 	}
 
-	log.Printf("DEBUG: Node %d: Running DISPLAYFILE for %s", nodeNumber, filename)
+	slog.Debug("running DISPLAYFILE", "node", nodeNumber, "file", filename)
 
 	err := e.displayFile(terminal, filename, outputMode)
 	if err != nil {
-		log.Printf("WARN: Node %d: Failed to display file %s: %v", nodeNumber, filename, err)
+		slog.Warn("failed to display file", "node", nodeNumber, "file", filename, "error", err)
 		// Non-fatal - continue login sequence even if file is missing
 	}
 
@@ -546,15 +545,15 @@ func runLoginDoor(c *cmdCtx, args string) (*user.User, string, error) {
 
 	scriptPath := strings.TrimSpace(args)
 	if scriptPath == "" {
-		log.Printf("WARN: Node %d: RUNDOOR called with no script path", nodeNumber)
+		slog.Warn("RUNDOOR called with no script path", "node", nodeNumber)
 		return currentUser, "", nil
 	}
 
-	log.Printf("INFO: Node %d: Running login door script: %s", nodeNumber, scriptPath)
+	slog.Info("running login door script", "node", nodeNumber, "path", scriptPath)
 
 	// Verify script exists
 	if _, err := os.Stat(scriptPath); os.IsNotExist(err) {
-		log.Printf("WARN: Node %d: Login door script not found: %s", nodeNumber, scriptPath)
+		slog.Warn("login door script not found", "node", nodeNumber, "path", scriptPath)
 		return currentUser, "", nil
 	}
 
@@ -565,7 +564,7 @@ func runLoginDoor(c *cmdCtx, args string) (*user.User, string, error) {
 	cmd.Stderr = s.Stderr()
 
 	if err := cmd.Run(); err != nil {
-		log.Printf("WARN: Node %d: Login door script %s exited with error: %v", nodeNumber, scriptPath, err)
+		slog.Warn("login door script exited with error", "node", nodeNumber, "path", scriptPath, "error", err)
 		// Non-fatal - continue login sequence
 	}
 
@@ -584,14 +583,14 @@ func runFastLogin(c *cmdCtx, args string) (*user.User, string, error) {
 	outputMode := c.outputMode
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running FASTLOGIN inline for user %s", nodeNumber, currentUser.Handle)
+	slog.Debug("running FASTLOGIN inline", "node", nodeNumber, "handle", currentUser.Handle)
 
 	// Load FASTLOGN menu definition (.MNU) for CLR/CLS + prompt behavior
 	var fastlognMenu *MenuRecord
 	menuMnuPath := filepath.Join(e.MenuSetPath, "mnu")
 	loadedMenu, menuErr := LoadMenu("FASTLOGN", menuMnuPath)
 	if menuErr != nil {
-		log.Printf("WARN: Node %d: Failed to load FASTLOGN.MNU: %v", nodeNumber, menuErr)
+		slog.Warn("failed to load FASTLOGN.MNU", "node", nodeNumber, "error", menuErr)
 	} else {
 		fastlognMenu = loadedMenu
 	}
@@ -599,7 +598,7 @@ func runFastLogin(c *cmdCtx, args string) (*user.User, string, error) {
 	renderFastLoginScreen := func() {
 		clearFirst := fastlognMenu != nil && fastlognMenu.GetClrScrBefore()
 		if displayErr := e.displayFile(terminal, "FASTLOGN.ANS", outputMode, clearFirst); displayErr != nil {
-			log.Printf("WARN: Node %d: Failed to display FASTLOGN.ANS: %v", nodeNumber, displayErr)
+			slog.Warn("failed to display FASTLOGN.ANS", "node", nodeNumber, "error", displayErr)
 		}
 
 		if fastlognMenu != nil && fastlognMenu.GetUsePrompt() {
@@ -621,7 +620,7 @@ func runFastLogin(c *cmdCtx, args string) (*user.User, string, error) {
 	cfgPath := filepath.Join(e.MenuSetPath, "cfg")
 	commands, err := LoadCommands("FASTLOGN", cfgPath)
 	if err != nil {
-		log.Printf("WARN: Node %d: Failed to load FASTLOGN.CFG: %v", nodeNumber, err)
+		slog.Warn("failed to load FASTLOGN.CFG", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
 
@@ -633,7 +632,7 @@ func runFastLogin(c *cmdCtx, args string) (*user.User, string, error) {
 	isLightbar := barLoadErr == nil && len(lightbarOptions) > 0
 	if barLoadErr != nil {
 		if _, statErr := os.Stat(barPath); statErr == nil {
-			log.Printf("WARN: Node %d: BAR file exists but failed to load: %v", nodeNumber, barLoadErr)
+			slog.Warn("BAR file exists but failed to load", "node", nodeNumber, "error", barLoadErr)
 		}
 	}
 
@@ -657,13 +656,13 @@ func runFastLogin(c *cmdCtx, args string) (*user.User, string, error) {
 				}
 			}
 			if cmd.Command == "RUN:FULL_LOGIN_SEQUENCE" {
-				log.Printf("DEBUG: Node %d: FASTLOGIN - user chose to continue full sequence", nodeNumber)
+				slog.Debug("FASTLOGIN - user chose to continue full sequence", "node", nodeNumber)
 				terminalio.WriteProcessedBytes(terminal, []byte("\r\n"), outputMode)
 				return currentUser, "", nil, true
 			}
 			if strings.HasPrefix(cmd.Command, "GOTO:") {
 				nextMenu := strings.ToUpper(strings.TrimPrefix(cmd.Command, "GOTO:"))
-				log.Printf("DEBUG: Node %d: FASTLOGIN - user chose GOTO:%s", nodeNumber, nextMenu)
+				slog.Debug("FASTLOGIN - user chose GOTO", "node", nodeNumber, "menu", nextMenu)
 				terminalio.WriteProcessedBytes(terminal, []byte("\r\n"), outputMode)
 				return currentUser, "GOTO:" + nextMenu, nil, true
 			}
@@ -682,7 +681,7 @@ func runFastLogin(c *cmdCtx, args string) (*user.User, string, error) {
 	ih := getSessionIH(s)
 
 	if isLightbar {
-		log.Printf("DEBUG: Node %d: FASTLOGIN using lightbar mode (%d options)", nodeNumber, len(lightbarOptions))
+		slog.Debug("FASTLOGIN using lightbar mode", "node", nodeNumber, "count", len(lightbarOptions))
 		selectedIndex := 0
 		_ = drawLightbarMenu(terminal, nil, lightbarOptions, selectedIndex, outputMode, false)
 
@@ -833,7 +832,7 @@ func runFullLoginSequence(c *cmdCtx, args string) (*user.User, string, error) {
 	termHeight := c.termHeight
 
 	loginSequence := e.GetLoginSequence()
-	log.Printf("INFO: Node %d: Running FULL_LOGIN_SEQUENCE for user %s (%d items configured)", nodeNumber, currentUser.Handle, len(loginSequence))
+	slog.Info("running FULL_LOGIN_SEQUENCE", "node", nodeNumber, "handle", currentUser.Handle, "count", len(loginSequence))
 
 	// Build dispatch map for login item commands
 	type loginHandler func(c *cmdCtx, args string) (*user.User, string, error)
@@ -858,12 +857,11 @@ func runFullLoginSequence(c *cmdCtx, args string) (*user.User, string, error) {
 	for i, item := range loginSequence {
 		// Check security level requirement
 		if item.SecLevel > 0 && currentUser.AccessLevel < item.SecLevel {
-			log.Printf("DEBUG: Node %d: Skipping login item %d (%s) - user level %d < required %d",
-				nodeNumber, i+1, item.Command, currentUser.AccessLevel, item.SecLevel)
+			slog.Debug("skipping login item - insufficient user level", "node", nodeNumber, "item", i+1, "command", item.Command, "level", currentUser.AccessLevel, "required", item.SecLevel)
 			continue
 		}
 
-		log.Printf("DEBUG: Node %d: Executing login item %d/%d: %s", nodeNumber, i+1, len(loginSequence), item.Command)
+		slog.Debug("executing login item", "node", nodeNumber, "item", i+1, "count", len(loginSequence), "command", item.Command)
 
 		// Clear screen if requested
 		if item.ClearScreen {
@@ -877,7 +875,7 @@ func runFullLoginSequence(c *cmdCtx, args string) (*user.User, string, error) {
 		if strings.HasPrefix(item.Command, "DOOR:") {
 			// Extract door name and execute via DOOR: handler
 			doorName := strings.TrimPrefix(item.Command, "DOOR:")
-			log.Printf("INFO: Node %d: Executing door '%s' from login sequence", nodeNumber, doorName)
+			slog.Info("executing door from login sequence", "node", nodeNumber, "door", doorName)
 
 			// Call the DOOR: handler from RunRegistry
 			if doorFunc, exists := e.RunRegistry["DOOR:"]; exists {
@@ -886,14 +884,14 @@ func runFullLoginSequence(c *cmdCtx, args string) (*user.User, string, error) {
 					currentUser = updatedUser
 				}
 			} else {
-				log.Printf("ERROR: Node %d: DOOR: handler not registered", nodeNumber)
+				slog.Error("DOOR: handler not registered", "node", nodeNumber)
 				continue
 			}
 		} else {
 			// Look up and execute the handler from the local handlers map
 			handler, exists := handlers[item.Command]
 			if !exists {
-				log.Printf("WARN: Node %d: Unknown login sequence command: %s", nodeNumber, item.Command)
+				slog.Warn("unknown login sequence command", "node", nodeNumber, "command", item.Command)
 				continue
 			}
 
@@ -909,7 +907,7 @@ func runFullLoginSequence(c *cmdCtx, args string) (*user.User, string, error) {
 			}
 		}
 		if err != nil {
-			log.Printf("ERROR: Node %d: Error during login item %s: %v", nodeNumber, item.Command, err)
+			slog.Error("error during login item", "node", nodeNumber, "command", item.Command, "error", err)
 			if errors.Is(err, io.EOF) {
 				return nil, "LOGOFF", io.EOF
 			}
@@ -921,7 +919,7 @@ func runFullLoginSequence(c *cmdCtx, args string) (*user.User, string, error) {
 			return nil, "LOGOFF", nil
 		}
 		if strings.HasPrefix(nextAction, "GOTO:") {
-			log.Printf("DEBUG: Node %d: Login sequence interrupted by %s -> %s", nodeNumber, item.Command, nextAction)
+			slog.Debug("login sequence interrupted", "node", nodeNumber, "command", item.Command, "action", nextAction)
 			return currentUser, nextAction, nil
 		}
 
@@ -936,7 +934,7 @@ func runFullLoginSequence(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	// Sequence completed - transition to MAIN menu
-	log.Printf("DEBUG: Node %d: FULL_LOGIN_SEQUENCE completed. Transitioning to MAIN.", nodeNumber)
+	slog.Debug("FULL_LOGIN_SEQUENCE completed, transitioning to MAIN", "node", nodeNumber)
 	return currentUser, "GOTO:MAIN", nil
 }
 

--- a/internal/menu/executor_messages.go
+++ b/internal/menu/executor_messages.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -31,7 +31,7 @@ func runListMessageAreas(c *cmdCtx, args string) (*user.User, string, error) {
 	sessionStartTime := c.sessionStartTime
 	outputMode := c.outputMode
 
-	log.Printf("DEBUG: Node %d: Running LISTMSGAR", nodeNumber)
+	slog.Debug("running LISTMSGAR", "node", nodeNumber)
 
 	// Filter to current conference if user is logged in, otherwise show all
 	filterConfID := -1
@@ -89,7 +89,7 @@ func runComposeMessage(c *cmdCtx, args string) (*user.User, string, error) {
 // ih is an optional pre-created *InputHandler shared with the caller's reader loop;
 // pass nil to create a new one inside the editor.
 func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHandler, terminal *term.Terminal, userManager *user.UserMgr, currentUser *user.User, nodeNumber int, sessionStartTime time.Time, args string, outputMode ansi.OutputMode, termWidth int, termHeight int) (*user.User, string, error) {
-	log.Printf("DEBUG: Node %d: Running COMPOSEMSG with args: %s", nodeNumber, args)
+	slog.Debug("running COMPOSEMSG", "node", nodeNumber, "args", args)
 
 	// 1. Determine Target Area
 	var areaTag string
@@ -99,7 +99,7 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 	if args == "" {
 		// No args provided, use current user's area
 		if currentUser == nil {
-			log.Printf("WARN: Node %d: COMPOSEMSG called without user and without args.", nodeNumber)
+			slog.Warn("COMPOSEMSG called without user and without args", "node", nodeNumber)
 			msg := "\r\n|01Error: Not logged in and no area specified.|07\r\n"
 			wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 			if wErr != nil { /* Log? */
@@ -108,7 +108,7 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 			return nil, "", nil // Return to menu
 		}
 		if currentUser.CurrentMessageAreaTag == "" || currentUser.CurrentMessageAreaID <= 0 {
-			log.Printf("WARN: Node %d: COMPOSEMSG called by %s, but no current message area is set.", nodeNumber, currentUser.Handle)
+			slog.Warn("COMPOSEMSG called but no current message area is set", "node", nodeNumber, "handle", currentUser.Handle)
 			msg := "\r\n|01Error: No current message area selected.|07\r\n"
 			wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 			if wErr != nil { /* Log? */
@@ -117,18 +117,18 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 			return nil, "", nil // Return to menu
 		}
 		areaTag = currentUser.CurrentMessageAreaTag
-		log.Printf("INFO: Node %d: COMPOSEMSG using current user area tag: %s", nodeNumber, areaTag)
+		slog.Info("COMPOSEMSG using current user area tag", "node", nodeNumber, "tag", areaTag)
 		area, exists = e.MessageMgr.GetAreaByTag(areaTag)
 	} else {
 		// Args provided, use args as the area tag
-		log.Printf("INFO: Node %d: COMPOSEMSG using provided area tag in args: %s", nodeNumber, args)
+		slog.Info("COMPOSEMSG using provided area tag in args", "node", nodeNumber, "tag", args)
 		areaTag = args
 		area, exists = e.MessageMgr.GetAreaByTag(areaTag)
 	}
 
 	// Common checks after determining areaTag/area
 	if !exists {
-		log.Printf("ERROR: Node %d: COMPOSEMSG called with invalid Area Tag: %s", nodeNumber, areaTag)
+		slog.Error("COMPOSEMSG called with invalid area tag", "node", nodeNumber, "tag", areaTag)
 		msg := fmt.Sprintf("\r\n|01Invalid message area: %s|07\r\n", areaTag)
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		if wErr != nil { /* Log? */
@@ -139,7 +139,7 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 
 	// Check user logged in (required for ACS check and posting)
 	if currentUser == nil {
-		log.Printf("WARN: Node %d: COMPOSEMSG reached ACS check without logged in user (Area: %s).", nodeNumber, areaTag)
+		slog.Warn("COMPOSEMSG reached ACS check without logged in user", "node", nodeNumber, "tag", areaTag)
 		msg := "\r\n|01Error: You must be logged in to post messages.|07\r\n"
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		if wErr != nil { /* Log? */
@@ -150,7 +150,7 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 
 	// Check ACSWrite permission for the area and currentUser
 	if !checkACS(area.ACSWrite, currentUser, s, terminal, sessionStartTime) {
-		log.Printf("WARN: Node %d: User %s denied post access to area %s (%s)", nodeNumber, currentUser.Handle, area.Tag, area.ACSWrite)
+		slog.Warn("user denied post access to area", "node", nodeNumber, "handle", currentUser.Handle, "tag", area.Tag, "acs", area.ACSWrite)
 		// TODO: Display user-friendly error message (e.g., Access Denied String)
 		time.Sleep(1 * time.Second)
 		return nil, "", nil // Return to menu, not an error
@@ -166,7 +166,7 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 	terminalio.WriteProcessedBytes(terminal, []byte("\r\n"), outputMode)
 	wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(titlePrompt)), outputMode)
 	if wErr != nil {
-		log.Printf("WARN: Node %d: Failed to write title prompt: %v", nodeNumber, wErr)
+		slog.Warn("failed to write title prompt", "node", nodeNumber, "error", wErr)
 	}
 
 	var subject string
@@ -175,7 +175,7 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 		subject, err = styledInput(terminal, s, outputMode, 30, "")
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				log.Printf("INFO: Node %d: User disconnected during title input.", nodeNumber)
+				slog.Info("user disconnected during title input", "node", nodeNumber)
 				return nil, "LOGOFF", io.EOF
 			}
 			if errors.Is(err, errInputAborted) {
@@ -192,11 +192,11 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 				// No — re-show prompt and retry
 				wErr = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(titlePrompt)), outputMode)
 				if wErr != nil {
-					log.Printf("WARN: Node %d: Failed to rewrite title prompt: %v", nodeNumber, wErr)
+					slog.Warn("failed to rewrite title prompt", "node", nodeNumber, "error", wErr)
 				}
 				continue
 			}
-			log.Printf("ERROR: Node %d: Failed reading title input: %v", nodeNumber, err)
+			slog.Error("failed reading title input", "node", nodeNumber, "error", err)
 			terminalio.WriteProcessedBytes(terminal, []byte("\r\nError reading title.\r\n"), outputMode)
 			time.Sleep(1 * time.Second)
 			return nil, "", nil // Return to menu
@@ -208,7 +208,7 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("|01Subject is required.|07\r\n")), outputMode)
 		wErr = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(titlePrompt)), outputMode)
 		if wErr != nil {
-			log.Printf("WARN: Node %d: Failed to rewrite title prompt: %v", nodeNumber, wErr)
+			slog.Warn("failed to rewrite title prompt", "node", nodeNumber, "error", wErr)
 		}
 	}
 
@@ -221,12 +221,12 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 	for {
 		wErr = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(toPrompt)), outputMode)
 		if wErr != nil {
-			log.Printf("WARN: Node %d: Failed to write 'to' prompt: %v", nodeNumber, wErr)
+			slog.Warn("failed to write 'to' prompt", "node", nodeNumber, "error", wErr)
 		}
 		toUser, err = styledInput(terminal, s, outputMode, 24, "All")
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				log.Printf("INFO: Node %d: User disconnected during 'to' input.", nodeNumber)
+				slog.Info("user disconnected during 'to' input", "node", nodeNumber)
 				return nil, "LOGOFF", io.EOF
 			}
 			if errors.Is(err, errInputAborted) {
@@ -242,7 +242,7 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 				}
 				continue // No — re-show prompt and retry
 			}
-			log.Printf("ERROR: Node %d: Failed reading 'to' input: %v", nodeNumber, err)
+			slog.Error("failed reading 'to' input", "node", nodeNumber, "error", err)
 			terminalio.WriteProcessedBytes(terminal, []byte("\r\nError reading recipient.\r\n"), outputMode)
 			time.Sleep(1 * time.Second)
 			return nil, "", nil
@@ -280,10 +280,10 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 		isAnon, err := e.PromptYesNo(s, terminal, anonPrompt, outputMode, nodeNumber, termWidth, termHeight, false)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				log.Printf("INFO: Node %d: User disconnected during anonymous input.", nodeNumber)
+				slog.Info("user disconnected during anonymous input", "node", nodeNumber)
 				return nil, "LOGOFF", io.EOF
 			}
-			log.Printf("ERROR: Node %d: Failed reading anonymous input: %v", nodeNumber, err)
+			slog.Error("failed reading anonymous input", "node", nodeNumber, "error", err)
 			isAnon = false
 		}
 		isAnonymous = isAnon
@@ -304,7 +304,7 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 	}
 
 	// 6. Call the Editor
-	log.Printf("DEBUG: Node %d: Clearing screen before calling editor.RunEditor", nodeNumber)
+	slog.Debug("clearing screen before calling editor", "node", nodeNumber)
 	terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode) // Clear screen before editor
 
 	// Build editor context for FSEDITOR.ANS header placeholders
@@ -326,10 +326,10 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 
 	// No quote data for new messages
 	body, saved, err := editor.RunEditorWithMetadata("", s, s, outputMode, subject, toUser, fromName, isAnonymous, "", "", "", "", false, nil, ih, editorCtx)
-	log.Printf("DEBUG: Node %d: editor.RunEditorWithMetadata returned. Error: %v, Saved: %v, Body length: %d", nodeNumber, err, saved, len(body))
+	slog.Debug("editor returned", "node", nodeNumber, "error", err, "saved", saved, "length", len(body))
 
 	if err != nil {
-		log.Printf("ERROR: Node %d: Editor failed for user %s: %v", nodeNumber, currentUser.Handle, err)
+		slog.Error("editor failed", "node", nodeNumber, "handle", currentUser.Handle, "error", err)
 		return nil, "", fmt.Errorf("editor error: %w", err)
 	}
 
@@ -337,14 +337,14 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 	terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 
 	if !saved {
-		log.Printf("INFO: Node %d: User %s aborted message composition for area %s.", nodeNumber, currentUser.Handle, area.Tag)
+		slog.Info("user aborted message composition", "node", nodeNumber, "handle", currentUser.Handle, "tag", area.Tag)
 		terminalio.WriteProcessedBytes(terminal, []byte("\r\nMessage aborted.\r\n"), outputMode)
 		time.Sleep(1 * time.Second)
 		return nil, "", nil // Return to current menu
 	}
 
 	if strings.TrimSpace(body) == "" {
-		log.Printf("INFO: Node %d: User %s saved empty message for area %s.", nodeNumber, currentUser.Handle, area.Tag)
+		slog.Info("user saved empty message", "node", nodeNumber, "handle", currentUser.Handle, "tag", area.Tag)
 		terminalio.WriteProcessedBytes(terminal, []byte("\r\nMessage body empty. Aborting post.\r\n"), outputMode)
 		time.Sleep(1 * time.Second)
 		return nil, "", nil // Return to current menu
@@ -359,7 +359,7 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 
 	msgNum, err := e.MessageMgr.AddMessage(area.ID, fromName, toUser, subject, body, "")
 	if err != nil {
-		log.Printf("ERROR: Node %d: Failed to save message from user %s to area %s: %v", nodeNumber, currentUser.Handle, area.Tag, err)
+		slog.Error("failed to save message", "node", nodeNumber, "handle", currentUser.Handle, "tag", area.Tag, "error", err)
 		errorMsg := ansi.ReplacePipeCodes([]byte("\r\n|01Error saving message!|07\r\n"))
 		terminalio.WriteProcessedBytes(terminal, errorMsg, outputMode)
 		time.Sleep(2 * time.Second)
@@ -369,11 +369,11 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 	// 8. Update user message counter
 	currentUser.MessagesPosted++
 	if err := userManager.UpdateUser(currentUser); err != nil {
-		log.Printf("ERROR: Node %d: Failed to update MessagesPosted for user %s: %v", nodeNumber, currentUser.Handle, err)
+		slog.Error("failed to update MessagesPosted", "node", nodeNumber, "handle", currentUser.Handle, "error", err)
 	}
 
 	// 9. Confirmation
-	log.Printf("INFO: Node %d: User %s successfully posted message #%d to area %s", nodeNumber, currentUser.Handle, msgNum, area.Tag)
+	slog.Info("user posted message", "node", nodeNumber, "handle", currentUser.Handle, "num", msgNum, "tag", area.Tag)
 	confirmMsg := ansi.ReplacePipeCodes([]byte("\r\n|02Message Posted!|07\r\n"))
 	terminalio.WriteProcessedBytes(terminal, confirmMsg, outputMode)
 	time.Sleep(1 * time.Second)
@@ -394,15 +394,15 @@ func runPromptAndComposeMessage(c *cmdCtx, args string) (*user.User, string, err
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running runPromptAndComposeMessage", nodeNumber)
+	slog.Debug("running runPromptAndComposeMessage", "node", nodeNumber)
 
 	if currentUser == nil {
-		log.Printf("WARN: Node %d: runPromptAndComposeMessage called without logged in user.", nodeNumber)
+		slog.Warn("runPromptAndComposeMessage called without logged in user", "node", nodeNumber)
 		// Display user-friendly error
 		msg := "\r\n|01Error: You must be logged in to post messages.|07\r\n"
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		if wErr != nil {
-			log.Printf("ERROR: Node %d: Failed writing login required message: %v", nodeNumber, wErr)
+			slog.Error("failed writing login required message", "node", nodeNumber, "error", wErr)
 		}
 		time.Sleep(1 * time.Second)
 		return nil, "", nil // Return to menu
@@ -422,7 +422,7 @@ func runPromptAndComposeMessage(c *cmdCtx, args string) (*user.User, string, err
 	botTemplateBytes, errBot := readTemplateFile(botTemplatePath) // Load BOT template
 
 	if errTop != nil || errMid != nil || errBot != nil { // Check BOT error too
-		log.Printf("ERROR: Node %d: Failed to load one or more MSGAREA template files for prompt: TOP(%v), MID(%v), BOT(%v)", nodeNumber, errTop, errMid, errBot)
+		slog.Error("failed to load one or more MSGAREA template files for prompt", "node", nodeNumber, "top", errTop, "mid", errMid, "bot", errBot)
 		msg := "\r\n|01Error loading Message Area screen templates.|07\r\n"
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
@@ -439,7 +439,7 @@ func runPromptAndComposeMessage(c *cmdCtx, args string) (*user.User, string, err
 	terminalio.WriteProcessedBytes(terminal, processedTopTemplate, outputMode)       // Write TOP
 
 	if len(areas) == 0 {
-		log.Printf("DEBUG: Node %d: No message areas available to post in.", nodeNumber)
+		slog.Debug("no message areas available to post in", "node", nodeNumber)
 		noAreasMsg := ansi.ReplacePipeCodes([]byte("\r\n|07No message areas available.|07\r\n"))
 		terminalio.WriteProcessedBytes(terminal, noAreasMsg, outputMode)
 		time.Sleep(1 * time.Second)
@@ -468,25 +468,25 @@ func runPromptAndComposeMessage(c *cmdCtx, args string) (*user.User, string, err
 
 	// 2. Prompt for Area Selection
 	prompt := "\r\n|07Enter Area # or Tag to Post In (or Enter to cancel): |15"
-	log.Printf("DEBUG: Node %d: Writing prompt for message area selection bytes (hex): %x", nodeNumber, ansi.ReplacePipeCodes([]byte(prompt)))
+	slog.Debug("writing prompt for message area selection", "node", nodeNumber, "bytes", fmt.Sprintf("%x", ansi.ReplacePipeCodes([]byte(prompt))))
 	wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(prompt)), outputMode)
 	if wErr != nil {
-		log.Printf("WARN: Node %d: Failed to write area selection prompt: %v", nodeNumber, wErr)
+		slog.Warn("failed to write area selection prompt", "node", nodeNumber, "error", wErr)
 	}
 
 	input, err := readLineFromSessionIH(s, terminal)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
-			log.Printf("INFO: Node %d: User disconnected during area selection.", nodeNumber)
+			slog.Info("user disconnected during area selection", "node", nodeNumber)
 			return nil, "LOGOFF", io.EOF
 		}
-		log.Printf("ERROR: Node %d: Failed reading area selection input: %v", nodeNumber, err)
+		slog.Error("failed reading area selection input", "node", nodeNumber, "error", err)
 		return nil, "", fmt.Errorf("failed reading area selection: %w", err)
 	}
 
 	selectedAreaStr := strings.TrimSpace(input)
 	if selectedAreaStr == "" {
-		log.Printf("INFO: Node %d: User cancelled message posting.", nodeNumber)
+		slog.Info("user cancelled message posting", "node", nodeNumber)
 		terminalio.WriteProcessedBytes(terminal, []byte("\r\nPost cancelled.\r\n"), outputMode)
 		time.Sleep(500 * time.Millisecond)
 		return nil, "", nil // Return to current menu
@@ -510,7 +510,7 @@ func runPromptAndComposeMessage(c *cmdCtx, args string) (*user.User, string, err
 	}
 
 	if !foundArea {
-		log.Printf("WARN: Node %d: Invalid area selection '%s' by user %s.", nodeNumber, selectedAreaStr, currentUser.Handle)
+		slog.Warn("invalid area selection", "node", nodeNumber, "selection", selectedAreaStr, "handle", currentUser.Handle)
 		// TODO: Use configurable string
 		msg := fmt.Sprintf("\r\n|01Invalid area: %s|07\r\n", selectedAreaStr)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
@@ -521,7 +521,7 @@ func runPromptAndComposeMessage(c *cmdCtx, args string) (*user.User, string, err
 
 	// Check write permission
 	if !checkACS(selectedArea.ACSWrite, currentUser, s, terminal, sessionStartTime) {
-		log.Printf("WARN: Node %d: User %s denied post access to selected area %s (%s)", nodeNumber, currentUser.Handle, selectedArea.Tag, selectedArea.ACSWrite)
+		slog.Warn("user denied post access to selected area", "node", nodeNumber, "handle", currentUser.Handle, "tag", selectedArea.Tag, "acs", selectedArea.ACSWrite)
 		// TODO: Use configurable string for access denied
 		msg := fmt.Sprintf("\r\n|01Access denied to post in area: %s|07\r\n", selectedArea.Name)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
@@ -530,7 +530,7 @@ func runPromptAndComposeMessage(c *cmdCtx, args string) (*user.User, string, err
 		return nil, "", nil // Return to menu
 	}
 
-	log.Printf("INFO: Node %d: User %s selected area %s (%s) to post in.", nodeNumber, currentUser.Handle, selectedArea.Name, selectedArea.Tag)
+	slog.Info("user selected area to post in", "node", nodeNumber, "handle", currentUser.Handle, "name", selectedArea.Name, "tag", selectedArea.Tag)
 
 	// 4. Call runComposeMessage with the selected Area Tag
 	// Pass the area tag as the argument string
@@ -551,7 +551,7 @@ func runReadMsgs(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running READMSGS", nodeNumber)
+	slog.Debug("running READMSGS", "node", nodeNumber)
 
 	if currentUser == nil {
 		msg := "\r\n|01Error: You must be logged in to read messages.|07\r\n"
@@ -668,7 +668,7 @@ func runNewscan(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running NEWSCAN for user %s", nodeNumber, currentUser.Handle)
+	slog.Debug("running NEWSCAN", "node", nodeNumber, "handle", currentUser.Handle)
 
 	// Refresh user from the in-process manager so we pick up any newscan
 	// setting changes saved during this session (e.g. tagged areas modified
@@ -719,7 +719,7 @@ func runSelectMessageArea(c *cmdCtx, args string) (*user.User, string, error) {
 	sessionStartTime := c.sessionStartTime
 	outputMode := c.outputMode
 
-	log.Printf("DEBUG: Node %d: Running SELECTMSGAREA", nodeNumber)
+	slog.Debug("running SELECTMSGAREA", "node", nodeNumber)
 
 	if currentUser == nil {
 		msg := "\r\n|01Error: You must be logged in to select a message area.|07\r\n"
@@ -871,7 +871,7 @@ func runSelectMessageArea(c *cmdCtx, args string) (*user.User, string, error) {
 		e.setUserMsgConference(currentUser, area.ConferenceID)
 
 		if err := userManager.UpdateUser(currentUser); err != nil {
-			log.Printf("ERROR: Node %d: Failed to save user data after updating message area: %v", nodeNumber, err)
+			slog.Error("failed to save user data after updating message area", "node", nodeNumber, "error", err)
 			msg := "\r\n|01Error: Could not save area selection.|07\r\n"
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 			time.Sleep(1 * time.Second)
@@ -879,7 +879,7 @@ func runSelectMessageArea(c *cmdCtx, args string) (*user.User, string, error) {
 			continue
 		}
 
-		log.Printf("INFO: Node %d: User %s changed message area to ID %d ('%s')", nodeNumber, currentUser.Handle, area.ID, area.Tag)
+		slog.Info("user changed message area", "node", nodeNumber, "handle", currentUser.Handle, "id", area.ID, "tag", area.Tag)
 		msg := fmt.Sprintf("\r\n|07Current message area set to: |15%s|07\r\n", area.Name)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
@@ -901,7 +901,7 @@ func runSendPrivateMail(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running SENDPRIVMAIL", nodeNumber)
+	slog.Debug("running SENDPRIVMAIL", "node", nodeNumber)
 
 	if currentUser == nil {
 		msg := "\r\n|01Error: You must be logged in to send private mail.|07\r\n"
@@ -913,7 +913,7 @@ func runSendPrivateMail(c *cmdCtx, args string) (*user.User, string, error) {
 	// Get PRIVMAIL area
 	privmailArea, exists := e.MessageMgr.GetAreaByTag("PRIVMAIL")
 	if !exists {
-		log.Printf("ERROR: Node %d: PRIVMAIL area not found", nodeNumber)
+		slog.Error("PRIVMAIL area not found", "node", nodeNumber)
 		msg := "\r\n|01Error: Private mail area not configured.|07\r\n"
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
@@ -927,13 +927,13 @@ func runSendPrivateMail(c *cmdCtx, args string) (*user.User, string, error) {
 	for {
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(recipientPrompt)), outputMode)
 		if wErr != nil {
-			log.Printf("WARN: Node %d: Failed to write recipient prompt: %v", nodeNumber, wErr)
+			slog.Warn("failed to write recipient prompt", "node", nodeNumber, "error", wErr)
 		}
 		var inputErr error
 		recipient, inputErr = styledInput(terminal, s, outputMode, 24, "")
 		if inputErr != nil {
 			if errors.Is(inputErr, io.EOF) {
-				log.Printf("INFO: Node %d: User disconnected during recipient input.", nodeNumber)
+				slog.Info("user disconnected during recipient input", "node", nodeNumber)
 				return nil, "LOGOFF", io.EOF
 			}
 			if errors.Is(inputErr, errInputAborted) {
@@ -949,7 +949,7 @@ func runSendPrivateMail(c *cmdCtx, args string) (*user.User, string, error) {
 				}
 				continue // No — re-show prompt and retry
 			}
-			log.Printf("ERROR: Node %d: Failed reading recipient input: %v", nodeNumber, inputErr)
+			slog.Error("failed reading recipient input", "node", nodeNumber, "error", inputErr)
 			terminalio.WriteProcessedBytes(terminal, []byte("\r\nError reading recipient.\r\n"), outputMode)
 			time.Sleep(1 * time.Second)
 			return nil, "", nil
@@ -978,13 +978,13 @@ func runSendPrivateMail(c *cmdCtx, args string) (*user.User, string, error) {
 	var subject string
 	for {
 		if wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(titlePrompt)), outputMode); wErr != nil {
-			log.Printf("WARN: Node %d: Failed to write subject prompt: %v", nodeNumber, wErr)
+			slog.Warn("failed to write subject prompt", "node", nodeNumber, "error", wErr)
 		}
 		var inputErr error
 		subject, inputErr = styledInput(terminal, s, outputMode, 30, "")
 		if inputErr != nil {
 			if errors.Is(inputErr, io.EOF) {
-				log.Printf("INFO: Node %d: User disconnected during subject input.", nodeNumber)
+				slog.Info("user disconnected during subject input", "node", nodeNumber)
 				return nil, "LOGOFF", io.EOF
 			}
 			if errors.Is(inputErr, errInputAborted) {
@@ -1000,7 +1000,7 @@ func runSendPrivateMail(c *cmdCtx, args string) (*user.User, string, error) {
 				}
 				continue // No — re-show prompt and retry
 			}
-			log.Printf("ERROR: Node %d: Failed reading subject input: %v", nodeNumber, inputErr)
+			slog.Error("failed reading subject input", "node", nodeNumber, "error", inputErr)
 			terminalio.WriteProcessedBytes(terminal, []byte("\r\nError reading subject.\r\n"), outputMode)
 			time.Sleep(1 * time.Second)
 			return nil, "", nil
@@ -1013,7 +1013,7 @@ func runSendPrivateMail(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	// Launch editor
-	log.Printf("DEBUG: Node %d: Clearing screen before calling editor for private mail", nodeNumber)
+	slog.Debug("clearing screen before calling editor for private mail", "node", nodeNumber)
 	terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 
 	// Launch editor for private mail (no anonymous option for private mail)
@@ -1027,10 +1027,10 @@ func runSendPrivateMail(c *cmdCtx, args string) (*user.User, string, error) {
 		ConfArea:   "Private Mail",
 	}
 	body, saved, err := editor.RunEditorWithMetadata("", s, s, outputMode, subject, recipientUser.Handle, currentUser.Handle, false, "", "", "", "", false, nil, nil, privEditorCtx)
-	log.Printf("DEBUG: Node %d: editor.RunEditorWithMetadata returned. Error: %v, Saved: %v, Body length: %d", nodeNumber, err, saved, len(body))
+	slog.Debug("editor returned", "node", nodeNumber, "error", err, "saved", saved, "length", len(body))
 
 	if err != nil {
-		log.Printf("ERROR: Node %d: Editor failed for user %s: %v", nodeNumber, currentUser.Handle, err)
+		slog.Error("editor failed", "node", nodeNumber, "handle", currentUser.Handle, "error", err)
 		return nil, "", fmt.Errorf("editor error: %w", err)
 	}
 
@@ -1038,14 +1038,14 @@ func runSendPrivateMail(c *cmdCtx, args string) (*user.User, string, error) {
 	terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 
 	if !saved {
-		log.Printf("INFO: Node %d: User %s aborted private mail composition.", nodeNumber, currentUser.Handle)
+		slog.Info("user aborted private mail composition", "node", nodeNumber, "handle", currentUser.Handle)
 		terminalio.WriteProcessedBytes(terminal, []byte("\r\nMessage aborted.\r\n"), outputMode)
 		time.Sleep(1 * time.Second)
 		return nil, "", nil
 	}
 
 	if strings.TrimSpace(body) == "" {
-		log.Printf("INFO: Node %d: User %s saved empty private mail.", nodeNumber, currentUser.Handle)
+		slog.Info("user saved empty private mail", "node", nodeNumber, "handle", currentUser.Handle)
 		terminalio.WriteProcessedBytes(terminal, []byte("\r\nMessage body empty. Aborting.\r\n"), outputMode)
 		time.Sleep(1 * time.Second)
 		return nil, "", nil
@@ -1059,7 +1059,7 @@ func runSendPrivateMail(c *cmdCtx, args string) (*user.User, string, error) {
 	// Save the private message with MSG_PRIVATE flag
 	msgNum, err := e.MessageMgr.AddPrivateMessage(privmailArea.ID, currentUser.Handle, recipientUser.Handle, subject, body, "")
 	if err != nil {
-		log.Printf("ERROR: Node %d: Failed to save private message from user %s to %s: %v", nodeNumber, currentUser.Handle, recipientUser.Handle, err)
+		slog.Error("failed to save private message", "node", nodeNumber, "handle", currentUser.Handle, "recipient", recipientUser.Handle, "error", err)
 		errorMsg := ansi.ReplacePipeCodes([]byte("\r\n|01Error saving private message!|07\r\n"))
 		terminalio.WriteProcessedBytes(terminal, errorMsg, outputMode)
 		time.Sleep(2 * time.Second)
@@ -1069,11 +1069,11 @@ func runSendPrivateMail(c *cmdCtx, args string) (*user.User, string, error) {
 	// Update user message counter
 	currentUser.MessagesPosted++
 	if err := userManager.UpdateUser(currentUser); err != nil {
-		log.Printf("ERROR: Node %d: Failed to update MessagesPosted for user %s: %v", nodeNumber, currentUser.Handle, err)
+		slog.Error("failed to update MessagesPosted", "node", nodeNumber, "handle", currentUser.Handle, "error", err)
 	}
 
 	// Confirmation
-	log.Printf("INFO: Node %d: User %s successfully sent private message #%d to %s", nodeNumber, currentUser.Handle, msgNum, recipientUser.Handle)
+	slog.Info("user sent private message", "node", nodeNumber, "handle", currentUser.Handle, "num", msgNum, "recipient", recipientUser.Handle)
 	confirmMsg := ansi.ReplacePipeCodes([]byte(fmt.Sprintf("\r\n|02Private message sent to %s!|07\r\n", recipientUser.Handle)))
 	terminalio.WriteProcessedBytes(terminal, confirmMsg, outputMode)
 	time.Sleep(1 * time.Second)
@@ -1105,7 +1105,7 @@ func runReadPrivateMail(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running READPRIVMAIL", nodeNumber)
+	slog.Debug("running READPRIVMAIL", "node", nodeNumber)
 
 	if currentUser == nil {
 		msg := "\r\n|01Error: You must be logged in to read private mail.|07\r\n"
@@ -1117,7 +1117,7 @@ func runReadPrivateMail(c *cmdCtx, args string) (*user.User, string, error) {
 	// Get PRIVMAIL area
 	privmailArea, exists := e.MessageMgr.GetAreaByTag("PRIVMAIL")
 	if !exists {
-		log.Printf("ERROR: Node %d: PRIVMAIL area not found", nodeNumber)
+		slog.Error("PRIVMAIL area not found", "node", nodeNumber)
 		msg := "\r\n|01Error: Private mail area not configured.|07\r\n"
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
@@ -1127,7 +1127,7 @@ func runReadPrivateMail(c *cmdCtx, args string) (*user.User, string, error) {
 	// Get JAM base for PRIVMAIL area
 	base, err := e.MessageMgr.GetBase(privmailArea.ID)
 	if err != nil {
-		log.Printf("ERROR: Node %d: JAM base not open for PRIVMAIL area: %v", nodeNumber, err)
+		slog.Error("JAM base not open for PRIVMAIL area", "node", nodeNumber, "error", err)
 		msg := "\r\n|01Error: Private mail base not available.|07\r\n"
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
@@ -1138,7 +1138,7 @@ func runReadPrivateMail(c *cmdCtx, args string) (*user.User, string, error) {
 	// Get total message count
 	totalMessages, err := e.MessageMgr.GetMessageCountForArea(privmailArea.ID)
 	if err != nil {
-		log.Printf("ERROR: Node %d: Failed to get message count for PRIVMAIL: %v", nodeNumber, err)
+		slog.Error("failed to get message count for PRIVMAIL", "node", nodeNumber, "error", err)
 		msg := "\r\n|01Error loading private mail.|07\r\n"
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
@@ -1158,7 +1158,7 @@ func runReadPrivateMail(c *cmdCtx, args string) (*user.User, string, error) {
 	for msgNum := 1; msgNum <= totalMessages; msgNum++ {
 		msg, err := base.ReadMessage(msgNum)
 		if err != nil {
-			log.Printf("WARN: Node %d: Failed to read message #%d in PRIVMAIL: %v", nodeNumber, msgNum, err)
+			slog.Warn("failed to read message in PRIVMAIL", "node", nodeNumber, "msg", msgNum, "error", err)
 			continue
 		}
 
@@ -1241,7 +1241,7 @@ func runListPrivateMail(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running LISTPRIVMAIL", nodeNumber)
+	slog.Debug("running LISTPRIVMAIL", "node", nodeNumber)
 
 	if currentUser == nil {
 		msg := "\r\n|01Error: You must be logged in to list private mail.|07\r\n"
@@ -1253,7 +1253,7 @@ func runListPrivateMail(c *cmdCtx, args string) (*user.User, string, error) {
 	// Get PRIVMAIL area
 	privmailArea, exists := e.MessageMgr.GetAreaByTag("PRIVMAIL")
 	if !exists {
-		log.Printf("ERROR: Node %d: PRIVMAIL area not found", nodeNumber)
+		slog.Error("PRIVMAIL area not found", "node", nodeNumber)
 		msg := "\r\n|01Error: Private mail area not configured.|07\r\n"
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)

--- a/internal/menu/executor_oneliners.go
+++ b/internal/menu/executor_oneliners.go
@@ -525,9 +525,8 @@ func runOneliners(c *cmdCtx, args string) (*user.User, string, error) {
 			}
 		}
 
-		// Log hex bytes before writing
 		enterPromptBytes := ansi.ReplacePipeCodes([]byte(enterPrompt))
-		slog.Debug("writing ONELINER enter prompt bytes", "node", nodeNumber, "bytes", enterPromptBytes)
+		slog.Debug("writing oneliner enter prompt bytes", "node", nodeNumber, "bytes", fmt.Sprintf("%X", enterPromptBytes))
 		wErr = terminalio.WriteProcessedBytes(terminal, enterPromptBytes, outputMode)
 		if wErr != nil {
 			slog.Error("failed writing EnterOneLiner prompt", "node", nodeNumber, "error", wErr)

--- a/internal/menu/executor_oneliners.go
+++ b/internal/menu/executor_oneliners.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -308,7 +308,7 @@ func runOneliners(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running ONELINER", nodeNumber)
+	slog.Debug("running ONELINER", "node", nodeNumber)
 
 	onelinerPath := filepath.Join("data", "oneliners.json")
 
@@ -317,12 +317,12 @@ func runOneliners(c *cmdCtx, args string) (*user.User, string, error) {
 	loadedOneLiners, loadErr := loadOnelinerRecords(onelinerPath)
 	onelinerMutex.Unlock()
 	if loadErr != nil {
-		log.Printf("ERROR: Failed loading oneliners from %s: %v", onelinerPath, loadErr)
+		slog.Error("failed loading oneliners", "path", onelinerPath, "error", loadErr)
 		currentOneLiners = []onelinerRecord{}
 	} else {
 		currentOneLiners = loadedOneLiners
 	}
-	log.Printf("DEBUG: Loaded %d oneliners from %s", len(currentOneLiners), onelinerPath)
+	slog.Debug("loaded oneliners", "count", len(currentOneLiners), "path", onelinerPath)
 
 	numLiners := len(currentOneLiners)
 	maxLinesToShow := oneLinerMaxDisplay
@@ -340,7 +340,7 @@ func runOneliners(c *cmdCtx, args string) (*user.User, string, error) {
 	midTemplateBytes, errMid := readTemplateFile(midTemplatePath)
 	botTemplateBytes, errBot := readTemplateFile(botTemplatePath)
 	if errTop != nil || errMid != nil || errBot != nil {
-		log.Printf("ERROR: Node %d: Failed to load one or more ONELINER template files: TOP(%v), MID(%v), BOT(%v)", nodeNumber, errTop, errMid, errBot)
+		slog.Error("failed to load one or more ONELINER template files", "node", nodeNumber, "topError", errTop, "midError", errMid, "botError", errBot)
 		msg := e.LoadedStrings.ExecOnelinerTemplateErr
 		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		if wErr != nil {
@@ -364,12 +364,12 @@ func runOneliners(c *cmdCtx, args string) (*user.User, string, error) {
 
 	wErr := terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 	if wErr != nil {
-		log.Printf("ERROR: Node %d: Failed clearing screen for ONELINER: %v", nodeNumber, wErr)
+		slog.Error("failed clearing screen for ONELINER", "node", nodeNumber, "error", wErr)
 	}
 
 	wErr = terminalio.WriteProcessedBytes(terminal, processedTopTemplate, outputMode)
 	if wErr != nil {
-		log.Printf("ERROR: Node %d: Failed writing ONELINER top template: %v", nodeNumber, wErr)
+		slog.Error("failed writing ONELINER top template", "node", nodeNumber, "error", wErr)
 		return nil, "", wErr
 	}
 
@@ -380,7 +380,7 @@ func runOneliners(c *cmdCtx, args string) (*user.User, string, error) {
 		lineBytes := ansi.ReplacePipeCodes([]byte(line))
 		wErr = terminalio.WriteProcessedBytes(terminal, lineBytes, outputMode)
 		if wErr != nil {
-			log.Printf("ERROR: Node %d: Failed writing empty oneliner state: %v", nodeNumber, wErr)
+			slog.Error("failed writing empty oneliner state", "node", nodeNumber, "error", wErr)
 			return nil, "", wErr
 		}
 	} else {
@@ -401,7 +401,7 @@ func runOneliners(c *cmdCtx, args string) (*user.User, string, error) {
 			lineBytes := ansi.ReplacePipeCodes([]byte(line))
 			wErr = terminalio.WriteProcessedBytes(terminal, lineBytes, outputMode)
 			if wErr != nil {
-				log.Printf("ERROR: Node %d: Failed writing oneliner line %d: %v", nodeNumber, i, wErr)
+				slog.Error("failed writing oneliner line", "node", nodeNumber, "line", i, "error", wErr)
 				return nil, "", wErr
 			}
 		}
@@ -409,13 +409,13 @@ func runOneliners(c *cmdCtx, args string) (*user.User, string, error) {
 
 	wErr = terminalio.WriteProcessedBytes(terminal, processedBotTemplate, outputMode)
 	if wErr != nil {
-		log.Printf("ERROR: Node %d: Failed writing ONELINER bottom template: %v", nodeNumber, wErr)
+		slog.Error("failed writing ONELINER bottom template", "node", nodeNumber, "error", wErr)
 		return nil, "", wErr
 	}
 	// --- Ask to Add New One ---
 	askPrompt := e.LoadedStrings.AskOneLiner
 	if askPrompt == "" {
-		log.Printf("ERROR: Required string 'AskOneLiner' is missing or empty in strings configuration.")
+		slog.Error("required string 'AskOneLiner' is missing or empty in strings configuration")
 		return nil, "", fmt.Errorf("missing AskOneLiner string in configuration")
 	}
 
@@ -425,18 +425,18 @@ func runOneliners(c *cmdCtx, args string) (*user.User, string, error) {
 		posCmd := fmt.Sprintf("\x1b[%d;1H", lastRow)
 		wErr = terminalio.WriteProcessedBytes(terminal, []byte(posCmd), outputMode)
 		if wErr != nil {
-			log.Printf("WARN: Node %d: Failed positioning cursor for ONELINER ask prompt: %v", nodeNumber, wErr)
+			slog.Warn("failed positioning cursor for ONELINER ask prompt", "node", nodeNumber, "error", wErr)
 		}
 	}
 
-	log.Printf("DEBUG: Node %d: Calling promptYesNo for ONELINER add prompt", nodeNumber)
+	slog.Debug("calling promptYesNo for ONELINER add prompt", "node", nodeNumber)
 	addYes, err := e.PromptYesNo(s, terminal, askPrompt, outputMode, nodeNumber, termWidth, termHeight, false)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
-			log.Printf("INFO: Node %d: User disconnected during ONELINER add prompt.", nodeNumber)
+			slog.Info("user disconnected during ONELINER add prompt", "node", nodeNumber)
 			return nil, "LOGOFF", io.EOF
 		}
-		log.Printf("ERROR: Failed getting Yes/No input for ONELINER add: %v", err)
+		slog.Error("failed getting Yes/No input for ONELINER add", "error", err)
 		return nil, "", err
 	}
 
@@ -451,15 +451,15 @@ func runOneliners(c *cmdCtx, args string) (*user.User, string, error) {
 			// Start anonymous prompt at column 1 to avoid inherited indentation.
 			wErr = terminalio.WriteProcessedBytes(terminal, []byte("\r\x1b[2K"), outputMode)
 			if wErr != nil {
-				log.Printf("WARN: Node %d: Failed to clear line before ONELINER anonymous prompt: %v", nodeNumber, wErr)
+				slog.Warn("failed to clear line before ONELINER anonymous prompt", "node", nodeNumber, "error", wErr)
 			}
 			anonYes, anonErr := e.PromptYesNo(s, terminal, anonPrompt, outputMode, nodeNumber, termWidth, termHeight, false)
 			if anonErr != nil {
 				if errors.Is(anonErr, io.EOF) {
-					log.Printf("INFO: Node %d: User disconnected during ONELINER anonymous prompt.", nodeNumber)
+					slog.Info("user disconnected during ONELINER anonymous prompt", "node", nodeNumber)
 					return nil, "LOGOFF", io.EOF
 				}
-				log.Printf("WARN: Node %d: Failed anonymous prompt for ONELINER: %v", nodeNumber, anonErr)
+				slog.Warn("failed anonymous prompt for ONELINER", "node", nodeNumber, "error", anonErr)
 			} else {
 				isAnonymous = anonYes
 			}
@@ -467,7 +467,7 @@ func runOneliners(c *cmdCtx, args string) (*user.User, string, error) {
 
 		enterPrompt := e.LoadedStrings.EnterOneLiner
 		if enterPrompt == "" {
-			log.Printf("ERROR: Required string 'EnterOneLiner' is missing or empty in strings configuration.")
+			slog.Error("required string 'EnterOneLiner' is missing or empty in strings configuration")
 			return nil, "", fmt.Errorf("missing EnterOneLiner string in configuration")
 		}
 
@@ -510,36 +510,36 @@ func runOneliners(c *cmdCtx, args string) (*user.User, string, error) {
 			legendPosCmd := fmt.Sprintf("\x1b[%d;1H", legendRow)
 			wErr = terminalio.WriteProcessedBytes(terminal, []byte(legendPosCmd), outputMode)
 			if wErr != nil {
-				log.Printf("WARN: Node %d: Failed positioning ONELINER legend row: %v", nodeNumber, wErr)
+				slog.Warn("failed positioning ONELINER legend row", "node", nodeNumber, "error", wErr)
 			}
 
 			legendBytes := ansi.ReplacePipeCodes([]byte(legendText))
 			wErr = terminalio.WriteProcessedBytes(terminal, legendBytes, outputMode)
 			if wErr != nil {
-				log.Printf("WARN: Node %d: Failed writing ONELINER legend: %v", nodeNumber, wErr)
+				slog.Warn("failed writing ONELINER legend", "node", nodeNumber, "error", wErr)
 			}
 
 			wErr = terminalio.WriteProcessedBytes(terminal, []byte(fmt.Sprintf("\x1b[%d;1H", inputRow)), outputMode)
 			if wErr != nil {
-				log.Printf("WARN: Node %d: Failed restoring ONELINER input row after legend: %v", nodeNumber, wErr)
+				slog.Warn("failed restoring ONELINER input row after legend", "node", nodeNumber, "error", wErr)
 			}
 		}
 
 		// Log hex bytes before writing
 		enterPromptBytes := ansi.ReplacePipeCodes([]byte(enterPrompt))
-		log.Printf("DEBUG: Node %d: Writing ONELINER enter prompt bytes (hex): %x", nodeNumber, enterPromptBytes)
+		slog.Debug("writing ONELINER enter prompt bytes", "node", nodeNumber, "bytes", enterPromptBytes)
 		wErr = terminalio.WriteProcessedBytes(terminal, enterPromptBytes, outputMode)
 		if wErr != nil {
-			log.Printf("ERROR: Node %d: Failed writing EnterOneLiner prompt: %v", nodeNumber, wErr)
+			slog.Error("failed writing EnterOneLiner prompt", "node", nodeNumber, "error", wErr)
 		}
 
 		newOneliner, err := readLineFromSessionIH(s, terminal)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				log.Printf("INFO: Node %d: User disconnected while entering oneliner.", nodeNumber)
+				slog.Info("user disconnected while entering oneliner", "node", nodeNumber)
 				return nil, "LOGOFF", io.EOF
 			}
-			log.Printf("ERROR: Failed reading new oneliner input: %v", err)
+			slog.Error("failed reading new oneliner input", "error", err)
 			return nil, "", err
 		}
 		newOneliner = truncateOnelinerPreservePipeCodes(newOneliner, oneLinerMaxLength)
@@ -570,7 +570,7 @@ func runOneliners(c *cmdCtx, args string) (*user.User, string, error) {
 			onelinerMutex.Lock()
 			latestOneLiners, latestErr := loadOnelinerRecords(onelinerPath)
 			if latestErr != nil {
-				log.Printf("WARN: Node %d: Failed reloading oneliners before save: %v", nodeNumber, latestErr)
+				slog.Warn("failed reloading oneliners before save", "node", nodeNumber, "error", latestErr)
 				latestOneLiners = currentOneLiners
 			}
 			latestOneLiners = append(latestOneLiners, entry)
@@ -578,11 +578,11 @@ func runOneliners(c *cmdCtx, args string) (*user.User, string, error) {
 			onelinerMutex.Unlock()
 
 			if saveErr != nil {
-				log.Printf("ERROR: Node %d: Failed to write updated oneliners JSON to %s: %v", nodeNumber, onelinerPath, saveErr)
+				slog.Error("failed to write updated oneliners JSON", "node", nodeNumber, "path", onelinerPath, "error", saveErr)
 				msg := e.LoadedStrings.ExecOnelinerWriteError
 				terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 			} else {
-				log.Printf("INFO: Node %d: Successfully saved updated oneliners to %s", nodeNumber, onelinerPath)
+				slog.Info("successfully saved updated oneliners", "node", nodeNumber, "path", onelinerPath)
 				msg := e.LoadedStrings.ExecOnelinerAdded
 				terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 				time.Sleep(500 * time.Millisecond)

--- a/internal/menu/executor_whosonline.go
+++ b/internal/menu/executor_whosonline.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -50,7 +50,7 @@ func runLoginWhosOnline(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running WHOISONLINE from login sequence", nodeNumber)
+	slog.Debug("running WHOISONLINE from login sequence", "node", nodeNumber)
 
 	// Check if there are any other visible users on other nodes before prompting
 	if e.SessionRegistry != nil {
@@ -75,7 +75,7 @@ func runLoginWhosOnline(c *cmdCtx, args string) (*user.User, string, error) {
 			otherVisible++
 		}
 		if otherVisible == 0 {
-			log.Printf("DEBUG: Node %d: No other visible users online, skipping WHOISONLINE prompt", nodeNumber)
+			slog.Debug("no other visible users online, skipping WHOISONLINE prompt", "node", nodeNumber)
 			return currentUser, "", nil
 		}
 	}
@@ -86,12 +86,12 @@ func runLoginWhosOnline(c *cmdCtx, args string) (*user.User, string, error) {
 		if errors.Is(err, io.EOF) {
 			return nil, "LOGOFF", io.EOF
 		}
-		log.Printf("ERROR: Node %d: Failed during WHOISONLINE YES/NO prompt: %v", nodeNumber, err)
+		slog.Error("failed during WHOISONLINE YES/NO prompt", "node", nodeNumber, "error", err)
 		return currentUser, "", nil // Non-fatal, skip
 	}
 
 	if !result {
-		log.Printf("DEBUG: Node %d: User declined to view who's online", nodeNumber)
+		slog.Debug("user declined to view who's online", "node", nodeNumber)
 		// Write a newline to move past the prompt
 		terminalio.WriteProcessedBytes(terminal, []byte("\r\n"), outputMode)
 		return currentUser, "", nil
@@ -112,7 +112,7 @@ func runWhoIsOnline(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running WHOISONLINE", nodeNumber)
+	slog.Debug("running WHOISONLINE", "node", nodeNumber)
 
 	topPath := filepath.Join(e.MenuSetPath, "templates", "WHOONLN.TOP")
 	midPath := filepath.Join(e.MenuSetPath, "templates", "WHOONLN.MID")
@@ -123,7 +123,7 @@ func runWhoIsOnline(c *cmdCtx, args string) (*user.User, string, error) {
 	botBytes, errBot := readTemplateFile(botPath)
 
 	if errTop != nil || errMid != nil || errBot != nil {
-		log.Printf("ERROR: Node %d: Failed to load WHOONLN templates: TOP(%v), MID(%v), BOT(%v)", nodeNumber, errTop, errMid, errBot)
+		slog.Error("failed to load WHOONLN templates", "node", nodeNumber, "top", errTop, "mid", errMid, "bot", errBot)
 		msg := "\r\n|01Error loading Who's Online templates.|07\r\n"
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
@@ -142,7 +142,7 @@ func runWhoIsOnline(c *cmdCtx, args string) (*user.User, string, error) {
 	processedBot := string(ansi.ReplacePipeCodes(botBytes))
 
 	if e.SessionRegistry == nil {
-		log.Printf("ERROR: Node %d: SessionRegistry is nil", nodeNumber)
+		slog.Error("session registry is nil", "node", nodeNumber)
 		msg := "\r\n|01Who's Online is unavailable.|07\r\n"
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
@@ -249,10 +249,10 @@ func runWhoIsOnline(c *cmdCtx, args string) (*user.User, string, error) {
 	err := writeCenteredPausePrompt(s, terminal, pausePrompt, outputMode, termWidth, termHeight)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
-			log.Printf("INFO: Node %d: User disconnected during WHOISONLINE pause.", nodeNumber)
+			slog.Info("user disconnected during WHOISONLINE pause", "node", nodeNumber)
 			return nil, "LOGOFF", io.EOF
 		}
-		log.Printf("ERROR: Node %d: Failed during WHOISONLINE pause: %v", nodeNumber, err)
+		slog.Error("failed during WHOISONLINE pause", "node", nodeNumber, "error", err)
 		return nil, "", err
 	}
 

--- a/internal/menu/file_area_lightbar_select.go
+++ b/internal/menu/file_area_lightbar_select.go
@@ -3,7 +3,7 @@ package menu
 import (
 	"errors"
 	"io"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -31,7 +31,7 @@ func runSelectFileAreaLightbar(c *cmdCtx, args string) (*user.User, string, erro
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running SELECTFILEAREA (lightbar)", nodeNumber)
+	slog.Debug("running SELECTFILEAREA (lightbar)", "node", nodeNumber)
 
 	// Resolve terminal dimensions: prefer passed values, then user prefs, then defaults.
 	if termWidth <= 0 && currentUser != nil {
@@ -59,7 +59,7 @@ func runSelectFileAreaLightbar(c *cmdCtx, args string) (*user.User, string, erro
 	midBytes, errMid := readTemplateFile(filepath.Join(templateDir, "FILEAREA.MID"))
 
 	if errTop != nil || errMid != nil {
-		log.Printf("WARN: Node %d: FILEAREA templates unavailable (%v/%v), using text mode", nodeNumber, errTop, errMid)
+		slog.Warn("FILEAREA templates unavailable, using text mode", "node", nodeNumber, "errTop", errTop, "errMid", errMid)
 		return runSelectFileArea(&cmdCtx{e: e, s: s, terminal: terminal, userManager: userManager, currentUser: currentUser, nodeNumber: nodeNumber, sessionStartTime: sessionStartTime, outputMode: outputMode, termWidth: termWidth, termHeight: termHeight}, args)
 	}
 
@@ -117,7 +117,7 @@ func runSelectFileAreaLightbar(c *cmdCtx, args string) (*user.User, string, erro
 	// Load optional highlight BAR file (FILEAREAHI.BAR) — same pattern as MSGAREAHI.BAR.
 	hiBarOptions, hiBarErr := loadBarFile("FILEAREAHI", e)
 	if hiBarErr != nil {
-		log.Printf("WARN: Node %d: Failed to load FILEAREAHI.BAR: %v", nodeNumber, hiBarErr)
+		slog.Warn("failed to load FILEAREAHI.BAR", "node", nodeNumber, "error", hiBarErr)
 	}
 
 	// Measure header rows using the same pipeline as renderTop so the count
@@ -387,7 +387,7 @@ func runSelectFileAreaLightbar(c *cmdCtx, args string) (*user.User, string, erro
 			currentUser.CurrentFileAreaTag = area.Tag
 			e.setUserFileConference(currentUser, area.ConferenceID)
 			if err := userManager.UpdateUser(currentUser); err != nil {
-				log.Printf("ERROR: Node %d: Failed to save user after file area change: %v", nodeNumber, err)
+				slog.Error("failed to save user after file area change", "node", nodeNumber, "error", err)
 			}
 
 			confirmMsg := "|08[ |15" + area.Name + " |08] |15Area Joined!|07"
@@ -395,8 +395,7 @@ func runSelectFileAreaLightbar(c *cmdCtx, args string) (*user.User, string, erro
 			_ = terminalio.WriteProcessedBytes(terminal, []byte(hintLine), outputMode)
 			time.Sleep(1 * time.Second)
 
-			log.Printf("INFO: Node %d: User %s changed file area to ID %d ('%s')",
-				nodeNumber, currentUser.Handle, area.ID, area.Tag)
+			slog.Info("user changed file area", "node", nodeNumber, "handle", currentUser.Handle, "id", area.ID, "tag", area.Tag)
 			return currentUser, "", nil
 
 		case editor.KeyEsc:

--- a/internal/menu/file_download.go
+++ b/internal/menu/file_download.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -41,7 +41,7 @@ func runClearBatch(c *cmdCtx, args string) (*user.User, string, error) {
 	currentUser.TaggedFileIDs = nil
 
 	if err := userManager.UpdateUser(currentUser); err != nil {
-		log.Printf("ERROR: Node %d: Failed to update user after clearing batch queue: %v", nodeNumber, err)
+		slog.Error("failed to update user after clearing batch queue", "node", nodeNumber, "error", err)
 		currentUser.TaggedFileIDs = oldTagged
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.SaveUserError)), outputMode)
 		time.Sleep(1 * time.Second)
@@ -49,7 +49,7 @@ func runClearBatch(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(fmt.Sprintf(e.LoadedStrings.BatchClearedFormat, count))), outputMode)
-	log.Printf("INFO: Node %d: User %s cleared %d file(s) from batch queue", nodeNumber, currentUser.Handle, count)
+	slog.Info("cleared files from batch queue", "node", nodeNumber, "handle", currentUser.Handle, "count", count)
 	time.Sleep(1 * time.Second)
 
 	return currentUser, "", nil
@@ -121,12 +121,12 @@ func (e *MenuExecutor) downloadLoop(
 		}
 		currentUser.TaggedFileIDs = append(currentUser.TaggedFileIDs, rec.ID)
 		if err := userManager.UpdateUser(currentUser); err != nil {
-			log.Printf("ERROR: Node %d: Failed to persist tagged file: %v", nodeNumber, err)
+			slog.Error("failed to persist tagged file", "node", nodeNumber, "error", err)
 			currentUser.TaggedFileIDs = currentUser.TaggedFileIDs[:len(currentUser.TaggedFileIDs)-1]
 			return false
 		}
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(fmt.Sprintf(e.LoadedStrings.AddedToBatchFormat, rec.Filename))), outputMode)
-		log.Printf("INFO: Node %d: User %s tagged file %s (%s)", nodeNumber, currentUser.Handle, rec.ID, rec.Filename)
+		slog.Info("tagged file", "node", nodeNumber, "handle", currentUser.Handle, "id", rec.ID, "file", rec.Filename)
 		return true
 	}
 
@@ -193,22 +193,22 @@ func (e *MenuExecutor) downloadLoop(
 		for _, id := range currentUser.TaggedFileIDs {
 			rec, err := e.FileMgr.GetFileRecordByID(id)
 			if err != nil {
-				log.Printf("WARN: Node %d: Could not find record for file %s: %v", nodeNumber, id, err)
+				slog.Warn("could not find record for file", "node", nodeNumber, "id", id, "error", err)
 				continue
 			}
 			area, ok := e.FileMgr.GetAreaByID(rec.AreaID)
 			if !ok {
-				log.Printf("WARN: Node %d: Area %d not found for file %s", nodeNumber, rec.AreaID, id)
+				slog.Warn("area not found for file", "node", nodeNumber, "area", rec.AreaID, "id", id)
 				continue
 			}
 			if area.ACSDownload != "" && !checkACS(area.ACSDownload, currentUser, s, terminal, sessionStartTime) {
-				log.Printf("WARN: Node %d: User %s no longer authorized to download from area %d (%s), skipping file %s",
-					nodeNumber, currentUser.Handle, area.ID, area.Name, id)
+				slog.Warn("user no longer authorized to download from area, skipping file",
+					"node", nodeNumber, "handle", currentUser.Handle, "area", area.ID, "name", area.Name, "id", id)
 				continue
 			}
 			p, err := e.FileMgr.GetFilePath(id)
 			if err != nil {
-				log.Printf("WARN: Node %d: Could not resolve path for file %s: %v", nodeNumber, id, err)
+				slog.Warn("could not resolve path for file", "node", nodeNumber, "id", id, "error", err)
 				continue
 			}
 			paths = append(paths, p)
@@ -219,7 +219,7 @@ func (e *MenuExecutor) downloadLoop(
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.FilesResolveError)), outputMode)
 			currentUser.TaggedFileIDs = nil
 			if err := userManager.UpdateUser(currentUser); err != nil {
-				log.Printf("ERROR: Node %d: Failed to persist cleared batch: %v", nodeNumber, err)
+				slog.Error("failed to persist cleared batch", "node", nodeNumber, "error", err)
 			}
 			time.Sleep(2 * time.Second)
 			return currentUser, nil
@@ -231,7 +231,7 @@ func (e *MenuExecutor) downloadLoop(
 			if errors.Is(err, io.EOF) {
 				return currentUser, err
 			}
-			log.Printf("ERROR: Node %d: Protocol selection error: %v", nodeNumber, err)
+			slog.Error("protocol selection error", "node", nodeNumber, "error", err)
 			return currentUser, nil
 		}
 		if !ok {
@@ -247,11 +247,11 @@ func (e *MenuExecutor) downloadLoop(
 		currentUser.NumDownloads += successCount
 
 		if err := userManager.UpdateUser(currentUser); err != nil {
-			log.Printf("ERROR: Node %d: Failed to update user after download: %v", nodeNumber, err)
+			slog.Error("failed to update user after download", "node", nodeNumber, "error", err)
 		}
 
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(fmt.Sprintf(e.LoadedStrings.DownloadFinishedFormat, successCount, failCount))), outputMode)
-		log.Printf("INFO: Node %d: User %s download complete — success=%d fail=%d", nodeNumber, currentUser.Handle, successCount, failCount)
+		slog.Info("download complete", "node", nodeNumber, "handle", currentUser.Handle, "success", successCount, "fail", failCount)
 		time.Sleep(2 * time.Second)
 
 		return currentUser, nil
@@ -297,7 +297,7 @@ func runDownloadFile(c *cmdCtx, args string) (*user.User, string, error) {
 		if errors.Is(err, io.EOF) {
 			return nil, "LOGOFF", io.EOF
 		}
-		log.Printf("ERROR: Node %d: downloadLoop error: %v", nodeNumber, err)
+		slog.Error("download loop error", "node", nodeNumber, "error", err)
 		if updatedUser != nil {
 			return updatedUser, "", nil
 		}
@@ -334,7 +334,7 @@ func runBatchDownload(c *cmdCtx, args string) (*user.User, string, error) {
 		if errors.Is(err, io.EOF) {
 			return nil, "LOGOFF", io.EOF
 		}
-		log.Printf("ERROR: Node %d: downloadLoop error: %v", nodeNumber, err)
+		slog.Error("download loop error", "node", nodeNumber, "error", err)
 		if updatedUser != nil {
 			return updatedUser, "", nil
 		}

--- a/internal/menu/file_edit.go
+++ b/internal/menu/file_edit.go
@@ -2,7 +2,7 @@ package menu
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -128,7 +128,7 @@ func runEditFileRecord(c *cmdCtx, args string) (*user.User, string, error) {
 					r.Reviewed = true
 				})
 				if updateErr != nil {
-					log.Printf("ERROR: Node %d: Failed to mark file %s as reviewed: %v", nodeNumber, rec.Filename, updateErr)
+					slog.Error("failed to mark file as reviewed", "node", nodeNumber, "file", rec.Filename, "error", updateErr)
 				} else {
 					terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.SysopReviewMarked+"\r\n")), outputMode)
 				}
@@ -186,7 +186,7 @@ func editFileChangeDescription(e *MenuExecutor, s ssh.Session, terminal *term.Te
 		r.Description = newDesc
 	})
 	if updateErr != nil {
-		log.Printf("ERROR: Node %d: Failed to update description for %s: %v", nodeNumber, rec.Filename, updateErr)
+		slog.Error("failed to update description", "node", nodeNumber, "file", rec.Filename, "error", updateErr)
 	}
 	return nil
 }
@@ -212,7 +212,7 @@ func editFileRename(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, rec
 
 	oldPath, pathErr := e.FileMgr.GetFilePath(rec.ID)
 	if pathErr != nil {
-		log.Printf("ERROR: Node %d: Failed to get file path for %s: %v", nodeNumber, rec.Filename, pathErr)
+		slog.Error("failed to get file path", "node", nodeNumber, "file", rec.Filename, "error", pathErr)
 		return nil
 	}
 
@@ -220,7 +220,7 @@ func editFileRename(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, rec
 	newPath := filepath.Join(dir, safeName)
 
 	if renameErr := os.Rename(oldPath, newPath); renameErr != nil {
-		log.Printf("ERROR: Node %d: Failed to rename %s to %s: %v", nodeNumber, oldPath, newPath, renameErr)
+		slog.Error("failed to rename file", "node", nodeNumber, "from", oldPath, "to", newPath, "error", renameErr)
 		return nil
 	}
 
@@ -228,9 +228,9 @@ func editFileRename(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, rec
 		r.Filename = safeName
 	})
 	if updateErr != nil {
-		log.Printf("ERROR: Node %d: Failed to update filename record for %s: %v", nodeNumber, rec.Filename, updateErr)
+		slog.Error("failed to update filename record", "node", nodeNumber, "file", rec.Filename, "error", updateErr)
 		if rollbackErr := os.Rename(newPath, oldPath); rollbackErr != nil {
-			log.Printf("ERROR: Node %d: Rollback rename failed %s -> %s: %v (disk/DB inconsistent)", nodeNumber, newPath, oldPath, rollbackErr)
+			slog.Error("rollback rename failed (disk/DB inconsistent)", "node", nodeNumber, "from", newPath, "to", oldPath, "error", rollbackErr)
 		}
 		return nil
 	}
@@ -252,7 +252,7 @@ func editFileDelete(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, rec
 
 	delErr := e.FileMgr.DeleteFileRecord(rec.ID, true)
 	if delErr != nil {
-		log.Printf("ERROR: Node %d: Failed to delete file %s: %v", nodeNumber, rec.Filename, delErr)
+		slog.Error("failed to delete file", "node", nodeNumber, "file", rec.Filename, "error", delErr)
 		return false, nil
 	}
 	return true, nil
@@ -304,7 +304,7 @@ func editFileMove(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, rec f
 
 	moveErr := e.FileMgr.MoveFileRecord(rec.ID, targetID)
 	if moveErr != nil {
-		log.Printf("ERROR: Node %d: Failed to move file %s to area %d: %v", nodeNumber, rec.Filename, targetID, moveErr)
+		slog.Error("failed to move file to area", "node", nodeNumber, "file", rec.Filename, "area", targetID, "error", moveErr)
 	}
 	return nil
 }

--- a/internal/menu/file_info.go
+++ b/internal/menu/file_info.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -26,7 +26,7 @@ func runShowFileInfo(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running SHOWFILEINFO", nodeNumber)
+	slog.Debug("running SHOWFILEINFO", "node", nodeNumber)
 
 	if currentUser == nil {
 		return nil, "", nil

--- a/internal/menu/file_lightbar.go
+++ b/internal/menu/file_lightbar.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -421,7 +421,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				}
 				lb.currentUser.TaggedFileIDs = newTaggedIDs
 				if err := lb.userManager.UpdateUser(lb.currentUser); err != nil {
-					log.Printf("ERROR: Node %d: Failed to save user after tag toggle: %v", lb.nodeNumber, err)
+					slog.Error("failed to save user after tag toggle", "node", lb.nodeNumber, "error", err)
 				}
 				// Redraw just the toggled row to show/hide the mark.
 				if row, h := lb.screenRowForFile(lb.selectedIndex); row >= 0 {
@@ -479,7 +479,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				sel := &lb.allFiles[lb.selectedIndex]
 				filePath, pathErr := lb.e.FileMgr.GetFilePath(sel.ID)
 				if pathErr != nil {
-					log.Printf("ERROR: Node %d: Failed to get path for file %s: %v", lb.nodeNumber, sel.ID, pathErr)
+					slog.Error("failed to get path for file", "node", lb.nodeNumber, "id", sel.ID, "error", pathErr)
 					continue
 				}
 				// Show cursor for the viewer.
@@ -519,7 +519,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				if errors.Is(promptErr, io.EOF) {
 					return nil, "LOGOFF", io.EOF
 				}
-				log.Printf("ERROR: Node %d: Error getting download confirmation: %v", lb.nodeNumber, promptErr)
+				slog.Error("error getting download confirmation", "node", lb.nodeNumber, "error", promptErr)
 				_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25l"), lb.outputMode)
 				needFullRedraw = true
 				continue
@@ -531,7 +531,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				continue
 			}
 
-			log.Printf("INFO: Node %d: User %s starting download of %d files.", lb.nodeNumber, lb.currentUser.Handle, len(lb.currentUser.TaggedFileIDs))
+			slog.Info("starting download", "node", lb.nodeNumber, "handle", lb.currentUser.Handle, "count", len(lb.currentUser.TaggedFileIDs))
 			// Clear the screen before the download process begins.
 			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[2J\x1b[H"), lb.outputMode)
 			_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("|07Preparing download...\r\n")), lb.outputMode)
@@ -545,16 +545,16 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			for _, fileID := range lb.currentUser.TaggedFileIDs {
 				fp, pathErr := lb.e.FileMgr.GetFilePath(fileID)
 				if pathErr != nil {
-					log.Printf("ERROR: Node %d: Failed to get path for file ID %s: %v", lb.nodeNumber, fileID, pathErr)
+					slog.Error("failed to get path for file ID", "node", lb.nodeNumber, "id", fileID, "error", pathErr)
 					failCount++
 					continue
 				}
 				if _, statErr := os.Stat(fp); os.IsNotExist(statErr) {
-					log.Printf("ERROR: Node %d: File path %s for ID %s does not exist.", lb.nodeNumber, fp, fileID)
+					slog.Error("file path for ID does not exist", "node", lb.nodeNumber, "path", fp, "id", fileID)
 					failCount++
 					continue
 				} else if statErr != nil {
-					log.Printf("ERROR: Node %d: Error stating file path %s for ID %s: %v", lb.nodeNumber, fp, fileID, statErr)
+					slog.Error("error stating file path for ID", "node", lb.nodeNumber, "path", fp, "id", fileID, "error", statErr)
 					failCount++
 					continue
 				}
@@ -563,7 +563,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			}
 
 			if len(filesToDownload) > 0 {
-				log.Printf("INFO: Node %d: Initiating transfer for %d file(s)", lb.nodeNumber, len(filesToDownload))
+				slog.Info("initiating transfer", "node", lb.nodeNumber, "count", len(filesToDownload))
 
 				// Use protocol selection (respects connection type - SSH vs Telnet)
 				proto, protoOK, protoErr := lb.e.selectTransferProtocol(lb.s, lb.terminal, lb.outputMode)
@@ -571,7 +571,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 					if errors.Is(protoErr, io.EOF) {
 						return nil, "LOGOFF", io.EOF
 					}
-					log.Printf("ERROR: Node %d: Protocol selection error: %v", lb.nodeNumber, protoErr)
+					slog.Error("protocol selection error", "node", lb.nodeNumber, "error", protoErr)
 					_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Error: No transfer protocols configured on this system.|07\r\n")), lb.outputMode)
 					failCount += len(filesToDownload)
 				} else if !protoOK {
@@ -584,7 +584,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				}
 				time.Sleep(1 * time.Second)
 			} else {
-				log.Printf("WARN: Node %d: No valid file paths found for tagged files.", lb.nodeNumber)
+				slog.Warn("no valid file paths found for tagged files", "node", lb.nodeNumber)
 				_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Could not find any of the marked files on the server.|07\r\n")), lb.outputMode)
 				// failCount already equals the number of missing files (every
 				// tagged ID incremented it in the collection loop above).
@@ -594,7 +594,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			lb.currentUser.TaggedFileIDs = nil
 			lb.currentUser.NumDownloads += successCount
 			if saveErr := lb.userManager.UpdateUser(lb.currentUser); saveErr != nil {
-				log.Printf("ERROR: Node %d: Failed to save user data after download: %v", lb.nodeNumber, saveErr)
+				slog.Error("failed to save user data after download", "node", lb.nodeNumber, "error", saveErr)
 			}
 
 			statusMsg := fmt.Sprintf("|07Download finished. Success: %d, Failed: %d.|07\r\n", successCount, failCount)
@@ -613,7 +613,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
 			uploadErr := lb.e.runUploadFiles(lb.s, lb.terminal, lb.currentUser, lb.userManager, lb.currentAreaID, lb.currentAreaTag, lb.outputMode, lb.nodeNumber, lb.sessionStartTime)
 			if uploadErr != nil {
-				log.Printf("ERROR: Node %d: Upload error: %v", lb.nodeNumber, uploadErr)
+				slog.Error("upload error", "node", lb.nodeNumber, "error", uploadErr)
 			}
 			// runUploadFiles calls resetSessionIH/getSessionIH internally,
 			// so the local ih is now stale — refresh it.
@@ -640,7 +640,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25l"), lb.outputMode)
 			if readErr == nil && newDesc != "" {
 				if updErr := lb.e.FileMgr.UpdateFileDescription(rec.ID, newDesc); updErr != nil {
-					log.Printf("ERROR: Node %d: Failed to update description for %s: %v", lb.nodeNumber, rec.Filename, updErr)
+					slog.Error("failed to update description", "node", lb.nodeNumber, "file", rec.Filename, "error", updErr)
 				} else {
 					lb.allFiles = lb.e.FileMgr.GetFilesForArea(lb.currentAreaID)
 				}
@@ -669,9 +669,9 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			}
 			if proceed {
 				if delErr := lb.e.FileMgr.DeleteFileRecord(rec.ID, true); delErr != nil {
-					log.Printf("ERROR: Node %d: Failed to delete file %s: %v", lb.nodeNumber, rec.Filename, delErr)
+					slog.Error("failed to delete file", "node", lb.nodeNumber, "file", rec.Filename, "error", delErr)
 				} else {
-					log.Printf("INFO: Node %d: Sysop deleted file '%s' from area %d.", lb.nodeNumber, rec.Filename, lb.currentAreaID)
+					slog.Info("sysop deleted file from area", "node", lb.nodeNumber, "file", rec.Filename, "area", lb.currentAreaID)
 					// Remove from user's tag list so stale IDs don't reach batch download.
 					filtered := lb.currentUser.TaggedFileIDs[:0]
 					for _, tid := range lb.currentUser.TaggedFileIDs {
@@ -737,9 +737,9 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			}
 			if proceed {
 				if mvErr := lb.e.FileMgr.MoveFileRecord(rec.ID, targetAreaID); mvErr != nil {
-					log.Printf("ERROR: Node %d: Failed to move file %s to area %d: %v", lb.nodeNumber, rec.Filename, targetAreaID, mvErr)
+					slog.Error("failed to move file to area", "node", lb.nodeNumber, "file", rec.Filename, "area", targetAreaID, "error", mvErr)
 				} else {
-					log.Printf("INFO: Node %d: Sysop moved file '%s' to area %d (%s).", lb.nodeNumber, rec.Filename, targetAreaID, targetArea.Tag)
+					slog.Info("sysop moved file to area", "node", lb.nodeNumber, "file", rec.Filename, "area", targetAreaID, "tag", targetArea.Tag)
 					lb.allFiles = lb.e.FileMgr.GetFilesForArea(lb.currentAreaID)
 					if lb.selectedIndex >= len(lb.allFiles) && len(lb.allFiles) > 0 {
 						lb.selectedIndex = len(lb.allFiles) - 1
@@ -787,7 +787,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			}
 			oldPath, pathErr := lb.e.FileMgr.GetFilePath(rec.ID)
 			if pathErr != nil {
-				log.Printf("ERROR: Node %d: Failed to resolve path for %s: %v", lb.nodeNumber, rec.Filename, pathErr)
+				slog.Error("failed to resolve path", "node", lb.nodeNumber, "file", rec.Filename, "error", pathErr)
 				needFullRedraw = true
 				continue
 			}
@@ -803,21 +803,21 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			case statErr == nil:
 				oldInfo, oldStatErr := os.Stat(oldPath)
 				if oldStatErr != nil || !os.SameFile(oldInfo, newInfo) {
-					log.Printf("ERROR: Node %d: Rename target %s already exists on disk.", lb.nodeNumber, newPath)
+					slog.Error("rename target already exists on disk", "node", lb.nodeNumber, "path", newPath)
 					_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|01A file with that name already exists.|07\r\n")), lb.outputMode)
 					time.Sleep(1 * time.Second)
 					needFullRedraw = true
 					continue
 				}
 			case !errors.Is(statErr, os.ErrNotExist):
-				log.Printf("ERROR: Node %d: Cannot stat rename target %s: %v", lb.nodeNumber, newPath, statErr)
+				slog.Error("cannot stat rename target", "node", lb.nodeNumber, "path", newPath, "error", statErr)
 				_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Rename failed.|07\r\n")), lb.outputMode)
 				time.Sleep(1 * time.Second)
 				needFullRedraw = true
 				continue
 			}
 			if renErr := os.Rename(oldPath, newPath); renErr != nil {
-				log.Printf("ERROR: Node %d: Failed to rename %s to %s: %v", lb.nodeNumber, rec.Filename, newName, renErr)
+				slog.Error("failed to rename file", "node", lb.nodeNumber, "from", rec.Filename, "to", newName, "error", renErr)
 				_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Rename failed.|07\r\n")), lb.outputMode)
 				time.Sleep(1 * time.Second)
 				needFullRedraw = true
@@ -826,12 +826,12 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			if updErr := lb.e.FileMgr.UpdateFileRecord(rec.ID, func(r *file.FileRecord) {
 				r.Filename = newName
 			}); updErr != nil {
-				log.Printf("ERROR: Node %d: Failed to update record for %s: %v", lb.nodeNumber, newName, updErr)
+				slog.Error("failed to update record", "node", lb.nodeNumber, "file", newName, "error", updErr)
 				if rollbackErr := os.Rename(newPath, oldPath); rollbackErr != nil {
-					log.Printf("ERROR: Node %d: Rollback rename failed for %s: %v (disk/DB inconsistent)", lb.nodeNumber, newName, rollbackErr)
+					slog.Error("rollback rename failed (disk/DB inconsistent)", "node", lb.nodeNumber, "file", newName, "error", rollbackErr)
 				}
 			} else {
-				log.Printf("INFO: Node %d: Sysop renamed file '%s' to '%s' in area %d.", lb.nodeNumber, rec.Filename, newName, lb.currentAreaID)
+				slog.Info("sysop renamed file in area", "node", lb.nodeNumber, "from", rec.Filename, "to", newName, "area", lb.currentAreaID)
 				lb.allFiles = lb.e.FileMgr.GetFilesForArea(lb.currentAreaID)
 			}
 			needFullRedraw = true

--- a/internal/menu/file_newscan.go
+++ b/internal/menu/file_newscan.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -34,8 +34,8 @@ func runFileNewscan(c *cmdCtx, args string) (*user.User, string, error) {
 		return currentUser, "", nil
 	}
 
-	log.Printf("INFO: Node %d: FILE_NEWSCAN for user %s (last login: %s, args: %q)",
-		nodeNumber, currentUser.Handle, currentUser.LastLogin.Format(time.RFC3339), args)
+	slog.Info("file newscan", "node", nodeNumber, "handle", currentUser.Handle,
+		"last_login", currentUser.LastLogin.Format(time.RFC3339), "args", args)
 
 	since := currentUser.LastLogin
 
@@ -539,7 +539,7 @@ func runFileNewscanConfig(c *cmdCtx, args string) (*user.User, string, error) {
 			currentUser.TaggedFileAreaTags = taggedTags
 			terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 			if err := userManager.UpdateUser(currentUser); err != nil {
-				log.Printf("ERROR: Node %d: Failed to save file newscan config: %v", nodeNumber, err)
+				slog.Error("failed to save file newscan config", "node", nodeNumber, "error", err)
 				terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ScanConfigError)), outputMode)
 			} else {
 				msg := fmt.Sprintf(e.LoadedStrings.FileNewscanConfigSaved, len(taggedTags))

--- a/internal/menu/file_search.go
+++ b/internal/menu/file_search.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"strings"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
@@ -25,7 +25,7 @@ func runSearchFiles(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running SEARCH_FILES", nodeNumber)
+	slog.Debug("running SEARCH_FILES", "node", nodeNumber)
 
 	if currentUser == nil {
 		return nil, "", nil
@@ -52,10 +52,10 @@ func runSearchFiles(c *cmdCtx, args string) (*user.User, string, error) {
 		return currentUser, "", nil
 	}
 
-	log.Printf("DEBUG: Node %d: SEARCH_FILES query=%q", nodeNumber, query)
+	slog.Debug("search files query", "node", nodeNumber, "query", query)
 
 	results := e.FileMgr.SearchFiles(query)
-	log.Printf("DEBUG: Node %d: SEARCH_FILES raw results=%d", nodeNumber, len(results))
+	slog.Debug("search files raw results", "node", nodeNumber, "count", len(results))
 
 	// Filter by area ACS and build display lines
 	type searchResult struct {

--- a/internal/menu/file_viewer.go
+++ b/internal/menu/file_viewer.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -85,7 +85,7 @@ func promptAndResolveFile(e *MenuExecutor, s ssh.Session, terminal *term.Termina
 
 	filePath, err := e.FileMgr.GetFilePath(record.ID)
 	if err != nil {
-		log.Printf("ERROR: Node %d: Failed to get path for file %s: %v", nodeNumber, record.ID, err)
+		slog.Error("failed to get path for file", "node", nodeNumber, "id", record.ID, "error", err)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.FileLocateError)), outputMode)
 		time.Sleep(1 * time.Second)
 		return nil, "", currentUser, "", nil
@@ -105,7 +105,7 @@ func runViewFile(c *cmdCtx, args string) (*user.User, string, error) {
 	outputMode := c.outputMode
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running VIEW_FILE", nodeNumber)
+	slog.Debug("running VIEW_FILE", "node", nodeNumber)
 
 	record, filePath, retUser, retAction, retErr := promptAndResolveFile(e, s, terminal, currentUser, nodeNumber, "view", outputMode)
 	if record == nil {
@@ -139,7 +139,7 @@ func runTypeTextFile(c *cmdCtx, args string) (*user.User, string, error) {
 	outputMode := c.outputMode
 	termHeight := c.termHeight
 
-	log.Printf("DEBUG: Node %d: Running TYPE_TEXT_FILE", nodeNumber)
+	slog.Debug("running TYPE_TEXT_FILE", "node", nodeNumber)
 
 	record, filePath, retUser, retAction, retErr := promptAndResolveFile(e, s, terminal, currentUser, nodeNumber, "type", outputMode)
 	if record == nil {
@@ -161,7 +161,7 @@ func runTypeTextFile(c *cmdCtx, args string) (*user.User, string, error) {
 func viewFileByRecord(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, record *file.FileRecord, outputMode ansi.OutputMode, termWidth int, termHeight int) {
 	filePath, err := e.FileMgr.GetFilePath(record.ID)
 	if err != nil {
-		log.Printf("ERROR: Failed to get path for file %s: %v", record.ID, err)
+		slog.Error("failed to get path for file", "id", record.ID, "error", err)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.FileLocateError)), outputMode)
 		time.Sleep(1 * time.Second)
 		return
@@ -192,7 +192,7 @@ const maxTextFilePagingBytes = 4 * 1024 * 1024 // 4 MB
 func displayTextWithPaging(s ssh.Session, terminal *term.Terminal, filePath string, filename string, outputMode ansi.OutputMode, termHeight int, viewingHeaderFmt string, endOfFile string, morePrompt string, pausePromptStr string, openError string) {
 	fi, statErr := os.Stat(filePath)
 	if statErr == nil && fi.Size() > maxTextFilePagingBytes {
-		log.Printf("WARN: File %s too large for text paging (%d bytes), refusing to load", filePath, fi.Size())
+		slog.Warn("file too large for text paging, refusing to load", "file", filePath, "bytes", fi.Size())
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(openError)), outputMode)
 		time.Sleep(1 * time.Second)
 		return
@@ -200,7 +200,7 @@ func displayTextWithPaging(s ssh.Session, terminal *term.Terminal, filePath stri
 
 	data, err := os.ReadFile(filePath)
 	if err != nil {
-		log.Printf("ERROR: Failed to open file %s: %v", filePath, err)
+		slog.Error("failed to open file", "file", filePath, "error", err)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(openError)), outputMode)
 		time.Sleep(1 * time.Second)
 		return
@@ -256,7 +256,7 @@ func displayTextWithPaging(s ssh.Session, terminal *term.Terminal, filePath stri
 	}
 
 	if err := scanner.Err(); err != nil {
-		log.Printf("WARN: Error reading file %s: %v", filePath, err)
+		slog.Warn("error reading file", "file", filePath, "error", err)
 	}
 
 	terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(endOfFile)), outputMode)
@@ -314,7 +314,7 @@ func getTerminalSize(s ssh.Session) (int, int) {
 func displayTextWithPaging_toWriter(w io.Writer, filePath string, filename string, termHeight int) {
 	f, err := os.Open(filePath)
 	if err != nil {
-		log.Printf("ERROR: Failed to open file %s: %v", filePath, err)
+		slog.Error("failed to open file", "file", filePath, "error", err)
 		fmt.Fprintf(w, "\r\nError opening file.\r\n")
 		return
 	}
@@ -331,7 +331,7 @@ func displayTextWithPaging_toWriter(w io.Writer, filePath string, filename strin
 	}
 
 	if err := scanner.Err(); err != nil {
-		log.Printf("WARN: Error reading file %s: %v", filePath, err)
+		slog.Warn("error reading file", "file", filePath, "error", err)
 	}
 
 	fmt.Fprintf(w, "\r\n--- End of File ---\r\n")

--- a/internal/menu/infoforms.go
+++ b/internal/menu/infoforms.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -289,7 +289,7 @@ func runInfoForms(c *cmdCtx, args string) (*user.User, string, error) {
 		return currentUser, "", nil
 	}
 
-	log.Printf("DEBUG: Node %d: Running INFOFORMS for user %s", nodeNumber, currentUser.Handle)
+	slog.Debug("running INFOFORMS", "node", nodeNumber, "handle", currentUser.Handle)
 
 	infoformsMu.Lock()
 	cfg, err := loadInfoFormConfig(e.RootConfigPath)
@@ -515,12 +515,12 @@ func fillInfoForm(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 	infoformsMu.Unlock()
 
 	if saveErr != nil {
-		log.Printf("ERROR: Node %d: Failed to save infoform response: %v", nodeNumber, saveErr)
+		slog.Error("failed to save infoform response", "node", nodeNumber, "error", saveErr)
 		wv(terminal, "\r\n|04Error saving your form.\r\n", outputMode)
 		return
 	}
 
-	log.Printf("INFO: Node %d: %s completed infoform #%d", nodeNumber, currentUser.Handle, formNum)
+	slog.Info("completed infoform", "node", nodeNumber, "handle", currentUser.Handle, "form", formNum)
 	wv(terminal, "\r\n|10Form completed!\r\n", outputMode)
 }
 
@@ -846,7 +846,7 @@ func runInfoFormRequired(c *cmdCtx, args string) (*user.User, string, error) {
 	cfg, err := loadInfoFormConfig(e.RootConfigPath)
 	infoformsMu.Unlock()
 	if err != nil {
-		log.Printf("ERROR: Node %d: Failed to load infoforms config in required check: %v", nodeNumber, err)
+		slog.Error("failed to load infoforms config in required check", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
 
@@ -865,8 +865,8 @@ func runInfoFormRequired(c *cmdCtx, args string) (*user.User, string, error) {
 		fillInfoForm(e, s, terminal, outputMode, nodeNumber, currentUser, formNum, termWidth, termHeight)
 		// Re-check: if form still not completed (save failed, user disconnected, etc.), block login
 		if !hasCompletedForm(e.RootConfigPath, currentUser.ID, formNum) {
-			log.Printf("WARN: Node %d: Required infoform #%d not completed by %s, blocking login",
-				nodeNumber, formNum, currentUser.Handle)
+			slog.Warn("required infoform not completed, blocking login",
+				"node", nodeNumber, "form", formNum, "handle", currentUser.Handle)
 			wv(terminal, fmt.Sprintf("\r\n|04Required form #%d was not completed. Disconnecting.\r\n", formNum), outputMode)
 			return currentUser, "LOGOFF", nil
 		}
@@ -929,6 +929,6 @@ func runInfoFormNuke(c *cmdCtx, args string) (*user.User, string, error) {
 	infoformsMu.Unlock()
 
 	wv(terminal, "\r\n|10All infoforms deleted.\r\n", outputMode)
-	log.Printf("INFO: Node %d: SysOp %s nuked infoforms for user %s", nodeNumber, currentUser.Handle, targetUser.Handle)
+	slog.Info("sysop nuked infoforms for user", "node", nodeNumber, "handle", currentUser.Handle, "target", targetUser.Handle)
 	return currentUser, "", nil
 }

--- a/internal/menu/loader.go
+++ b/internal/menu/loader.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"log"
+	"log/slog"
 	// "vision3/config" // TODO: Get MenuDir from config
 )
 
@@ -39,12 +39,12 @@ func LoadMenu(menuName string, configPath string) (*MenuRecord, error) {
 // LoadCommands reads a .CFG file (assumed JSON) for the given menu name.
 func LoadCommands(menuName string, configPath string) ([]CommandRecord, error) {
 	filePath := filepath.Join(configPath, menuName+".CFG")
-	log.Printf("DEBUG: Attempting to load command file: %s (menuName='%s', configPath='%s')", filePath, menuName, configPath)
+	slog.Debug("attempting to load command file", "file", filePath, "menu", menuName, "path", configPath)
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// It's valid for a menu to have no commands, return empty slice
-			log.Printf("WARN: Command file %s does not exist, menu will have no commands.", filePath)
+			slog.Warn("command file does not exist, menu will have no commands", "file", filePath)
 			return []CommandRecord{}, nil
 		}
 		return nil, fmt.Errorf("failed to read command file %s: %w", filePath, err)
@@ -52,7 +52,7 @@ func LoadCommands(menuName string, configPath string) ([]CommandRecord, error) {
 
 	// Handle empty file case explicitly
 	if len(data) == 0 {
-		log.Printf("DEBUG: Command file %s is empty.", filePath)
+		slog.Debug("command file is empty", "file", filePath)
 		return []CommandRecord{}, nil
 	}
 
@@ -65,7 +65,7 @@ func LoadCommands(menuName string, configPath string) ([]CommandRecord, error) {
 
 	// Optional: Log loaded commands for tracing
 	for _, cmd := range commands {
-		log.Printf("TRACE: Loaded command: Keys='%s', Cmd='%s', ACS='%s', Hidden=%t", cmd.Keys, cmd.Command, cmd.ACS, cmd.Hidden)
+		slog.Debug("loaded command", "keys", cmd.Keys, "command", cmd.Command, "acs", cmd.ACS, "hidden", cmd.Hidden)
 	}
 
 	return commands, nil

--- a/internal/menu/matrix.go
+++ b/internal/menu/matrix.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,11 +36,11 @@ func (e *MenuExecutor) RunMatrixScreen(
 	// Load lightbar options from PDMATRIX.BAR
 	options, err := loadLightbarOptions(menuName, e)
 	if err != nil {
-		log.Printf("WARN: Node %d: Failed to load %s.BAR: %v, skipping matrix", nodeNumber, menuName, err)
+		slog.Warn("failed to load BAR file, skipping matrix", "node", nodeNumber, "menu", menuName, "error", err)
 		return "LOGIN", nil
 	}
 	if len(options) == 0 {
-		log.Printf("WARN: Node %d: No options in %s.BAR, skipping matrix", nodeNumber, menuName)
+		slog.Warn("no options in BAR file, skipping matrix", "node", nodeNumber, "menu", menuName)
 		return "LOGIN", nil
 	}
 
@@ -48,7 +48,7 @@ func (e *MenuExecutor) RunMatrixScreen(
 	cfgPath := filepath.Join(e.MenuSetPath, "cfg")
 	commands, err := LoadCommands(menuName, cfgPath)
 	if err != nil {
-		log.Printf("WARN: Node %d: Failed to load %s.CFG: %v, skipping matrix", nodeNumber, menuName, err)
+		slog.Warn("failed to load CFG file, skipping matrix", "node", nodeNumber, "menu", menuName, "error", err)
 		return "LOGIN", nil
 	}
 
@@ -63,11 +63,11 @@ func (e *MenuExecutor) RunMatrixScreen(
 	ansPath := filepath.Join(e.MenuSetPath, "ansi", menuName+".ANS")
 	ansBackground, err := ansi.GetAnsiFileContent(ansPath)
 	if err != nil {
-		log.Printf("WARN: Node %d: Failed to load %s.ANS: %v, skipping matrix", nodeNumber, menuName, err)
+		slog.Warn("failed to load ANS file, skipping matrix", "node", nodeNumber, "menu", menuName, "error", err)
 		return "LOGIN", nil
 	}
 
-	log.Printf("INFO: Node %d: Displaying pre-login matrix screen (%d options)", nodeNumber, len(options))
+	slog.Info("displaying pre-login matrix screen", "node", nodeNumber, "count", len(options))
 
 	// Ensure cursor is restored when we exit the matrix screen
 	defer func() {
@@ -80,7 +80,7 @@ func (e *MenuExecutor) RunMatrixScreen(
 
 	// Draw the initial screen
 	if err := drawMatrixScreen(terminal, ansBackground, options, selectedIndex, outputMode); err != nil {
-		log.Printf("ERROR: Node %d: Failed to draw matrix screen: %v", nodeNumber, err)
+		slog.Error("failed to draw matrix screen", "node", nodeNumber, "error", err)
 		return "LOGIN", nil
 	}
 
@@ -173,10 +173,10 @@ func (e *MenuExecutor) RunMatrixScreen(
 			hotkey := options[selectedIndex].HotKey
 			action, ok := commandMap[hotkey]
 			if !ok {
-				log.Printf("WARN: Node %d: No command mapped for hotkey '%s'", nodeNumber, hotkey)
+				slog.Warn("no command mapped for hotkey", "node", nodeNumber, "hotkey", hotkey)
 				continue
 			}
-			log.Printf("INFO: Node %d: Matrix selection: %s (%s)", nodeNumber, options[selectedIndex].Text, action)
+			slog.Info("matrix selection", "node", nodeNumber, "text", options[selectedIndex].Text, "action", action)
 
 			result, err := e.processMatrixAction(action, s, terminal, userManager, nodeNumber, outputMode, termWidth, termHeight)
 			if err != nil {
@@ -195,7 +195,7 @@ func (e *MenuExecutor) RunMatrixScreen(
 	}
 
 	// Max tries exceeded
-	log.Printf("INFO: Node %d: Matrix max tries exceeded, disconnecting", nodeNumber)
+	slog.Info("matrix max tries exceeded, disconnecting", "node", nodeNumber)
 	return "DISCONNECT", nil
 }
 
@@ -225,7 +225,7 @@ func (e *MenuExecutor) processMatrixAction(
 			if errors.Is(err, io.EOF) {
 				return "DISCONNECT", io.EOF
 			}
-			log.Printf("ERROR: Node %d: New user application error from matrix: %v", nodeNumber, err)
+			slog.Error("new user application error from matrix", "node", nodeNumber, "error", err)
 		}
 		return "MATRIX", nil // Return to matrix after signup
 
@@ -238,7 +238,7 @@ func (e *MenuExecutor) processMatrixAction(
 		return "DISCONNECT", nil
 
 	default:
-		log.Printf("WARN: Node %d: Unknown matrix action: %s", nodeNumber, action)
+		slog.Warn("unknown matrix action", "node", nodeNumber, "action", action)
 		e.showUndefinedMenuInput(terminal, outputMode, nodeNumber)
 		return "MATRIX", nil
 	}
@@ -350,11 +350,11 @@ func (e *MenuExecutor) showPrelogon(s ssh.Session, terminal *term.Terminal, node
 	// Use GetAnsiFileContent to automatically strip SAUCE metadata
 	rawContent, err := ansi.GetAnsiFileContent(candidates[idx])
 	if err != nil {
-		log.Printf("WARN: Node %d: Failed to read prelogon file %s: %v", nodeNumber, candidates[idx], err)
+		slog.Warn("failed to read prelogon file", "node", nodeNumber, "file", candidates[idx], "error", err)
 		return
 	}
 
-	log.Printf("INFO: Node %d: Displaying prelogon screen: %s", nodeNumber, filepath.Base(candidates[idx]))
+	slog.Info("displaying prelogon screen", "node", nodeNumber, "file", filepath.Base(candidates[idx]))
 	terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 	// For CP437 mode, write raw bytes directly to avoid UTF-8 false positives
 	if outputMode == ansi.OutputModeCP437 {

--- a/internal/menu/message_lightbar.go
+++ b/internal/menu/message_lightbar.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"strings"
 	"unicode"
 
@@ -262,7 +262,7 @@ func promptSingleChar(reader *bufio.Reader, terminal *term.Terminal, prompt stri
 	processedPrompt := ansi.ReplacePipeCodes([]byte(prompt))
 	wErr := terminalio.WriteProcessedBytes(terminal, processedPrompt, outputMode)
 	if wErr != nil {
-		log.Printf("ERROR: Failed writing prompt: %v", wErr)
+		slog.Error("failed writing prompt", "error", wErr)
 	}
 
 	r, err := readSingleKey(reader)

--- a/internal/menu/message_list.go
+++ b/internal/menu/message_list.go
@@ -2,7 +2,7 @@ package menu
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -96,7 +96,7 @@ func buildMessageList(msgMgr *message.MessageManager, areaID int, username strin
 	// Get lastread pointer
 	lastRead, err := msgMgr.GetLastRead(areaID, username)
 	if err != nil {
-		log.Printf("WARN: Failed to get lastread for area %d, user %s: %v", areaID, username, err)
+		slog.Warn("failed to get lastread", "area", areaID, "handle", username, "error", err)
 		lastRead = 0 // Default to all unread
 	}
 
@@ -107,7 +107,7 @@ func buildMessageList(msgMgr *message.MessageManager, areaID int, username strin
 		msg, err := msgMgr.GetMessage(areaID, msgNum)
 		if err != nil {
 			// Skip deleted or unreadable messages
-			log.Printf("WARN: Failed to read message %d in area %d: %v", msgNum, areaID, err)
+			slog.Warn("failed to read message", "msg", msgNum, "area", areaID, "error", err)
 			continue
 		}
 
@@ -507,7 +507,7 @@ func runListMsgsFiltered(c *cmdCtx, args string, msgFilter msgOwnershipFilter) (
 
 	// Validate user is logged in
 	if currentUser == nil {
-		log.Printf("WARN: Node %d: LISTMSGS called without logged in user.", nodeNumber)
+		slog.Warn("LISTMSGS called without logged in user", "node", nodeNumber)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.MsgListLoginRequired)), outputMode)
 		time.Sleep(1 * time.Second)
 		return nil, "", nil
@@ -540,7 +540,7 @@ func runListMsgsFiltered(c *cmdCtx, args string, msgFilter msgOwnershipFilter) (
 	// Build message list
 	entries, lastRead, err := buildMessageList(e.MessageMgr, currentAreaID, currentUser.Handle, msgFilter)
 	if err != nil {
-		log.Printf("ERROR: Node %d: Failed to build message list: %v", nodeNumber, err)
+		slog.Error("failed to build message list", "node", nodeNumber, "error", err)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.MsgListLoadError)), outputMode)
 		time.Sleep(1 * time.Second)
 		return currentUser, "", nil
@@ -596,7 +596,7 @@ func runListMsgsFiltered(c *cmdCtx, args string, msgFilter msgOwnershipFilter) (
 
 	// Draw initial screen
 	if err := drawMessageListScreen(terminal, state, area.Name, confName, outputMode); err != nil {
-		log.Printf("ERROR: Node %d: Failed to draw message list: %v", nodeNumber, err)
+		slog.Error("failed to draw message list", "node", nodeNumber, "error", err)
 		return currentUser, "", err
 	}
 
@@ -606,7 +606,7 @@ func runListMsgsFiltered(c *cmdCtx, args string, msgFilter msgOwnershipFilter) (
 		// Handle navigation
 		action, selectedMsg, err := runMessageListNavigation(sessionIH, state)
 		if err != nil {
-			log.Printf("ERROR: Node %d: Navigation error: %v", nodeNumber, err)
+			slog.Error("navigation error", "node", nodeNumber, "error", err)
 			return currentUser, "LOGOFF", err
 		}
 
@@ -640,7 +640,7 @@ func runListMsgsFiltered(c *cmdCtx, args string, msgFilter msgOwnershipFilter) (
 				selectedMsg, areaMsgCount, false, tw, th, msgFilter)
 
 			if err != nil {
-				log.Printf("ERROR: Node %d: Message reader error: %v", nodeNumber, err)
+				slog.Error("message reader error", "node", nodeNumber, "error", err)
 				return currentUser, "", err
 			}
 
@@ -652,7 +652,7 @@ func runListMsgsFiltered(c *cmdCtx, args string, msgFilter msgOwnershipFilter) (
 			// Rebuild list to pick up posted/deleted messages and updated lastread markers
 			newEntries, newLastRead, rebuildErr := buildMessageList(e.MessageMgr, currentAreaID, currentUser.Handle, msgFilter)
 			if rebuildErr != nil {
-				log.Printf("ERROR: Node %d: Failed to rebuild message list: %v", nodeNumber, rebuildErr)
+				slog.Error("failed to rebuild message list", "node", nodeNumber, "error", rebuildErr)
 			} else {
 				state.Entries = newEntries
 				state.TotalMessages = len(newEntries)
@@ -686,7 +686,7 @@ func runListMsgsFiltered(c *cmdCtx, args string, msgFilter msgOwnershipFilter) (
 
 			// Redraw full screen after returning from reader
 			if err := drawMessageListScreen(terminal, state, area.Name, confName, outputMode); err != nil {
-				log.Printf("ERROR: Node %d: Failed to redraw message list: %v", nodeNumber, err)
+				slog.Error("failed to redraw message list", "node", nodeNumber, "error", err)
 				return currentUser, "", err
 			}
 			previousIndex = state.SelectedIndex // Track highlighted line after redraw
@@ -694,7 +694,7 @@ func runListMsgsFiltered(c *cmdCtx, args string, msgFilter msgOwnershipFilter) (
 		case "REFRESH_FULL":
 			// Optimized page refresh (only redraw message lines and page info, no screen clear)
 			if err := refreshPageContent(terminal, state, outputMode); err != nil {
-				log.Printf("ERROR: Node %d: Failed to refresh page content: %v", nodeNumber, err)
+				slog.Error("failed to refresh page content", "node", nodeNumber, "error", err)
 				return currentUser, "", err
 			}
 			previousIndex = state.SelectedIndex // Track highlighted line after redraw

--- a/internal/menu/message_reader.go
+++ b/internal/menu/message_reader.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -85,7 +85,7 @@ func runMessageReader(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 		fmt.Sprintf("MSGHDR.%d.ans", hdrStyle))
 	hdrTemplateBytes, hdrErr := ansi.GetAnsiFileContent(hdrTemplatePath)
 	if hdrErr != nil {
-		log.Printf("ERROR: Node %d: Failed to load MSGHDR.%d.ans: %v", nodeNumber, hdrStyle, hdrErr)
+		slog.Error("failed to load message header", "node", nodeNumber, "file", fmt.Sprintf("MSGHDR.%d.ans", hdrStyle), "error", hdrErr)
 		// Fallback to style 2 (simple text format)
 		hdrTemplatePath = filepath.Join(e.MenuSetPath, "templates", "message_headers", "MSGHDR.2.ans")
 		hdrTemplateBytes, hdrErr = ansi.GetAnsiFileContent(hdrTemplatePath)
@@ -177,8 +177,7 @@ readerLoop:
 		// Load current message
 		currentMsg, msgErr := e.MessageMgr.GetMessage(currentAreaID, currentMsgNum)
 		if msgErr != nil {
-			log.Printf("ERROR: Node %d: Failed to read message %d in area %d: %v",
-				nodeNumber, currentMsgNum, currentAreaID, msgErr)
+			slog.Error("failed to read message", "node", nodeNumber, "msg", currentMsgNum, "area", currentAreaID, "error", msgErr)
 			// Try next message
 			currentMsgNum++
 			continue
@@ -207,7 +206,7 @@ readerLoop:
 		replyCount := 0
 		if e.MessageMgr != nil {
 			if count, err := e.MessageMgr.GetThreadReplyCount(currentAreaID, currentMsg.MsgNum, currentMsg.Subject); err != nil {
-				log.Printf("WARN: Failed to get reply count for area %d msg %d: %v", currentAreaID, currentMsg.MsgNum, err)
+				slog.Warn("failed to get reply count", "area", currentAreaID, "msg", currentMsg.MsgNum, "error", err)
 			} else {
 				replyCount = count
 			}
@@ -291,7 +290,7 @@ readerLoop:
 
 		// Update lastread when first displaying message
 		if lrErr := e.MessageMgr.SetLastRead(currentAreaID, currentUser.Handle, currentMsgNum); lrErr != nil {
-			log.Printf("ERROR: Node %d: Failed to update last read: %v", nodeNumber, lrErr)
+			slog.Error("failed to update last read", "node", nodeNumber, "error", lrErr)
 		}
 
 		// Inner loop for scrolling and command handling
@@ -424,7 +423,7 @@ readerLoop:
 					if errors.Is(lbErr, io.EOF) {
 						return nil, "LOGOFF", io.EOF
 					}
-					log.Printf("ERROR: Node %d: Lightbar error: %v", nodeNumber, lbErr)
+					slog.Error("lightbar error", "node", nodeNumber, "error", lbErr)
 					break readerLoop
 				}
 				selectedKey = rune(selKey)
@@ -457,7 +456,7 @@ readerLoop:
 							if errors.Is(lbErr, io.EOF) {
 								return nil, "LOGOFF", io.EOF
 							}
-							log.Printf("ERROR: Node %d: Lightbar error: %v", nodeNumber, lbErr)
+							slog.Error("lightbar error", "node", nodeNumber, "error", lbErr)
 							break readerLoop
 						}
 						selectedKey = rune(selKey)
@@ -482,7 +481,7 @@ readerLoop:
 						if errors.Is(lbErr, io.EOF) {
 							return nil, "LOGOFF", io.EOF
 						}
-						log.Printf("ERROR: Node %d: Lightbar error: %v", nodeNumber, lbErr)
+						slog.Error("lightbar error", "node", nodeNumber, "error", lbErr)
 						break readerLoop
 					}
 					selectedKey = rune(selKey)
@@ -604,8 +603,7 @@ readerLoop:
 					continue
 				}
 				if delErr := e.MessageMgr.DeleteMessage(currentAreaID, currentMsg.MsgNum); delErr != nil {
-					log.Printf("ERROR: Node %d: delete message %d area %d: %v",
-						nodeNumber, currentMsg.MsgNum, currentAreaID, delErr)
+					slog.Error("delete message", "node", nodeNumber, "msg", currentMsg.MsgNum, "area", currentAreaID, "error", delErr)
 					terminalio.WriteProcessedBytes(terminal,
 						ansi.ReplacePipeCodes([]byte("\r\n|01Error deleting message.|07\r\n")), outputMode)
 					time.Sleep(1 * time.Second)
@@ -615,8 +613,7 @@ readerLoop:
 				// Pack the base (physically remove deleted messages and
 				// renumber) then rebuild reply threading chains.
 				if packErr := e.MessageMgr.PackAndLinkArea(currentAreaID); packErr != nil {
-					log.Printf("ERROR: Node %d: pack/link area %d after delete: %v",
-						nodeNumber, currentAreaID, packErr)
+					slog.Error("pack/link area after delete", "node", nodeNumber, "area", currentAreaID, "error", packErr)
 				}
 				// Refresh total count after pack renumbered messages
 				newTotal, _ := e.MessageMgr.GetMessageCountForArea(currentAreaID)
@@ -652,7 +649,7 @@ readerLoop:
 	// Update lastread on exit
 	if currentMsgNum >= 1 && currentMsgNum <= totalMsgCount {
 		if lrErr := e.MessageMgr.SetLastRead(currentAreaID, currentUser.Handle, currentMsgNum); lrErr != nil {
-			log.Printf("ERROR: Node %d: Failed to update last read on exit: %v", nodeNumber, lrErr)
+			slog.Error("failed to update last read on exit", "node", nodeNumber, "error", lrErr)
 		}
 	}
 

--- a/internal/menu/message_reader_headers.go
+++ b/internal/menu/message_reader_headers.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -58,7 +58,7 @@ func discoverMessageHeaders(templatesPath string) ([]MessageHeaderTemplate, erro
 
 		num, err := extractHeaderNumber(base)
 		if err != nil {
-			log.Printf("WARN: Skipping malformed header filename: %s (error: %v)", base, err)
+			slog.Warn("skipping malformed header filename", "file", base, "error", err)
 			continue
 		}
 
@@ -103,7 +103,7 @@ func runGetHeaderType(c *cmdCtx, args string) (*user.User, string, error) {
 	// Load lightbar options from MSGHDR.BAR
 	options, err := loadLightbarOptions("MSGHDR", e)
 	if err != nil {
-		log.Printf("ERROR: Node %d: Failed to load MSGHDR.BAR: %v", nodeNumber, err)
+		slog.Error("failed to load MSGHDR.BAR", "node", nodeNumber, "error", err)
 		msg := "\r\n|01Error loading MSGHDR.BAR!|07\r\n"
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
@@ -111,7 +111,7 @@ func runGetHeaderType(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	if len(options) == 0 {
-		log.Printf("ERROR: Node %d: No options in MSGHDR.BAR", nodeNumber)
+		slog.Error("no options in MSGHDR.BAR", "node", nodeNumber)
 		msg := "\r\n|01No message header options found!|07\r\n"
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
@@ -125,14 +125,14 @@ func runGetHeaderType(c *cmdCtx, args string) (*user.User, string, error) {
 		// Parse template number from return value (not hotkey, since 10+ use letters)
 		templateNum, parseErr := strconv.Atoi(opt.ReturnValue)
 		if parseErr != nil {
-			log.Printf("WARN: Invalid return value in MSGHDR.BAR: %s", opt.ReturnValue)
+			slog.Warn("invalid return value in MSGHDR.BAR", "value", opt.ReturnValue)
 			continue
 		}
 
 		// Verify template file exists
 		templateFile := filepath.Join(templatesPath, fmt.Sprintf("MSGHDR.%d.ans", templateNum))
 		if _, statErr := os.Stat(templateFile); statErr != nil {
-			log.Printf("WARN: Template file not found: MSGHDR.%d.ans", templateNum)
+			slog.Warn("template file not found", "file", fmt.Sprintf("MSGHDR.%d.ans", templateNum))
 			continue
 		}
 
@@ -140,7 +140,7 @@ func runGetHeaderType(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	if len(validOptions) == 0 {
-		log.Printf("ERROR: Node %d: No valid message header templates found", nodeNumber)
+		slog.Error("no valid message header templates found", "node", nodeNumber)
 		msg := "\r\n|01No valid message header templates!|07\r\n"
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
@@ -148,13 +148,13 @@ func runGetHeaderType(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	options = validOptions
-	log.Printf("INFO: Node %d: Loaded %d message header options from BAR file", nodeNumber, len(options))
+	slog.Info("loaded message header options from BAR file", "node", nodeNumber, "count", len(options))
 
 	// Display the header selection ANSI screen
 	selectionPath := filepath.Join(e.MenuSetPath, "templates", "message_headers", "MSGHDR.ANS")
 	selectionBytes, err := ansi.GetAnsiFileContent(selectionPath)
 	if err != nil {
-		log.Printf("ERROR: Node %d: Failed to load MSGHDR.ANS: %v", nodeNumber, err)
+		slog.Error("failed to load MSGHDR.ANS", "node", nodeNumber, "error", err)
 		msg := "\r\n|01MSGHDR.ANS not found! Please notify SysOp.|07\r\n"
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
@@ -298,7 +298,7 @@ func runGetHeaderType(c *cmdCtx, args string) (*user.User, string, error) {
 			// Preview with sample data
 			hdrBytes, readErr := ansi.GetAnsiFileContent(hdrPath)
 			if readErr != nil {
-				log.Printf("ERROR: Node %d: Failed to read header file MSGHDR.%d.ans: %v", nodeNumber, templateNum, readErr)
+				slog.Error("failed to read header file", "node", nodeNumber, "file", fmt.Sprintf("MSGHDR.%d.ans", templateNum), "error", readErr)
 				continue
 			}
 			hdrBytes = bytes.TrimRight(hdrBytes, "\r\n ")
@@ -411,9 +411,9 @@ func saveHeaderSelection(userManager *user.UserMgr, u *user.User, templateNum, n
 	u.MsgHdr = templateNum
 	if err := userManager.UpdateUser(u); err != nil {
 		u.MsgHdr = prev
-		log.Printf("ERROR: Node %d: Failed to save header selection for %s: %v", nodeNumber, u.Handle, err)
+		slog.Error("failed to save header selection", "node", nodeNumber, "handle", u.Handle, "error", err)
 		return err
 	}
-	log.Printf("INFO: Node %d: User %s selected header style %d", nodeNumber, u.Handle, templateNum)
+	slog.Info("user selected header style", "node", nodeNumber, "handle", u.Handle, "style", templateNum)
 	return nil
 }

--- a/internal/menu/message_reader_nav.go
+++ b/internal/menu/message_reader_nav.go
@@ -3,7 +3,7 @@ package menu
 import (
 	"bufio"
 	"fmt"
-	"log"
+	"log/slog"
 	"strconv"
 	"strings"
 	"time"
@@ -53,7 +53,7 @@ func handleReply(e *MenuExecutor, s ssh.Session, ih *editor.InputHandler, termin
 	replyBody, saved, editErr := editor.RunEditorWithMetadata("", s, s, outputMode, newSubject, currentMsg.To, currentUser.Handle, false,
 		currentMsg.From, currentMsg.Subject, quoteDate, quoteTime, false, quoteLines, ih, replyCtx)
 	if editErr != nil {
-		log.Printf("ERROR: Node %d: Editor failed: %v", nodeNumber, editErr)
+		slog.Error("editor failed", "node", nodeNumber, "error", editErr)
 		terminalio.WriteProcessedBytes(terminal, []byte(e.LoadedStrings.MsgEditorError), outputMode)
 		time.Sleep(2 * time.Second)
 		return ""
@@ -75,13 +75,13 @@ func handleReply(e *MenuExecutor, s ssh.Session, ih *editor.InputHandler, termin
 	_, err := e.MessageMgr.AddMessage(currentAreaID, currentUser.Handle, currentMsg.From,
 		newSubject, replyBody, replyMsgID)
 	if err != nil {
-		log.Printf("ERROR: Node %d: Failed to save reply: %v", nodeNumber, err)
+		slog.Error("failed to save reply", "node", nodeNumber, "error", err)
 		terminalio.WriteProcessedBytes(terminal, []byte(e.LoadedStrings.MsgReplyError), outputMode)
 		time.Sleep(2 * time.Second)
 	} else {
 		currentUser.MessagesPosted++
 		if err := userManager.UpdateUser(currentUser); err != nil {
-			log.Printf("ERROR: Node %d: Failed to update MessagesPosted for user %s: %v", nodeNumber, currentUser.Handle, err)
+			slog.Error("failed to update MessagesPosted", "node", nodeNumber, "handle", currentUser.Handle, "error", err)
 		}
 		terminalio.WriteProcessedBytes(terminal, []byte(e.LoadedStrings.MsgReplySuccess), outputMode)
 		time.Sleep(1 * time.Second)

--- a/internal/menu/message_scan_config.go
+++ b/internal/menu/message_scan_config.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -492,7 +492,7 @@ func runNewscanConfig(c *cmdCtx, args string) (*user.User, string, error) {
 
 			terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 			if err := userManager.UpdateUser(currentUser); err != nil {
-				log.Printf("ERROR: Node %d: Failed to save newscan config: %v", nodeNumber, err)
+				slog.Error("failed to save newscan config", "node", nodeNumber, "error", err)
 				terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ScanConfigError)), outputMode)
 			} else {
 				msg := fmt.Sprintf(e.LoadedStrings.ScanConfigSaved, len(taggedTags))

--- a/internal/menu/message_scan_run.go
+++ b/internal/menu/message_scan_run.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -112,7 +112,7 @@ func runNewScanAll(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 	// Load scan area header template (ANSI art) if available
 	scanHeaderTemplate, headerErr := readTemplateFile(filepath.Join(e.MenuSetPath, "templates", "system_header", "HEADER"))
 	if headerErr != nil && !os.IsNotExist(headerErr) {
-		log.Printf("WARN: Node %d: Failed to load scan header template: %v", nodeNumber, headerErr)
+		slog.Warn("failed to load scan header template", "node", nodeNumber, "error", headerErr)
 	}
 
 	// Multi-area scan: iterate through accessible areas
@@ -265,7 +265,7 @@ func runNewScanAll(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 		// Update pointers
 		if scanCfg.UpdatePointers {
 			if saveErr := userManager.UpdateUser(currentUser); saveErr != nil {
-				log.Printf("ERROR: Node %d: Failed to save user data during newscan: %v", nodeNumber, saveErr)
+				slog.Error("failed to save user data during newscan", "node", nodeNumber, "error", saveErr)
 			}
 		}
 	}
@@ -278,7 +278,7 @@ func runNewScanAll(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 	currentUser.CurrentMsgConferenceID = origConfID
 	currentUser.CurrentMsgConferenceTag = origConfTag
 	if err := userManager.UpdateUser(currentUser); err != nil {
-		log.Printf("ERROR: Node %d: Failed to restore user area after newscan: %v", nodeNumber, err)
+		slog.Error("failed to restore user area after newscan", "node", nodeNumber, "error", err)
 	}
 
 	terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ScanComplete)), outputMode)
@@ -403,7 +403,7 @@ func runUpdateNewscanPointers(c *cmdCtx, args string) (*user.User, string, error
 		}
 
 		if setErr := e.MessageMgr.SetLastRead(area.ID, currentUser.Handle, newLastRead); setErr != nil {
-			log.Printf("ERROR: Node %d: Failed to set lastread for area %d: %v", nodeNumber, area.ID, setErr)
+			slog.Error("failed to set lastread", "node", nodeNumber, "area", area.ID, "error", setErr)
 			saveErr = true
 			continue
 		}

--- a/internal/menu/news.go
+++ b/internal/menu/news.go
@@ -3,7 +3,7 @@ package menu
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -117,7 +117,7 @@ func runPrintNews(c *cmdCtx, args string) (*user.User, string, error) {
 	nd, err := loadNewsData(e.RootConfigPath)
 	newsMu.Unlock()
 	if err != nil {
-		log.Printf("WARN: Node %d: Failed to load news data: %v", nodeNumber, err)
+		slog.Warn("failed to load news data", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
 
@@ -142,7 +142,7 @@ func runPrintNews(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	if shown > 0 {
-		log.Printf("DEBUG: Node %d: Displayed %d news item(s) to %s", nodeNumber, shown, currentUser.Handle)
+		slog.Debug("displayed news items", "node", nodeNumber, "count", shown, "handle", currentUser.Handle)
 	}
 	return currentUser, "", nil
 }
@@ -163,7 +163,7 @@ func runListNews(c *cmdCtx, args string) (*user.User, string, error) {
 		return currentUser, "", nil
 	}
 
-	log.Printf("DEBUG: Node %d: Running LISTNEWS for user %s", nodeNumber, currentUser.Handle)
+	slog.Debug("running LISTNEWS", "node", nodeNumber, "handle", currentUser.Handle)
 
 	newsMu.Lock()
 	nd, err := loadNewsData(e.RootConfigPath)

--- a/internal/menu/news_edit.go
+++ b/internal/menu/news_edit.go
@@ -2,7 +2,7 @@ package menu
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"strconv"
 	"strings"
 	"time"
@@ -29,7 +29,7 @@ func runEditNews(c *cmdCtx, args string) (*user.User, string, error) {
 	if !e.isCoSysOpOrAbove(currentUser) {
 		return currentUser, "", nil
 	}
-	log.Printf("DEBUG: Node %d: Running EDITNEWS (sysop) for user %s", nodeNumber, currentUser.Handle)
+	slog.Debug("running EDITNEWS (sysop)", "node", nodeNumber, "handle", currentUser.Handle)
 
 	for {
 		terminalio.WriteProcessedBytes(terminal, []byte("\x1b[2J\x1b[H"), outputMode)
@@ -148,7 +148,7 @@ func newsAddItem(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 	fresh, loadErr := loadNewsData(e.RootConfigPath)
 	if loadErr != nil {
 		newsMu.Unlock()
-		log.Printf("ERROR: Failed to load news data before add: %v", loadErr)
+		slog.Error("failed to load news data before add", "error", loadErr)
 		wv(terminal, "|04Error adding news item.\r\n", outputMode)
 		return
 	}
@@ -166,7 +166,7 @@ func newsAddItem(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 	saveErr := saveNewsData(e.RootConfigPath, fresh)
 	newsMu.Unlock()
 	if saveErr != nil {
-		log.Printf("ERROR: Failed to save news data after add: %v", saveErr)
+		slog.Error("failed to save news data after add", "error", saveErr)
 		wv(terminal, "|04Error saving news item.\r\n", outputMode)
 		return
 	}
@@ -202,7 +202,7 @@ func newsDeleteItem(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 	fresh, loadErr := loadNewsData(e.RootConfigPath)
 	if loadErr != nil {
 		newsMu.Unlock()
-		log.Printf("ERROR: Failed to load news data before delete: %v", loadErr)
+		slog.Error("failed to load news data before delete", "error", loadErr)
 		wv(terminal, "|04Error deleting news item.\r\n", outputMode)
 		return
 	}
@@ -215,7 +215,7 @@ func newsDeleteItem(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 	saveErr := saveNewsData(e.RootConfigPath, fresh)
 	newsMu.Unlock()
 	if saveErr != nil {
-		log.Printf("ERROR: Failed to save news data after delete: %v", saveErr)
+		slog.Error("failed to save news data after delete", "error", saveErr)
 		wv(terminal, "|04Error deleting news item.\r\n", outputMode)
 		return
 	}
@@ -265,7 +265,7 @@ func newsEditItem(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 			fresh, loadErr := loadNewsData(e.RootConfigPath)
 			if loadErr != nil {
 				newsMu.Unlock()
-				log.Printf("ERROR: Failed to load news data before edit save: %v", loadErr)
+				slog.Error("failed to load news data before edit save", "error", loadErr)
 				wv(terminal, "|04Error saving news item.\r\n", outputMode)
 				return
 			}
@@ -278,7 +278,7 @@ func newsEditItem(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 			saveErr := saveNewsData(e.RootConfigPath, fresh)
 			newsMu.Unlock()
 			if saveErr != nil {
-				log.Printf("ERROR: Failed to save news data after edit: %v", saveErr)
+				slog.Error("failed to save news data after edit", "error", saveErr)
 				wv(terminal, "|04Error saving news item.\r\n", outputMode)
 				return
 			}

--- a/internal/menu/newuser.go
+++ b/internal/menu/newuser.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -77,12 +77,12 @@ func (e *MenuExecutor) handleNewUserApplication(
 	termWidth int,
 	termHeight int,
 ) error {
-	log.Printf("INFO: Node %d: Starting new user application", nodeNumber)
+	slog.Info("starting new user application", "node", nodeNumber)
 
 	// Check if new user registration is allowed
 	serverCfg := e.GetServerConfig()
 	if !serverCfg.AllowNewUsers {
-		log.Printf("INFO: Node %d: New user registration is disabled", nodeNumber)
+		slog.Info("new user registration is disabled", "node", nodeNumber)
 		closedMsg := e.LoadedStrings.NewUsersClosedStr
 		if closedMsg == "" {
 			closedMsg = "\r\n|12This BBS is not accepting new users at this time.|07\r\n"
@@ -107,11 +107,11 @@ func (e *MenuExecutor) handleNewUserApplication(
 		if errors.Is(err, io.EOF) {
 			return io.EOF
 		}
-		log.Printf("ERROR: Node %d: Error during apply prompt: %v", nodeNumber, err)
+		slog.Error("error during apply prompt", "node", nodeNumber, "error", err)
 		return err
 	}
 	if !applyYes {
-		log.Printf("INFO: Node %d: User declined new user application", nodeNumber)
+		slog.Info("user declined new user application", "node", nodeNumber)
 		return nil
 	}
 
@@ -120,7 +120,7 @@ func (e *MenuExecutor) handleNewUserApplication(
 
 	// 2. Display NEWUSER.ANS welcome screen with pause
 	if err := e.displayNewUserScreen(terminal, outputMode, nodeNumber); err != nil {
-		log.Printf("WARN: Node %d: Failed to display NEWUSER.ANS: %v", nodeNumber, err)
+		slog.Warn("failed to display NEWUSER.ANS", "node", nodeNumber, "error", err)
 		// Continue without the screen - not fatal
 	} else {
 		// Pause after displaying the ANS screen (matching Pascal HoldScreen)
@@ -193,7 +193,7 @@ func (e *MenuExecutor) handleNewUserApplication(
 		location,
 	)
 	if addErr != nil {
-		log.Printf("ERROR: Node %d: Failed to create new user '%s': %v", nodeNumber, handle, addErr)
+		slog.Error("failed to create new user", "node", nodeNumber, "handle", handle, "error", addErr)
 		errMsg := e.LoadedStrings.NewUserCreationError
 		terminalio.WriteStringCP437(terminal, ansi.ReplacePipeCodes([]byte(errMsg)), outputMode)
 		time.Sleep(2 * time.Second)
@@ -214,15 +214,15 @@ func (e *MenuExecutor) handleNewUserApplication(
 		}
 		if len(autoJoinTags) > 0 {
 			newUser.TaggedMessageAreaTags = autoJoinTags
-			log.Printf("INFO: Node %d: Auto-joining %d message area(s) for new user '%s'", nodeNumber, len(autoJoinTags), handle)
+			slog.Info("auto-joining message areas for new user", "node", nodeNumber, "count", len(autoJoinTags), "handle", handle)
 		}
 	}
 
 	if saveErr := userManager.UpdateUser(newUser); saveErr != nil {
-		log.Printf("ERROR: Node %d: Failed to save user note for '%s': %v", nodeNumber, handle, saveErr)
+		slog.Error("failed to save user note", "node", nodeNumber, "handle", handle, "error", saveErr)
 	}
 
-	log.Printf("INFO: Node %d: New user '%s' created (ID: %d)", nodeNumber, newUser.Handle, newUser.ID)
+	slog.Info("new user created", "node", nodeNumber, "handle", newUser.Handle, "id", newUser.ID)
 
 	// Add to NUV queue if configured.
 	cfg := e.GetServerConfig()
@@ -253,7 +253,7 @@ func (e *MenuExecutor) displayNewUserScreen(terminal *term.Terminal, outputMode 
 	rawContent, err := ansi.GetAnsiFileContent(fullAnsPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("DEBUG: Node %d: NEWUSER.ANS not found, skipping display", nodeNumber)
+			slog.Debug("NEWUSER.ANS not found, skipping display", "node", nodeNumber)
 			return nil
 		}
 		return fmt.Errorf("failed to read NEWUSER.ANS: %w", err)
@@ -351,7 +351,7 @@ func (e *MenuExecutor) promptForHandle(
 			continue
 		}
 
-		log.Printf("INFO: Node %d: Handle '%s' accepted for new user application", nodeNumber, handle)
+		slog.Info("handle accepted for new user application", "node", nodeNumber, "handle", handle)
 		return handle, nil
 	}
 
@@ -447,7 +447,7 @@ func (e *MenuExecutor) promptForPassword(
 			continue
 		}
 
-		log.Printf("INFO: Node %d: Password accepted for new user application", nodeNumber)
+		slog.Info("password accepted for new user application", "node", nodeNumber)
 		return password, nil
 	}
 
@@ -511,7 +511,7 @@ func (e *MenuExecutor) promptForRealName(
 			continue
 		}
 
-		log.Printf("INFO: Node %d: Real name '%s' accepted for new user application", nodeNumber, name)
+		slog.Info("real name accepted for new user application", "node", nodeNumber, "name", name)
 		return name, nil
 	}
 

--- a/internal/menu/nuv.go
+++ b/internal/menu/nuv.go
@@ -3,7 +3,7 @@ package menu
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -75,7 +75,7 @@ func nuvAddCandidate(rootConfigPath, handle string) error {
 	defer nuvMu.Unlock()
 	nd, err := loadNUVData(rootConfigPath)
 	if err != nil {
-		log.Printf("WARN: NUV: failed to load nuv.json: %v", err)
+		slog.Warn("failed to load nuv.json", "error", err)
 		return fmt.Errorf("load nuv data: %w", err)
 	}
 	lower := strings.ToLower(handle)
@@ -89,10 +89,10 @@ func nuvAddCandidate(rootConfigPath, handle string) error {
 		When:   time.Now(),
 	})
 	if err := saveNUVData(rootConfigPath, nd); err != nil {
-		log.Printf("WARN: NUV: failed to save nuv.json: %v", err)
+		slog.Warn("failed to save nuv.json", "error", err)
 		return fmt.Errorf("save nuv data: %w", err)
 	}
-	log.Printf("INFO: NUV: added candidate '%s' to queue", handle)
+	slog.Info("added candidate to queue", "handle", handle)
 	return nil
 }
 
@@ -207,16 +207,16 @@ func nuvApplyThresholds(e *MenuExecutor, nd *NUVData, idx int, userManager *user
 				u.AccessLevel = cfg.NUVLevel
 				u.Validated = true
 				if err := userManager.UpdateUser(u); err != nil {
-					log.Printf("ERROR: NUV: failed to validate user '%s': %v", c.Handle, err)
+					slog.Error("failed to validate user", "handle", c.Handle, "error", err)
 				} else {
-					log.Printf("INFO: NUV: auto-validated '%s' (level %d)", c.Handle, cfg.NUVLevel)
+					slog.Info("auto-validated candidate", "handle", c.Handle, "level", cfg.NUVLevel)
 					shouldRemove = true
 				}
 			} else {
-				log.Printf("ERROR: NUV: user '%s' not found during validation", c.Handle)
+				slog.Error("user not found during validation", "handle", c.Handle)
 			}
 		} else {
-			log.Printf("INFO: NUV: '%s' reached YES threshold — notify SysOp to validate", c.Handle)
+			slog.Info("candidate reached YES threshold — notify SysOp to validate", "handle", c.Handle)
 		}
 		if shouldRemove {
 			nd.Candidates = append(nd.Candidates[:idx], nd.Candidates[idx+1:]...)
@@ -230,13 +230,13 @@ func nuvApplyThresholds(e *MenuExecutor, nd *NUVData, idx int, userManager *user
 			if u, ok := userManager.GetUser(c.Handle); ok {
 				u.DeletedUser = true
 				if err := userManager.UpdateUser(u); err != nil {
-					log.Printf("ERROR: NUV: failed to delete user '%s': %v", c.Handle, err)
+					slog.Error("failed to delete user", "handle", c.Handle, "error", err)
 				} else {
-					log.Printf("INFO: NUV: auto-deleted '%s' (voted off)", c.Handle)
+					slog.Info("auto-deleted candidate (voted off)", "handle", c.Handle)
 				}
 			}
 		} else {
-			log.Printf("INFO: NUV: '%s' reached NO threshold — notify SysOp to delete", c.Handle)
+			slog.Info("candidate reached NO threshold — notify SysOp to delete", "handle", c.Handle)
 		}
 		nd.Candidates = append(nd.Candidates[:idx], nd.Candidates[idx+1:]...)
 		return true
@@ -275,7 +275,7 @@ func nuvPromptComment(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 			if vi >= 0 {
 				fresh.Candidates[freshIdx].Votes[vi].Comment = comment
 				if err := saveNUVData(e.RootConfigPath, fresh); err != nil {
-					log.Printf("WARN: NUV: failed to save comment: %v", err)
+					slog.Warn("failed to save comment", "error", err)
 				} else {
 					*nd = *fresh
 				}
@@ -452,7 +452,7 @@ func nuvVoteOn(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 					if castYes {
 						voteStr = "YES"
 					}
-					log.Printf("INFO: NUV: %s voted %s on '%s'", currentUser.Handle, voteStr, c.Handle)
+					slog.Info("user voted on candidate", "handle", currentUser.Handle, "vote", voteStr, "candidate", c.Handle)
 					removed = nuvApplyThresholds(e, nd, idx, userManager)
 					_ = saveNUVData(e.RootConfigPath, nd)
 

--- a/internal/menu/nuv_scan.go
+++ b/internal/menu/nuv_scan.go
@@ -2,7 +2,7 @@ package menu
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"strconv"
 	"strings"
 	"time"
@@ -119,7 +119,7 @@ func runNUVScan(c *cmdCtx, args string) (*user.User, string, error) {
 	nd, err := loadNUVData(e.RootConfigPath)
 	nuvMu.Unlock()
 	if err != nil {
-		log.Printf("WARN: Node %d: SCANNUV: load error: %v", nodeNumber, err)
+		slog.Warn("SCANNUV load error", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
 
@@ -155,7 +155,7 @@ func runNUVList(c *cmdCtx, args string) (*user.User, string, error) {
 	nd, err := loadNUVData(e.RootConfigPath)
 	nuvMu.Unlock()
 	if err != nil {
-		log.Printf("WARN: Node %d: LISTNUV: load error: %v", nodeNumber, err)
+		slog.Warn("LISTNUV load error", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
 
@@ -242,12 +242,12 @@ func runNUVList(c *cmdCtx, args string) (*user.User, string, error) {
 			nd.Candidates = append(nd.Candidates[:num-1], nd.Candidates[num:]...)
 			if err := saveNUVData(e.RootConfigPath, nd); err != nil {
 				nuvMu.Unlock()
-				log.Printf("ERROR: NUV: failed to save after removing '%s': %v", removed.Handle, err)
+				slog.Error("failed to save after removing candidate", "handle", removed.Handle, "error", err)
 				wv(terminal, "|12Failed to save changes.\r\n", outputMode)
 				continue
 			}
 			nuvMu.Unlock()
-			log.Printf("INFO: NUV: SysOp %s removed candidate '%s' from queue", currentUser.Handle, removed.Handle)
+			slog.Info("sysop removed candidate from queue", "handle", currentUser.Handle, "candidate", removed.Handle)
 			wv(terminal, fmt.Sprintf("|10Removed '%s' from queue.\r\n", removed.Handle), outputMode)
 
 		case key == 'V' || key == 'v':

--- a/internal/menu/page.go
+++ b/internal/menu/page.go
@@ -3,7 +3,7 @@ package menu
 import (
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"strconv"
 	"strings"
 	"time"
@@ -113,7 +113,7 @@ func runPage(c *cmdCtx, args string) (*user.User, string, error) {
 	pageMsg := fmt.Sprintf(e.LoadedStrings.PageMessageFormat, handle, msgInput)
 	targetSession.AddPage(pageMsg)
 
-	log.Printf("INFO: Node %d (%s) paged Node %d (%d chars)", nodeNumber, handle, targetNodeID, len(msgInput))
+	slog.Info("paged node", "node", nodeNumber, "handle", handle, "target", targetNodeID, "chars", len(msgInput))
 	confirm := fmt.Sprintf(e.LoadedStrings.PageSent, targetNodeID)
 	terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(confirm)), outputMode)
 	time.Sleep(500 * time.Millisecond)

--- a/internal/menu/qwk_handler.go
+++ b/internal/menu/qwk_handler.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,7 +47,7 @@ func runQWKDownload(c *cmdCtx, args string) (*user.User, string, error) {
 	nodeNumber := c.nodeNumber
 	outputMode := c.outputMode
 
-	log.Printf("DEBUG: Node %d: Running QWKDOWNLOAD", nodeNumber)
+	slog.Debug("running QWKDOWNLOAD", "node", nodeNumber)
 
 	if currentUser == nil {
 		msg := "\r\n|01Error: You must be logged in.|07\r\n"
@@ -92,13 +92,13 @@ func runQWKDownload(c *cmdCtx, args string) (*user.User, string, error) {
 		// Get last read for this user in this area
 		lastRead, err := e.MessageMgr.GetLastRead(area.ID, currentUser.Handle)
 		if err != nil {
-			log.Printf("WARN: Node %d: QWK: failed to get lastread for area %d: %v", nodeNumber, area.ID, err)
+			slog.Warn("failed to get lastread for area", "node", nodeNumber, "area", area.ID, "error", err)
 			continue
 		}
 
 		msgCount, err := e.MessageMgr.GetMessageCountForArea(area.ID)
 		if err != nil {
-			log.Printf("WARN: Node %d: QWK: failed to get msg count for area %d: %v", nodeNumber, area.ID, err)
+			slog.Warn("failed to get msg count for area", "node", nodeNumber, "area", area.ID, "error", err)
 			continue
 		}
 
@@ -166,7 +166,7 @@ func runQWKDownload(c *cmdCtx, args string) (*user.User, string, error) {
 	// Write packet to temp file
 	tmpFile, err := os.CreateTemp("", "qwk-*.zip")
 	if err != nil {
-		log.Printf("ERROR: Node %d: QWK: failed to create temp file: %v", nodeNumber, err)
+		slog.Error("failed to create temp file", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
 	tmpPath := tmpFile.Name()
@@ -174,7 +174,7 @@ func runQWKDownload(c *cmdCtx, args string) (*user.User, string, error) {
 
 	if err := pw.WritePacket(tmpFile); err != nil {
 		tmpFile.Close()
-		log.Printf("ERROR: Node %d: QWK: failed to write packet: %v", nodeNumber, err)
+		slog.Error("failed to write packet", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
 	tmpFile.Close()
@@ -182,7 +182,7 @@ func runQWKDownload(c *cmdCtx, args string) (*user.User, string, error) {
 	// Rename to BBSID.QWK for the transfer
 	qwkPath := filepath.Join(filepath.Dir(tmpPath), bbsID+".QWK")
 	if err := os.Rename(tmpPath, qwkPath); err != nil {
-		log.Printf("ERROR: Node %d: QWK: rename failed: %v", nodeNumber, err)
+		slog.Error("rename failed", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
 	defer os.Remove(qwkPath)
@@ -212,14 +212,14 @@ func runQWKDownload(c *cmdCtx, args string) (*user.User, string, error) {
 		if errors.Is(sendErr, transfer.ErrBinaryNotFound) {
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Transfer program not found!|07\r\n")), outputMode)
 		} else {
-			log.Printf("WARN: Node %d: QWK download transfer failed: %v", nodeNumber, sendErr)
+			slog.Warn("QWK download transfer failed", "node", nodeNumber, "error", sendErr)
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Transfer failed.|07\r\n")), outputMode)
 		}
 	} else {
 		// Transfer succeeded — commit the newscan pointer advances.
 		for _, upd := range pendingLastRead {
 			if err := e.MessageMgr.SetLastRead(upd.areaID, currentUser.Handle, upd.msgNum); err != nil {
-				log.Printf("WARN: Node %d: QWK: failed to update lastread for area %d: %v", nodeNumber, upd.areaID, err)
+				slog.Warn("failed to update lastread for area", "node", nodeNumber, "area", upd.areaID, "error", err)
 			}
 		}
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|10QWK packet sent successfully.|07\r\n")), outputMode)
@@ -240,7 +240,7 @@ func runQWKUpload(c *cmdCtx, args string) (*user.User, string, error) {
 	sessionStartTime := c.sessionStartTime
 	outputMode := c.outputMode
 
-	log.Printf("DEBUG: Node %d: Running QWKUPLOAD", nodeNumber)
+	slog.Debug("running QWKUPLOAD", "node", nodeNumber)
 
 	if currentUser == nil {
 		msg := "\r\n|01Error: You must be logged in.|07\r\n"
@@ -268,7 +268,7 @@ func runQWKUpload(c *cmdCtx, args string) (*user.User, string, error) {
 	// Receive into temp directory
 	incomingDir, err := os.MkdirTemp("", "qwk-rep-*")
 	if err != nil {
-		log.Printf("ERROR: Node %d: QWK: failed to create temp dir: %v", nodeNumber, err)
+		slog.Error("failed to create temp dir", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
 	defer os.RemoveAll(incomingDir)
@@ -281,7 +281,7 @@ func runQWKUpload(c *cmdCtx, args string) (*user.User, string, error) {
 	getSessionIH(s)
 
 	if recvErr != nil && !errors.Is(recvErr, context.Canceled) {
-		log.Printf("WARN: Node %d: QWK REP receive: %v (checking for files anyway)", nodeNumber, recvErr)
+		slog.Warn("QWK REP receive error, checking for files anyway", "node", nodeNumber, "error", recvErr)
 	}
 
 	// Find the .REP file
@@ -295,19 +295,19 @@ func runQWKUpload(c *cmdCtx, args string) (*user.User, string, error) {
 	// Process the REP packet
 	repInfo, err := os.Stat(repPath)
 	if err != nil {
-		log.Printf("ERROR: Node %d: QWK: failed to stat REP: %v", nodeNumber, err)
+		slog.Error("failed to stat REP", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
 
 	repData, err := os.ReadFile(repPath)
 	if err != nil {
-		log.Printf("ERROR: Node %d: QWK: failed to read REP: %v", nodeNumber, err)
+		slog.Error("failed to read REP", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
 
 	messages, err := qwk.ReadREP(bytes.NewReader(repData), repInfo.Size(), bbsID)
 	if err != nil {
-		log.Printf("ERROR: Node %d: QWK: failed to parse REP: %v", nodeNumber, err)
+		slog.Error("failed to parse REP", "node", nodeNumber, "error", err)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Error reading REP packet.|07\r\n")), outputMode)
 		time.Sleep(2 * time.Second)
 		return currentUser, "", nil
@@ -324,13 +324,13 @@ func runQWKUpload(c *cmdCtx, args string) (*user.User, string, error) {
 	for _, msg := range messages {
 		area, exists := e.MessageMgr.GetAreaByID(msg.Conference)
 		if !exists {
-			log.Printf("WARN: Node %d: QWK REP: unknown conference %d, skipping", nodeNumber, msg.Conference)
+			slog.Warn("unknown conference, skipping", "node", nodeNumber, "conference", msg.Conference)
 			continue
 		}
 
 		// Check write ACS
 		if area.ACSWrite != "" && !checkACS(area.ACSWrite, currentUser, s, terminal, sessionStartTime) {
-			log.Printf("WARN: Node %d: QWK REP: user lacks write ACS for area %s", nodeNumber, area.Tag)
+			slog.Warn("user lacks write ACS for area", "node", nodeNumber, "tag", area.Tag)
 			continue
 		}
 
@@ -344,7 +344,7 @@ func runQWKUpload(c *cmdCtx, args string) (*user.User, string, error) {
 		}
 		_, err := e.MessageMgr.AddMessage(area.ID, currentUser.Handle, msg.To, msg.Subject, qwkBody, "")
 		if err != nil {
-			log.Printf("ERROR: Node %d: QWK REP: failed to post to area %d: %v", nodeNumber, area.ID, err)
+			slog.Error("failed to post to area", "node", nodeNumber, "area", area.ID, "error", err)
 			continue
 		}
 		posted++
@@ -354,7 +354,7 @@ func runQWKUpload(c *cmdCtx, args string) (*user.User, string, error) {
 	if posted > 0 && userManager != nil {
 		currentUser.MessagesPosted += posted
 		if updateErr := userManager.UpdateUser(currentUser); updateErr != nil {
-			log.Printf("ERROR: Node %d: QWK: failed to update user stats: %v", nodeNumber, updateErr)
+			slog.Error("failed to update user stats", "node", nodeNumber, "error", updateErr)
 		}
 	}
 

--- a/internal/menu/rumors.go
+++ b/internal/menu/rumors.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -179,7 +179,7 @@ func runRumorsList(c *cmdCtx, args string) (*user.User, string, error) {
 		return currentUser, "", nil
 	}
 
-	log.Printf("DEBUG: Node %d: Running RUMORSLIST for user %s", nodeNumber, currentUser.Handle)
+	slog.Debug("running RUMORSLIST", "node", nodeNumber, "handle", currentUser.Handle)
 
 	// Clear screen before listing
 	wv(terminal, "\x1b[2J\x1b[H", outputMode)
@@ -232,7 +232,7 @@ func runRumorsAdd(c *cmdCtx, args string) (*user.User, string, error) {
 		return currentUser, "", nil
 	}
 
-	log.Printf("DEBUG: Node %d: Running RUMORSADD for user %s", nodeNumber, currentUser.Handle)
+	slog.Debug("running RUMORSADD", "node", nodeNumber, "handle", currentUser.Handle)
 
 	userLevel := currentUser.AccessLevel
 	anonName := rumorAnonName(e)
@@ -347,7 +347,7 @@ func runRumorsAdd(c *cmdCtx, args string) (*user.User, string, error) {
 	rumorsMu.Unlock()
 
 	if saveErr != nil {
-		log.Printf("ERROR: Node %d: Failed to save rumor: %v", nodeNumber, saveErr)
+		slog.Error("failed to save rumor", "node", nodeNumber, "error", saveErr)
 		wv(terminal, "\r\n|04Error saving rumor.\r\n", outputMode)
 		return currentUser, "", nil
 	}
@@ -358,7 +358,7 @@ func runRumorsAdd(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 	wv(terminal, "\r\n"+addedMsg+"\r\n", outputMode)
 	time.Sleep(1 * time.Second)
-	log.Printf("INFO: Node %d: %s added rumor #%d", nodeNumber, currentUser.Handle, newRumor.ID)
+	slog.Info("rumor added", "node", nodeNumber, "handle", currentUser.Handle, "id", newRumor.ID)
 	return currentUser, "", nil
 }
 
@@ -379,7 +379,7 @@ func runRumorsDelete(c *cmdCtx, args string) (*user.User, string, error) {
 		return currentUser, "", nil
 	}
 
-	log.Printf("DEBUG: Node %d: Running RUMORSDELETE for user %s", nodeNumber, currentUser.Handle)
+	slog.Debug("running RUMORSDELETE", "node", nodeNumber, "handle", currentUser.Handle)
 
 	isSysop := currentUser.AccessLevel >= 255
 	userLevel := currentUser.AccessLevel
@@ -496,13 +496,13 @@ func runRumorsDelete(c *cmdCtx, args string) (*user.User, string, error) {
 	rumorsMu.Unlock()
 
 	if saveErr != nil {
-		log.Printf("ERROR: Node %d: Failed to delete rumor #%d: %v", nodeNumber, num, saveErr)
+		slog.Error("failed to delete rumor", "node", nodeNumber, "id", num, "error", saveErr)
 		wv(terminal, "\r\n|04Error deleting rumor.\r\n", outputMode)
 		return currentUser, "", nil
 	}
 
 	wv(terminal, "\r\n|10Rumor deleted.\r\n", outputMode)
-	log.Printf("INFO: Node %d: %s deleted rumor #%d", nodeNumber, currentUser.Handle, num)
+	slog.Info("rumor deleted", "node", nodeNumber, "handle", currentUser.Handle, "id", num)
 	return currentUser, "", nil
 }
 
@@ -520,7 +520,7 @@ func runRumorsSearch(c *cmdCtx, args string) (*user.User, string, error) {
 		return currentUser, "", nil
 	}
 
-	log.Printf("DEBUG: Node %d: Running RUMORSSEARCH for user %s", nodeNumber, currentUser.Handle)
+	slog.Debug("running RUMORSSEARCH", "node", nodeNumber, "handle", currentUser.Handle)
 
 	isSysop := currentUser.AccessLevel >= 255
 	userLevel := currentUser.AccessLevel
@@ -591,7 +591,7 @@ func runRumorsNewscan(c *cmdCtx, args string) (*user.User, string, error) {
 		return currentUser, "", nil
 	}
 
-	log.Printf("DEBUG: Node %d: Running RUMORSNEWSCAN for user %s", nodeNumber, currentUser.Handle)
+	slog.Debug("running RUMORSNEWSCAN", "node", nodeNumber, "handle", currentUser.Handle)
 
 	// Clear screen before newscan
 	wv(terminal, "\x1b[2J\x1b[H", outputMode)

--- a/internal/menu/sponsor_menu.go
+++ b/internal/menu/sponsor_menu.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -25,7 +25,7 @@ func (e *MenuExecutor) displaySponsorHeader(terminal *term.Terminal, menuRec *Me
 		_ = terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 	}
 	if err := e.displayFile(terminal, "SPONSORM.ANS", outputMode); err != nil {
-		log.Printf("WARN: Node %d: Failed to display SPONSORM.ANS: %v", nodeNumber, err)
+		slog.Warn("failed to display SPONSORM.ANS", "node", nodeNumber, "error", err)
 	}
 }
 
@@ -72,18 +72,18 @@ func runSponsorMenu(c *cmdCtx, args string) (*user.User, string, error) {
 
 	cfg := e.GetServerConfig()
 	if !CanAccessSponsorMenu(currentUser, area, cfg) {
-		log.Printf("INFO: Node %d: User %s denied sponsor menu for area %s",
-			nodeNumber, currentUser.Handle, area.Tag)
+		slog.Info("user denied sponsor menu for area",
+			"node", nodeNumber, "handle", currentUser.Handle, "tag", area.Tag)
 		return currentUser, "", nil
 	}
 
-	log.Printf("INFO: Node %d: User %s entering sponsor menu for area %s",
-		nodeNumber, currentUser.Handle, area.Tag)
+	slog.Info("user entering sponsor menu for area",
+		"node", nodeNumber, "handle", currentUser.Handle, "tag", area.Tag)
 
 	menuMnuPath := filepath.Join(e.MenuSetPath, "mnu")
 	menuRec, loadErr := LoadMenu("SPONSORM", menuMnuPath)
 	if loadErr != nil {
-		log.Printf("WARN: Node %d: Failed to load SPONSORM.MNU: %v. Using fallback prompt.", nodeNumber, loadErr)
+		slog.Warn("failed to load SPONSORM.MNU, using fallback prompt", "node", nodeNumber, "error", loadErr)
 		menuRec = nil
 	}
 
@@ -93,7 +93,7 @@ func runSponsorMenu(c *cmdCtx, args string) (*user.User, string, error) {
 	for {
 		if menuRec != nil && menuRec.GetUsePrompt() {
 			if err := e.displayPrompt(terminal, menuRec, currentUser, userManager, nodeNumber, "SPONSORM", sessionStartTime, outputMode, ""); err != nil {
-				log.Printf("WARN: Node %d: displayPrompt failed for SPONSORM: %v", nodeNumber, err)
+				slog.Warn("displayPrompt failed for SPONSORM", "node", nodeNumber, "error", err)
 			}
 		} else {
 			prompt := fmt.Sprintf("\r\n|15[|14%s|15] Sponsor: |11E|07=Edit  |11P|07=Position  |11[|07/|11]|07=Prev/Next  |11Q|07=Quit: ", area.Tag)
@@ -154,13 +154,13 @@ func runSponsorMenu(c *cmdCtx, args string) (*user.User, string, error) {
 				currentUser.CurrentMessageAreaTag = newArea.Tag
 				if userManager != nil {
 					if err := userManager.UpdateUser(currentUser); err != nil {
-						log.Printf("ERROR: Node %d: Failed to save user after sponsor area nav: %v", nodeNumber, err)
+						slog.Error("failed to save user after sponsor area nav", "node", nodeNumber, "error", err)
 					}
 				} else {
-					log.Printf("WARN: Node %d: userManager is nil; sponsor area nav not persisted", nodeNumber)
+					slog.Warn("userManager is nil; sponsor area nav not persisted", "node", nodeNumber)
 				}
 				area = newArea
-				log.Printf("INFO: Node %d: User %s sponsor-navigated to area %d (%s)", nodeNumber, currentUser.Handle, newArea.ID, newArea.Tag)
+				slog.Info("user sponsor-navigated to area", "node", nodeNumber, "handle", currentUser.Handle, "id", newArea.ID, "tag", newArea.Tag)
 				e.displaySponsorHeader(terminal, menuRec, outputMode, nodeNumber)
 			}
 
@@ -275,21 +275,21 @@ func runSponsorMenu(c *cmdCtx, args string) (*user.User, string, error) {
 
 				// Perform the move within this conference
 				if moveErr := e.MessageMgr.MoveAreaPositionInConference(selectedArea.ID, targetPos); moveErr != nil {
-					log.Printf("ERROR: Node %d: Failed to move area position: %v", nodeNumber, moveErr)
+					slog.Error("failed to move area position", "node", nodeNumber, "error", moveErr)
 					msg := "\r\n|01Error moving area position.|07\r\n"
 					_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 					time.Sleep(1 * time.Second)
 					continue
 				}
 				if saveErr := e.MessageMgr.SaveAreas(); saveErr != nil {
-					log.Printf("ERROR: Node %d: Failed to save areas after reposition: %v", nodeNumber, saveErr)
+					slog.Error("failed to save areas after reposition", "node", nodeNumber, "error", saveErr)
 					msg := "\r\n|01Error saving areas.|07\r\n"
 					_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 					time.Sleep(1 * time.Second)
 					continue
 				}
-				log.Printf("INFO: Node %d: User %s repositioned area %s to position %d in conf %s",
-					nodeNumber, currentUser.Handle, selectedArea.Tag, targetPos, confName)
+				slog.Info("user repositioned area",
+					"node", nodeNumber, "handle", currentUser.Handle, "tag", selectedArea.Tag, "position", targetPos, "conference", confName)
 				// Loop: list will refresh at top of next iteration
 			}
 
@@ -751,17 +751,17 @@ func runSponsorEditArea(c *cmdCtx, args string) (*user.User, string, error) {
 				switch saveKey {
 				case int('y'), int('Y'):
 					if updateErr := e.MessageMgr.UpdateAreaByID(edited.ID, edited); updateErr != nil {
-						log.Printf("ERROR: Node %d: Failed to update area: %v", nodeNumber, updateErr)
+						slog.Error("failed to update area", "node", nodeNumber, "error", updateErr)
 						msg := "|01Error updating area.|07\r\n"
 						_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 						time.Sleep(1 * time.Second)
 					} else if saveErr := e.MessageMgr.SaveAreas(); saveErr != nil {
-						log.Printf("ERROR: Node %d: Failed to save areas: %v", nodeNumber, saveErr)
+						slog.Error("failed to save areas", "node", nodeNumber, "error", saveErr)
 						msg := "|01Error saving area.|07\r\n"
 						_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 						time.Sleep(1 * time.Second)
 					} else {
-						log.Printf("INFO: Node %d: User %s saved area %s", nodeNumber, currentUser.Handle, edited.Tag)
+						slog.Info("user saved area", "node", nodeNumber, "handle", currentUser.Handle, "tag", edited.Tag)
 						saveMsg := fmt.Sprintf("|02Area |14%s|02 saved.|07\r\n", edited.Tag)
 						_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(saveMsg)), outputMode)
 						time.Sleep(500 * time.Millisecond)
@@ -812,11 +812,11 @@ func runSponsorEditArea(c *cmdCtx, args string) (*user.User, string, error) {
 			currentUser.CurrentMessageAreaTag = newArea.Tag
 			if userManager != nil {
 				if persistErr := userManager.UpdateUser(currentUser); persistErr != nil {
-					log.Printf("ERROR: Node %d: Failed to persist user after area nav: %v", nodeNumber, persistErr)
+					slog.Error("failed to persist user after area nav", "node", nodeNumber, "error", persistErr)
 				}
 			}
-			log.Printf("INFO: Node %d: User %s editor-navigated to area %d (%s)",
-				nodeNumber, currentUser.Handle, newArea.ID, newArea.Tag)
+			slog.Info("user editor-navigated to area",
+				"node", nodeNumber, "handle", currentUser.Handle, "id", newArea.ID, "tag", newArea.Tag)
 			_ = terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 			showFields()
 
@@ -832,7 +832,7 @@ func runSponsorEditArea(c *cmdCtx, args string) (*user.User, string, error) {
 				hasPrevArea = true
 			}
 			if updateErr := e.MessageMgr.UpdateAreaByID(edited.ID, edited); updateErr != nil {
-				log.Printf("ERROR: Node %d: Failed to update area: %v", nodeNumber, updateErr)
+				slog.Error("failed to update area", "node", nodeNumber, "error", updateErr)
 				msg := "|01Error updating area — changes may be lost.|07\r\n"
 				_ = terminalio.WriteProcessedBytes(terminal,
 					ansi.ReplacePipeCodes([]byte(msg)), outputMode)
@@ -840,7 +840,7 @@ func runSponsorEditArea(c *cmdCtx, args string) (*user.User, string, error) {
 				return currentUser, "", nil
 			}
 			if saveErr := e.MessageMgr.SaveAreas(); saveErr != nil {
-				log.Printf("ERROR: Node %d: Failed to save areas: %v", nodeNumber, saveErr)
+				slog.Error("failed to save areas", "node", nodeNumber, "error", saveErr)
 				msg := "|01Error saving area — changes may be lost.|07\r\n"
 				_ = terminalio.WriteProcessedBytes(terminal,
 					ansi.ReplacePipeCodes([]byte(msg)), outputMode)
@@ -850,7 +850,7 @@ func runSponsorEditArea(c *cmdCtx, args string) (*user.User, string, error) {
 					_ = e.MessageMgr.UpdateAreaByID(edited.ID, prevAreaSnapshot)
 				}
 			} else {
-				log.Printf("INFO: Node %d: User %s saved area %s", nodeNumber, currentUser.Handle, edited.Tag)
+				slog.Info("user saved area", "node", nodeNumber, "handle", currentUser.Handle, "tag", edited.Tag)
 				msg := fmt.Sprintf("|02Area |14%s|02 saved.|07\r\n", edited.Tag)
 				_ = terminalio.WriteProcessedBytes(terminal,
 					ansi.ReplacePipeCodes([]byte(msg)), outputMode)

--- a/internal/menu/syncjs_door.go
+++ b/internal/menu/syncjs_door.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -84,8 +84,8 @@ func executeSyncJSDoor(ctx *DoorCtx) error {
 
 	eng := syncjs.NewEngine(engineCtx, session, cfg)
 
-	log.Printf("INFO: Node %d: Starting Synchronet JS door '%s' (script: %s)",
-		ctx.NodeNumber, ctx.DoorName, ctx.Config.Script)
+	slog.Info("starting Synchronet JS door",
+		"node", ctx.NodeNumber, "door", ctx.DoorName, "script", ctx.Config.Script)
 
 	runErr := eng.Run(cfg.Script)
 
@@ -96,16 +96,16 @@ func executeSyncJSDoor(ctx *DoorCtx) error {
 
 	if runErr != nil {
 		if errors.Is(runErr, syncjs.ErrDisconnect) {
-			log.Printf("INFO: Node %d: User disconnected from JS door '%s'",
-				ctx.NodeNumber, ctx.DoorName)
+			slog.Info("user disconnected from JS door",
+				"node", ctx.NodeNumber, "door", ctx.DoorName)
 			return nil
 		}
-		log.Printf("ERROR: Node %d: JS door '%s' error: %v",
-			ctx.NodeNumber, ctx.DoorName, runErr)
+		slog.Error("JS door error",
+			"node", ctx.NodeNumber, "door", ctx.DoorName, "error", runErr)
 		return runErr
 	}
 
-	log.Printf("INFO: Node %d: Synchronet JS door '%s' completed normally",
-		ctx.NodeNumber, ctx.DoorName)
+	slog.Info("Synchronet JS door completed normally",
+		"node", ctx.NodeNumber, "door", ctx.DoorName)
 	return nil
 }

--- a/internal/menu/system_stats.go
+++ b/internal/menu/system_stats.go
@@ -3,7 +3,7 @@ package menu
 import (
 	"bytes"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -36,11 +36,11 @@ func runSystemStats(c *cmdCtx, args string) (*user.User, string, error) {
 
 	topBytes, err := readTemplateFile(topPath)
 	if err != nil && !os.IsNotExist(err) {
-		log.Printf("WARN: Node %d: Failed to read %s: %v", nodeNumber, topPath, err)
+		slog.Warn("failed to read template", "node", nodeNumber, "path", topPath, "error", err)
 	}
 	botBytes, err := readTemplateFile(botPath)
 	if err != nil && !os.IsNotExist(err) {
-		log.Printf("WARN: Node %d: Failed to read %s: %v", nodeNumber, botPath, err)
+		slog.Warn("failed to read template", "node", nodeNumber, "path", botPath, "error", err)
 	}
 
 	topBytes = stripSauceMetadata(topBytes)

--- a/internal/menu/user_config.go
+++ b/internal/menu/user_config.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -50,7 +50,7 @@ func runCfgToggle(
 
 	if err := userManager.UpdateUser(currentUser); err != nil {
 		setter(currentUser, original)
-		log.Printf("ERROR: Node %d: Failed to save %s: %v", nodeNumber, fieldName, err)
+		slog.Error("failed to save field", "node", nodeNumber, "name", fieldName, "error", err)
 		msg := fmt.Sprintf(e.LoadedStrings.CfgSaveError, fieldName)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
@@ -146,7 +146,7 @@ func runCfgScreenWidth(c *cmdCtx, args string) (*user.User, string, error) {
 
 	currentUser.ScreenWidth = val
 	if err := userManager.UpdateUser(currentUser); err != nil {
-		log.Printf("ERROR: Node %d: Failed to save screen width: %v", nodeNumber, err)
+		slog.Error("failed to save screen width", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
 
@@ -199,7 +199,7 @@ func runCfgScreenHeight(c *cmdCtx, args string) (*user.User, string, error) {
 
 	currentUser.ScreenHeight = val
 	if err := userManager.UpdateUser(currentUser); err != nil {
-		log.Printf("ERROR: Node %d: Failed to save screen height: %v", nodeNumber, err)
+		slog.Error("failed to save screen height", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
 
@@ -233,7 +233,7 @@ func runCfgTermType(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	if err := userManager.UpdateUser(currentUser); err != nil {
-		log.Printf("ERROR: Node %d: Failed to save terminal type: %v", nodeNumber, err)
+		slog.Error("failed to save terminal type", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
 
@@ -282,7 +282,7 @@ func runCfgStringInput(
 
 	setter(currentUser, input)
 	if err := userManager.UpdateUser(currentUser); err != nil {
-		log.Printf("ERROR: Node %d: Failed to save %s: %v", nodeNumber, fieldName, err)
+		slog.Error("failed to save field", "node", nodeNumber, "name", fieldName, "error", err)
 		return currentUser, "", nil
 	}
 
@@ -374,13 +374,13 @@ func runCfgPassword(c *cmdCtx, args string) (*user.User, string, error) {
 	// Hash and save
 	hashed, err := bcrypt.GenerateFromPassword([]byte(newPw), bcrypt.DefaultCost)
 	if err != nil {
-		log.Printf("ERROR: Node %d: Failed to hash new password: %v", nodeNumber, err)
+		slog.Error("failed to hash new password", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
 
 	currentUser.PasswordHash = string(hashed)
 	if err := userManager.UpdateUser(currentUser); err != nil {
-		log.Printf("ERROR: Node %d: Failed to save password: %v", nodeNumber, err)
+		slog.Error("failed to save password", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
 
@@ -449,7 +449,7 @@ func runCfgColor(c *cmdCtx, args string) (*user.User, string, error) {
 
 	currentUser.Colors[slot] = val
 	if err := userManager.UpdateUser(currentUser); err != nil {
-		log.Printf("ERROR: Node %d: Failed to save color: %v", nodeNumber, err)
+		slog.Error("failed to save color", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
 
@@ -478,11 +478,11 @@ func runCfgViewConfig(c *cmdCtx, args string) (*user.User, string, error) {
 
 	topBytes, err := os.ReadFile(topPath)
 	if err != nil && !os.IsNotExist(err) {
-		log.Printf("WARN: Node %d: Failed to read %s: %v", nodeNumber, topPath, err)
+		slog.Warn("failed to read template", "node", nodeNumber, "path", topPath, "error", err)
 	}
 	botBytes, err := os.ReadFile(botPath)
 	if err != nil && !os.IsNotExist(err) {
-		log.Printf("WARN: Node %d: Failed to read %s: %v", nodeNumber, botPath, err)
+		slog.Warn("failed to read template", "node", nodeNumber, "path", botPath, "error", err)
 	}
 
 	topBytes = stripSauceMetadata(topBytes)
@@ -594,7 +594,7 @@ func runCfgFileListMode(c *cmdCtx, args string) (*user.User, string, error) {
 
 	if err := userManager.UpdateUser(currentUser); err != nil {
 		currentUser.FileListingMode = originalMode
-		log.Printf("ERROR: Node %d: Failed to save file listing mode: %v", nodeNumber, err)
+		slog.Error("failed to save file listing mode", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
 
@@ -670,7 +670,7 @@ func runCfgAutoSig(c *cmdCtx, args string) (*user.User, string, error) {
 			terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 
 			if edErr != nil {
-				log.Printf("ERROR: Node %d: Editor failed for auto-sig: %v", nodeNumber, edErr)
+				slog.Error("editor failed for auto-sig", "node", nodeNumber, "error", edErr)
 				return currentUser, "", nil
 			}
 			if !saved {
@@ -694,7 +694,7 @@ func runCfgAutoSig(c *cmdCtx, args string) (*user.User, string, error) {
 
 			currentUser.AutoSignature = body
 			if err := userManager.UpdateUser(currentUser); err != nil {
-				log.Printf("ERROR: Node %d: Failed to save auto-signature: %v", nodeNumber, err)
+				slog.Error("failed to save auto-signature", "node", nodeNumber, "error", err)
 				return currentUser, "", nil
 			}
 			if body == "" {
@@ -710,7 +710,7 @@ func runCfgAutoSig(c *cmdCtx, args string) (*user.User, string, error) {
 			} else {
 				currentUser.AutoSignature = ""
 				if err := userManager.UpdateUser(currentUser); err != nil {
-					log.Printf("ERROR: Node %d: Failed to delete auto-signature: %v", nodeNumber, err)
+					slog.Error("failed to delete auto-signature", "node", nodeNumber, "error", err)
 					return currentUser, "", nil
 				}
 				terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|03Auto-Signature has been deleted.|07\r\n")), outputMode)
@@ -773,7 +773,7 @@ func runCfgFileColumns(c *cmdCtx, args string) (*user.User, string, error) {
 		input = strings.TrimSpace(strings.ToUpper(input))
 		if input == "" || input == "Q" {
 			if err := userManager.UpdateUser(currentUser); err != nil {
-				log.Printf("ERROR: Node %d: Failed to save file column preferences: %v", nodeNumber, err)
+				slog.Error("failed to save file column preferences", "node", nodeNumber, "error", err)
 			}
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.CfgFileColumnsSaved)), outputMode)
 			time.Sleep(500 * time.Millisecond)

--- a/internal/menu/v3net_areas.go
+++ b/internal/menu/v3net_areas.go
@@ -43,7 +43,7 @@ func runV3NetAreas(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	svc := e.V3NetStatus
-	slog.Debug("V3NetAreas", "termWidth", termWidth, "termHeight", termHeight, "outputMode", outputMode)
+	slog.Debug("rendering v3net areas", "termWidth", termWidth, "termHeight", termHeight, "outputMode", outputMode)
 
 	// Determine which networks to show.
 	var networks []string

--- a/internal/menu/v3net_areas.go
+++ b/internal/menu/v3net_areas.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -43,7 +43,7 @@ func runV3NetAreas(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	svc := e.V3NetStatus
-	log.Printf("DEBUG: V3NetAreas: termWidth=%d termHeight=%d outputMode=%d", termWidth, termHeight, outputMode)
+	slog.Debug("V3NetAreas", "termWidth", termWidth, "termHeight", termHeight, "outputMode", outputMode)
 
 	// Determine which networks to show.
 	var networks []string

--- a/internal/menu/v3script_door.go
+++ b/internal/menu/v3script_door.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/scripting"
@@ -76,8 +76,8 @@ func executeV3ScriptDoor(ctx *DoorCtx) error {
 
 	eng := scripting.NewEngine(engineCtx, session, cfg, providers)
 
-	log.Printf("INFO: Node %d: Starting V3 script '%s' (script: %s)",
-		ctx.NodeNumber, ctx.DoorName, ctx.Config.Script)
+	slog.Info("starting V3 script",
+		"node", ctx.NodeNumber, "door", ctx.DoorName, "script", ctx.Config.Script)
 
 	runErr := eng.Run(cfg.Script)
 
@@ -88,16 +88,16 @@ func executeV3ScriptDoor(ctx *DoorCtx) error {
 
 	if runErr != nil {
 		if errors.Is(runErr, scripting.ErrDisconnect) {
-			log.Printf("INFO: Node %d: User disconnected from V3 script '%s'",
-				ctx.NodeNumber, ctx.DoorName)
+			slog.Info("user disconnected from V3 script",
+				"node", ctx.NodeNumber, "door", ctx.DoorName)
 			return nil
 		}
-		log.Printf("ERROR: Node %d: V3 script '%s' error: %v",
-			ctx.NodeNumber, ctx.DoorName, runErr)
+		slog.Error("V3 script error",
+			"node", ctx.NodeNumber, "door", ctx.DoorName, "error", runErr)
 		return runErr
 	}
 
-	log.Printf("INFO: Node %d: V3 script '%s' completed normally",
-		ctx.NodeNumber, ctx.DoorName)
+	slog.Info("V3 script completed normally",
+		"node", ctx.NodeNumber, "door", ctx.DoorName)
 	return nil
 }

--- a/internal/menu/v3script_door_windows.go
+++ b/internal/menu/v3script_door_windows.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/scripting"
@@ -76,8 +76,8 @@ func executeV3ScriptDoor(ctx *DoorCtx) error {
 
 	eng := scripting.NewEngine(engineCtx, session, cfg, providers)
 
-	log.Printf("INFO: Node %d: Starting V3 script '%s' (script: %s)",
-		ctx.NodeNumber, ctx.DoorName, ctx.Config.Script)
+	slog.Info("starting V3 script",
+		"node", ctx.NodeNumber, "door", ctx.DoorName, "script", ctx.Config.Script)
 
 	runErr := eng.Run(cfg.Script)
 
@@ -88,16 +88,16 @@ func executeV3ScriptDoor(ctx *DoorCtx) error {
 
 	if runErr != nil {
 		if errors.Is(runErr, scripting.ErrDisconnect) {
-			log.Printf("INFO: Node %d: User disconnected from V3 script '%s'",
-				ctx.NodeNumber, ctx.DoorName)
+			slog.Info("user disconnected from V3 script",
+				"node", ctx.NodeNumber, "door", ctx.DoorName)
 			return nil
 		}
-		log.Printf("ERROR: Node %d: V3 script '%s' error: %v",
-			ctx.NodeNumber, ctx.DoorName, runErr)
+		slog.Error("V3 script error",
+			"node", ctx.NodeNumber, "door", ctx.DoorName, "error", runErr)
 		return runErr
 	}
 
-	log.Printf("INFO: Node %d: V3 script '%s' completed normally",
-		ctx.NodeNumber, ctx.DoorName)
+	slog.Info("V3 script completed normally",
+		"node", ctx.NodeNumber, "door", ctx.DoorName)
 	return nil
 }

--- a/internal/menu/voting.go
+++ b/internal/menu/voting.go
@@ -3,7 +3,7 @@ package menu
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -202,7 +202,7 @@ func doVoteOnTopic(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 			if freshIdx >= 0 {
 				fresh.Topics[freshIdx].Options = append(fresh.Topics[freshIdx].Options, strings.TrimSpace(choice))
 				if saveErr := saveVotingData(e.RootConfigPath, fresh); saveErr != nil {
-					log.Printf("ERROR: Failed to save voting data after adding choice: %v", saveErr)
+					slog.Error("failed to save voting data after adding choice", "error", saveErr)
 					votingMu.Unlock()
 					wv(terminal, "|04Error saving choice.\r\n", outputMode)
 					return false
@@ -223,7 +223,7 @@ func doVoteOnTopic(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 
 	updated, saveErr := voteRecordVote(e.RootConfigPath, topicIdx, n-1, currentUser.Handle)
 	if saveErr != nil {
-		log.Printf("ERROR: Node vote save failed: %v", saveErr)
+		slog.Error("vote save failed", "error", saveErr)
 		wv(terminal, "\r\n|04Error saving vote.\r\n", outputMode)
 		return false
 	}
@@ -281,7 +281,7 @@ func runVote(c *cmdCtx, args string) (*user.User, string, error) {
 		return nil, "", nil
 	}
 
-	log.Printf("DEBUG: Node %d: Running VOTE for user %s", nodeNumber, currentUser.Handle)
+	slog.Debug("running VOTE", "node", nodeNumber, "handle", currentUser.Handle)
 	isSysOp := e.isCoSysOpOrAbove(currentUser)
 
 	votingMu.Lock()
@@ -372,7 +372,7 @@ func runVote(c *cmdCtx, args string) (*user.User, string, error) {
 					if freshIdx >= 0 {
 						fresh.Topics = append(fresh.Topics[:freshIdx], fresh.Topics[freshIdx+1:]...)
 						if saveErr := saveVotingData(e.RootConfigPath, fresh); saveErr != nil {
-							log.Printf("ERROR: Failed to save voting data after topic deletion: %v", saveErr)
+							slog.Error("failed to save voting data after topic deletion", "error", saveErr)
 						} else {
 							vd = fresh
 							curIdx = freshIdx
@@ -449,7 +449,7 @@ func voteAddTopic(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 		t.ID = len(fresh.Topics) + 1
 		fresh.Topics = append(fresh.Topics, t)
 		if saveErr := saveVotingData(e.RootConfigPath, fresh); saveErr != nil {
-			log.Printf("ERROR: Failed to save voting data after topic creation: %v", saveErr)
+			slog.Error("failed to save voting data after topic creation", "error", saveErr)
 		} else {
 			vd = fresh
 		}


### PR DESCRIPTION
Phase B slog migration — mechanical conversion of ~1000 log.Printf calls to structured slog across all ~48 files in internal/menu.

- All log.Printf/Println calls converted to leveled slog calls
- Level prefixes stripped from messages (INFO:/WARN:/ERROR:/DEBUG:/TRACE:)
- Messages lowercased, no subsystem prefix
- Structured attributes: node, handle, id, area, tag, error, count, file, path, door, etc.
- SECURITY: calls in executor_login.go converted to logging.Security() with node/ip/locked_until/attempts attrs
- logging import added only to executor_login.go (only file with SECURITY: calls)

Part of the logging overhaul described in docs-internal/plans/2026-06-28-logging-overhaul-design.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Switched runtime logging across menu, message, file, door, chat, login, voting, and utility flows to structured logging.
  * Log output now includes consistent fields like node, handle, area, file, and error details.

* **New Features**
  * Added hot-reload style accessors and setters for several runtime configuration values in the main menu executor.

* **Bug Fixes**
  * Improved diagnostics for error paths, fallback handling, and save failures while keeping user-facing behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->