### PR TITLE
docs(sysop): make the WFC console discoverable from setup/SSH/security docs

### DIFF
--- a/docs/sysop/_sidebar.md
+++ b/docs/sysop/_sidebar.md
@@ -83,6 +83,7 @@
 * **NETWORKING**
 * [SSH Server](networking/ssh.md)
 * [Telnet Server](networking/telnet.md)
+* [WFC Sysop Console](how-to-guides/wfc-console.md)
 
 * **ADVANCED**
 * [Config Editor](configuration/configuration.md#configuration-editor-tui)

--- a/docs/sysop/configuration/security.md
+++ b/docs/sysop/configuration/security.md
@@ -13,6 +13,11 @@ This guide covers security features and best practices for protecting your BBS.
 
 ViSiON/3 includes built-in connection management to prevent resource exhaustion and abuse.
 
+> **Sysop remote console (WFC):** the `wfc` admin console rides the existing SSH
+> server and is gated by per-user SSH **public keys** (CoSysOp level or above) —
+> it adds no new open port and accepts no password. See the
+> [WFC Sysop Console](how-to-guides/wfc-console.md) guide for key registration.
+
 ### Configuring Connection Limits
 
 Open the config editor and navigate to **System Configuration → Connection Limits** (sub-screen 2):

--- a/docs/sysop/getting-started/installation.md
+++ b/docs/sysop/getting-started/installation.md
@@ -199,3 +199,4 @@ This builds all binaries, creates a full BBS directory at the target path, and s
 - Configure [Door Programs](doors/doors.md) if desired
 - Review [File Transfer Protocols](files/file-transfer.md) (sexyz ZModem 8k)
 - Refer to [User Management](users/user-management.md) for managing users
+- Set up the [WFC Sysop Console](how-to-guides/wfc-console.md) to monitor live callers remotely over SSH

--- a/docs/sysop/networking/ssh.md
+++ b/docs/sysop/networking/ssh.md
@@ -59,6 +59,14 @@ Tested and working:
 - **PuTTY**
 - **mRemoteNG**
 
+## Remote Sysop Console (WFC)
+
+The `wfc` Waiting-For-Caller console connects over **this same SSH server** to
+monitor live node/caller activity from your own machine — no extra port to open.
+Sysops are authenticated by SSH public key (CoSysOp level or above). See the
+[WFC Sysop Console](how-to-guides/wfc-console.md) guide for building `wfc`,
+registering a key, and connecting.
+
 ## Troubleshooting
 
 ### Connection Refused


### PR DESCRIPTION
Integrates the existing WFC sysop-console guide into the natural setup paths so sysops actually find it.

- **getting-started/installation.md** — adds a WFC bullet under Next Steps.
- **networking/ssh.md** — adds a 'Remote Sysop Console (WFC)' note (it rides the same SSH server, key-auth, no extra port).
- **configuration/security.md** — notes WFC's per-user public-key gating (CoSysOp+) under Connection Security.
- **_sidebar.md** — promotes the guide under the NETWORKING section (was only under HOW-TO GUIDES).

No new content/pages — all four point to the existing `docs/sysop/how-to-guides/wfc-console.md`. Root-relative links, consistent with the sidebar.