### PR TITLE
feat(docs): add skip button and fix keyboard nav on splash page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 
 ## Overview
 
-This project is a work-in-progress refactor and modernization of the classic ViSiON/2 BBS software, written in Go. The goal is to recreate the core functionality of the classic BBS experience using modern technologies.
+This project is a work-in-progress refactor and modernization of the classic ViSiON/2 BBS software. The goal is to recreate the core functionality of the classic BBS experience using modern technologies. 
 
-**Note:** This is currently under active development and is not yet feature-complete.
+There's detailed SysOp documentation [here](https://vision3bbs.com/sysop/#/).
+
+**Note:** This is currently under active development and is not quite feature-complete.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-This project is a work-in-progress refactor and modernization of the classic ViSiON/2 BBS software. The goal is to recreate the core functionality of the classic BBS experience using modern technologies. 
+This project is a work-in-progress refactor and modernization of the classic ViSiON/2 BBS software. The goal is to recreate the core functionality of the classic BBS experience using modern technologies.
 
 There's detailed SysOp documentation [here](https://vision3bbs.com/sysop/#/).
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,6 +16,7 @@
     <div id="telix-splash" class="telix-splash" role="button" tabindex="0">
         <div class="telix-screen">
             <div class="telix-terminal" id="telix-terminal"><span class="telix-prompt">Click to connect...</span><span class="telix-cursor">&#9608;</span></div>
+            <button class="telix-skip" id="telix-skip" aria-label="Skip modem sequence">[ESC] Skip</button>
             <div class="telix-status-bar"></div>
         </div>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,7 @@
 </head>
 <body>
     <!-- Telix dialer splash — first visit only -->
-    <div id="telix-splash" class="telix-splash" role="button" tabindex="0">
+    <div id="telix-splash" class="telix-splash">
         <div class="telix-screen">
             <div class="telix-terminal" id="telix-terminal"><span class="telix-prompt">Click to connect...</span><span class="telix-cursor">&#9608;</span></div>
             <button class="telix-skip" id="telix-skip" aria-label="Skip modem sequence">[ESC] Skip</button>

--- a/docs/main.js
+++ b/docs/main.js
@@ -151,10 +151,29 @@ function buildStatusBar(isOnline) {
         '<span>' + rightContent + '</span>';
 }
 
