### PR TITLE
feat(qwk): explicit, sysop-configurable QWK BBS ID

### DIFF
--- a/docs/superpowers/plans/2026-06-30-qwk-explicit-bbs-id.md
+++ b/docs/superpowers/plans/2026-06-30-qwk-explicit-bbs-id.md
@@ -1,0 +1,414 @@
+# QWK Explicit BBS ID — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a sysop set an explicit, stable QWK BBS ID (config + config TUI) instead of always deriving it from the board name, with the derived behavior as a backward-compatible default.
+
+**Architecture:** Add `ServerConfig.QWKID` plus a shared `config.NormalizeQWKID` normalizer. The menu resolves the effective ID as "explicit-if-set, else derive from board name, else BBS"; the config editor exposes an editable, normalize-on-set "QWK ID" field. Empty QWKID reproduces today's exact behavior.
+
+**Tech Stack:** Go (stdlib `strings`, `encoding/json`, `testing`); existing `internal/config`, `internal/menu`, `internal/configeditor`.
+
+## Global Constraints
+
+- No new dependencies; `slog` for logging (none new here).
+- TDD: failing test first → run red → minimal implementation → run green → commit.
+- QWK BBS-ID rules (exact): keep ASCII `A–Z`, `a–z`, `0–9` only, upper-case, at most 8 chars. `NormalizeQWKID` returns `""` when nothing valid remains; the `"BBS"` fallback belongs to the resolver/`qwkBBSID`, not the normalizer.
+- Empty `QWKID` ⇒ derive from `BoardName` ⇒ identical to current behavior (back-compat).
+- Config TUI stores the **normalized** value (normalize-on-set; WYSIWYG).
+- Spec: `docs/superpowers/specs/2026-06-30-qwk-explicit-bbs-id-design.md`.
+
+---
+
+## File Structure
+
+- Modify: `internal/config/config.go` — add `QWKID` field to `ServerConfig`.
+- Create: `internal/config/qwkid.go` — `NormalizeQWKID`.
+- Create: `internal/config/qwkid_test.go` — `NormalizeQWKID` table test.
+- Modify: `internal/config/config_test.go` — `QWKID` load/save round-trip + default.
+- Modify: `internal/menu/qwk_handler.go` — reimplement `qwkBBSID` on the shared normalizer, add `resolveQWKID`, rewire both call sites.
+- Modify: `internal/menu/qwk_handler_test.go` — `resolveQWKID` test (keep `TestQwkBBSID`).
+- Modify: `internal/configeditor/fields_system.go` — add the "QWK ID" editable field.
+- Create: `internal/configeditor/fields_system_test.go` — assert the field normalizes on set.
+- Modify: `docs/sysop/messages/qwk.md` — document the setting.
+
+---
+
+## Task 1: Config field + shared normalizer
+
+**Files:**
+- Modify: `internal/config/config.go` (add `QWKID` to `ServerConfig`, ~line 841)
+- Create: `internal/config/qwkid.go`
+- Test: `internal/config/qwkid_test.go` (create), `internal/config/config_test.go` (modify)
+
+**Interfaces:**
+- Produces:
+  - `ServerConfig` field `QWKID string` (`json:"qwkID,omitempty"`)
+  - `func NormalizeQWKID(s string) string`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/config/qwkid_test.go`:
+
+```go
+package config
+
+import "testing"
+
+func TestNormalizeQWKID(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "VISION3", "VISION3"},
+		{"lowercased", "vision3", "VISION3"},
+		{"spaces stripped", "My Cool BBS", "MYCOOLBB"},
+		{"symbols stripped", "V!S!O#N/3", "VSON3"},
+		{"truncated to 8", "LongBoardName123", "LONGBOAR"},
+		{"empty", "", ""},
+		{"all symbols", "!@#$%^&*()", ""},
+		{"unicode stripped", "Café BBS", "CAFBBS"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeQWKID(tt.in); got != tt.want {
+				t.Errorf("NormalizeQWKID(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+```
+
+Add to `internal/config/config_test.go` (it already imports `encoding/json`, `os`, `path/filepath`, `testing`):
+
+```go
+func TestServerConfig_QWKID_RoundTrip(t *testing.T) {
+	// Explicit qwkID in config.json loads through.
+	dir := t.TempDir()
+	data, _ := json.Marshal(map[string]interface{}{"qwkID": "VISION3"})
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadServerConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.QWKID != "VISION3" {
+		t.Errorf("loaded QWKID: want VISION3, got %q", loaded.QWKID)
+	}
+
+	// Absent qwkID defaults to empty.
+	def, err := LoadServerConfig(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if def.QWKID != "" {
+		t.Errorf("default QWKID: want empty, got %q", def.QWKID)
+	}
+
+	// Save then load preserves QWKID.
+	saveDir := t.TempDir()
+	if err := SaveServerConfig(saveDir, ServerConfig{QWKID: "ABC123"}); err != nil {
+		t.Fatal(err)
+	}
+	back, err := LoadServerConfig(saveDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if back.QWKID != "ABC123" {
+		t.Errorf("round-trip QWKID: want ABC123, got %q", back.QWKID)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/config/ -run 'TestNormalizeQWKID|TestServerConfig_QWKID' -v`
+Expected: FAIL — `undefined: NormalizeQWKID`, and `ServerConfig` has no field `QWKID`.
+
+- [ ] **Step 3: Add the config field**
+
+In `internal/config/config.go`, add the field to `ServerConfig` immediately after the `SysOpName` line (currently `SysOpName string \`json:"sysOpName"\`` at line ~841):
+
+```go
+	QWKID string `json:"qwkID,omitempty"` // Explicit QWK packet ID; blank = derive from BoardName
+```
+
+No change to `defaultConfig` (the zero value `""` is the intended default).
+
+- [ ] **Step 4: Add the normalizer**
+
+Create `internal/config/qwkid.go`:
+
+```go
+package config
+
+import "strings"
+
+// NormalizeQWKID reduces a string to a valid QWK BBS ID: ASCII letters and
+// digits only, upper-cased, at most 8 characters. It returns "" when nothing
+// valid remains; callers decide the fallback (e.g. derive from another field or
+// use "BBS").
+func NormalizeQWKID(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			if b.Len() >= 8 {
+				break
+			}
+		}
+	}
+	return strings.ToUpper(b.String())
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/config/ -run 'TestNormalizeQWKID|TestServerConfig_QWKID' -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+gofmt -w internal/config/config.go internal/config/qwkid.go internal/config/qwkid_test.go internal/config/config_test.go
+go vet ./internal/config/
+git add internal/config/config.go internal/config/qwkid.go internal/config/qwkid_test.go internal/config/config_test.go
+git commit -m "feat(config): add explicit QWKID field and NormalizeQWKID"
+```
+
+---
+
+## Task 2: Menu resolver + rewire call sites
+
+**Files:**
+- Modify: `internal/menu/qwk_handler.go`
+- Test: `internal/menu/qwk_handler_test.go`
+
+**Interfaces:**
+- Consumes: `config.NormalizeQWKID` (Task 1), `config.ServerConfig` (with `QWKID`).
+- Produces: `func resolveQWKID(cfg config.ServerConfig) string`; `qwkBBSID` reimplemented on the shared normalizer (signature unchanged).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/menu/qwk_handler_test.go`. It currently imports `os`, `path/filepath`, `testing`; add the config import:
+
+```go
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+```
+
+Add the test:
+
+```go
+func TestResolveQWKID(t *testing.T) {
+	// Explicit QWKID wins and is normalized.
+	if got := resolveQWKID(config.ServerConfig{QWKID: "my id!", BoardName: "Whatever"}); got != "MYID" {
+		t.Errorf("explicit: want MYID, got %q", got)
+	}
+	// Blank QWKID falls back to board-name derivation.
+	if got := resolveQWKID(config.ServerConfig{QWKID: "", BoardName: "ViSiON/3 BBS"}); got != "VISION3B" {
+		t.Errorf("derive: want VISION3B, got %q", got)
+	}
+	// Both blank/invalid → BBS.
+	if got := resolveQWKID(config.ServerConfig{QWKID: "!!!", BoardName: "###"}); got != "BBS" {
+		t.Errorf("fallback: want BBS, got %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/menu/ -run TestResolveQWKID -v`
+Expected: FAIL — `undefined: resolveQWKID`.
+
+- [ ] **Step 3: Reimplement `qwkBBSID` and add `resolveQWKID`**
+
+In `internal/menu/qwk_handler.go`, add the config import to the import block:
+
+```go
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+```
+
+Replace the existing `qwkBBSID` function (the comment block + body, currently lines ~22–39 — `func qwkBBSID(boardName string) string { ... }`) with:
+
+```go
+// qwkBBSID returns a short BBS identifier derived from the board name
+// (alphanumeric, max 8 chars, uppercase), falling back to "BBS".
+func qwkBBSID(boardName string) string {
+	if id := config.NormalizeQWKID(boardName); id != "" {
+		return id
+	}
+	return "BBS"
+}
+
+// resolveQWKID returns the BBS's QWK packet ID: the explicitly configured ID
+// (normalized) if set, otherwise one derived from the board name (qwkBBSID).
+func resolveQWKID(cfg config.ServerConfig) string {
+	if id := config.NormalizeQWKID(cfg.QWKID); id != "" {
+		return id
+	}
+	return qwkBBSID(cfg.BoardName)
+}
+```
+
+- [ ] **Step 4: Rewire both call sites**
+
+In `internal/menu/qwk_handler.go`, replace both occurrences of:
+
+```go
+	bbsID := qwkBBSID(e.ServerCfg.BoardName)
+```
+
+(one in `runQWKDownload` ~line 59, one in `runQWKUpload` ~line 183) with:
+
+```go
+	bbsID := resolveQWKID(e.ServerCfg)
+```
+
+Verify none remain: `grep -n 'qwkBBSID(e.ServerCfg' internal/menu/qwk_handler.go` → no output.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/menu/ -run 'TestResolveQWKID|TestQwkBBSID' -v`
+Expected: PASS — both the new `TestResolveQWKID` and the existing `TestQwkBBSID` (qwkBBSID's behavior is unchanged: derive + "BBS" fallback).
+
+- [ ] **Step 6: Commit**
+
+```bash
+gofmt -w internal/menu/qwk_handler.go internal/menu/qwk_handler_test.go
+go vet ./internal/menu/
+git add internal/menu/qwk_handler.go internal/menu/qwk_handler_test.go
+git commit -m "feat(qwk): resolve QWK ID from explicit config, deriving as fallback"
+```
+
+---
+
+## Task 3: Config TUI field + docs + verification
+
+**Files:**
+- Modify: `internal/configeditor/fields_system.go`
+- Create: `internal/configeditor/fields_system_test.go`
+- Modify: `docs/sysop/messages/qwk.md`
+
+**Interfaces:**
+- Consumes: `config.NormalizeQWKID`, `ServerConfig.QWKID` (Task 1).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/configeditor/fields_system_test.go`:
+
+```go
+package configeditor
+
+import (
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+)
+
+func TestSysFieldsRegistration_QWKIDNormalizesOnSet(t *testing.T) {
+	cfg := &config.ServerConfig{}
+	fields := sysFieldsRegistration(cfg)
+
+	var f *fieldDef
+	for i := range fields {
+		if fields[i].Label == "QWK ID" {
+			f = &fields[i]
+			break
+		}
+	}
+	if f == nil {
+		t.Fatal("QWK ID field not found in registration screen")
+	}
+	if err := f.Set("my id!"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if cfg.QWKID != "MYID" {
+		t.Errorf("Set should normalize: want cfg.QWKID == MYID, got %q", cfg.QWKID)
+	}
+	if got := f.Get(); got != "MYID" {
+		t.Errorf("Get: want MYID, got %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/configeditor/ -run TestSysFieldsRegistration_QWKIDNormalizesOnSet -v`
+Expected: FAIL — "QWK ID field not found in registration screen".
+
+- [ ] **Step 3: Add the editable field**
+
+In `internal/configeditor/fields_system.go`, inside the slice returned by
+`sysFieldsRegistration` (after the `Timezone` field at `Row: 4`, before the
+closing `}` of the slice), add:
+
+```go
+		{
+			Label: "QWK ID", Help: "Stable QWK packet ID (max 8, A-Z/0-9); blank = derive from Board Name",
+			Type: ftString, Col: 3, Row: 5, Width: 8,
+			Get: func() string { return cfg.QWKID },
+			Set: func(val string) error { cfg.QWKID = config.NormalizeQWKID(val); return nil },
+		},
+```
+
+(`config` is already imported in this file — `sysFieldsRegistration` takes
+`*config.ServerConfig`.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./internal/configeditor/ -run TestSysFieldsRegistration_QWKIDNormalizesOnSet -v`
+Expected: PASS.
+
+- [ ] **Step 5: Document the setting**
+
+In `docs/sysop/messages/qwk.md`, add a short subsection (adapt heading level to
+the file; a good spot is near the conference-numbering / upload notes):
+
+```markdown
+## QWK ID
+
+The **QWK ID** is the short identifier (max 8 characters, letters and digits)
+used for packet filenames (`<ID>.QWK` / `<ID>.REP`) and for the destination
+check on REP uploads. Set it in the config editor (System → Registration → QWK
+ID). Leave it blank to derive it automatically from the board name.
+
+Treat the QWK ID as a **stable identity** — set it once, early. Changing it later
+re-keys your packets: offline readers will see a different BBS ID, and saved
+`.QWK`/`.REP` files keyed to the old ID stop matching.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+gofmt -w internal/configeditor/fields_system.go internal/configeditor/fields_system_test.go
+git add internal/configeditor/fields_system.go internal/configeditor/fields_system_test.go docs/sysop/messages/qwk.md
+git commit -m "feat(configeditor): add editable QWK ID field; document it"
+```
+
+- [ ] **Step 7: Full verification**
+
+Run: `gofmt -l internal/config internal/menu internal/configeditor`
+Expected: no output.
+
+Run: `go vet ./... 2>&1 | tail -5`
+Expected: no issues.
+
+Run: `go test ./... 2>&1 | tail -10`
+Expected: all packages PASS.
+
+- [ ] **Step 8: Final commit (only if cleanup was needed)**
+
+```bash
+git add -A
+git commit -m "chore(qwk): explicit BBS ID cleanup and verification"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+- **Spec coverage:** config field + `NormalizeQWKID` → Task 1; resolver + rewire + `qwkBBSID` reuse → Task 2; config TUI field (normalize-on-set) + docs → Task 3. Tests for normalizer, round-trip, resolver, and TUI-field-normalizes are all present. All spec sections covered.
+- **Refinement vs spec:** the spec said "keep `qwkBBSID`"; the resolver here *delegates* its board-name path to `qwkBBSID` so the function stays live (no dead code) and its existing test stays meaningful — fully consistent with the spec's intent.
+- **Placeholder scan:** no TBD/TODO; every code step shows full code; the TUI row (`Row: 5`) is pinned (Rows 1–4 are Board Name / SysOp / Location / Timezone).
+- **Type consistency:** `NormalizeQWKID(string) string`, `resolveQWKID(config.ServerConfig) string`, `qwkBBSID(string) string`, and `ServerConfig.QWKID` are used consistently across tasks; `fieldDef`'s `Get`/`Set`/`Label`/`Type`/`Col`/`Row`/`Width` match the existing descriptor shape.

--- a/docs/superpowers/specs/2026-06-30-qwk-explicit-bbs-id-design.md
+++ b/docs/superpowers/specs/2026-06-30-qwk-explicit-bbs-id-design.md
@@ -1,0 +1,177 @@
+# QWK Explicit BBS ID
+
+**Date:** 2026-06-30
+**Status:** Approved design
+**Branch:** `qwk-explicit-bbs-id`
+
+---
+
+## Problem
+
+The QWK BBS ID is derived at runtime from the board name:
+`qwkBBSID(e.ServerCfg.BoardName)` in `internal/menu/qwk_handler.go` (alphanumeric,
+≤8 chars, uppercase, `"BBS"` fallback). After QWK Phases 2–3 this ID is no longer
+cosmetic — it is a **stable identity**:
+
+- the `.QWK` / `.REP` filename (`VISION3.QWK`, `VISION3.MSG`),
+- the destination ID written into REP packets and **validated on import**
+  (`ErrWrongBBS`),
+- the BBS identity handed to `qwkservice.New(...)`.
+
+Deriving that from the mutable `BoardName` is the same anti-pattern Phase 2
+eliminated for conference numbers: a stable exported contract must not depend on
+an incidental, mutable value. Renaming the board silently changes the QWK ID,
+breaking offline readers' saved packets and changing the packet filename match.
+
+## Goal
+
+Let the sysop set an explicit, stable QWK ID (config + config TUI), independent
+of the board name, while keeping the derived behavior as a backward-compatible
+default.
+
+## Non-goals
+
+- No change to how packets are built/validated beyond *which* ID string is used.
+- No migration of existing `config.json` files (a new optional field; absent ⇒
+  current behavior).
+- No multi-ID / per-conference ID support.
+
+## Decisions (confirmed)
+
+| Decision | Choice |
+| --- | --- |
+| Config field | `ServerConfig.QWKID string` (`json:"qwkID,omitempty"`), default empty |
+| Empty semantics | Empty ⇒ derive from `BoardName` (current behavior, back-compat) |
+| Normalizer location | `config.NormalizeQWKID` (both menu and configeditor consume it; configeditor already imports config — no cycle) |
+| Config TUI storage | Normalize-on-Set (canonical storage; WYSIWYG) |
+
+---
+
+## Design
+
+### 1. Config field — `internal/config/config.go`
+
+Add to `ServerConfig` (near `BoardName`, line ~840):
+
+```go
+QWKID string `json:"qwkID,omitempty"`
+```
+
+Default is the zero value `""` (no entry needed in `defaultConfig`). `Load`/`Save`
+already round-trip arbitrary `ServerConfig` fields, so no loader change is needed.
+
+### 2. Normalizer — `internal/config` (new function)
+
+```go
+// NormalizeQWKID reduces a string to a valid QWK BBS ID: ASCII letters and
+// digits only, upper-cased, at most 8 characters. Returns "" if nothing valid
+// remains (the caller decides the fallback).
+func NormalizeQWKID(s string) string
+```
+
+Implementation mirrors the existing `qwkBBSID` body (keep only `A–Z`, `a–z`,
+`0–9`; stop at 8; upper-case) **without** the `"BBS"` fallback — that belongs to
+the resolver. Lives in a small file, e.g. `internal/config/qwkid.go`.
+
+### 3. Resolver + `qwkBBSID` — `internal/menu/qwk_handler.go`
+
+Add:
+
+```go
+// resolveQWKID returns the BBS's QWK packet ID: the explicitly configured ID if
+// set, otherwise one derived from the board name, otherwise "BBS".
+func resolveQWKID(cfg config.ServerConfig) string {
+	if id := config.NormalizeQWKID(cfg.QWKID); id != "" {
+		return id
+	}
+	if id := config.NormalizeQWKID(cfg.BoardName); id != "" {
+		return id
+	}
+	return "BBS"
+}
+```
+
+Reimplement the existing `qwkBBSID` on top of the shared normalizer so its
+current contract and tests are preserved:
+
+```go
+func qwkBBSID(boardName string) string {
+	if id := config.NormalizeQWKID(boardName); id != "" {
+		return id
+	}
+	return "BBS"
+}
+```
+
+Replace both `bbsID := qwkBBSID(e.ServerCfg.BoardName)` call sites
+(`runQWKDownload` line ~59, `runQWKUpload` line ~183) with
+`bbsID := resolveQWKID(e.ServerCfg)`.
+
+`e.ServerCfg` is a `config.ServerConfig` value on `MenuExecutor`
+(`internal/menu/executor.go:224`).
+
+### 4. Config TUI field — `internal/configeditor/fields_system.go`
+
+The editor uses `fieldDef` descriptors (`internal/configeditor/fields.go:26`)
+with `Label/Help/Type/Col/Row/Width/Get/Set`. Add a row next to "Board Name" on
+the registration screen (`sysFieldsRegistration`):
+
+```go
+{
+	Label: "QWK ID", Help: "Stable QWK packet ID (max 8, A-Z/0-9); blank = derive from Board Name",
+	Type: ftString, Col: 3, Row: <next>, Width: 8,
+	Get: func() string { return cfg.QWKID },
+	Set: func(val string) error { cfg.QWKID = config.NormalizeQWKID(val); return nil },
+}
+```
+
+Normalize-on-Set means the stored and displayed value is always the canonical ID
+that will actually be used — no divergence between what the sysop sees and what
+ships in packets. `Width: 8` also bounds the input length (`CharLimit`,
+`update_syscfg.go:187`). Place the row so it does not overlap an existing
+`Row`/`Col`; renumber neighboring rows if needed.
+
+### 5. Documentation — `docs/sysop/messages/qwk.md`
+
+Add a short note: the QWK ID can be set explicitly in the config editor; it is a
+**stable identity** (like the conference map — set once, early). Blank derives it
+from the board name. Changing it later re-keys packet identity (filenames + REP
+first-block validation), so offline readers will see it as a different BBS.
+
+---
+
+## Testing
+
+**`internal/config`:**
+- `NormalizeQWKID` table test: plain id; lowercase → upper; spaces/symbols
+  stripped; >8 truncated; all-invalid → `""`; empty → `""`.
+- Load/save round-trip preserves `QWKID`; absent `qwkID` in JSON → `""`.
+
+**`internal/menu`:**
+- `resolveQWKID`: explicit `QWKID` wins (and is normalized); blank `QWKID` falls
+  back to board-name derivation; both blank/invalid → `"BBS"`.
+- Existing `TestQwkBBSID` continues to pass unchanged.
+
+**`internal/configeditor`:** if a focused test fits the existing patterns, assert
+the QWK ID field's `Set` normalizes; otherwise the field is covered by build +
+the resolver/normalizer unit tests (the editor wiring is declarative).
+
+---
+
+## Risks / notes
+
+- **Identity change on edit:** setting a QWK ID different from the previously
+  derived one changes packet filenames and the REP first-block ID; documented as
+  a deliberate, set-once action.
+- **Hand-edited config:** the resolver re-normalizes `cfg.QWKID` at consume time,
+  so a malformed hand-edited value still yields a valid ID.
+- **Back-compat:** absent/empty `qwkID` reproduces today's exact behavior.
+
+## Acceptance criteria
+
+- A sysop can set an explicit QWK ID in the config editor; it is used for QWK
+  download/upload filenames and REP validation.
+- With no QWK ID set, behavior is identical to today (derived from board name).
+- Renaming the board no longer changes the QWK ID when an explicit ID is set.
+- `config.NormalizeQWKID`, `resolveQWKID`, and config round-trip are tested;
+  existing `qwkBBSID` tests still pass.

--- a/docs/sysop/messages/qwk.md
+++ b/docs/sysop/messages/qwk.md
@@ -42,7 +42,7 @@ The menu ANSI art is `menus/v3/ansi/QWKM.ANS`.
 
 The BBS ID is the short identifier (max 8 characters, letters and digits) used for packet filenames (`<ID>.QWK` / `<ID>.REP`) and for the destination check on REP uploads.
 
-Set it explicitly in the config editor (System → Registration → **QWK ID**), or in `configs/config.json` as `qwkID`. Leave it blank to derive it automatically from `BoardName` (alphanumeric only, max 8 characters, uppercased — e.g. `"ViSiON/3 BBS"` → `VISION3B`).
+Set it explicitly in the config editor (System → Registration → **QWK ID**), or in `configs/config.json` as `qwkID`. Leave it blank to derive it automatically from `BoardName` (alphanumeric only, max 8 characters, uppercased — e.g. `"ViSiON/3 BBS"` → `VISION3B`; if nothing valid remains, the system uses `BBS`).
 
 Treat the QWK ID as a **stable identity** — set it once, early. Changing it later re-keys your packets: offline readers will see a different BBS ID, and saved `.QWK`/`.REP` files keyed to the old ID stop matching. Setting an explicit ID also means renaming the board no longer changes the QWK ID.
 

--- a/docs/sysop/messages/qwk.md
+++ b/docs/sysop/messages/qwk.md
@@ -40,7 +40,11 @@ The menu ANSI art is `menus/v3/ansi/QWKM.ANS`.
 
 ## BBS ID
 
-The BBS ID used for packet filenames is derived from `BoardName` in `configs/config.json`: alphanumeric characters only, max 8 characters, uppercased. For example, `"ViSiON/3 BBS"` → `VISION3B`.
+The BBS ID is the short identifier (max 8 characters, letters and digits) used for packet filenames (`<ID>.QWK` / `<ID>.REP`) and for the destination check on REP uploads.
+
+Set it explicitly in the config editor (System → Registration → **QWK ID**), or in `configs/config.json` as `qwkID`. Leave it blank to derive it automatically from `BoardName` (alphanumeric only, max 8 characters, uppercased — e.g. `"ViSiON/3 BBS"` → `VISION3B`).
+
+Treat the QWK ID as a **stable identity** — set it once, early. Changing it later re-keys your packets: offline readers will see a different BBS ID, and saved `.QWK`/`.REP` files keyed to the old ID stop matching. Setting an explicit ID also means renaming the board no longer changes the QWK ID.
 
 ## Tagged Areas and Newscan
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -839,6 +839,7 @@ type FTNConfig struct {
 type ServerConfig struct {
 	BoardName           string `json:"boardName"`
 	SysOpName           string `json:"sysOpName"`
+	QWKID               string `json:"qwkID,omitempty"` // Explicit QWK packet ID; blank = derive from BoardName
 	BBSLocation         string `json:"bbsLocation,omitempty"`
 	Timezone            string `json:"timezone,omitempty"`
 	SysOpLevel          int    `json:"sysOpLevel"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -742,3 +742,41 @@ func TestLoadStrings_NewUsersClosedStr(t *testing.T) {
 		t.Errorf("expected custom NewUsersClosedStr, got %q", result.NewUsersClosedStr)
 	}
 }
+
+func TestServerConfig_QWKID_RoundTrip(t *testing.T) {
+	// Explicit qwkID in config.json loads through.
+	dir := t.TempDir()
+	data, _ := json.Marshal(map[string]interface{}{"qwkID": "VISION3"})
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadServerConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.QWKID != "VISION3" {
+		t.Errorf("loaded QWKID: want VISION3, got %q", loaded.QWKID)
+	}
+
+	// Absent qwkID defaults to empty.
+	def, err := LoadServerConfig(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if def.QWKID != "" {
+		t.Errorf("default QWKID: want empty, got %q", def.QWKID)
+	}
+
+	// Save then load preserves QWKID.
+	saveDir := t.TempDir()
+	if err := SaveServerConfig(saveDir, ServerConfig{QWKID: "ABC123"}); err != nil {
+		t.Fatal(err)
+	}
+	back, err := LoadServerConfig(saveDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if back.QWKID != "ABC123" {
+		t.Errorf("round-trip QWKID: want ABC123, got %q", back.QWKID)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -767,9 +767,16 @@ func TestServerConfig_QWKID_RoundTrip(t *testing.T) {
 		t.Errorf("default QWKID: want empty, got %q", def.QWKID)
 	}
 
-	// Save then load preserves QWKID.
+	// Save then load preserves QWKID. Start from a defaults-initialized config
+	// (as the editor does: load, edit, save) rather than a zeroed struct, so the
+	// round-trip reflects a realistic save and other defaults are retained.
 	saveDir := t.TempDir()
-	if err := SaveServerConfig(saveDir, ServerConfig{QWKID: "ABC123"}); err != nil {
+	cfg, err := LoadServerConfig(saveDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.QWKID = "ABC123"
+	if err := SaveServerConfig(saveDir, cfg); err != nil {
 		t.Fatal(err)
 	}
 	back, err := LoadServerConfig(saveDir)
@@ -778,5 +785,8 @@ func TestServerConfig_QWKID_RoundTrip(t *testing.T) {
 	}
 	if back.QWKID != "ABC123" {
 		t.Errorf("round-trip QWKID: want ABC123, got %q", back.QWKID)
+	}
+	if back.BoardName != cfg.BoardName {
+		t.Errorf("round-trip should retain other defaults: BoardName want %q, got %q", cfg.BoardName, back.BoardName)
 	}
 }

--- a/internal/config/qwkid.go
+++ b/internal/config/qwkid.go
@@ -1,0 +1,20 @@
+package config
+
+import "strings"
+
+// NormalizeQWKID reduces a string to a valid QWK BBS ID: ASCII letters and
+// digits only, upper-cased, at most 8 characters. It returns "" when nothing
+// valid remains; callers decide the fallback (e.g. derive from another field or
+// use "BBS").
+func NormalizeQWKID(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			if b.Len() >= 8 {
+				break
+			}
+		}
+	}
+	return strings.ToUpper(b.String())
+}

--- a/internal/config/qwkid_test.go
+++ b/internal/config/qwkid_test.go
@@ -1,0 +1,27 @@
+package config
+
+import "testing"
+
+func TestNormalizeQWKID(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "VISION3", "VISION3"},
+		{"lowercased", "vision3", "VISION3"},
+		{"spaces stripped", "My Cool BBS", "MYCOOLBB"},
+		{"symbols stripped", "V!S!O#N/3", "VSON3"},
+		{"truncated to 8", "LongBoardName123", "LONGBOAR"},
+		{"empty", "", ""},
+		{"all symbols", "!@#$%^&*()", ""},
+		{"unicode stripped", "Café BBS", "CAFBBS"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeQWKID(tt.in); got != tt.want {
+				t.Errorf("NormalizeQWKID(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/configeditor/fields_system.go
+++ b/internal/configeditor/fields_system.go
@@ -146,6 +146,12 @@ func sysFieldsRegistration(cfg *config.ServerConfig) []fieldDef {
 				return items
 			},
 		},
+		{
+			Label: "QWK ID", Help: "Stable QWK packet ID (max 8, A-Z/0-9); blank = derive from Board Name",
+			Type: ftString, Col: 3, Row: 5, Width: 8,
+			Get: func() string { return cfg.QWKID },
+			Set: func(val string) error { cfg.QWKID = config.NormalizeQWKID(val); return nil },
+		},
 	}
 }
 

--- a/internal/configeditor/fields_system_test.go
+++ b/internal/configeditor/fields_system_test.go
@@ -1,0 +1,32 @@
+package configeditor
+
+import (
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+)
+
+func TestSysFieldsRegistration_QWKIDNormalizesOnSet(t *testing.T) {
+	cfg := &config.ServerConfig{}
+	fields := sysFieldsRegistration(cfg)
+
+	var f *fieldDef
+	for i := range fields {
+		if fields[i].Label == "QWK ID" {
+			f = &fields[i]
+			break
+		}
+	}
+	if f == nil {
+		t.Fatal("QWK ID field not found in registration screen")
+	}
+	if err := f.Set("my id!"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if cfg.QWKID != "MYID" {
+		t.Errorf("Set should normalize: want cfg.QWKID == MYID, got %q", cfg.QWKID)
+	}
+	if got := f.Get(); got != "MYID" {
+		t.Errorf("Get: want MYID, got %q", got)
+	}
+}

--- a/internal/menu/qwk_handler.go
+++ b/internal/menu/qwk_handler.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
 	"github.com/ViSiON-3/vision-3-bbs/internal/message"
 	"github.com/ViSiON-3/vision-3-bbs/internal/qwkservice"
 	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
@@ -19,23 +20,22 @@ import (
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 )
 
-// qwkBBSID returns a short BBS identifier for QWK packet filenames.
-// Derived from BoardName: alphanumeric only, max 8 chars, uppercase.
+// qwkBBSID returns a short BBS identifier derived from the board name
+// (alphanumeric, max 8 chars, uppercase), falling back to "BBS".
 func qwkBBSID(boardName string) string {
-	var b strings.Builder
-	for _, r := range boardName {
-		if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
-			b.WriteRune(r)
-			if b.Len() >= 8 {
-				break
-			}
-		}
+	if id := config.NormalizeQWKID(boardName); id != "" {
+		return id
 	}
-	id := strings.ToUpper(b.String())
-	if id == "" {
-		id = "BBS"
+	return "BBS"
+}
+
+// resolveQWKID returns the BBS's QWK packet ID: the explicitly configured ID
+// (normalized) if set, otherwise one derived from the board name (qwkBBSID).
+func resolveQWKID(cfg config.ServerConfig) string {
+	if id := config.NormalizeQWKID(cfg.QWKID); id != "" {
+		return id
 	}
-	return id
+	return qwkBBSID(cfg.BoardName)
 }
 
 // runQWKDownload builds and sends a QWK mail packet to the user.
@@ -56,7 +56,7 @@ func runQWKDownload(c *cmdCtx, args string) (*user.User, string, error) {
 		return nil, "", nil
 	}
 
-	bbsID := qwkBBSID(e.ServerCfg.BoardName)
+	bbsID := resolveQWKID(e.ServerCfg)
 	svc := qwkservice.New(e.MessageMgr, bbsID, e.ServerCfg.BoardName, e.ServerCfg.SysOpName, e.MessageMgr.DataPath())
 
 	terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|15Building QWK packet...|07\r\n")), outputMode)
@@ -180,7 +180,7 @@ func runQWKUpload(c *cmdCtx, args string) (*user.User, string, error) {
 		return nil, "", nil
 	}
 
-	bbsID := qwkBBSID(e.ServerCfg.BoardName)
+	bbsID := resolveQWKID(e.ServerCfg)
 
 	// Protocol selection
 	proto, ok, protoErr := e.selectTransferProtocol(s, terminal, outputMode)

--- a/internal/menu/qwk_handler_test.go
+++ b/internal/menu/qwk_handler_test.go
@@ -4,7 +4,24 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
 )
+
+func TestResolveQWKID(t *testing.T) {
+	// Explicit QWKID wins and is normalized.
+	if got := resolveQWKID(config.ServerConfig{QWKID: "my id!", BoardName: "Whatever"}); got != "MYID" {
+		t.Errorf("explicit: want MYID, got %q", got)
+	}
+	// Blank QWKID falls back to board-name derivation.
+	if got := resolveQWKID(config.ServerConfig{QWKID: "", BoardName: "ViSiON/3 BBS"}); got != "VISION3B" {
+		t.Errorf("derive: want VISION3B, got %q", got)
+	}
+	// Both blank/invalid → BBS.
+	if got := resolveQWKID(config.ServerConfig{QWKID: "!!!", BoardName: "###"}); got != "BBS" {
+		t.Errorf("fallback: want BBS, got %q", got)
+	}
+}
 
 func TestQwkBBSID(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Let sysops set an explicit, stable QWK BBS ID instead of always deriving it from the board name.

Design: `docs/superpowers/specs/2026-06-30-qwk-explicit-bbs-id-design.md`
Plan: `docs/superpowers/plans/2026-06-30-qwk-explicit-bbs-id.md`

## Why
After QWK Phases 2–3, the BBS ID is no longer cosmetic — it's a **stable identity**: the `.QWK`/`.REP` filename, the destination ID validated on REP import (`ErrWrongBBS`), and the identity handed to the QWK service. Deriving it from the mutable `BoardName` is the same anti-pattern Phase 2 eliminated for conference numbers: rename the board and the QWK ID silently changes, breaking offline readers' saved packets and the packet filename match. Synchronet has an explicit `QWKID` field for exactly this reason.

## What changed
- **`config`** — new `ServerConfig.QWKID` field (`json:"qwkID,omitempty"`) and a shared `config.NormalizeQWKID(s)` (A–Z/0–9 only, upper, ≤8; `""` if nothing valid).
- **`menu`** — `resolveQWKID(cfg)`: explicit `QWKID` (normalized) wins, else derive from board name (`qwkBBSID`), else `"BBS"`. Both `runQWKDownload`/`runQWKUpload` call sites rewired. `qwkBBSID` is reimplemented on the shared normalizer and reused as the derive path (no dead code; its tests stay green).
- **`configeditor`** — editable "QWK ID" field on the System → Registration screen, **normalize-on-set** (what you see stored is the canonical ID used in packets).
- **docs** — updated the `BBS ID` section in `docs/sysop/messages/qwk.md` (explicit config option + set-once stable-identity guidance).

## Backward compatibility
Blank `qwkID` ⇒ derive from board name ⇒ **identical to today's behavior**. No config migration; the field is optional.

## Verification
- `go test ./...` → 1624 pass (54 packages); `go vet` clean; touched files gofmt-clean.
- New tests: `NormalizeQWKID` table; `QWKID` load/save round-trip + default-empty; `resolveQWKID` (explicit wins / derive fallback / "BBS"); config-editor field normalizes on set. Existing `TestQwkBBSID` preserved.

Developed via TDD (spec → plan → executing-plans), one commit per task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional QWK ID setting in the system registration area and config file, letting sysops define a stable packet identity.
  * QWK IDs are now normalized automatically to a short uppercase alphanumeric value.

* **Bug Fixes**
  * QWK packet and REP naming now use the explicit QWK ID when set, and otherwise fall back to the board name or a default value.
  * Updated help text to explain how changing the ID affects offline reader file matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->