### PR TITLE
Fix SysOp documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This project is a work-in-progress refactor and modernization of the classic ViSiON/2 BBS software. The goal is to recreate the core functionality of the classic BBS experience using modern technologies.
 
-There's detailed SysOp documentation [here]([https://vision3bbs.com/sysop/](https://vision-3.github.io/vision-3-bbs/sysop)/#/).
+There's detailed SysOp documentation [here](https://vision-3.github.io/vision-3-bbs/sysop).
 
 **Note:** This is currently under active development and is not quite feature-complete.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the SysOp documentation link in the README so it now points cleanly to the updated documentation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->