+// Active audio handles — tracked so skip can stop them
+var activeAudioContext = null;
+var activeModemAudio = null;
+
+function skipSplash(splash) {
+    if (activeModemAudio) {
+        activeModemAudio.pause();
+        activeModemAudio.currentTime = 0;
+    }
+    if (activeAudioContext) {
+        activeAudioContext.close();
+        activeAudioContext = null;
+    }
+    splash.remove();
+    document.body.classList.remove('splash-active');
+    setVisitedCookie();
+}
+
 // Main dialer sequence - chained callbacks for synchronous execution
 function runDialerSequence(splash) {
     var terminal = document.getElementById('telix-terminal');
     var audioContext = new (window.AudioContext || window.webkitAudioContext)();
+    activeAudioContext = audioContext;
     var phoneDigits = '13145673833';
 
     // Resume AudioContext if suspended (iOS Safari)
@@ -167,6 +186,7 @@ function runDialerSequence(splash) {
     if (prompt) prompt.remove();
 
     var modemAudio = audioPool.modem;
+    activeModemAudio = modemAudio;
 
     // Phase 1: Type AT&F, wait for OK
     typeText(terminal, 'AT&F\n', function () {
@@ -317,13 +337,28 @@ function runDialerSequence(splash) {
 
     splash.addEventListener('click', clickHandler);
     splash.addEventListener('keydown', keyHandler);
+
+    var skipBtn = document.getElementById('telix-skip');
+    if (skipBtn) {
+        skipBtn.addEventListener('click', function (e) {
+            e.stopPropagation(); // don't trigger splash clickHandler
+            skipSplash(splash);
+        });
+    }
+
+    document.addEventListener('keydown', function escHandler(e) {
+        if (e.key === 'Escape') {
+            document.removeEventListener('keydown', escHandler);
+            skipSplash(splash);
+        }
+    });
 })();
 
 /* ---- BBS Menu Keyboard Navigation ---- */
 (function () {
     'use strict';
 
-    var keymap = {
+    var anchorMap = {
         'f': '#features',
         'F': '#features',
         'g': '#get-started',
@@ -332,6 +367,11 @@ function runDialerSequence(splash) {
         'J': '#get-involved',
         'h': '#history',
         'H': '#history'
+    };
+
+    var hrefMap = {
+        'd': '/sysop/',
+        'D': '/sysop/'
     };
 
     document.addEventListener('keydown', function (e) {
@@ -345,7 +385,13 @@ function runDialerSequence(splash) {
             return;
         }
 
-        var section = keymap[e.key];
+        if (hrefMap[e.key]) {
+            e.preventDefault();
+            window.location.href = hrefMap[e.key];
+            return;
+        }
+
+        var section = anchorMap[e.key];
         if (section) {
             e.preventDefault();
             var element = document.querySelector(section);

--- a/docs/main.js
+++ b/docs/main.js
@@ -122,7 +122,7 @@ function typeText(terminal, text, callback) {
         if (index < text.length) {
             cursor.insertAdjacentText('beforebegin', text[index]);
             index++;
-            setTimeout(typeChar, 30 + Math.random() * 20);
+            trackTimeout(typeChar, 30 + Math.random() * 20);
         } else if (callback) {
             callback();
         }
@@ -155,10 +155,44 @@ function buildStatusBar(isOnline) {
 var activeAudioContext = null;
 var activeModemAudio = null;
 
-function skipSplash(splash) {
+// Pending sequence timers — tracked so skip can cancel them all
+var splashTimers = [];
+
+// Document-level ESC handler — tracked so teardown can always detach it
+var splashEscHandler = null;
+
+function trackTimeout(fn, delay) {
+    var id = setTimeout(fn, delay);
+    splashTimers.push(id);
+    return id;
+}
+
+function trackInterval(fn, delay) {
+    var id = setInterval(fn, delay);
+    splashTimers.push(id);
+    return id;
+}
+
+function clearSplashTimers() {
+    splashTimers.forEach(function (id) {
+        clearTimeout(id);
+        clearInterval(id);
+    });
+    splashTimers = [];
+}
+
+// Tear down the splash: cancel pending timers, stop audio, remove overlay.
+// Safe to call once; subsequent calls are no-ops because the splash is gone.
+function teardownSplash(splash) {
+    clearSplashTimers();
+    if (splashEscHandler) {
+        document.removeEventListener('keydown', splashEscHandler);
+        splashEscHandler = null;
+    }
     if (activeModemAudio) {
         activeModemAudio.pause();
         activeModemAudio.currentTime = 0;
+        activeModemAudio = null;
     }
     if (activeAudioContext) {
         activeAudioContext.close();
@@ -167,6 +201,10 @@ function skipSplash(splash) {
     splash.remove();
     document.body.classList.remove('splash-active');
     setVisitedCookie();
+}
+
+function skipSplash(splash) {
+    teardownSplash(splash);
 }
 
 // Main dialer sequence - chained callbacks for synchronous execution
@@ -193,17 +231,17 @@ function runDialerSequence(splash) {
         printLine(terminal, 'OK');
 
         // Phase 2: Wait, then type init string
-        setTimeout(function () {
+        trackTimeout(function () {
             typeText(terminal, 'AT&C1&D2&K3&M4&N6\n', function () {
                 printLine(terminal, 'OK');
 
                 // Phase 3: Wait, then type ATDT
-                setTimeout(function () {
+                trackTimeout(function () {
                     var atdtChars = 'ATDT';
                     var atdtIndex = 0;
                     var cursor = terminal.querySelector('.telix-cursor');
 
-                    var atdtInterval = setInterval(function () {
+                    var atdtInterval = trackInterval(function () {
                         if (atdtIndex < atdtChars.length) {
                             cursor.insertAdjacentText('beforebegin', atdtChars[atdtIndex]);
                             atdtIndex++;
@@ -214,13 +252,13 @@ function runDialerSequence(splash) {
                             playPhonePickup();
 
                             // Wait 0.5s, then start dial tone
-                            setTimeout(function () {
+                            trackTimeout(function () {
                                 playDialTone(audioContext, audioContext.currentTime, 1.5);
 
                                 // Phase 4: Type phone number with DTMF
-                                setTimeout(function () {
+                                trackTimeout(function () {
                                     var digitIndex = 0;
-                                    var digitInterval = setInterval(function () {
+                                    var digitInterval = trackInterval(function () {
                                         if (digitIndex < phoneDigits.length) {
                                             var digit = phoneDigits[digitIndex];
                                             cursor.insertAdjacentText('beforebegin', digit);
@@ -236,23 +274,23 @@ function runDialerSequence(splash) {
                                             cursor.insertAdjacentText('beforebegin', '\n');
 
                                             // Phase 5: First ring
-                                            setTimeout(function () {
+                                            trackTimeout(function () {
                                                 playRingTone(audioContext, audioContext.currentTime);
 
                                                 // Phase 6: Wait 4.5s, then second ring
-                                                setTimeout(function () {
+                                                trackTimeout(function () {
                                                     playRingTone(audioContext, audioContext.currentTime);
 
                                                     // Show RING text shortly after second ring starts
-                                                    setTimeout(function () {
+                                                    trackTimeout(function () {
                                                         printLine(terminal, 'RING');
 
                                                     // Phase 7: Wait 1.5s, phone pickup click
-                                                    setTimeout(function () {
+                                                    trackTimeout(function () {
                                                         playPhonePickup();
 
                                                         // Phase 8: Wait 0.5s, then modem screech (plays once, ~5s)
-                                                        setTimeout(function () {
+                                                        trackTimeout(function () {
                                                             // Play screech file once
                                                             if (modemAudio) {
                                                                 modemAudio.currentTime = 0;
@@ -262,18 +300,15 @@ function runDialerSequence(splash) {
                                                             }
 
                                                             // Phase 9: CONNECT after screech finishes (~18.5s)
-                                                            setTimeout(function () {
+                                                            trackTimeout(function () {
                                                                 printLine(terminal, 'CONNECT 14400/ARQ/V32bis/LAPM');
 
                                                                 // Update status bar to ONLINE
                                                                 buildStatusBar(true);
 
                                                                 // Phase 10: Remove overlay after brief pause
-                                                                setTimeout(function () {
-                                                                    audioContext.close();
-                                                                    splash.remove();
-                                                                    document.body.classList.remove('splash-active');
-                                                                    setVisitedCookie();
+                                                                trackTimeout(function () {
+                                                                    teardownSplash(splash);
                                                                 }, 2000);
                                                             }, 18500);
                                                         }, 500);
@@ -344,14 +379,24 @@ function runDialerSequence(splash) {
             e.stopPropagation(); // don't trigger splash clickHandler
             skipSplash(splash);
         });
+        // Keep Enter/Space on the button from bubbling to the splash's
+        // keyHandler and starting the modem sequence — the native button
+        // click already fires skipSplash.
+        skipBtn.addEventListener('keydown', function (e) {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.stopPropagation();
+            }
+        });
     }
 
-    document.addEventListener('keydown', function escHandler(e) {
+    // Tracked so teardownSplash detaches it on skip OR normal completion,
+    // not just when ESC is pressed.
+    splashEscHandler = function (e) {
         if (e.key === 'Escape') {
-            document.removeEventListener('keydown', escHandler);
             skipSplash(splash);
         }
-    });
+    };
+    document.addEventListener('keydown', splashEscHandler);
 })();
 
 /* ---- BBS Menu Keyboard Navigation ---- */
@@ -375,8 +420,9 @@ function runDialerSequence(splash) {
     };
 
     document.addEventListener('keydown', function (e) {
-        // Don't hijack if modifier keys are pressed or user is typing
-        if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) {
+        // Don't hijack if command/control modifiers are pressed or user is
+        // typing. Shift is allowed so Shift+F (and Caps Lock) still navigate.
+        if (e.ctrlKey || e.metaKey || e.altKey) {
             return;
         }
 

--- a/docs/main.js
+++ b/docs/main.js
@@ -353,7 +353,6 @@ function runDialerSequence(splash) {
 
     function startSequence() {
         splash.removeEventListener('click', clickHandler);
-        splash.removeEventListener('keydown', keyHandler);
         splash.style.cursor = 'default';
         unlockAudioPool();
         runDialerSequence(splash);
@@ -363,15 +362,7 @@ function runDialerSequence(splash) {
         startSequence();
     }
 
-    function keyHandler(e) {
-        if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            startSequence();
-        }
-    }
-
     splash.addEventListener('click', clickHandler);
-    splash.addEventListener('keydown', keyHandler);
 
     var skipBtn = document.getElementById('telix-skip');
     if (skipBtn) {

--- a/docs/style.css
+++ b/docs/style.css
@@ -653,6 +653,27 @@ section:nth-of-type(even) {
     justify-content: space-between;
 }
 
+.telix-skip {
+    position: absolute;
+    bottom: 2.5rem; /* sits above the status bar */
+    right: 1rem;
+    font-family: var(--font-dos);
+    font-size: 0.85rem;
+    color: #888888;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0.25rem 0.5rem;
+    z-index: 1;
+    transition: color 0.15s;
+}
+
+.telix-skip:hover,
+.telix-skip:focus-visible {
+    color: #ffff55;
+    outline: none;
+}
+
 .telix-splash.hidden {
     display: none;
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -668,10 +668,14 @@ section:nth-of-type(even) {
     transition: color 0.15s;
 }
 
-.telix-skip:hover,
+.telix-skip:hover {
+    color: #ffff55;
+}
+
 .telix-skip:focus-visible {
     color: #ffff55;
-    outline: none;
+    outline: 1px solid #ffff55;
+    outline-offset: 2px;
 }
 
 .telix-splash.hidden {

--- a/docs/sysop/advanced/string-editor.md
+++ b/docs/sysop/advanced/string-editor.md
@@ -162,7 +162,12 @@ The editor contains approximately 250 string entries organized by function:
 | 121–140 | File operations (ratios, listings, newscan) |
 | 141–160 | QWK mail, chat, announcements |
 | 161–178 | Advanced file/message operations |
-| 179+ | ViSiON/3 additions (SSH, ANSI, conference, etc.) |
+| 179–200 | ViSiON/3: SSH/ANSI, Door, Matrix/Login |
+| 201–220 | ViSiON/3: Conference, Executor |
+| 221–240 | ViSiON/3: Terminal/Session, File Search, File Info |
+| 241–250+ | ViSiON/3: File Newscan, Sysop File Review, Column Config, Want List |
+
+Reserved entries (keys prefixed with `_`) appear in the list as non-editable rows and are skipped when saving.
 
 ## Building
 

--- a/docs/sysop/configuration/configuration.md
+++ b/docs/sysop/configuration/configuration.md
@@ -18,38 +18,75 @@ ViSiON/3 includes an interactive TUI configuration editor modeled after ViSiON/2
 
 ### Main Menu
 
-The editor opens to a main menu with sections for each configuration area:
+The editor opens to a main menu. Keys **1**, **2**, **3**, and **4** open sub-menus; the rest go directly to record lists.
 
-| Key | Section | Description |
-|-----|---------|-------------|
-| 1 | System Configuration | BBS name, network, connection limits, access levels, defaults, IP lists |
-| 2 | Message Areas | Message area records with conference grouping |
-| 3 | File Areas | File area records |
-| 4 | Conferences | Conference definitions and ordering |
-| 5 | Door Programs | External door configurations |
-| 6 | Event Scheduler | Automated event definitions |
-| 7 | Echomail Networks | FTN network settings (own address, paths, tosser) |
-| 8 | Echomail Links | FTN hub links (address, packet_password, areafix_password) |
-| 9 | Transfer Protocols | File transfer protocol definitions |
-| A | Archivers | Archive format tool definitions |
-| B | Login Sequence | Login step sequence |
-| Q | Quit Program | Exit the configuration editor |
+| Key | Section | What it covers |
+|-----|---------|----------------|
+| 1 | System Configuration | Opens 9 sub-screens: BBS identity, server setup, connection limits, access levels, default settings, IP lists, NUV, DOS emulation, logging |
+| 2 | Areas and Conferences | Sub-menu: Message Areas, File Areas, Conferences |
+| 3 | Echomail Networking | Sub-menu: Echomail Networks, Echomail Links, FTN Setup Wizard |
+| 4 | ViSiON/3 Networking (V3Net) | Sub-menu: Node Identity, Subscriptions, Hosted Networks |
+| 5 | Door Programs | External door program record list |
+| 6 | Transfer Protocols | File transfer protocol record list |
+| 7 | Archivers | Archive format record list |
+| 8 | Event Scheduler | Automated event record list |
+| 9 | Login Sequence | Login step record list |
+| Q | Quit | Exit (prompts to save if there are unsaved changes) |
+
+### System Configuration Sub-screens
+
+Choosing **System Configuration** (key 1) opens an inner menu with nine numbered sub-screens, all writing to `configs/config.json`. Use Up/Down and Enter (or the sub-screen number) to navigate; Esc returns to the main menu.
+
+| Sub-screen | Name | Fields |
+|------------|------|--------|
+| 0 | BBS Registration | Board Name, SysOp Name, BBS Location, Timezone |
+| 1 | Server Setup | SSH enabled/host/port/legacy-algorithms, Telnet enabled/host/port, V3Net enabled + hub settings |
+| 2 | Connection Limits | Max Nodes, Max Per IP, Failed Logins (0=off), Lockout Minutes, Idle Timeout, Transfer Timeout |
+| 3 | Access Levels | SysOp Level, CoSysOp Level, Invisible Level, New User Level, Regular Level, Logon Level, Anonymous Level |
+| 4 | Default Settings | Allow New Users (Y/N), File List Mode (lightbar/classic), Deleted User Retention Days |
+| 5 | IP Blocklist/Allowlist | Blocklist Path, Allowlist Path |
+| 6 | New User Voting (NUV) | Use NUV, Auto Add NUV, NUV Use Level, Yes/No vote thresholds, Validate/Kill on threshold, NUV Level, NUV Form |
+| 7 | DOS Emulation | DOSemu Path |
+| 8 | Logging | Log Directory, Min Level, Rolling Type, Cache Writes, Max Files, Max Size KB |
+
+**Server Setup (sub-screen 1)** also writes to `configs/v3net.json` for the V3Net fields (keystore path, dedup DB path, registry URL, hub enabled/host/port/data dir/auto-approve).
+
+### Areas and Conferences Sub-menu
+
+| Item | What it edits | File written |
+|------|---------------|--------------|
+| Message Areas | Area tag, name, type (local/echomail/v3net/netmail), ACS, paths, conference, networking fields | `configs/message_areas.json` |
+| File Areas | Area tag, name, description, path, ACS, conference | `configs/file_areas.json` |
+| Conferences | Tag, name, description, ACS, display order | `configs/conferences.json` |
+
+### Echomail Networking Sub-menu
+
+| Item | What it edits |
+|------|---------------|
+| Echomail Networks | Global FTN paths (inbound, outbound, temp, bad/dupe tags) and per-network settings (own address, poll interval, tearline) |
+| Echomail Links | Per-hub link settings (address, packet/session/AreaFix passwords, flavour) |
+| FTN Setup Wizard | Guided flow: downloads a network's echolist, lets you browse and subscribe to areas, then writes `ftn.json`, `message_areas.json`, and `conferences.json` automatically |
+
+### ViSiON/3 Networking (V3Net) Sub-menu
+
+| Item | What it edits |
+|------|---------------|
+| Node Identity | View public key / mnemonic phrase, generate a new keypair, or recover from a seed phrase |
+| Subscriptions | Add/edit hub subscriptions (hub URL, network name, poll interval, origin); includes a V3Net Area Browser and a Registry Browser for discovering networks |
+| Hosted Networks | Manage networks your hub hosts, including their areas (add/edit/delete/rename with optional JAM base operations) |
 
 ### Navigation
 
 | Key | Action |
 |-----|--------|
-| Up/Down | Move highlight |
-| Enter | Select / edit field |
-| I | Insert new record |
-| D | Delete record |
-| P | Reorder record position (supported record types) |
-| PgUp/PgDn | Navigate between records in the field editor |
-| ESC | Return to previous screen |
-
-### Reordering Records
-
-Press **P** in a record list to enter reorder mode. Use Up/Down to choose the new position and Enter to confirm. For message areas, reordering is constrained to within the same conference.
+| Up / Down | Move highlight |
+| Enter | Select / activate field |
+| I | Insert new record (record list screens) |
+| D | Delete record (record list screens) |
+| P | Reorder mode — Up/Down picks new position, Enter confirms |
+| PgUp / PgDn | Previous/Next record from within an edit screen |
+| Home / End | Jump to first/last item |
+| Esc | Return to previous screen (or exit-confirm at top menu) |
 
 ### Saving
 
@@ -224,7 +261,7 @@ Configures external door programs that can be launched from the BBS. The file co
 
 ## archivers.json
 
-> *Use the [Configuration Editor](#configuration-editor-tui) (section A — Archivers) to manage archiver settings interactively. The JSON structure below is for reference or manual editing.*
+> *Use the [Configuration Editor](#configuration-editor-tui) (key 7 — Archivers) to manage archiver settings interactively. The JSON structure below is for reference.*
 
 Defines archive formats and the external tools used to pack, unpack, test, and list them. This centralized configuration ensures all subsystems (ZipLab upload pipeline, file area management, archive viewing) use the same archiver definitions, and that different platforms can specify their preferred tool versions.
 
@@ -291,7 +328,7 @@ FTN echomail bundles always use ZIP format (per FidoNet standard practice) and a
 
 ## file_areas.json
 
-> *Use the [Configuration Editor](#configuration-editor-tui) (section 3 — File Areas) to manage file area settings interactively. The JSON structure below is for reference or manual editing.*
+> *Use the [Configuration Editor](#configuration-editor-tui) (key 2 → File Areas) to manage file area settings interactively. The JSON structure below is for reference.*
 
 Defines file areas available on the BBS. The file contains an array of file area configurations.
 
@@ -335,112 +372,103 @@ Defines file areas available on the BBS. The file contains an array of file area
 
 ## config.json
 
-General BBS configuration settings.
+General BBS configuration. All settings in this file are managed through the **System Configuration** section of `./config` — you should not need to hand-edit it.
 
-### Current Structure
+### TUI Paths
 
-```json
-{
-  "boardName": "PiRATE MiND STATiON",
-  "boardPhoneNumber": "314-567-3833",
-  "timezone": "America/Los_Angeles",
-  "sysOpLevel": 255,
-  "coSysOpLevel": 250,
-  "logonLevel": 100,
-  "sshPort": 2222,
-  "sshHost": "0.0.0.0",
-  "sshEnabled": true,
-  "telnetPort": 2323,
-  "telnetHost": "0.0.0.0",
-  "telnetEnabled": true,
-  "maxNodes": 10,
-  "maxConnectionsPerIP": 3,
-  "ipBlocklistPath": "",
-  "ipAllowlistPath": "",
-  "maxFailedLogins": 5,
-  "lockoutMinutes": 30,
-  "dosemuPath": "",
-  "logging": {
-    "dir": "data/logs",
-    "level": "INFO",
-    "cache": true,
-    "type": 0,
-    "maxFiles": 5,
-    "maxSizeKB": 1024
-  }
-}
-```
+| Setting group | TUI path |
+|---------------|----------|
+| Board name, sysop name, location, timezone | System Configuration → BBS Registration (sub-screen 0) |
+| SSH / Telnet ports and enabled flags | System Configuration → Server Setup (sub-screen 1) |
+| Max nodes, per-IP limits, timeouts | System Configuration → Connection Limits (sub-screen 2) |
+| Access levels (sysop, new user, logon, etc.) | System Configuration → Access Levels (sub-screen 3) |
+| New user registration, file list mode, retention | System Configuration → Default Settings (sub-screen 4) |
+| Blocklist / allowlist file paths | System Configuration → IP Blocklist/Allowlist (sub-screen 5) |
+| NUV voting thresholds and behavior | System Configuration → New User Voting (sub-screen 6) |
+| DOSemu binary path | System Configuration → DOS Emulation (sub-screen 7) |
+| Log directory, level, rotation | System Configuration → Logging (sub-screen 8) |
 
-### General Configuration Field Descriptions
+### Field Reference
 
-**BBS Settings:**
+**BBS Registration:**
 
-- `boardName` - BBS name displayed to users
-- `boardPhoneNumber` - Phone number (historical/display purposes)
-- `timezone` - IANA timezone for display formatting (example: `America/Los_Angeles`)
-- `sysOpLevel` - Security level for SysOp access
-- `coSysOpLevel` - Security level for Co-SysOp access
-- `logonLevel` - Security level granted after successful login
+- `boardName` — BBS name displayed to users (default: `"ViSiON/3 BBS"`)
+- `sysOpName` — Sysop's handle
+- `bbsLocation` — Location string (city/region)
+- `timezone` — IANA timezone for display formatting (e.g., `America/Los_Angeles`). If unset, falls back to `VISION3_TIMEZONE` env var, then `TZ`, then server local time.
 
-**SSH Server:**
+**Server Setup:**
 
-- `sshPort` - Port for SSH connections (default: 2222)
-- `sshHost` - Bind address for SSH listener (default: `0.0.0.0`)
-- `sshEnabled` - Enable or disable the SSH server
+- `sshEnabled` — Enable/disable the SSH server (default: `true`)
+- `sshHost` — Bind address (default: `"0.0.0.0"`)
+- `sshPort` — TCP port (default: `2222`)
+- `legacySSHAlgorithms` — Older SSH algorithms for retro clients like SyncTERM (default: `true`)
+- `telnetEnabled` — Enable/disable the Telnet server (default: `false`)
+- `telnetHost` — Bind address (default: `"0.0.0.0"`)
+- `telnetPort` — TCP port (default: `2323`)
 
-**Telnet Server:**
+**Connection Limits:**
 
-- `telnetPort` - Port for telnet connections (default: 2323)
-- `telnetHost` - Bind address for telnet listener (default: `0.0.0.0`)
-- `telnetEnabled` - Enable or disable the telnet server
+- `maxNodes` — Maximum simultaneous connections (default: `10`)
+- `maxConnectionsPerIP` — Max concurrent connections from one IP (default: `3`)
+- `maxFailedLogins` — Failed BBS logins from an IP before lockout (default: `5`, `0` = disabled)
+- `lockoutMinutes` — Lockout duration in minutes (default: `30`)
+- `sessionIdleTimeoutMinutes` — Idle session cutoff (default: `5`)
+- `transferTimeoutMinutes` — File transfer timeout (default: `10`)
 
-**Connection Security:**
+**Access Levels:**
 
-- `maxNodes` - Maximum simultaneous connections allowed (default: 10, 0 = unlimited)
-- `maxConnectionsPerIP` - Maximum simultaneous connections per IP address (default: 3, 0 = unlimited)
-- `ipBlocklistPath` - Path to IP blocklist file (optional, leave empty to disable)
-- `ipAllowlistPath` - Path to IP allowlist file (optional, leave empty to disable)
+- `sysOpLevel` — Security level for SysOp access (default: `255`)
+- `coSysOpLevel` — Security level for Co-SysOp access (default: `250`)
+- `invisibleLevel` — Level at which a user is invisible in the who's-online list (default: `0`, falls back to `coSysOpLevel`)
+- `newUserLevel` — Level assigned to a brand-new account (default: `1`)
+- `regularUserLevel` — Level for validated/regular users (default: `10`)
+- `logonLevel` — Level granted on successful login (default: `10`)
+- `anonymousLevel` — Level for guest/anonymous access (default: `5`, `0` = disabled)
 
-**Authentication Security:**
+**Default Settings:**
 
-- `maxFailedLogins` - Maximum failed login attempts from a single IP before lockout (default: 5, 0 = disabled)
-- `lockoutMinutes` - Duration of IP lockout in minutes (default: 30)
+- `allowNewUsers` — Accept new user registrations (default: `true`)
+- `fileListingMode` — `""` or `"lightbar"` (default) / `"classic"`
+- `deletedUserRetentionDays` — Days to keep soft-deleted user records before `helper users purge` removes them (default: `30`, `-1` = keep forever)
+
+**IP Blocklist/Allowlist:**
+
+- `ipBlocklistPath` — Path to blocklist file (empty = disabled)
+- `ipAllowlistPath` — Path to allowlist file (empty = disabled)
+
+Both files are plain text: one IP or CIDR range per line, `#` for comments. They are watched for changes and reloaded automatically — no restart required. See [Security Guide](configuration/security.md) for format details.
 
 **New User Voting (NUV):**
 
-- `useNuv` - Enable the NUV system (default: `false`). All NUV commands are silent no-ops when disabled
-- `autoAddNuv` - Automatically add new registrations to the NUV queue (default: `false`)
-- `nuvUseLevel` - Minimum access level required to cast NUV votes (default: `25`)
-- `nuvYesVotes` - YES vote count that triggers the yes threshold (default: `5`)
-- `nuvNoVotes` - NO vote count that triggers the no threshold (default: `5`)
-- `nuvValidate` - If `true`, auto-validate the user when yes threshold is reached; if `false`, log a notice (default: `true`)
-- `nuvKill` - If `true`, auto-soft-delete the user when no threshold is reached; if `false`, log a notice (default: `false`)
-- `nuvLevel` - Access level assigned to auto-validated NUV users (default: `25`)
+- `useNuv` — Enable the NUV system (default: `false`)
+- `autoAddNuv` — Automatically queue new registrations for voting (default: `false`)
+- `nuvUseLevel` — Minimum level to cast votes (default: `25`)
+- `nuvYesVotes` — YES votes needed to trigger the yes threshold (default: `5`)
+- `nuvNoVotes` — NO votes needed to trigger the no threshold (default: `5`)
+- `nuvValidate` — Auto-validate when yes threshold is reached (default: `true`)
+- `nuvKill` — Auto-soft-delete when no threshold is reached (default: `false`)
+- `nuvLevel` — Level assigned to auto-validated users (default: `25`)
+- `nuvForm` — Infoform number shown during NUV registration (default: `1`)
 
 See [New User Voting](users/nuv.md) for full details.
 
 **DOS Emulation:**
 
-- `dosemuPath` - Path to the dosemu2 binary (default: `/usr/libexec/dosemu2/dosemu2.bin`). ViSiON/3 calls the binary directly, bypassing the bash wrapper which mangles backslash arguments. Leave blank to use the default path.
+- `dosemuPath` — Path to the dosemu2 binary. ViSiON/3 calls it directly (bypassing the bash wrapper which mangles backslash arguments). Leave blank to use the default path.
 
 See [Door Programs](doors/doors.md#running-dos-doors) for full DOS door setup documentation.
 
 **Logging:**
 
-- `logging.dir` - Directory for log files (default: `data/logs`)
-- `logging.level` - Minimum log level written: `DEBUG`, `INFO`, `WARN`, or `ERROR` (default: `INFO`)
-- `logging.cache` - Buffer writes in an 8 KB in-memory cache; flushed on errors and shutdown (default: `true`)
-- `logging.type` - Log rotation mode: `0` = none, `1` = size-based, `2` = daily (default: `0`)
-- `logging.maxFiles` - For size mode: number of numbered backups to keep. For daily mode: days of dated files to retain (default: `5`)
-- `logging.maxSizeKB` - Rotation threshold in KB; only used when `type` is `1` (default: `1024`)
+- `logging.dir` — Directory for log files (default: `data/logs`)
+- `logging.level` — Minimum log level: `DEBUG`, `INFO`, `WARN`, or `ERROR` (default: `INFO`)
+- `logging.cache` — Buffer writes in an 8 KB cache; flushed on errors and clean exit (default: `true`)
+- `logging.type` — Rotation mode: `0` = none, `1` = size-based, `2` = daily (default: `0`)
+- `logging.maxFiles` — Numbered backups to keep (size mode) or days of files to retain (daily mode) (default: `5`)
+- `logging.maxSizeKB` — Rotation threshold in KB; size mode only (default: `1024`)
 
 See [Logging](#logging) for full details and examples.
-
-**Timezone behavior:**
-
-- Last Callers time fields use `config.json` `timezone` first.
-- If unset, the app checks environment variables `VISION3_TIMEZONE`, then `TZ`.
-- If none are set or invalid, server local timezone is used.
 
 ### IP Blocklist/Allowlist Files
 
@@ -580,7 +608,7 @@ Additional structured attributes (node, user, error, etc.) vary by event.
 
 ## message_areas.json
 
-> *Use the [Configuration Editor](#configuration-editor-tui) (section 2 — Message Areas) to manage message area settings interactively. The JSON structure below is for reference or manual editing.*
+> *Use the [Configuration Editor](#configuration-editor-tui) (key 2 → Message Areas) to manage message area settings interactively. The JSON structure below is for reference.*
 
 Located in the `configs/` directory. Defines message areas available on the BBS.
 
@@ -588,7 +616,7 @@ See [Message Areas Guide](messages/message-areas.md) for detailed configuration.
 
 ## ftn.json
 
-> *Use the [Configuration Editor](#configuration-editor-tui) (section 7 — Echomail Networks, section 8 — Echomail Links) to manage FTN settings interactively. The JSON structure below is for reference or manual editing.*
+> *Use the [Configuration Editor](#configuration-editor-tui) (key 3 → Echomail Networks / Echomail Links) to manage FTN settings interactively. The JSON structure below is for reference.*
 
 Located in the `configs/` directory. Configures the internal FTN tosser (v3mail) for echomail. Global fields include directory paths (`inbound_path`, `outbound_path`, `binkd_outbound_path`, `temp_path`) and routing tags (`bad_area_tag`, `dupe_area_tag`). Per-network fields include `own_address`, `internal_tosser_enabled`, `poll_interval_seconds`, and `tearline`. Per-link fields include `address`, `packet_password`, `areafix_password`, `name`, and `flavour`.
 
@@ -596,7 +624,7 @@ See [FTN Echomail Guide](messages/ftn-echomail.md) for setup and full field refe
 
 ## conferences.json
 
-> *Use the [Configuration Editor](#configuration-editor-tui) (section 4 — Conferences) to manage conference settings interactively. The JSON structure below is for reference or manual editing.*
+> *Use the [Configuration Editor](#configuration-editor-tui) (key 2 → Conferences) to manage conference settings interactively. The JSON structure below is for reference.*
 
 Located in the `configs/` directory. Defines conferences that group message areas and file areas together for organized display.
 
@@ -873,25 +901,17 @@ ssh-keygen -t rsa -f ssh_host_rsa_key -N ""
 
 The BBS will fail to start if the host key is missing.
 
-## Best Practices
-
-1. **Backup Before Editing**: Always backup configuration files before making changes
-2. **Test Changes**: Test configuration changes with a test user account
-3. **Use Valid JSON**: Ensure JSON syntax is valid (use a JSON validator)
-4. **Document Changes**: Keep notes on what you've customized
-
 ## Applying Configuration Changes
 
-Most configuration changes take effect:
+Most configuration changes take effect after a BBS restart. The TUI writes changes to disk when you save; restart `./vision3` to pick them up.
 
-- **Immediately**: String changes, theme changes
-- **On user login**: User-specific settings
-- **On restart**: Door configurations, file areas, general config
+Exceptions that take effect without a restart:
 
-Some changes may require a server restart:
+- **IP blocklist/allowlist files** — watched by the BBS and reloaded automatically on save (no restart needed)
+- **strings.json** — loaded fresh on each display
 
 ```bash
-# Stop the server (Ctrl+C)
-# Start it again
+# Restart the BBS
+# (Ctrl+C to stop, then:)
 ./vision3
 ```

--- a/docs/sysop/configuration/configuration.md
+++ b/docs/sysop/configuration/configuration.md
@@ -122,7 +122,7 @@ Configuration files are split between two directories:
 
 ## strings.json
 
-> *Use the [String Editor](advanced/string-editor.md) (`./strings`) to edit display strings interactively. It is a Go reimplementation of the original Vision/2 `STRINGS.EXE` utility. The JSON structure below is for reference or manual editing.*
+> *Use the [String Editor](advanced/string-editor.md) (`./strings`) to edit display strings interactively. It is a Go reimplementation of the original Vision/2 `STRINGS.EXE` utility. The JSON structure below is for reference.*
 
 This file contains all the customizable text strings displayed by the BBS. You can modify these to personalize your system.
 
@@ -187,7 +187,7 @@ The strings support pipe color codes:
 
 ## doors.json
 
-> *Use the [Configuration Editor](#configuration-editor-tui) (section 5 — Door Programs) to manage door settings interactively. The JSON structure below is for reference or manual editing.*
+> *Use the [Configuration Editor](#configuration-editor-tui) (section 5 — Door Programs) to manage door settings interactively. The JSON structure below is for reference.*
 
 Configures external door programs that can be launched from the BBS. The file contains an array of door configurations. See the [Door Programs Guide](doors/doors.md) for full documentation including DOS door setup, FOSSIL drivers, and dosemu2 configuration.
 
@@ -518,7 +518,7 @@ Leave paths empty (`""`) to disable the feature.
 
 ## Logging
 
-> *Use the [Configuration Editor](#configuration-editor-tui) (System Configuration → Logging) to manage logging settings interactively. The JSON structure below is for reference or manual editing.*
+> *Use the [Configuration Editor](#configuration-editor-tui) (System Configuration → Logging) to manage logging settings interactively. The JSON structure below is for reference.*
 
 ViSiON/3 writes structured JSON logs (one object per line) to a configurable directory. All settings live under the `"logging"` key in `configs/config.json` and are shared by every binary (`vision3`, `v3mail`). If the key is absent, defaults are applied automatically so existing installs continue to work unchanged.
 

--- a/docs/sysop/configuration/security.md
+++ b/docs/sysop/configuration/security.md
@@ -13,63 +13,39 @@ This guide covers security features and best practices for protecting your BBS.
 
 ViSiON/3 includes built-in connection management to prevent resource exhaustion and abuse.
 
-### Configuration Options
+### Configuring Connection Limits
 
-Edit `configs/config.json`:
+Open the config editor and navigate to **System Configuration → Connection Limits** (sub-screen 2):
 
-```json
-{
-  "maxNodes": 10,
-  "maxConnectionsPerIP": 3,
-  "ipBlocklistPath": "configs/blocklist.txt",
-  "ipAllowlistPath": "configs/allowlist.txt"
-}
+```bash
+./config
+# → 1 System Configuration → 2 Connection Limits
 ```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| Max Nodes | 10 | Maximum simultaneous connections. When reached, new connections are rejected with "maximum nodes reached". |
+| Max Per IP | 3 | Maximum concurrent connections from a single IP address. Prevents connection flooding. |
+| Failed Logins | 5 | Failed BBS login attempts from one IP before lockout. Set to 0 to disable. |
+| Lockout Mins | 30 | Duration of IP lockout after failed login threshold is reached. |
+| Idle Timeout | 5 | Minutes before an idle session is disconnected. |
+| Xfer Timeout | 10 | Minutes before a stalled file transfer is aborted. |
+
+To set IP blocklist and allowlist file paths, use **System Configuration → IP Blocklist/Allowlist** (sub-screen 5).
 
 ### Max Nodes
 
 Limits the total number of simultaneous connections to your BBS.
 
-- **Default:** 10
-- **Range:** 1-999 (0 = unlimited, not recommended)
-- **Purpose:** Prevents server overload from too many connections
-
-**Example:**
-
-```json
-{
-  "maxNodes": 5
-}
-```
-
-This allows only 5 users to be connected at the same time. When the limit is reached, new connections receive:
-
-```text
-Connection rejected: maximum nodes reached
-Please try again later.
-```
+- **Default:** 10 — prevents server overload from too many connections
+- When the limit is reached, new connections receive: `Connection rejected: maximum nodes reached`
 
 ### Max Connections Per IP
 
 Limits how many simultaneous connections a single IP address can make.
 
-- **Default:** 3
-- **Range:** 1-99 (0 = unlimited, not recommended)
-- **Purpose:** Prevents connection flooding from a single source
-
-**Example:**
-
-```json
-{
-  "maxConnectionsPerIP": 2
-}
-```
-
-This allows each IP address to maintain up to 2 concurrent connections. Useful for:
-
-- Preventing multi-connection abuse
-- Limiting resource usage per user
-- Mitigating simple DoS attempts
+- **Default:** 3 — prevents connection flooding from a single source
+- Useful for preventing multi-connection abuse and mitigating simple DoS attempts
 
 ## IP Filtering
 
@@ -103,15 +79,7 @@ Block specific IPs or IP ranges from connecting.
    2001:db8::/32
    ```
 
-2. Update `configs/config.json`:
-
-   ```json
-   {
-     "ipBlocklistPath": "configs/blocklist.txt"
-   }
-   ```
-
-3. Restart the BBS
+2. Set the path in `./config` → **System Configuration → IP Blocklist/Allowlist** (sub-screen 5), Blocklist Path field.
 
 **When to use:**
 
@@ -146,15 +114,7 @@ Allow specific IPs to bypass all connection limits.
    2001:db8:admin::/48
    ```
 
-2. Update `configs/config.json`:
-
-   ```json
-   {
-     "ipAllowlistPath": "configs/allowlist.txt"
-   }
-   ```
-
-3. Restart the BBS
+2. Set the path in `./config` → **System Configuration → IP Blocklist/Allowlist** (sub-screen 5), Allowlist Path field.
 
 **When to use:**
 
@@ -264,14 +224,8 @@ Connection requests are evaluated in this order:
 
 #### Example 1: Public BBS with Admin Protection
 
-```json
-{
-  "maxNodes": 20,
-  "maxConnectionsPerIP": 3,
-  "ipBlocklistPath": "configs/blocklist.txt",
-  "ipAllowlistPath": "configs/allowlist.txt"
-}
-```
+In `./config` → System Configuration → Connection Limits: Max Nodes = 20, Max Per IP = 3.
+In System Configuration → IP Blocklist/Allowlist: set both file paths.
 
 `configs/allowlist.txt`:
 
@@ -303,13 +257,8 @@ Connection requests are evaluated in this order:
 
 #### Example 2: Private BBS (Members Only)
 
-```json
-{
-  "maxNodes": 10,
-  "maxConnectionsPerIP": 2,
-  "ipAllowlistPath": "configs/allowlist.txt"
-}
-```
+In `./config` → System Configuration → Connection Limits: Max Nodes = 10, Max Per IP = 2.
+In System Configuration → IP Blocklist/Allowlist: set allowlist path, leave blocklist empty.
 
 `configs/allowlist.txt`:
 
@@ -422,37 +371,26 @@ CIDR mask must be 0-32 for IPv4, 0-128 for IPv6.
 
 ### Security Levels
 
-ViSiON/3 uses numeric security levels for access control:
+ViSiON/3 uses numeric security levels for access control. Configure them in `./config` → **System Configuration → Access Levels** (sub-screen 3):
 
-```json
-{
-  "sysOpLevel": 255,
-  "coSysOpLevel": 250,
-  "logonLevel": 100,
-  "anonymousLevel": 5
-}
-```
-
-- **sysOpLevel (255):** Full system access
-- **coSysOpLevel (250):** Co-SysOp privileges
-- **logonLevel (100):** Standard user after login
-- **anonymousLevel (5):** Guest/unvalidated users
+| Field | Default | Description |
+|-------|---------|-------------|
+| SysOp Level | 255 | Full system access |
+| CoSysOp Level | 250 | Co-SysOp privileges |
+| Invisible Level | 0 | Level at which users are hidden from who's-online (0 = use CoSysOp level) |
+| New User Level | 1 | Level assigned when an account is first created |
+| Regular Level | 10 | Level for validated/regular users |
+| Logon Level | 10 | Level granted on successful login (0 = disabled) |
+| Anonymous Level | 5 | Level for guest/anonymous access (0 = disabled) |
 
 ### Authentication Lockout
 
-Protect against brute-force attacks with automatic **IP-based** lockout after failed login attempts.
+Protect against brute-force attacks with automatic **IP-based** lockout after failed login attempts. Configure in `./config` → **System Configuration → Connection Limits** (sub-screen 2):
 
-**Configuration** (`configs/config.json`):
-
-```json
-{
-  "maxFailedLogins": 5,
-  "lockoutMinutes": 30
-}
-```
-
-- **maxFailedLogins:** Number of failed login attempts from a single IP before lockout (0 = disabled)
-- **lockoutMinutes:** Duration the IP remains locked after threshold is reached
+| Field | Default | Description |
+|-------|---------|-------------|
+| Failed Logins | 5 | Failed BBS login attempts from one IP before lockout (0 = disabled) |
+| Lockout Mins | 30 | Duration the IP remains locked after the threshold is reached |
 
 **How it works:**
 
@@ -556,18 +494,12 @@ The system protects against SSH brute force attempts through:
 
 #### Configuration Example
 
-For a secure public BBS that allows new users:
+For a secure public BBS that allows new users, set these in `./config` → System Configuration → Connection Limits:
 
-```json
-{
-  "maxFailedLogins": 5,
-  "lockoutMinutes": 30,
-  "maxConnectionsPerIP": 3,
-  "maxNodes": 20
-}
-```
+- Failed Logins: **5**, Lockout Mins: **30**
+- Max Per IP: **3**, Max Nodes: **20**
 
-This configuration:
+This:
 - Allows new users to register via SSH
 - Limits each IP to 3 concurrent connections
 - Locks out IPs after 5 failed BBS logins for 30 minutes
@@ -678,13 +610,8 @@ grep "authenticated successfully" data/logs/vision3.log
    PubkeyAuthentication yes
    ```
 
-2. **BBS: Use Non-Standard Port**
-
-   ```json
-   {
-     "sshPort": 2222
-   }
-   ```
+2. **BBS: Use a Non-Standard Port**
+   Change the SSH port in `./config` → **System Configuration → Server Setup** (sub-screen 1), SSH Port field. Default is `2222`.
 
 3. **Limit SSH to Specific IPs**
    Use allowlist for trusted admin IPs.
@@ -751,7 +678,7 @@ iptables -A INPUT -p tcp --dport 2222 -m state --state NEW \
 ## Security Checklist
 
 - [ ] Change default password
-- [ ] Configure maxNodes and maxConnectionsPerIP
+- [ ] Configure maxNodes and maxConnectionsPerIP (System Configuration → Connection Limits)
 - [ ] Set up IP blocklist (if needed)
 - [ ] Set up IP allowlist for admins
 - [ ] Use IP allowlist to restrict host admin SSH access (if running system sshd)

--- a/docs/sysop/files/bulk-import.md
+++ b/docs/sysop/files/bulk-import.md
@@ -157,7 +157,9 @@ cat data/files/general/metadata.json | python3 -m json.tool | head -20
 ### Setting Up a New File Area with Files
 
 ```bash
-# 1. Add area to configs/file_areas.json (or use existing area)
+# 1. Create the area in ./config → File Areas (key 3), then create the directory
+mkdir -p data/files/utils
+echo '[]' > data/files/utils/metadata.json
 
 # 2. Import files
 ./helper files import --dir ~/bbs-files/utils --area UTILS --uploader "Sysop"

--- a/docs/sysop/files/file-areas.md
+++ b/docs/sysop/files/file-areas.md
@@ -139,34 +139,22 @@ The `LISTFILES` function shows files in current area:
 
 ## Creating a New File Area
 
-1. Create directory structure:
+1. Add the area in `./config` → **File Areas** (key 3). Set the tag, name, description, path, and ACS fields. The editor creates the area in `configs/file_areas.json`.
+
+2. Create the area directory and empty metadata file:
 
 ```bash
 mkdir -p data/files/myarea
-```
-
-1. Add to `configs/file_areas.json`:
-
-```json
-{
-  "id": 2,
-  "tag": "MYAREA",
-  "name": "My File Area",
-  "description": "Description here",
-  "path": "myarea",
-  "acs_list": "",
-  "acs_upload": "s10",
-  "acs_download": ""
-}
-```
-
-1. Create empty metadata file:
-
-```bash
 echo '[]' > data/files/myarea/metadata.json
 ```
 
-1. Restart BBS or reload configuration
+3. Import files with `helper files import` (see [Bulk File Import](files/bulk-import.md)):
+
+```bash
+./helper files import --dir /path/to/files --area MYAREA
+```
+
+4. Restart the BBS (or reload configuration) to make the area visible to users.
 
 ## File Display Templates
 
@@ -271,30 +259,15 @@ This produces: `■ Local > General Files          Files:  1    Page 1 of 1` wit
 
 ## File Management
 
-### Adding Files Manually
+### Adding Files
 
-1. Copy file to area directory:
+Use `helper files import` to bulk-import files into an area. It copies files, extracts `FILE_ID.DIZ` descriptions from archives, generates UUIDs, and updates `metadata.json` automatically:
 
 ```bash
-cp myfile.zip data/files/general/
+./helper files import --dir /path/to/files --area GENERAL --preserve-dates
 ```
 
-1. Update area's `metadata.json`:
-
-```json
-{
-  "id": "44444444-4444-4444-4444-444444444444",
-  "area_id": 1,
-  "filename": "myfile.zip",
-  "description": "My file",
-  "size": 1024,
-  "uploaded_at": "2025-01-01T00:00:00Z",
-  "uploaded_by": "SysOp",
-  "download_count": 0
-}
-```
-
-Note: Generate a unique UUID for the `id` field.
+See [Bulk File Import](files/bulk-import.md) for full documentation including all flags, skip logic, and dry-run support.
 
 ### Removing Files
 
@@ -304,17 +277,7 @@ Note: Generate a unique UUID for the `id` field.
 rm data/files/general/oldfile.zip
 ```
 
-1. Remove entry from `metadata.json`
-
-### Batch Import
-
-Use the `helper files import` command to bulk import files from a directory:
-
-```bash
-./helper files import --dir /path/to/files --area GENERAL --preserve-dates
-```
-
-This automatically copies files, extracts FILE_ID.DIZ descriptions from archives, generates UUIDs, and updates `metadata.json`. See [Bulk File Import](files/bulk-import.md) for full documentation.
+2. Remove the corresponding entry from the area's `metadata.json`.
 
 ## Best Practices
 

--- a/docs/sysop/getting-started/docker.md
+++ b/docs/sysop/getting-started/docker.md
@@ -79,7 +79,7 @@ If you prefer not to use Docker Compose:
 
 ViSiON/3 uses a pure-Go SSH implementation (`gliderlabs/ssh`) — no CGO or native libraries required. The Dockerfile:
 
-- Builds all Go binaries: `ViSiON3`, `v3mail`, `helper`, `strings`
+- Builds all Go binaries: `vision3`, `v3mail`, `config`, `strings`, `ue`, `menuedit`, `helper`
 - Copies `bin/sexyz` for ZModem 8k file transfers (works on both SSH and telnet)
 - Copies the static `binkd` binary for FTN mailer support
 
@@ -118,15 +118,31 @@ On first run, the entrypoint script will:
 
 ### Configuration
 
-After first run, edit the configuration files in the `configs/` directory:
+After first run, use the TUI tools to configure your BBS. Run them via `docker exec`:
 
 ```bash
-# Edit main config
-nano configs/config.json
+# Main config editor (BBS name, ports, access levels, networking, etc.)
+docker exec -it vision3-bbs ./config
 
-# Restart to apply changes
+# String editor (display text and prompts)
+docker exec -it vision3-bbs ./strings
+
+# User editor
+docker exec -it vision3-bbs ./ue
+
+# Menu editor
+docker exec -it vision3-bbs ./menuedit
+```
+
+The container's working directory is `/vision3`, which is where `configs/`, `data/`, and `menus/` are mounted — so the TUI tools find your files automatically without extra flags.
+
+After saving changes in the TUI, restart to apply most settings:
+
+```bash
 docker compose restart
 ```
+
+Exception: IP blocklist/allowlist files are watched and reload automatically — no restart needed.
 
 ## Private Mail Setup
 
@@ -237,14 +253,8 @@ For production deployments:
 - Limit exposed ports (only expose 2222)
 - Consider running with a non-root user inside the container
 - Set up firewall rules on the host
-- Configure connection limits in `config.json`:
-  - `maxNodes`: Maximum simultaneous connections (default: 10)
-  - `maxConnectionsPerIP`: Maximum connections per IP address (default: 3)
-  - Set to 0 to disable limits (not recommended for public BBSes)
-- Configure IP filtering (optional):
-  - `ipBlocklistPath`: Path to file containing blocked IPs/CIDR ranges
-  - `ipAllowlistPath`: Path to file containing allowed IPs (bypasses all limits)
-  - File format: one IP or CIDR range per line, # for comments
+- Configure connection limits via `docker exec -it vision3-bbs ./config` → System Configuration → Connection Limits (Max Nodes, Max Per IP, failed login lockout)
+- Configure IP filtering via System Configuration → IP Blocklist/Allowlist (paths to plain-text files with one IP or CIDR per line)
 
 ## Support
 

--- a/docs/sysop/getting-started/installation.md
+++ b/docs/sysop/getting-started/installation.md
@@ -66,14 +66,20 @@ On macOS, the setup script also removes quarantine attributes from the downloade
 
 ## Step 4: Configure Your BBS
 
-Open `configs/config.json` and set at minimum your BBS name, sysop name, and hostname:
+Run the interactive config editor and set at minimum your BBS name, sysop name, location, and server settings:
 
 ```bash
-nano configs/config.json       # Linux/macOS
-notepad configs\config.json    # Windows
+./config          # Linux/macOS
+.\config.exe      # Windows
 ```
 
-See the [Configuration Guide](configuration/configuration.md) for all settings.
+Navigate to **System Configuration** (key 1), then:
+- **BBS Registration** (sub-screen 0) — board name, sysop name, location, timezone
+- **Server Setup** (sub-screen 1) — SSH/Telnet ports and enabled flags
+
+Press **Q** to quit and save when done.
+
+See the [Configuration Guide](configuration/configuration.md) for all available settings.
 
 ## Step 5: Start the BBS
 
@@ -158,7 +164,7 @@ Available output modes:
 
 ### Port Already in Use
 
-Change `"sshPort": 2222` in `configs/config.json` and restart the server.
+Change the SSH port in `./config` → System Configuration → Server Setup (sub-screen 1), then restart the server.
 
 ### Permission Denied
 

--- a/docs/sysop/menus/menu-system.md
+++ b/docs/sysop/menus/menu-system.md
@@ -2,7 +2,109 @@
 
 The ViSiON/3 menu system is the core of the BBS user interface. This guide explains how menus work and how to create or modify them.
 
-> **📋 In Development:** A TUI menu editor (`menuedit`) is currently in development. Once complete, it will replace the need to manually edit `.MNU`, `.CFG`, and `.BAR` files. Until then, menus are configured by hand as described in this guide.
+## Menu Editor (`menuedit`)
+
+`menuedit` is the interactive TUI for creating and modifying menus. Run it from your ViSiON/3 directory:
+
+```bash
+./menuedit                            # uses menus/v3 by default
+./menuedit --menus /path/to/menus/v3  # explicit path
+```
+
+The `--menus` path must contain `mnu/` and `cfg/` subdirectories. The BBS does not need to be stopped to run `menuedit`, but changes take effect on next menu load.
+
+### Menu List
+
+The opening screen lists all menus in `menus/v3/mnu/`. Columns show the menu title and its filename pair (`.MNU` / `.CFG`).
+
+| Key | Action |
+|-----|--------|
+| Up / Down / PgUp / PgDn / Home / End | Navigate |
+| Enter | Open Menu Edit for selected menu |
+| F2 | Delete selected menu (removes both `.MNU` and `.CFG`) |
+| F5 | Add new menu (prompts for filename) |
+| F10 | Open Command List for selected menu |
+| Alt-H | Help overlay |
+| Esc | Exit |
+
+### Menu Edit
+
+Edits the 13 properties of a single menu's `.MNU` file:
+
+| Field | Description |
+|-------|-------------|
+| Title | Friendly display name |
+| Clear Screen | Clear screen before displaying this menu |
+| Use Prompt | Whether to show the input prompt |
+| Prompt 1 | Primary prompt (supports pipe codes; renders in color live) |
+| Prompt 2 | Secondary prompt (rarely used) |
+| Fallback Menu | Menu to load when no command matches input |
+| ACS | Access control string; empty = allow all |
+| Password | Password required to enter this menu |
+| Help Menu | Reserved (`HelpMenu` from Pascal `MenuRec`) |
+| Force Help Level | Reserved (`ForceHelpLevel` from Pascal `MenuRec`) |
+| Msg Conference | Reserved (`Mes_Conf` from Pascal `MenuRec`) |
+| File Conference | Reserved (`File_Conf` from Pascal `MenuRec`) |
+| Force Hotkey | Force single-keypress input regardless of user preference |
+
+| Key | Action |
+|-----|--------|
+| Up / Down / Tab | Navigate fields |
+| Enter | Edit field (Y/N fields toggle immediately) |
+| PgUp / PgDn | Save current, go to previous / next menu |
+| F2 | Delete current menu |
+| F5 | Add new menu |
+| F10 | Save current, open Command List |
+| Esc | Save current, return to Menu List |
+
+### Command List
+
+Lists all commands in the selected menu's `.CFG` file. Columns show Node Activity, Keys, and Command.
+
+| Key | Action |
+|-----|--------|
+| Up / Down / PgUp / PgDn / Home / End | Navigate |
+| Enter | Open Command Edit for selected command |
+| F2 | Delete selected command |
+| F5 | Append new empty command |
+| Esc | Save if changed, return to Menu Edit |
+
+### Command Edit
+
+Edits the 6 fields of a single command:
+
+| Field | Description |
+|-------|-------------|
+| Node Activity | Which nodes see this command: `*` (all), `1` (node 1 only), etc. |
+| Keys | Key(s) that trigger the command; space-separate for multiple |
+| Command | Action to execute (see [Command Actions](#command-actions) below) |
+| ACS | Access control string |
+| Hidden | Whether command is hidden from menu display |
+| Auto-Run | Use `//` or `~~` in the Keys field to set auto-run behavior |
+
+| Key | Action |
+|-----|--------|
+| Up / Down / Tab | Navigate fields |
+| Enter | Edit field (Y/N fields toggle immediately) |
+| PgUp / PgDn | Move to previous / next command |
+| F2 | Delete current command |
+| F5 | Append new command |
+| F8 | Abort — discard changes |
+| Esc | Save changes, return to Command List |
+
+### Operations
+
+**Creating a menu:** Press F5 from Menu List or Menu Edit. Enter a name (A-Z, 0-9, underscore, max 8 characters). The editor creates empty `.MNU` and `.CFG` files and opens Menu Edit for the new menu.
+
+**Deleting a menu:** F2 from Menu List or Menu Edit. This removes **both** `.MNU` and `.CFG` files permanently — there is no undo.
+
+**Saving:** Changes are written when you press Esc from an edit screen, navigate with PgUp/PgDn, or press F10 to jump to the Command List.
+
+### Limitations
+
+`.BAR` lightbar files (used by `PDMATRIX` and other lightbar menus) are **not** managed by `menuedit` — they must still be hand-edited. See [Lightbar Menus](#lightbar-menus) for the format.
+
+---
 
 ## Menu System Overview
 
@@ -265,71 +367,14 @@ Control who can access menus and commands:
 
 ## Creating a New Menu
 
-### Step 1: Create Menu Configuration
+1. Run `./menuedit` and press **F5** from the Menu List.
+2. Enter a filename (A-Z, 0-9, underscore, max 8 characters — e.g., `MYMENU`). This becomes `MYMENU.MNU` and `MYMENU.CFG`.
+3. Fill in the Menu Edit fields: set **Title**, adjust **Clear Screen** and **Use Prompt**, write your **Prompt 1** text, and set a **Fallback Menu** (usually `MAIN`).
+4. Press **F10** to open the Command List and add commands with **F5**. For each command, enter the trigger key(s), the action (e.g., `GOTO:MAIN`, `RUN:SHOWSTATS`), and ACS if needed.
+5. Press **Esc** to save and return. Create `menus/v3/ansi/MYMENU.ANS` with your ANSI art separately.
+6. Add a `GOTO:MYMENU` command in another menu (e.g., MAIN) to make the new menu reachable.
 
-Create `menus/v3/mnu/MYMENU.MNU`:
-
-```json
-{
-  "TITLE": "My Menu",
-  "CLR": true,
-  "USEPROMPT": true,
-  "PROMPT1": "|15Select: ",
-  "PROMPT2": "",
-  "FALLBACK": "MAIN",
-  "ACS": "",
-  "PASS": "",
-  "HELPMENU": "",
-  "FORCEHELPLEVEL": 0,
-  "MES_CONF": 0,
-  "FILE_CONF": 0,
-  "FORCEHOTKEY": false
-}
-```
-
-### Step 2: Create Command Definitions
-
-Create `menus/v3/cfg/MYMENU.CFG`:
-
-```json
-[
-  {
-    "KEYS": "1",
-    "CMD": "RUN:OPTION1",
-    "ACS": "*",
-    "HIDDEN": false
-  },
-  {
-    "KEYS": "2",
-    "CMD": "RUN:OPTION2",
-    "ACS": "*",
-    "HIDDEN": false
-  },
-  {
-    "KEYS": "Q",
-    "CMD": "GOTO:MAIN",
-    "ACS": "*",
-    "HIDDEN": false
-  }
-]
-```
-
-### Step 3: Create ANSI Art
-
-Create `menus/v3/ansi/MYMENU.ANS` with your menu design.
-
-### Step 4: Link to Menu
-
-Add a command in another menu to access it:
-
-```json
-{
-  "KEYS": "M",
-  "CMD": "GOTO:MYMENU",
-  "ACS": "*",
-  "HIDDEN": false
-}
-```
+> The JSON file reference is below if you need to understand the format or make bulk changes outside of `menuedit`.
 
 ## Pre-Login Matrix Screen
 

--- a/docs/sysop/networking/ssh.md
+++ b/docs/sysop/networking/ssh.md
@@ -16,23 +16,16 @@ Key features:
 
 ## Configuration
 
-SSH settings live in `configs/config.json`:
+SSH settings are managed in `./config` → **System Configuration → Server Setup** (sub-screen 1):
 
-```json
-{
-  "sshPort": 2222,
-  "sshHost": "0.0.0.0",
-  "sshEnabled": true,
-  "legacySSHAlgorithms": false
-}
-```
+| Field | Default | Description |
+|-------|---------|-------------|
+| SSH Enabled | Y | Enable/disable the SSH server |
+| SSH Host | `0.0.0.0` | Interface to bind (all interfaces) |
+| SSH Port | `2222` | TCP port to listen on |
+| Legacy SSH | Y | Enable older SSH algorithms for retro client compatibility (see below) |
 
-### Fields
-
-- `sshPort` — TCP port to listen on (default: `2222`)
-- `sshHost` — Interface to bind (default: `"0.0.0.0"` for all interfaces)
-- `sshEnabled` — Enable/disable the SSH server
-- `legacySSHAlgorithms` — Enable older SSH algorithms for retro client compatibility (see below)
+These settings write to `configs/config.json` under the keys `sshEnabled`, `sshHost`, `sshPort`, and `legacySSHAlgorithms`.
 
 ## SSH Host Keys
 
@@ -70,13 +63,13 @@ Tested and working:
 
 ### Connection Refused
 
-- Check `sshEnabled: true` in `configs/config.json`
+- Check that SSH Enabled is **Y** in `./config` → System Configuration → Server Setup
 - Verify the port is not in use: `netstat -ln | grep 2222`
 - Check that `configs/ssh_host_rsa_key` exists and is readable
 
 ### SyncTERM or Retro Client Fails to Connect
 
-- Enable `legacySSHAlgorithms: true` in `configs/config.json` and restart the BBS
+- Enable Legacy SSH in `./config` → System Configuration → Server Setup, then restart the BBS
 
 ### Authentication Fails
 

--- a/docs/sysop/networking/telnet.md
+++ b/docs/sysop/networking/telnet.md
@@ -222,21 +222,17 @@ A key difference between the two protocols:
 
 ## Configuration
 
-### config.json
+Telnet settings are managed in `./config` → **System Configuration → Server Setup** (sub-screen 1):
 
-```json
-{
-  "telnetPort": 2323,
-  "telnetHost": "0.0.0.0",
-  "telnetEnabled": true
-}
-```
+| Field | Default | Description |
+|-------|---------|-------------|
+| Telnet Enabled | N | Enable/disable the Telnet server |
+| Telnet Host | `0.0.0.0` | Bind address for the telnet listener |
+| Telnet Port | `2323` | TCP port for telnet connections |
 
-| Field           | Type   | Default   | Description                         |
-| --------------- | ------ | --------- | ----------------------------------- |
-| `telnetPort`    | int    | 2323      | TCP port for telnet connections     |
-| `telnetHost`    | string | `0.0.0.0` | Bind address for telnet listener    |
-| `telnetEnabled` | bool   | true      | Enable or disable the telnet server |
+These write to `configs/config.json` under `telnetEnabled`, `telnetHost`, and `telnetPort`. Telnet is disabled by default — enable it only if you have clients that need it, since telnet transmits all data in cleartext.
+
+> **Note:** The `Current Limitations` section below reflects a snapshot in time. IP filtering is now fully implemented and configured via System Configuration → IP Blocklist/Allowlist.
 
 ### Command-Line Testing
 
@@ -285,9 +281,7 @@ nc localhost 2323
 ## Current Limitations
 
 1. **No Encryption**: Telnet transmits data in cleartext (use SSH for secure access)
-2. **No Rate Limiting**: Should add connection rate limiting
-3. **No IP Filtering**: Should add IP whitelist/blacklist support
-4. **80x25 Cap**: Terminal dimensions are capped to 80x25 for BBS compatibility
+2. **80x25 Cap**: Terminal dimensions are capped to 80x25 for BBS compatibility
 
 ## References
 

--- a/docs/sysop/users/nuv.md
+++ b/docs/sysop/users/nuv.md
@@ -83,7 +83,7 @@ Pressing `Y` immediately starts a scan of unvoted candidates. Pressing `N` conti
 {"command": "CHECKNUV"}
 ```
 
-This is included in the default `configs/login.json`. If upgrading an existing deployment, add this entry manually to your login sequence.
+This is included in the default `configs/login.json`. If upgrading an existing deployment, add it via `./config` → System Configuration → Login Sequence (sub-screen 5).
 
 ---
 

--- a/docs/sysop/users/sponsor-menus.md
+++ b/docs/sysop/users/sponsor-menus.md
@@ -22,7 +22,9 @@ All other users are silently refused — the `%` key does nothing for them, and 
 
 ## Configuring a Sponsor
 
-Set the `"sponsor"` field in `configs/message_areas.json` to the user's handle:
+The easiest way is from within the BBS: enter the Sponsor Menu for the area (`%` from Messages Menu) and press `E` → `S` to set the Sponsor field. See [Edit Area Screen](#edit-area-screen) below.
+
+Alternatively, set the `"sponsor"` field directly in `configs/message_areas.json`:
 
 ```json
 {
@@ -39,8 +41,6 @@ Set the `"sponsor"` field in `configs/message_areas.json` to the user's handle:
 ```
 
 The handle comparison is **case-insensitive** — `"techguru"`, `"TechGuru"`, and `"TECHGURU"` all match a user whose handle is `TechGuru`.
-
-The sponsor can also be set from within the BBS via the Edit Area screen (see below).
 
 ## Using the Sponsor Menu
 

--- a/docs/sysop/users/user-editor.md
+++ b/docs/sysop/users/user-editor.md
@@ -28,17 +28,19 @@ Displays all users in a scrollable list. Four column views are available, toggle
 | 3 | Messages Posted, Validated |
 | 4 | Last Login Date, Last Login Time |
 
-Users can be tagged with Space for bulk operations (validate, delete).
+Deleted users appear at the bottom of the list below a `--- DELETED USERS ---` separator. Users can be tagged with Space for bulk operations (validate, delete, purge).
 
 ### Field Editor
 
-Press Enter on any user to open the field editor. Displays 27 fields across two columns:
+Press Enter on any user to open the field editor. Displays 29 fields across two columns:
 
 **Left column:** Handle, Real Name, Access Level, Total Calls, Group/Location, Access Flags, Private Note, File Points, Custom Prompt, Time Limit
 
-**Right column:** Validated, Hot Keys, More Prompts, Screen Width, Screen Height, Encoding, Msg Header, Output Mode, Deleted User, Created At, Updated At, Last Login, Last Bulletin
+**Right column:** Validated, Hot Keys, More Prompts, Screen Width, Screen Height, Encoding, Msg Header, Output Mode, Deleted User (read-only), Deleted At (read-only), Auto Purge (read-only), InfoForms (read-only), Created At, Updated At, Last Login, Last Bulletin
 
 The Password field opens a dialog — new password is bcrypt-hashed before saving.
+
+**Read-only fields:** Deleted User, Deleted At, and Auto Purge reflect the user's current deletion state and purge eligibility. InfoForms shows which infoform responses exist on disk (e.g., `1[x] 2[ ] 3[ ]`).
 
 ---
 
@@ -54,9 +56,11 @@ The Password field opens a dialog — new password is bcrypt-hashed before savin
 | Left / Right | Cycle column views |
 | Space | Toggle tag on current user |
 | Enter | Open field editor |
-| F2 | Delete highlighted user (confirm) |
-| Shift-F2 | Delete all tagged users (confirm) |
+| F2 | Soft-delete highlighted user (confirm); if confirmed, immediately offers purge |
+| Shift-F2 | Soft-delete all tagged users (confirm) |
 | F3 | Toggle alphabetical / numeric sort |
+| F4 | Purge highlighted deleted user (permanent — removes user and infoform files) |
+| Shift-F4 | Purge all deleted users (permanent) |
 | F5 | Auto-validate highlighted user |
 | Shift-F5 | Auto-validate all tagged users |
 | F10 | Tag all users |
@@ -74,8 +78,9 @@ The Password field opens a dialog — new password is bcrypt-hashed before savin
 | Ctrl-End | Jump to last field |
 | PgDn | Save changes + open next user |
 | PgUp | Save changes + open previous user |
-| F2 | Delete current user |
-| F5 | Reset to default values |
+| F2 | Soft-delete / undelete current user |
+| F4 | Purge current user (must already be deleted) |
+| F5 | Auto-validate current user |
 | F10 | Abort (discard changes) |
 | Esc | Save changes + return to list |
 
@@ -104,7 +109,11 @@ Sets standard approval values for a new user:
 
 ### Delete User
 
-Soft-delete: sets `deletedUser=true` and records a `deletedAt` timestamp. The record stays in `users.json` but is flagged as deleted — matching the V3 soft-delete pattern used by the BBS itself.
+Soft-delete (F2): sets `deletedUser=true` and records a `deletedAt` timestamp. After confirming the soft-delete, the editor immediately offers a follow-on purge dialog — press Y to purge on the spot, or N to leave the user in the deleted state for later.
+
+### Purge User
+
+Permanent removal (F4 from list, or F4 from the field editor when the user is already deleted). Purge deletes the user's record from `users.json` and removes any infoform response files (`data/infoforms/responses/<id>_*.json`). Purged user IDs are not recycled. Mass purge via Shift-F4 removes all currently-deleted users at once.
 
 ### Sort Order
 

--- a/docs/sysop/users/user-management.md
+++ b/docs/sysop/users/user-management.md
@@ -281,7 +281,6 @@ User levels can be changed through:
 
 1. **Admin Menu** (in-BBS): Press `G` to edit access level
 2. **User Editor** (`./ue`): Edit the Access Level field
-3. **Manual editing**: Modify `accessLevel` in `data/users/users.json` (not recommended)
 
 When validating a user through the Admin Menu with the `H` key, their level is automatically set to `regularUserLevel`.
 
@@ -341,14 +340,6 @@ Users are added through:
 
 1. New user application (type "new" at login screen)
 2. The `ue` TUI user editor (see [User Editor](users/user-editor.md))
-3. Manual editing of `users.json` (not recommended)
-
-When adding users manually, ensure:
-
-- Unique `id` number
-- Unique `username` (case-insensitive)
-- Unique `handle` (case-insensitive)
-- Valid bcrypt `passwordHash`
 
 ## New User Application
 
@@ -433,18 +424,6 @@ The SysOp can validate users in-BBS from the Admin Menu (`X` from MAIN → `V`).
 SysOp accounts also receive an automatic notification on MAIN menu entry when there are pending unvalidated users.
 
 Regular-user validation level is configurable in `configs/config.json` as `regularUserLevel` (default `10`).
-
-Manual editing of `data/users/users.json` is still supported when the BBS is stopped.
-
-### Modifying Users
-
-To modify a user manually:
-
-1. Stop the BBS
-2. Edit `data/users/users.json`
-3. Update the desired fields
-4. Ensure valid JSON syntax
-5. Restart the BBS
 
 ## Access Control System (ACS)
 
@@ -604,31 +583,13 @@ The access level threshold is driven by `coSysOpLevel` in `configs/config.json` 
 
 ### Resetting a Password
 
-Since passwords are hashed, you cannot recover them. To reset:
-
-**Option 1 — `ue` TUI (recommended):** Run `./ue` from the BBS root, select the user, and use the password reset field. See [User Editor](users/user-editor.md).
-
-**Option 2 — manual JSON edit:**
-
-1. Generate a new bcrypt hash:
-
-```go
-password := "newpassword"
-hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
-if err != nil {
-    log.Fatal(err)
-}
-fmt.Println(string(hash))
-```
-
-2. Update the `passwordHash` field in `users.json`
-3. Inform the user of their new password
+Since passwords are hashed, you cannot recover them. To reset: run `./ue`, select the user, navigate to the Password field, and press Enter. Type the new password in the masked dialog. The editor bcrypt-hashes it before saving. See [User Editor](users/user-editor.md).
 
 ### Validating New Users
 
 **Recommended:** use the in-BBS Admin Menu (`X` from MAIN → `V`) to validate pending accounts. The screen shows all unvalidated users with a detail panel; press `H` to toggle validation status, then `S` to save. See [Admin Menu](users/admin-menu.md) for all key bindings.
 
-**Manual alternative:** change `validated` from `false` to `true` and set appropriate `accessLevel` (typically 10) in `data/users/users.json` while the BBS is stopped.
+**Alternative:** use `./ue`, select the user, and toggle the Validated field to `Y` and set Access Level to 10.
 
 ### Banning Users
 
@@ -645,11 +606,9 @@ The ban feature sets a user's access level to 0 and marks them as unvalidated, p
 
 Note: Pressing `0` toggles the ban status. If a user is already banned (level 0, unvalidated), pressing `0` will unban them by restoring them to the regular user level (default 10) and setting validated to true.
 
-**Option 2: Manual Edit (while BBS is stopped)**
-1. Stop the BBS
-2. Edit `data/users/users.json`
-3. Set `"accessLevel": 0` and `"validated": false`
-4. Restart the BBS
+**Option 2: User Editor (`./ue`)**
+
+Run `./ue`, select the user, edit the Access Level field to `0`, and set Validated to `N`.
 
 **Alternative Methods:**
 1. Add a ban flag (e.g., 'B') and use `!fB` in ACS strings
@@ -681,11 +640,9 @@ The soft-delete feature marks users as deleted without removing their data. This
 
 Note: Pressing `9` toggles the deletion status. If a user is already deleted, pressing `9` will undelete them and clear the deletion timestamp.
 
-**Option 2: Manual Edit (while BBS is stopped)**
-1. Stop the BBS
-2. Edit `data/users/users.json`
-3. Set `"deletedUser": true` and `"deletedAt": "2026-02-14T12:00:00Z"`
-4. Restart the BBS
+**Option 2: User Editor (`./ue`)**
+
+Run `./ue`, navigate to the user, and press **F2** to soft-delete. The editor prompts for confirmation and then immediately offers a purge dialog if you want to remove the account permanently right away.
 
 #### Effects of Soft Delete
 


### PR DESCRIPTION
## Summary

- Adds `[ESC] Skip` button to the modem dialer splash so first-time visitors can dismiss it immediately — visible before and during the sequence
- ESC key also skips from anywhere on the page; both paths stop audio, remove the overlay, restore scroll, and set the visited cookie
- Fixes BBS keyboard nav: `d`/`D` was missing entirely (now navigates to `/sysop/`) and the key handler now correctly separates anchor-scroll keys from full-page-navigate keys
- Minor README wording tweak + adds link to sysop docs

## Test plan

- [ ] First visit: splash shows with `[ESC] Skip` in bottom-right corner
- [ ] Click `[ESC] Skip` before starting sequence → splash dismisses instantly, site loads
- [ ] Click terminal to start sequence, then click `[ESC] Skip` mid-sequence → audio stops, splash dismisses
- [ ] Press ESC during sequence → same result
- [ ] Press `F`, `G`, `J`, `H` → smooth-scroll to respective sections
- [ ] Press `D` → navigates to `/sysop/`
- [ ] Second visit (cookie set) → splash skipped automatically

https://claude.ai/code/session_01AqwkvVBx8L1wABS78q2EoQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Skip** control to the Telix dialer splash, letting the intro be bypassed via mouse or keyboard.
  * Enhanced keyboard navigation, including direct access to the SysOp section and improved Shift-modified behavior.

* **Bug Fixes**
  * Improved splash reliability when cancelled/skipped, ensuring proper cleanup (timers/audio/UI teardown).

* **Documentation**
  * Updated the project overview and expanded SysOp configuration, security, installation, Docker, SSH, and Telnet guides to match the current interactive TUI workflow and settings locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->