### PR TITLE
fix(docs): make github.io project-pages URL navigable (host-agnostic links)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
             <span class="nav-item"><span class="nav-bracket">[</span><span class="nav-key">G</span><span class="nav-bracket">]</span> <a href="#get-started"><span class="fade-1">G</span><span class="fade-2">e</span><span class="fade-3">t Start</span><span class="fade-2">e</span><span class="fade-1">d</span></a></span>
             <span class="nav-item"><span class="nav-bracket">[</span><span class="nav-key">J</span><span class="nav-bracket">]</span> <a href="#get-involved"><span class="fade-1">G</span><span class="fade-2">e</span><span class="fade-3">t Involv</span><span class="fade-2">e</span><span class="fade-1">d</span></a></span>
             <span class="nav-item"><span class="nav-bracket">[</span><span class="nav-key">H</span><span class="nav-bracket">]</span> <a href="#history"><span class="fade-1">H</span><span class="fade-2">i</span><span class="fade-3">sto</span><span class="fade-2">r</span><span class="fade-1">y</span></a></span>
-            <span class="nav-item"><span class="nav-bracket">[</span><span class="nav-key">D</span><span class="nav-bracket">]</span> <a href="/sysop/"><span class="fade-1">S</span><span class="fade-2">y</span><span class="fade-3">sop Doc</span><span class="fade-2">s</span></a></span>
+            <span class="nav-item"><span class="nav-bracket">[</span><span class="nav-key">D</span><span class="nav-bracket">]</span> <a href="sysop/"><span class="fade-1">S</span><span class="fade-2">y</span><span class="fade-3">sop Doc</span><span class="fade-2">s</span></a></span>
         </div>
     </nav>
 

--- a/docs/sysop/index.html
+++ b/docs/sysop/index.html
@@ -17,7 +17,7 @@
     <script>
         window.$docsify = {
             name: '<span class="nav-bracket">[</span><span class="nav-key">D</span><span class="nav-bracket">]</span> ViSiON/3 Docs',
-            nameLink: './',
+            nameLink: '#/',
             repo: 'https://github.com/ViSiON-3/vision-3-bbs',
             loadSidebar: true,
             subMaxLevel: 0,


### PR DESCRIPTION
The landing page's Sysop Docs link used an absolute `/sysop/` and the sysop Docsify title used a relative `nameLink`, both of which 404 under the `github.io` project sub-path (`/vision-3-bbs/...`). Switches to a relative `sysop/` link and a `#/` hash nameLink so navigation works on both the custom-domain root and the github.io origin (useful as a cache-bypass while the Cloudflare cache is stale).