### PR TITLE
feat(user): add PublicKeys field and authorized-key lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ Thumbs.db
 
 # Claude Code (local developer settings)
 .claude/
+.codex/
 
 # Beads runtime data
 .beads/*.pid

--- a/internal/user/admin_log.go
+++ b/internal/user/admin_log.go
@@ -10,17 +10,17 @@ import "time"
 // - Implement appropriate data retention policies per GDPR/CCPA requirements
 // - Consider redacting or hashing sensitive fields for audit purposes
 type AdminActivityLog struct {
-	ID            int       `json:"id"`
-	Timestamp     time.Time `json:"timestamp"`
+	ID           int       `json:"id"`
+	Timestamp    time.Time `json:"timestamp"`
 	AdminHandle  string    `json:"adminUsername"` // Admin who made the change (JSON key kept for backward compat)
-	AdminID       int       `json:"adminId"`       // Admin user ID
-	TargetUserID  int       `json:"targetUserId"`  // User being modified
-	TargetHandle  string    `json:"targetHandle"`  // Handle of user being modified
-	Action        string    `json:"action"`        // Type of action (e.g., "EDIT_USER", "BAN_USER", "DELETE_USER")
-	FieldName     string    `json:"fieldName"`     // Field that was changed (for edits)
-	OldValue      string    `json:"oldValue"`      // Previous value - may contain PII
-	NewValue      string    `json:"newValue"`      // New value - may contain PII
-	Notes         string    `json:"notes"`         // Optional notes/reason
+	AdminID      int       `json:"adminId"`       // Admin user ID
+	TargetUserID int       `json:"targetUserId"`  // User being modified
+	TargetHandle string    `json:"targetHandle"`  // Handle of user being modified
+	Action       string    `json:"action"`        // Type of action (e.g., "EDIT_USER", "BAN_USER", "DELETE_USER")
+	FieldName    string    `json:"fieldName"`     // Field that was changed (for edits)
+	OldValue     string    `json:"oldValue"`      // Previous value - may contain PII
+	NewValue     string    `json:"newValue"`      // New value - may contain PII
+	Notes        string    `json:"notes"`         // Optional notes/reason
 }
 
 // AdminActivityLogEntry creates a formatted log entry for a single field change
@@ -28,12 +28,12 @@ func AdminActivityLogEntry(adminHandle string, adminID int, targetUserID int, ta
 	return AdminActivityLog{
 		Timestamp:    time.Now().UTC(),
 		AdminHandle:  adminHandle,
-		AdminID:       adminID,
-		TargetUserID:  targetUserID,
-		TargetHandle:  targetHandle,
-		Action:        "EDIT_USER",
-		FieldName:     fieldName,
-		OldValue:      oldValue,
-		NewValue:      newValue,
+		AdminID:      adminID,
+		TargetUserID: targetUserID,
+		TargetHandle: targetHandle,
+		Action:       "EDIT_USER",
+		FieldName:    fieldName,
+		OldValue:     oldValue,
+		NewValue:     newValue,
 	}
 }

--- a/internal/user/manager.go
+++ b/internal/user/manager.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"golang.org/x/crypto/bcrypt" // Import bcrypt
+	"golang.org/x/crypto/ssh"
 )
 
 // Predefined errors for user management
@@ -781,4 +782,36 @@ func (um *UserMgr) PurgeDeletedUsers(retentionDays int) ([]PurgeResult, error) {
 	}
 	slog.Info("purged soft-deleted user accounts", "count", len(purged))
 	return purged, nil
+}
+
+// FindByAuthorizedKey returns the user whose registered PublicKeys include a
+// key matching the given marshaled wire bytes (ssh.PublicKey.Marshal()).
+// Matching is by exact key bytes; access-level authorization is enforced by
+// the caller, not here.
+func (um *UserMgr) FindByAuthorizedKey(marshaled []byte) (*User, bool) {
+	um.mu.RLock()
+	defer um.mu.RUnlock()
+	for _, u := range um.users { // um.users is map[string]*User
+		for _, line := range u.PublicKeys {
+			pub, _, _, _, err := ssh.ParseAuthorizedKey([]byte(line))
+			if err != nil {
+				continue
+			}
+			if string(pub.Marshal()) == string(marshaled) {
+				return u, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// NewUserMgrForTest builds a UserMgr seeded with the given users, keyed by
+// handle. Exported so tests in other packages (e.g. cmd/vision3) can seed a
+// manager without touching the JSON load path.
+func NewUserMgrForTest(users ...*User) *UserMgr {
+	m := &UserMgr{users: make(map[string]*User, len(users))}
+	for _, u := range users {
+		m.users[u.Handle] = u
+	}
+	return m
 }

--- a/internal/user/manager_core_test.go
+++ b/internal/user/manager_core_test.go
@@ -679,13 +679,13 @@ func TestLogAdminActivity_WritesFile(t *testing.T) {
 
 	entry := AdminActivityLog{
 		AdminHandle:  "sysop",
-		AdminID:       1,
-		TargetUserID:  2,
-		TargetHandle:  "Bob",
-		Action:        "EDIT_USER",
-		FieldName:     "accessLevel",
-		OldValue:      "10",
-		NewValue:      "50",
+		AdminID:      1,
+		TargetUserID: 2,
+		TargetHandle: "Bob",
+		Action:       "EDIT_USER",
+		FieldName:    "accessLevel",
+		OldValue:     "10",
+		NewValue:     "50",
 	}
 
 	if err := um.LogAdminActivity(entry); err != nil {

--- a/internal/user/manager_purge_test.go
+++ b/internal/user/manager_purge_test.go
@@ -14,8 +14,8 @@ func setupPurgeTestManager(t *testing.T) (*UserMgr, time.Time) {
 	t.Helper()
 	tmpDir := t.TempDir()
 
-	longAgo := time.Now().AddDate(0, 0, -60)   // 60 days ago — past any reasonable retention
-	recently := time.Now().AddDate(0, 0, -5)   // 5 days ago — within a 30-day retention window
+	longAgo := time.Now().AddDate(0, 0, -60) // 60 days ago — past any reasonable retention
+	recently := time.Now().AddDate(0, 0, -5) // 5 days ago — within a 30-day retention window
 
 	users := []User{
 		{ID: 1, Handle: "SysOp", AccessLevel: 255},

--- a/internal/user/pubkey_test.go
+++ b/internal/user/pubkey_test.go
@@ -1,0 +1,35 @@
+package user
+
+import (
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func TestFindByAuthorizedKey(t *testing.T) {
+	// A deterministic test key (ed25519 authorized_keys line).
+	const line = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGb9ECWmEzf6FdyLqHU2eXvUjEjzaQjqQVZsGZ3GqGZ7 sysop@test"
+	pub, _, _, _, err := ssh.ParseAuthorizedKey([]byte(line))
+	if err != nil {
+		t.Fatalf("parse test key: %v", err)
+	}
+
+	// This test is package user, so it may set the unexported map directly.
+	// UserMgr.users is map[string]*User keyed by handle (confirmed in manager.go).
+	m := &UserMgr{users: map[string]*User{
+		"nobody": {ID: 1, Handle: "nobody", AccessLevel: 10},
+		"sysop":  {ID: 2, Handle: "sysop", AccessLevel: 255, PublicKeys: []string{line}},
+	}}
+
+	got, ok := m.FindByAuthorizedKey(pub.Marshal())
+	if !ok || got.Handle != "sysop" {
+		t.Fatalf("expected sysop, got %v %+v", ok, got)
+	}
+
+	// Unknown key → not found.
+	const other = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA other@x"
+	opub, _, _, _, _ := ssh.ParseAuthorizedKey([]byte(other))
+	if _, ok := m.FindByAuthorizedKey(opub.Marshal()); ok {
+		t.Fatal("unknown key should not match")
+	}
+}

--- a/internal/user/user.go
+++ b/internal/user/user.go
@@ -16,12 +16,13 @@ type LoginEvent struct {
 
 // User represents a user account.
 type User struct {
-	ID               int       `json:"id"` // Added User ID for ACS 'U' check
+	ID               int       `json:"id"`           // Added User ID for ACS 'U' check
 	PasswordHash     string    `json:"passwordHash"` // Changed from []byte to string
 	Handle           string    `json:"handle"`
 	LegacyUsername   string    `json:"username,omitempty"` // Migration only: used during load when Handle is absent; cleared on save
 	AccessLevel      int       `json:"accessLevel"`
-	Flags            string    `json:"flags"` // Added Flags string for ACS 'F' check (e.g., "XYZ")
+	Flags            string    `json:"flags"`                // Added Flags string for ACS 'F' check (e.g., "XYZ")
+	PublicKeys       []string  `json:"publicKeys,omitempty"` // OpenSSH authorized_keys lines authorized for WFC admin
 	LastLogin        time.Time `json:"lastLogin"`
 	TimesCalled      int       `json:"timesCalled"` // Used for E (NumLogons)
 	LastBulletinRead time.Time `json:"lastBulletinRead"`
@@ -29,22 +30,22 @@ type User struct {
 	CreatedAt        time.Time `json:"createdAt"`
 	UpdatedAt        time.Time `json:"updatedAt"` // For optimistic locking - tracks last modification
 	Validated        bool      `json:"validated"`
-	FilePoints       int       `json:"filePoints"`    // Added for P
-	NumUploads       int       `json:"numUploads"`    // Added for E
-	NumDownloads     int       `json:"numDownloads,omitempty"` // Download count for ACS 'B' ratio
+	FilePoints       int       `json:"filePoints"`               // Added for P
+	NumUploads       int       `json:"numUploads"`               // Added for E
+	NumDownloads     int       `json:"numDownloads,omitempty"`   // Download count for ACS 'B' ratio
 	MessagesPosted   int       `json:"messagesPosted,omitempty"` // Number of messages posted by user
 	// NumLogons is TimesCalled
 	TimeLimit   int    `json:"timeLimit"`   // Added for T (in minutes)
 	PrivateNote string `json:"privateNote"` // Added for Z
 	// Conference tracking for ACS codes C (message conference) and X (file conference)
-	CurrentMsgConferenceID   int    `json:"current_msg_conference_id,omitempty"`
-	CurrentMsgConferenceTag  string `json:"current_msg_conference_tag,omitempty"`
-	CurrentFileConferenceID  int    `json:"current_file_conference_id,omitempty"`
-	CurrentFileConferenceTag string `json:"current_file_conference_tag,omitempty"`
-	GroupLocation         string         `json:"group_location,omitempty"`           // Added Group / Location field
-	CurrentMessageAreaID  int            `json:"current_message_area_id,omitempty"`  // Added for default area tracking
-	CurrentMessageAreaTag string         `json:"current_message_area_tag,omitempty"` // Added for default area tracking
-	LastReadMessageIDs    map[int]string `json:"last_read_message_ids,omitempty"`    // Map AreaID -> Last Read Message UUID string
+	CurrentMsgConferenceID   int            `json:"current_msg_conference_id,omitempty"`
+	CurrentMsgConferenceTag  string         `json:"current_msg_conference_tag,omitempty"`
+	CurrentFileConferenceID  int            `json:"current_file_conference_id,omitempty"`
+	CurrentFileConferenceTag string         `json:"current_file_conference_tag,omitempty"`
+	GroupLocation            string         `json:"group_location,omitempty"`           // Added Group / Location field
+	CurrentMessageAreaID     int            `json:"current_message_area_id,omitempty"`  // Added for default area tracking
+	CurrentMessageAreaTag    string         `json:"current_message_area_tag,omitempty"` // Added for default area tracking
+	LastReadMessageIDs       map[int]string `json:"last_read_message_ids,omitempty"`    // Map AreaID -> Last Read Message UUID string
 
 	// File System Related
 	CurrentFileAreaID  int         `json:"current_file_area_id,omitempty"`  // Added for default file area tracking
@@ -76,8 +77,8 @@ type User struct {
 		Uploader    bool `json:"uploader"`
 		Description bool `json:"description"`
 	} `json:"file_list_columns,omitempty"`
-	AutoSignature   string `json:"autoSignature,omitempty"`   // Auto-signature appended to messages (max 5 lines)
-	Colors           [7]int `json:"colors,omitempty"`
+	AutoSignature string `json:"autoSignature,omitempty"` // Auto-signature appended to messages (max 5 lines)
+	Colors        [7]int `json:"colors,omitempty"`
 
 	// Soft Delete (user marked as deleted but data preserved)
 	DeletedUser bool       `json:"deletedUser,omitempty"` // True if user is soft-deleted


### PR DESCRIPTION
## Summary
Adds a `PublicKeys` field to the user model and an authorized-key lookup path in the user manager, with supporting test coverage.

## Changes
- `internal/user/user.go`, `internal/user/manager.go` — add `PublicKeys` field and authorized-key lookup
- `internal/user/pubkey_test.go` — coverage for pubkey lookup
- `internal/user/admin_log.go` + tests — logging cleanup

## Notes
These commits were authored on the `docs/skip-button-and-nav-fix` branch after PR #54 was already merged; rebased onto current `main` as their own PR since they are code (not docs) changes.

## Testing
`go test ./internal/user/` — 71 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for finding users by SSH public key, enabling key-based account matching in supported flows.

* **Chores**
  * Updated local ignore settings to exclude a new development directory from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->