### PR TITLE
Fix SysOp documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This project is a work-in-progress refactor and modernization of the classic ViSiON/2 BBS software. The goal is to recreate the core functionality of the classic BBS experience using modern technologies.
 
-There's detailed SysOp documentation [here](https://vision3bbs.com/sysop/#/).
+There's detailed SysOp documentation [here]([https://vision3bbs.com/sysop/](https://vision-3.github.io/vision-3-bbs/sysop)/#/).
 
 **Note:** This is currently under active development and is not quite feature-complete.
 


### PR DESCRIPTION
Updated the link to SysOp documentation in README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the SysOp documentation link to point to the new GitHub Pages site.
  * Adjusted the link format to match the updated site structure.
  * Minor formatting cleanup in the acknowledgments section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->