### PR TITLE
feat: local message reply threading

### DIFF
--- a/docs/superpowers/plans/2026-06-30-local-reply-threading.md
+++ b/docs/superpowers/plans/2026-06-30-local-reply-threading.md
@@ -1,0 +1,509 @@
+# Local Message Reply Threading — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Record a parent-message pointer when a user replies, so the reader shows "Reply#: N" for local message areas (and echomail replies link immediately).
+
+**Architecture:** Add a `jam.Message.ReplyTo` convenience field that `WriteMessage`/`WriteMessageExt` write into the JAM header. Consolidate the `Add*` posting methods in the manager into one internal `addMessage` and add `AddReply` (carrying both the FTN `ReplyID` and the numeric `ReplyTo`). The reader's single shared reply path passes the parent's number. Display is already wired (substitution key `P`; the default MSGHDR template already shows `Reply#: @P@`).
+
+**Tech Stack:** Go (stdlib `testing`, `time`); existing `internal/jam`, `internal/message`, `internal/menu`.
+
+## Global Constraints
+
+- No new dependencies; `slog` for logging.
+- TDD: failing test first → run red → minimal implementation → run green → commit. For the consolidation refactor, write characterization tests that pass on the CURRENT code first, then refactor and keep them green.
+- Backward compatible: `msg.ReplyTo` defaults to `0`, so every existing caller writes `ReplyTo == 0` (today's behavior). The three existing `Add*` methods keep identical signatures and behavior.
+- Reply data flows through `jam.Message.ReplyTo` (a convenience field), NOT `msg.Header` — `Message.GetAttribute()` returns `Header.Attribute` when `Header != nil` (`internal/jam/types.go:109`), so routing `ReplyTo` through `Header` would corrupt message attributes.
+- Spec: `docs/superpowers/specs/2026-06-30-local-reply-threading-design.md`.
+
+---
+
+## File Structure
+
+- Modify: `internal/jam/types.go` — add `Message.ReplyTo uint32`.
+- Modify: `internal/jam/message.go` — `WriteMessage` sets `hdr.ReplyTo`.
+- Modify: `internal/jam/echomail.go` — `WriteMessageExt` sets `hdr.ReplyTo`.
+- Create: `internal/jam/replyto_test.go` — write/read round-trip of `ReplyTo`.
+- Modify: `internal/message/manager.go` — internal `addMessage`; `AddMessage`/`AddMessageWithDate`/`AddPrivateMessage` become wrappers; add `AddReply`.
+- Create: `internal/message/reply_test.go` — characterization tests + `AddReply` test.
+- Modify: `internal/menu/message_reader_nav.go` — `handleReply` calls `AddReply`.
+
+No template or display-code changes (already wired).
+
+---
+
+## Task 1: JAM writes a `ReplyTo` parent pointer
+
+**Files:**
+- Modify: `internal/jam/types.go` (add field to `Message`, ~line 77)
+- Modify: `internal/jam/message.go` (`WriteMessage`, ~line 454)
+- Modify: `internal/jam/echomail.go` (`WriteMessageExt`, ~line 32)
+- Test: `internal/jam/replyto_test.go` (create)
+
+**Interfaces:**
+- Produces: `jam.Message` field `ReplyTo uint32`; `WriteMessage`/`WriteMessageExt` persist it to `MessageHeader.ReplyTo`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/jam/replyto_test.go`:
+
+```go
+package jam
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteMessage_PreservesReplyTo(t *testing.T) {
+	b, err := Open(filepath.Join(t.TempDir(), "base"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer b.Close()
+
+	msg := NewMessage()
+	msg.From, msg.To, msg.Subject, msg.Text = "alice", "bob", "Hi", "body"
+	msg.ReplyTo = 5
+
+	n, err := b.WriteMessage(msg)
+	if err != nil {
+		t.Fatalf("WriteMessage: %v", err)
+	}
+	got, err := b.ReadMessage(n)
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	if got.Header == nil || got.Header.ReplyTo != 5 {
+		t.Errorf("ReplyTo: want 5, got %+v", got.Header)
+	}
+}
+
+func TestWriteMessage_ZeroReplyTo(t *testing.T) {
+	b, err := Open(filepath.Join(t.TempDir(), "base"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer b.Close()
+
+	msg := NewMessage()
+	msg.From, msg.To, msg.Subject, msg.Text = "alice", "bob", "Hi", "body"
+
+	n, err := b.WriteMessage(msg)
+	if err != nil {
+		t.Fatalf("WriteMessage: %v", err)
+	}
+	got, err := b.ReadMessage(n)
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	if got.Header != nil && got.Header.ReplyTo != 0 {
+		t.Errorf("ReplyTo: want 0, got %d", got.Header.ReplyTo)
+	}
+}
+
+func TestWriteMessageExt_PreservesReplyTo(t *testing.T) {
+	b := openTestBase(t)
+
+	msg := NewMessage()
+	msg.From, msg.To, msg.Subject, msg.Text = "u1", "u2", "Re", "reply"
+	msg.ReplyTo = 3
+
+	n, err := b.WriteMessageExt(msg, MsgTypeLocalMsg, "", "Test BBS", "")
+	if err != nil {
+		t.Fatalf("WriteMessageExt: %v", err)
+	}
+	got, err := b.ReadMessage(n)
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	if got.Header == nil || got.Header.ReplyTo != 3 {
+		t.Errorf("ReplyTo: want 3, got %+v", got.Header)
+	}
+}
+```
+
+(`openTestBase(t)` is an existing helper in the jam test package — see
+`internal/jam/echomail_test.go`.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/jam/ -run 'TestWriteMessage_PreservesReplyTo|TestWriteMessageExt_PreservesReplyTo' -v`
+Expected: FAIL — `msg.ReplyTo` undefined (compile error).
+
+- [ ] **Step 3: Add the field**
+
+In `internal/jam/types.go`, add to the `Message` struct (after the `ReplyID string` field, ~line 77):
+
+```go
+	ReplyTo  uint32 // JAM parent message number (0 = none); written to the header
+```
+
+- [ ] **Step 4: Persist it in WriteMessage**
+
+In `internal/jam/message.go`, after the `hdr := &MessageHeader{...}` block and the
+`copy(hdr.Signature[:], Signature)` line (~line 460), add:
+
+```go
+	hdr.ReplyTo = msg.ReplyTo
+```
+
+- [ ] **Step 5: Persist it in WriteMessageExt**
+
+In `internal/jam/echomail.go`, after its `hdr := &MessageHeader{...}` block and the
+`copy(hdr.Signature[:], Signature)` line (~line 40), add:
+
+```go
+	hdr.ReplyTo = msg.ReplyTo
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test ./internal/jam/ 2>&1 | tail -5`
+Expected: PASS — the three new tests plus all existing jam tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+gofmt -w internal/jam/types.go internal/jam/message.go internal/jam/echomail.go internal/jam/replyto_test.go
+go vet ./internal/jam/
+git add internal/jam/types.go internal/jam/message.go internal/jam/echomail.go internal/jam/replyto_test.go
+git commit -m "feat(jam): write Message.ReplyTo parent pointer into the header"
+```
+
+---
+
+## Task 2: Manager consolidation + `AddReply`
+
+**Files:**
+- Modify: `internal/message/manager.go` (`AddMessage`/`AddMessageWithDate`/`AddPrivateMessage` → wrappers over new internal `addMessage`; add `AddReply`)
+- Test: `internal/message/reply_test.go` (create)
+
+**Interfaces:**
+- Consumes: `jam.Message.ReplyTo` (Task 1).
+- Produces: `func (mm *MessageManager) AddReply(areaID int, from, to, subject, body, replyToMsgID string, replyToNum int) (int, error)`. Existing `Add*` signatures unchanged.
+
+- [ ] **Step 1: Write the characterization + AddReply tests**
+
+Create `internal/message/reply_test.go`:
+
+```go
+package message
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newReplyTestManager(t *testing.T) *MessageManager {
+	t.Helper()
+	tmp := t.TempDir()
+	cfg := filepath.Join(tmp, "config")
+	if err := os.MkdirAll(cfg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	areas := `[{"id":1,"tag":"GENERAL","name":"General","base_path":"general","area_type":"local"},
+	           {"id":2,"tag":"PRIVMAIL","name":"Private Mail","base_path":"privmail","area_type":"local"}]`
+	if err := os.WriteFile(filepath.Join(cfg, "message_areas.json"), []byte(areas), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mm, err := NewMessageManager(tmp, cfg, "TestBBS", nil)
+	if err != nil {
+		t.Fatalf("NewMessageManager: %v", err)
+	}
+	return mm
+}
+
+// Characterization: lock the existing Add* behavior before consolidating.
+func TestAddFamily_Characterization(t *testing.T) {
+	mm := newReplyTestManager(t)
+
+	posted := 0
+	mm.OnMessagePosted = func(area *MessageArea, msgNum int, from, to, subject, body string) { posted++ }
+
+	if _, err := mm.AddMessage(1, "a", "All", "s", "b", ""); err != nil {
+		t.Fatal(err)
+	}
+	if posted != 1 {
+		t.Errorf("AddMessage should fire OnMessagePosted once, got %d", posted)
+	}
+
+	pn, err := mm.AddPrivateMessage(2, "a", "b", "s", "b", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if posted != 1 {
+		t.Errorf("AddPrivateMessage must NOT fire OnMessagePosted; count=%d", posted)
+	}
+	pm, err := mm.GetMessage(2, pn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pm.IsPrivate {
+		t.Error("AddPrivateMessage should set IsPrivate")
+	}
+
+	when := time.Date(2020, 1, 2, 3, 4, 0, 0, time.UTC)
+	dn, err := mm.AddMessageWithDate(1, "a", "All", "s3", "b3", "", when)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dmsg, err := mm.GetMessage(1, dn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !dmsg.DateTime.Equal(when) {
+		t.Errorf("AddMessageWithDate: want %v, got %v", when, dmsg.DateTime)
+	}
+}
+
+func TestAddReply_SetsReplyTo(t *testing.T) {
+	mm := newReplyTestManager(t)
+
+	parent, err := mm.AddMessage(1, "alice", "All", "Topic", "first", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	reply, err := mm.AddReply(1, "bob", "alice", "Re: Topic", "second", "", parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dm, err := mm.GetMessage(1, reply)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dm.ReplyToNum != parent {
+		t.Errorf("ReplyToNum: want %d, got %d", parent, dm.ReplyToNum)
+	}
+}
+
+func TestAddReply_AlsoSetsReplyID(t *testing.T) {
+	mm := newReplyTestManager(t)
+	parent, _ := mm.AddMessage(1, "alice", "All", "Topic", "first", "")
+	reply, err := mm.AddReply(1, "bob", "alice", "Re: Topic", "second", "PARENTMSGID", parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dm, err := mm.GetMessage(1, reply)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dm.ReplyID != "PARENTMSGID" {
+		t.Errorf("ReplyID: want PARENTMSGID, got %q", dm.ReplyID)
+	}
+	if dm.ReplyToNum != parent {
+		t.Errorf("ReplyToNum: want %d, got %d", parent, dm.ReplyToNum)
+	}
+}
+```
+
+- [ ] **Step 2: Run the characterization tests against the CURRENT code**
+
+Run: `go test ./internal/message/ -run TestAddFamily_Characterization -v`
+Expected: PASS (locks existing behavior). Then run the reply tests:
+
+Run: `go test ./internal/message/ -run 'TestAddReply_' -v`
+Expected: FAIL — `mm.AddReply undefined`.
+
+- [ ] **Step 3: Add the internal `addMessage` and rewrite the wrappers**
+
+In `internal/message/manager.go`, replace the three methods `AddMessage`
+(~585-641), `AddMessageWithDate` (~645-694), and `AddPrivateMessage` (~701-747)
+with one internal implementation plus thin wrappers and the new `AddReply`:
+
+```go
+// addMessage is the shared implementation behind AddMessage, AddMessageWithDate,
+// AddPrivateMessage, and AddReply.
+func (mm *MessageManager) addMessage(areaID int, from, to, subject, body, replyToMsgID string,
+	replyToNum int, dateTime time.Time, private bool) (int, error) {
+	b, area, err := mm.openBase(areaID)
+	if err != nil {
+		return 0, err
+	}
+
+	// Apply body transform (e.g. V3Net tearline/origin) for the local JAM copy.
+	// The original body is preserved for OnMessagePosted so the wire message
+	// carries tearline/origin as separate protocol fields, not inline.
+	jamBody := body
+	if mm.BodyTransform != nil {
+		jamBody = mm.BodyTransform(areaID, body)
+	}
+
+	msg := jam.NewMessage()
+	msg.From = from
+	msg.To = to
+	msg.Subject = subject
+	msg.Text = jamBody
+	msg.DateTime = dateTime
+
+	if private {
+		msg.Header = &jam.MessageHeader{Attribute: jam.MsgPrivate | jam.MsgLocal}
+	}
+	if replyToNum > 0 {
+		msg.ReplyTo = uint32(replyToNum)
+	}
+	if replyToMsgID != "" {
+		msg.ReplyID = replyToMsgID
+	}
+
+	msgType := jam.DetermineMessageType(area.AreaType, area.EchoTag)
+
+	// For netmail, split "user@address" into separate To and DestAddr fields.
+	if msgType.IsNetmail() {
+		name, addr := splitNetmailTo(to)
+		msg.To = name
+		if addr != "" {
+			msg.DestAddr = addr
+		}
+	}
+
+	var msgNum int
+	if msgType.IsEchomail() || msgType.IsNetmail() {
+		msg.OrigAddr = area.OriginAddr
+		msgNum, err = b.WriteMessageExt(msg, msgType, area.EchoTag, mm.boardName, mm.tearlineForNetwork(area.Network))
+	} else {
+		msgNum, err = b.WriteMessage(msg)
+	}
+
+	// Close the base before firing the callback. The V3Net hook calls
+	// MarkMessageSent which re-opens the same JAM base, so having it
+	// still open here can cause nested-open/file-sharing issues.
+	b.Close()
+
+	if err == nil {
+		mm.invalidateThreadIndex(areaID)
+		if !private && mm.OnMessagePosted != nil {
+			mm.OnMessagePosted(area, msgNum, from, to, subject, body)
+		}
+	}
+	return msgNum, err
+}
+
+// AddMessage creates and writes a new message to the specified area.
+// For echomail areas, it automatically handles MSGID, kludges, tearline, and origin.
+// For netmail areas, "user@zone:net/node" in the To field is automatically split
+// into the username and destination address.
+// Returns the 1-based message number assigned.
+func (mm *MessageManager) AddMessage(areaID int, from, to, subject, body, replyToMsgID string) (int, error) {
+	return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, 0, time.Now(), false)
+}
+
+// AddMessageWithDate is like AddMessage but uses the provided timestamp instead
+// of time.Now(). Used by V3Net to preserve the original authored date.
+func (mm *MessageManager) AddMessageWithDate(areaID int, from, to, subject, body, replyToMsgID string, dateTime time.Time) (int, error) {
+	return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, 0, dateTime, false)
+}
+
+// AddPrivateMessage creates and writes a new private (MSG_PRIVATE) message.
+// For netmail areas, "user@zone:net/node" in the To field is automatically split
+// into the username and destination address. Returns the 1-based message number.
+func (mm *MessageManager) AddPrivateMessage(areaID int, from, to, subject, body, replyToMsgID string) (int, error) {
+	return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, 0, time.Now(), true)
+}
+
+// AddReply creates and writes a reply, recording the parent's message number
+// (replyToNum) as the JAM ReplyTo so local areas thread, and the parent's FTN
+// MSGID (replyToMsgID, may be "") as ReplyID so echomail links via jam.Link().
+func (mm *MessageManager) AddReply(areaID int, from, to, subject, body, replyToMsgID string, replyToNum int) (int, error) {
+	return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, replyToNum, time.Now(), false)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/message/ -run 'TestAddFamily_Characterization|TestAddReply_' -v`
+Expected: PASS (characterization still green after the refactor; the two AddReply tests pass).
+
+Run: `go test ./internal/message/ 2>&1 | tail -5`
+Expected: all `internal/message` tests PASS (no regression in the consolidated post path).
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/message/manager.go internal/message/reply_test.go
+go vet ./internal/message/
+git add internal/message/manager.go internal/message/reply_test.go
+git commit -m "feat(message): consolidate Add* posting and add AddReply with parent pointer"
+```
+
+---
+
+## Task 3: Reader records the parent on reply + full verification
+
+**Files:**
+- Modify: `internal/menu/message_reader_nav.go` (`handleReply`, ~line 74)
+
+**Interfaces:**
+- Consumes: `MessageManager.AddReply` (Task 2).
+
+- [ ] **Step 1: Wire the reply call site**
+
+In `internal/menu/message_reader_nav.go` `handleReply`, the current reply post is:
+
+```go
+	replyMsgID := currentMsg.MsgID
+	_, err := e.MessageMgr.AddMessage(currentAreaID, currentUser.Handle, currentMsg.From,
+		newSubject, replyBody, replyMsgID)
+```
+
+Replace it with `AddReply`, passing the parent's number:
+
+```go
+	replyMsgID := currentMsg.MsgID
+	_, err := e.MessageMgr.AddReply(currentAreaID, currentUser.Handle, currentMsg.From,
+		newSubject, replyBody, replyMsgID, currentMsg.MsgNum)
+```
+
+`currentMsg.MsgNum` is the parent's 1-based number in this area; `currentMsg.MsgID`
+keeps echomail linking working. Because `READPRIVMAIL` and public reading both
+route through `runMessageReader` → `handleReply`, this single change covers public
+and private-mail replies. Leave the rest of `handleReply` unchanged.
+
+- [ ] **Step 2: Build and run the menu tests**
+
+Run: `go build ./internal/menu/ && go vet ./internal/menu/`
+Expected: success, no issues.
+
+Run: `go test ./internal/menu/ 2>&1 | tail -3`
+Expected: PASS (existing menu tests unaffected; the reply-threading behavior is
+covered by the `internal/message` AddReply tests and the `internal/jam` ReplyTo
+tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+gofmt -w internal/menu/message_reader_nav.go
+git add internal/menu/message_reader_nav.go
+git commit -m "feat(reader): record parent message number when replying"
+```
+
+- [ ] **Step 4: Full verification**
+
+Run: `gofmt -l internal/jam internal/message internal/menu/message_reader_nav.go`
+Expected: no output.
+
+Run: `go vet ./... 2>&1 | tail -5`
+Expected: no issues.
+
+Run: `go test ./... 2>&1 | tail -10`
+Expected: all packages PASS.
+
+Run: `go test -race ./internal/jam ./internal/message 2>&1 | tail -5`
+Expected: PASS, no race warnings.
+
+- [ ] **Step 5: Final commit (only if cleanup was needed)**
+
+```bash
+git add -A
+git commit -m "chore: reply-threading cleanup and verification"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+- **Spec coverage:** JAM `Message.ReplyTo` + write-side → Task 1; manager consolidation + `AddReply` (with characterization tests) → Task 2; reader reply wiring (covers public + private via the shared `handleReply`) → Task 3; display → already wired (no task needed; MSGHDR.1.ans shows `Reply#: @P@`). All spec sections covered.
+- **Placeholder scan:** no TBD/TODO; every code step shows full code; the unchanged parts of `handleReply` and `addMessage` are shown in full, not elided.
+- **Type consistency:** `Message.ReplyTo uint32`, `AddReply(... replyToMsgID string, replyToNum int)`, internal `addMessage(... replyToNum int, dateTime time.Time, private bool)`, and `DisplayMessage.ReplyToNum` are used consistently. Wrappers preserve the exact existing `Add*` signatures.

--- a/docs/superpowers/specs/2026-06-30-local-reply-threading-design.md
+++ b/docs/superpowers/specs/2026-06-30-local-reply-threading-design.md
@@ -36,8 +36,14 @@ echomail replies link immediately rather than only after `Link()`).
 
 - Thread navigation commands (jump-to-parent, next-in-chain).
 - QWK export/import of the reply reference (QWK Phase 4 — now unblocked).
-- Changing the private-flag behavior of replies to private mail.
 - Backfilling reply pointers for existing messages.
+
+> Update (during review): originally scoped out, but a reply to a private
+> message must stay private to remain visible to its recipient (the private-mail
+> reader only shows `IsPrivate` messages), so `handleReply` now routes private
+> replies through `AddPrivateReply` — preserving the `MSG_PRIVATE` flag while
+> recording the parent pointer. Without this, the private-mail half of the
+> feature would be dormant.
 
 ## Decisions (confirmed)
 

--- a/docs/superpowers/specs/2026-06-30-local-reply-threading-design.md
+++ b/docs/superpowers/specs/2026-06-30-local-reply-threading-design.md
@@ -109,18 +109,18 @@ behavior:
 
 ```go
 func (mm *MessageManager) AddMessage(areaID int, from, to, subject, body, replyToMsgID string) (int, error) {
-    return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, 0, time.Time{}, false)
+    return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, 0, time.Now(), false)
 }
 func (mm *MessageManager) AddMessageWithDate(areaID int, from, to, subject, body, replyToMsgID string, dateTime time.Time) (int, error) {
     return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, 0, dateTime, false)
 }
 func (mm *MessageManager) AddPrivateMessage(areaID int, from, to, subject, body, replyToMsgID string) (int, error) {
-    return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, 0, time.Time{}, true)
+    return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, 0, time.Now(), true)
 }
 // New: a reply carrying both the FTN ReplyID (for echomail Link()) and the
 // numeric parent (for local threading).
 func (mm *MessageManager) AddReply(areaID int, from, to, subject, body, replyToMsgID string, replyToNum int) (int, error) {
-    return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, replyToNum, time.Time{}, false)
+    return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, replyToNum, time.Now(), false)
 }
 ```
 

--- a/docs/superpowers/specs/2026-06-30-local-reply-threading-design.md
+++ b/docs/superpowers/specs/2026-06-30-local-reply-threading-design.md
@@ -63,22 +63,26 @@ preferred at review.
 
 ## Design
 
-### 1. JAM: preserve `Header.ReplyTo` on write
+### 1. JAM: a `Message.ReplyTo` convenience field, written into the header
 
-`internal/jam/message.go` `WriteMessage` builds a fresh `hdr` (line ~454) and
-drops any pre-set `msg.Header.ReplyTo`. `internal/jam/echomail.go`
-`WriteMessageExt` (line ~32) does the same. Patch both to copy a non-zero
-`msg.Header.ReplyTo` into the header being written:
+Add a `ReplyTo uint32` field to `jam.Message` (`internal/jam/types.go`, alongside
+`MsgID`/`ReplyID`). `WriteMessage` (`message.go` ~454) and `WriteMessageExt`
+(`echomail.go` ~32) set it into the header they build:
 
 ```go
-if msg.Header != nil && msg.Header.ReplyTo > 0 {
-    hdr.ReplyTo = msg.Header.ReplyTo
-}
+hdr.ReplyTo = msg.ReplyTo
 ```
 
-This is backward-compatible — `Header.ReplyTo` is always `0` at write time today.
-`ReadMessageHeader` already returns `ReplyTo` (`message.go:79`), so the value
-round-trips to disk and back.
+**Why a convenience field, not `msg.Header.ReplyTo`:** `Message.GetAttribute()`
+returns `m.Header.Attribute` whenever `Header != nil` (`types.go:109`). Creating
+or reusing `msg.Header` just to carry `ReplyTo` would change a local message's
+attribute from the `MsgLocal|MsgTypeLocal` default to whatever (possibly 0) the
+Header holds, and would OR stray flags into echomail. A top-level `Message.ReplyTo`
+maps straight to the header field with no attribute coupling.
+
+Backward-compatible — `msg.ReplyTo` is `0` for every existing caller, so the
+header's `ReplyTo` stays `0` as today. `ReadMessageHeader` already returns
+`ReplyTo` (`message.go:79`), so `GetMessage` (`manager.go:763`) keeps reading it.
 
 ### 2. Manager: consolidate posting + add `AddReply`
 
@@ -91,9 +95,11 @@ func (mm *MessageManager) addMessage(areaID int, from, to, subject, body, replyT
 
 It reproduces the current `AddMessage` body, plus:
 
-- `msg.DateTime = dateTime` if non-zero, else `time.Now()`.
+- `msg.DateTime = dateTime` (wrappers pass `time.Now()` explicitly; only
+  `AddMessageWithDate` passes a caller date — no zero-time sentinel, so the
+  current verbatim-date behavior is preserved exactly).
 - if `private`: `msg.Header = &jam.MessageHeader{Attribute: jam.MsgPrivate | jam.MsgLocal}`.
-- if `replyToNum > 0`: ensure `msg.Header != nil`, then `msg.Header.ReplyTo = uint32(replyToNum)`.
+- if `replyToNum > 0`: `msg.ReplyTo = uint32(replyToNum)` (the convenience field, no Header coupling).
 - if `replyToMsgID != ""`: `msg.ReplyID = replyToMsgID`.
 - fire `OnMessagePosted` only when `!private` (matching today: `AddPrivateMessage`
   does not fire it).
@@ -142,18 +148,20 @@ private-mail replies.
 
 ### 4. Display: ensure the header shows the reference
 
-`ReplyToNum` is already substituted as key `P` ("Reply to: #N", else "None").
-Confirm the shipped default MSGHDR template renders the reply reference; if it
-does not, add the field to the default template so the relationship is visible
-out of the box. (Sysop custom templates remain free to place/omit it.)
+`ReplyToNum` is already substituted as key `P` (`@P…@` field; value is the
+parent number, else "None"), and the shipped default template already renders it
+— `menus/v3/templates/message_headers/MSGHDR.1.ans` contains `Reply#: @P…@`. So
+once `ReplyToNum` becomes non-zero, the header shows the parent automatically;
+**no template change is required.** (Sysop/custom templates remain free to place
+or omit the `@P@` field.)
 
 ---
 
 ## Testing
 
-**`internal/jam`:** a message written with `Header.ReplyTo = N` reads back with
-`ReplyTo == N` (WriteMessage and WriteMessageExt); a message with no/zero
-`Header.ReplyTo` still writes `0` (no regression).
+**`internal/jam`:** a message written with `msg.ReplyTo = N` reads back with
+`Header.ReplyTo == N` (WriteMessage and WriteMessageExt); a message with
+`msg.ReplyTo == 0` still writes `0` (no regression).
 
 **`internal/message`:**
 - `AddReply` sets the new message's `Header.ReplyTo` to the parent number

--- a/docs/superpowers/specs/2026-06-30-local-reply-threading-design.md
+++ b/docs/superpowers/specs/2026-06-30-local-reply-threading-design.md
@@ -1,0 +1,192 @@
+# Local Message Reply Threading
+
+**Date:** 2026-06-30
+**Status:** Approved design
+**Branch:** `msg-reply-threading`
+
+---
+
+## Problem
+
+Local message areas (the QWK use case: GENERAL, PRIVMAIL) carry no reply-chain
+linkage. JAM threads on FTN `MSGID`↔`ReplyID` strings via `jam.Link()`
+(`internal/jam/link.go:14`), but local messages get no MSGID (those are generated
+only for echomail/netmail). The reader's reply path sets `ReplyID = parent.MsgID`
+(`internal/menu/message_reader_nav.go:74`), which is `""` for a local parent — so
+no link is created, `Header.ReplyTo` stays `0`, and the reader can only group by
+normalized subject ("Re:" stripping).
+
+The display side is already built: `buildMsgSubstitutions`
+(`internal/menu/message_reader_subst.go:127`) reads `msg.ReplyToNum` and exposes
+a "Reply to: #N" value as template substitution key `P`, and `GetMessage`
+populates `ReplyToNum` from `Header.ReplyTo` (`internal/message/manager.go:763`).
+The only gap is the **write side**: nothing ever sets `Header.ReplyTo` for local
+messages.
+
+This feature makes local replies record and display their parent message number.
+It also unblocks QWK Phase 4 (which had no reply data to preserve).
+
+## Goal
+
+When a user replies to a message, record the parent message number
+(`Header.ReplyTo`) so the reader shows "Reply to: #N" for local areas (and
+echomail replies link immediately rather than only after `Link()`).
+
+## Non-goals (deferred)
+
+- Thread navigation commands (jump-to-parent, next-in-chain).
+- QWK export/import of the reply reference (QWK Phase 4 — now unblocked).
+- Changing the private-flag behavior of replies to private mail.
+- Backfilling reply pointers for existing messages.
+
+## Decisions (confirmed)
+
+| Decision | Choice |
+| --- | --- |
+| Display | Display-only (header "Reply to: #N"); no new navigation keys |
+| Area scope | Public + private mail (both reached via the single shared `handleReply`) |
+| Reply API | New `AddReply(...)` carrying both `replyToMsgID` (echomail) and `replyToNum` (local) |
+
+## Open decision for the review gate
+
+**Consolidate vs standalone (`Add*` posting methods).** `AddMessage`,
+`AddMessageWithDate`, and `AddPrivateMessage` (`manager.go:585/645/701`) are
+near-duplicates. The recommended design **consolidates** them into one internal
+`addMessage(...)` (with thin public wrappers) plus the new `AddReply`, removing
+the pre-existing triplication. This touches the central post path; behavior is
+locked with characterization tests. The lower-blast-radius alternative is to add
+`AddReply` as a standalone method and leave the three existing methods untouched
+(accepting some duplication). **Default: consolidate**; switch to standalone if
+preferred at review.
+
+---
+
+## Design
+
+### 1. JAM: preserve `Header.ReplyTo` on write
+
+`internal/jam/message.go` `WriteMessage` builds a fresh `hdr` (line ~454) and
+drops any pre-set `msg.Header.ReplyTo`. `internal/jam/echomail.go`
+`WriteMessageExt` (line ~32) does the same. Patch both to copy a non-zero
+`msg.Header.ReplyTo` into the header being written:
+
+```go
+if msg.Header != nil && msg.Header.ReplyTo > 0 {
+    hdr.ReplyTo = msg.Header.ReplyTo
+}
+```
+
+This is backward-compatible — `Header.ReplyTo` is always `0` at write time today.
+`ReadMessageHeader` already returns `ReplyTo` (`message.go:79`), so the value
+round-trips to disk and back.
+
+### 2. Manager: consolidate posting + add `AddReply`
+
+Introduce one internal implementation:
+
+```go
+func (mm *MessageManager) addMessage(areaID int, from, to, subject, body, replyToMsgID string,
+    replyToNum int, dateTime time.Time, private bool) (int, error)
+```
+
+It reproduces the current `AddMessage` body, plus:
+
+- `msg.DateTime = dateTime` if non-zero, else `time.Now()`.
+- if `private`: `msg.Header = &jam.MessageHeader{Attribute: jam.MsgPrivate | jam.MsgLocal}`.
+- if `replyToNum > 0`: ensure `msg.Header != nil`, then `msg.Header.ReplyTo = uint32(replyToNum)`.
+- if `replyToMsgID != ""`: `msg.ReplyID = replyToMsgID`.
+- fire `OnMessagePosted` only when `!private` (matching today: `AddPrivateMessage`
+  does not fire it).
+
+Public methods become thin wrappers preserving exact current signatures and
+behavior:
+
+```go
+func (mm *MessageManager) AddMessage(areaID int, from, to, subject, body, replyToMsgID string) (int, error) {
+    return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, 0, time.Time{}, false)
+}
+func (mm *MessageManager) AddMessageWithDate(areaID int, from, to, subject, body, replyToMsgID string, dateTime time.Time) (int, error) {
+    return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, 0, dateTime, false)
+}
+func (mm *MessageManager) AddPrivateMessage(areaID int, from, to, subject, body, replyToMsgID string) (int, error) {
+    return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, 0, time.Time{}, true)
+}
+// New: a reply carrying both the FTN ReplyID (for echomail Link()) and the
+// numeric parent (for local threading).
+func (mm *MessageManager) AddReply(areaID int, from, to, subject, body, replyToMsgID string, replyToNum int) (int, error) {
+    return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, replyToNum, time.Time{}, false)
+}
+```
+
+Behavior to preserve verbatim (lock with characterization tests before
+refactoring): the netmail `To`/`DestAddr` split; echomail/netmail →
+`WriteMessageExt` with origin/tearline, else `WriteMessage`; `BodyTransform`
+applied to the JAM copy while `OnMessagePosted` receives the original `body`;
+`b.Close()` before the callback; `invalidateThreadIndex` on success; the private
+path's `MsgPrivate|MsgLocal` attribute and *no* `OnMessagePosted`.
+
+### 3. Reader: pass the parent on reply
+
+In `internal/menu/message_reader_nav.go` `handleReply`, replace the
+`AddMessage(..., replyMsgID)` call with:
+
+```go
+_, err := e.MessageMgr.AddReply(currentAreaID, currentUser.Handle, currentMsg.From,
+    newSubject, replyBody, currentMsg.MsgID, currentMsg.MsgNum)
+```
+
+`currentMsg.MsgID` keeps echomail linking working; `currentMsg.MsgNum` sets the
+local parent pointer. Because `READPRIVMAIL` and public reading both route
+through `runMessageReader` → `handleReply`, this single change covers public and
+private-mail replies.
+
+### 4. Display: ensure the header shows the reference
+
+`ReplyToNum` is already substituted as key `P` ("Reply to: #N", else "None").
+Confirm the shipped default MSGHDR template renders the reply reference; if it
+does not, add the field to the default template so the relationship is visible
+out of the box. (Sysop custom templates remain free to place/omit it.)
+
+---
+
+## Testing
+
+**`internal/jam`:** a message written with `Header.ReplyTo = N` reads back with
+`ReplyTo == N` (WriteMessage and WriteMessageExt); a message with no/zero
+`Header.ReplyTo` still writes `0` (no regression).
+
+**`internal/message`:**
+- `AddReply` sets the new message's `Header.ReplyTo` to the parent number
+  (verify via `GetMessage(...).ReplyToNum`).
+- `AddReply` with a non-empty `replyToMsgID` also sets `ReplyID`.
+- Characterization: `AddMessage` (local), `AddMessageWithDate` (date preserved),
+  `AddPrivateMessage` (private attribute set, `OnMessagePosted` NOT fired) behave
+  exactly as before the consolidation — including `OnMessagePosted` firing for
+  the non-private wrappers and the netmail To/DestAddr split.
+
+**`internal/menu`:** `handleReply` posts a reply whose `ReplyToNum` equals the
+parent's `MsgNum` (a focused test against a seeded area, if the reader has a
+testable seam; otherwise covered by build + the manager/jam tests, with the
+one-line call-site change verified by inspection).
+
+---
+
+## Risks / notes
+
+- **Central post path:** the consolidation is the main risk; mitigated by
+  characterization tests and exact behavior preservation. The standalone
+  alternative is available if lower risk is preferred.
+- **Echomail double-set:** `AddReply` sets `ReplyTo` directly to the local parent
+  number *and* `ReplyID`; `Link()` would compute the same `ReplyTo`, so this is
+  consistent (and makes the link immediate rather than deferred).
+- **Existing messages:** not backfilled — only new replies thread.
+
+## Acceptance criteria
+
+- Replying to a local message records the parent number; `GetMessage` returns a
+  non-zero `ReplyToNum` for it.
+- The message header shows "Reply to: #N" for replies (default template).
+- Echomail replies still link via `ReplyID`/`Link()`; private-mail and public
+  replies both set the parent pointer.
+- The three existing `Add*` methods behave identically (characterization tests
+  pass); full suite green.

--- a/internal/jam/echomail.go
+++ b/internal/jam/echomail.go
@@ -37,6 +37,7 @@ func (b *Base) WriteMessageExt(msg *Message, msgType MessageType, echoTag, bbsNa
 			Attribute:     attr,
 		}
 		copy(hdr.Signature[:], Signature)
+		hdr.ReplyTo = msg.ReplyTo
 
 		// For local messages, set DateProcessed to now (already "processed")
 		if msgType.IsLocal() {

--- a/internal/jam/message.go
+++ b/internal/jam/message.go
@@ -458,6 +458,7 @@ func (b *Base) WriteMessage(msg *Message) (int, error) {
 			Attribute:     msg.GetAttribute(),
 		}
 		copy(hdr.Signature[:], Signature)
+		hdr.ReplyTo = msg.ReplyTo
 
 		hdr.Subfields = buildSubfields(msg)
 

--- a/internal/jam/replyto_test.go
+++ b/internal/jam/replyto_test.go
@@ -47,7 +47,10 @@ func TestWriteMessage_ZeroReplyTo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadMessage: %v", err)
 	}
-	if got.Header != nil && got.Header.ReplyTo != 0 {
+	if got.Header == nil {
+		t.Fatal("Header was nil — message not written")
+	}
+	if got.Header.ReplyTo != 0 {
 		t.Errorf("ReplyTo: want 0, got %d", got.Header.ReplyTo)
 	}
 }

--- a/internal/jam/replyto_test.go
+++ b/internal/jam/replyto_test.go
@@ -1,0 +1,73 @@
+package jam
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteMessage_PreservesReplyTo(t *testing.T) {
+	b, err := Open(filepath.Join(t.TempDir(), "base"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer b.Close()
+
+	msg := NewMessage()
+	msg.From, msg.To, msg.Subject, msg.Text = "alice", "bob", "Hi", "body"
+	msg.ReplyTo = 5
+
+	n, err := b.WriteMessage(msg)
+	if err != nil {
+		t.Fatalf("WriteMessage: %v", err)
+	}
+	got, err := b.ReadMessage(n)
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	if got.Header == nil || got.Header.ReplyTo != 5 {
+		t.Errorf("ReplyTo: want 5, got %+v", got.Header)
+	}
+}
+
+func TestWriteMessage_ZeroReplyTo(t *testing.T) {
+	b, err := Open(filepath.Join(t.TempDir(), "base"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer b.Close()
+
+	msg := NewMessage()
+	msg.From, msg.To, msg.Subject, msg.Text = "alice", "bob", "Hi", "body"
+
+	n, err := b.WriteMessage(msg)
+	if err != nil {
+		t.Fatalf("WriteMessage: %v", err)
+	}
+	got, err := b.ReadMessage(n)
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	if got.Header != nil && got.Header.ReplyTo != 0 {
+		t.Errorf("ReplyTo: want 0, got %d", got.Header.ReplyTo)
+	}
+}
+
+func TestWriteMessageExt_PreservesReplyTo(t *testing.T) {
+	b := openTestBase(t)
+
+	msg := NewMessage()
+	msg.From, msg.To, msg.Subject, msg.Text = "u1", "u2", "Re", "reply"
+	msg.ReplyTo = 3
+
+	n, err := b.WriteMessageExt(msg, MsgTypeLocalMsg, "", "Test BBS", "")
+	if err != nil {
+		t.Fatalf("WriteMessageExt: %v", err)
+	}
+	got, err := b.ReadMessage(n)
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	if got.Header == nil || got.Header.ReplyTo != 3 {
+		t.Errorf("ReplyTo: want 3, got %+v", got.Header)
+	}
+}

--- a/internal/jam/types.go
+++ b/internal/jam/types.go
@@ -75,6 +75,7 @@ type Message struct {
 	DestAddr string // FidoNet destination address
 	MsgID    string
 	ReplyID  string
+	ReplyTo  uint32 // JAM parent message number (0 = none); written to the header
 	PID      string
 	Flags    string
 	SeenBy   string

--- a/internal/menu/message_reader_nav.go
+++ b/internal/menu/message_reader_nav.go
@@ -70,10 +70,17 @@ func handleReply(e *MenuExecutor, s ssh.Session, ih *editor.InputHandler, termin
 		replyBody = replyBody + "\n\n" + currentUser.AutoSignature
 	}
 
-	// Save reply
+	// Save reply, recording the parent message number for threading. A reply to
+	// a private message stays private so it remains visible to its recipient.
 	replyMsgID := currentMsg.MsgID
-	_, err := e.MessageMgr.AddReply(currentAreaID, currentUser.Handle, currentMsg.From,
-		newSubject, replyBody, replyMsgID, currentMsg.MsgNum)
+	var err error
+	if currentMsg.IsPrivate {
+		_, err = e.MessageMgr.AddPrivateReply(currentAreaID, currentUser.Handle, currentMsg.From,
+			newSubject, replyBody, replyMsgID, currentMsg.MsgNum)
+	} else {
+		_, err = e.MessageMgr.AddReply(currentAreaID, currentUser.Handle, currentMsg.From,
+			newSubject, replyBody, replyMsgID, currentMsg.MsgNum)
+	}
 	if err != nil {
 		slog.Error("failed to save reply", "node", nodeNumber, "error", err)
 		terminalio.WriteProcessedBytes(terminal, []byte(e.LoadedStrings.MsgReplyError), outputMode)

--- a/internal/menu/message_reader_nav.go
+++ b/internal/menu/message_reader_nav.go
@@ -72,8 +72,8 @@ func handleReply(e *MenuExecutor, s ssh.Session, ih *editor.InputHandler, termin
 
 	// Save reply
 	replyMsgID := currentMsg.MsgID
-	_, err := e.MessageMgr.AddMessage(currentAreaID, currentUser.Handle, currentMsg.From,
-		newSubject, replyBody, replyMsgID)
+	_, err := e.MessageMgr.AddReply(currentAreaID, currentUser.Handle, currentMsg.From,
+		newSubject, replyBody, replyMsgID, currentMsg.MsgNum)
 	if err != nil {
 		slog.Error("failed to save reply", "node", nodeNumber, "error", err)
 		terminalio.WriteProcessedBytes(terminal, []byte(e.LoadedStrings.MsgReplyError), outputMode)

--- a/internal/message/manager.go
+++ b/internal/message/manager.go
@@ -577,12 +577,10 @@ func splitNetmailTo(to string) (name, addr string) {
 	return strings.TrimSpace(to[:idx]), candidate
 }
 
-// AddMessage creates and writes a new message to the specified area.
-// For echomail areas, it automatically handles MSGID, kludges, tearline, and origin.
-// For netmail areas, "user@zone:net/node" in the To field is automatically split
-// into the username and destination address.
-// Returns the 1-based message number assigned.
-func (mm *MessageManager) AddMessage(areaID int, from, to, subject, body, replyToMsgID string) (int, error) {
+// addMessage is the shared implementation behind AddMessage, AddMessageWithDate,
+// AddPrivateMessage, and AddReply.
+func (mm *MessageManager) addMessage(areaID int, from, to, subject, body, replyToMsgID string,
+	replyToNum int, dateTime time.Time, private bool) (int, error) {
 	b, area, err := mm.openBase(areaID)
 	if err != nil {
 		return 0, err
@@ -601,15 +599,21 @@ func (mm *MessageManager) AddMessage(areaID int, from, to, subject, body, replyT
 	msg.To = to
 	msg.Subject = subject
 	msg.Text = jamBody
-	msg.DateTime = time.Now()
+	msg.DateTime = dateTime
 
+	if private {
+		msg.Header = &jam.MessageHeader{Attribute: jam.MsgPrivate | jam.MsgLocal}
+	}
+	if replyToNum > 0 {
+		msg.ReplyTo = uint32(replyToNum)
+	}
 	if replyToMsgID != "" {
 		msg.ReplyID = replyToMsgID
 	}
 
 	msgType := jam.DetermineMessageType(area.AreaType, area.EchoTag)
 
-	// For netmail, split "user@address" into separate To and DestAddr fields
+	// For netmail, split "user@address" into separate To and DestAddr fields.
 	if msgType.IsNetmail() {
 		name, addr := splitNetmailTo(to)
 		msg.To = name
@@ -633,117 +637,40 @@ func (mm *MessageManager) AddMessage(areaID int, from, to, subject, body, replyT
 
 	if err == nil {
 		mm.invalidateThreadIndex(areaID)
-		if mm.OnMessagePosted != nil {
+		if !private && mm.OnMessagePosted != nil {
 			mm.OnMessagePosted(area, msgNum, from, to, subject, body)
 		}
 	}
 	return msgNum, err
+}
+
+// AddMessage creates and writes a new message to the specified area.
+// For echomail areas, it automatically handles MSGID, kludges, tearline, and origin.
+// For netmail areas, "user@zone:net/node" in the To field is automatically split
+// into the username and destination address.
+// Returns the 1-based message number assigned.
+func (mm *MessageManager) AddMessage(areaID int, from, to, subject, body, replyToMsgID string) (int, error) {
+	return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, 0, time.Now(), false)
 }
 
 // AddMessageWithDate is like AddMessage but uses the provided timestamp instead
 // of time.Now(). Used by V3Net to preserve the original authored date.
 func (mm *MessageManager) AddMessageWithDate(areaID int, from, to, subject, body, replyToMsgID string, dateTime time.Time) (int, error) {
-	b, area, err := mm.openBase(areaID)
-	if err != nil {
-		return 0, err
-	}
-
-	jamBody := body
-	if mm.BodyTransform != nil {
-		jamBody = mm.BodyTransform(areaID, body)
-	}
-
-	msg := jam.NewMessage()
-	msg.From = from
-	msg.To = to
-	msg.Subject = subject
-	msg.Text = jamBody
-	msg.DateTime = dateTime
-
-	if replyToMsgID != "" {
-		msg.ReplyID = replyToMsgID
-	}
-
-	msgType := jam.DetermineMessageType(area.AreaType, area.EchoTag)
-
-	if msgType.IsNetmail() {
-		name, addr := splitNetmailTo(to)
-		msg.To = name
-		if addr != "" {
-			msg.DestAddr = addr
-		}
-	}
-
-	var msgNum int
-	if msgType.IsEchomail() || msgType.IsNetmail() {
-		msg.OrigAddr = area.OriginAddr
-		msgNum, err = b.WriteMessageExt(msg, msgType, area.EchoTag, mm.boardName, mm.tearlineForNetwork(area.Network))
-	} else {
-		msgNum, err = b.WriteMessage(msg)
-	}
-
-	b.Close()
-
-	if err == nil {
-		mm.invalidateThreadIndex(areaID)
-		if mm.OnMessagePosted != nil {
-			mm.OnMessagePosted(area, msgNum, from, to, subject, body)
-		}
-	}
-	return msgNum, err
+	return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, 0, dateTime, false)
 }
 
-// AddPrivateMessage creates and writes a new private message to the specified area.
-// It sets the MSG_PRIVATE flag on the message to indicate it's private user-to-user mail.
+// AddPrivateMessage creates and writes a new private (MSG_PRIVATE) message.
 // For netmail areas, "user@zone:net/node" in the To field is automatically split
-// into the username and destination address.
-// Returns the 1-based message number assigned.
+// into the username and destination address. Returns the 1-based message number.
 func (mm *MessageManager) AddPrivateMessage(areaID int, from, to, subject, body, replyToMsgID string) (int, error) {
-	b, area, err := mm.openBase(areaID)
-	if err != nil {
-		return 0, err
-	}
-	defer b.Close()
+	return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, 0, time.Now(), true)
+}
 
-	msg := jam.NewMessage()
-	msg.From = from
-	msg.To = to
-	msg.Subject = subject
-	msg.Text = body
-	msg.DateTime = time.Now()
-
-	// Initialize header to set the MSG_PRIVATE flag
-	msg.Header = &jam.MessageHeader{
-		Attribute: jam.MsgPrivate | jam.MsgLocal,
-	}
-
-	if replyToMsgID != "" {
-		msg.ReplyID = replyToMsgID
-	}
-
-	msgType := jam.DetermineMessageType(area.AreaType, area.EchoTag)
-
-	// For netmail, split "user@address" into separate To and DestAddr fields
-	if msgType.IsNetmail() {
-		name, addr := splitNetmailTo(to)
-		msg.To = name
-		if addr != "" {
-			msg.DestAddr = addr
-		}
-	}
-
-	var msgNum int
-	if msgType.IsEchomail() || msgType.IsNetmail() {
-		msg.OrigAddr = area.OriginAddr
-		msgNum, err = b.WriteMessageExt(msg, msgType, area.EchoTag, mm.boardName, mm.tearlineForNetwork(area.Network))
-	} else {
-		msgNum, err = b.WriteMessage(msg)
-	}
-
-	if err == nil {
-		mm.invalidateThreadIndex(areaID)
-	}
-	return msgNum, err
+// AddReply creates and writes a reply, recording the parent's message number
+// (replyToNum) as the JAM ReplyTo so local areas thread, and the parent's FTN
+// MSGID (replyToMsgID, may be "") as ReplyID so echomail links via jam.Link().
+func (mm *MessageManager) AddReply(areaID int, from, to, subject, body, replyToMsgID string, replyToNum int) (int, error) {
+	return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, replyToNum, time.Now(), false)
 }
 
 // GetMessage reads a single message by area ID and 1-based message number.

--- a/internal/message/manager.go
+++ b/internal/message/manager.go
@@ -590,7 +590,7 @@ func (mm *MessageManager) addMessage(areaID int, from, to, subject, body, replyT
 	// The original body is preserved for OnMessagePosted so the wire message
 	// carries tearline/origin as separate protocol fields, not inline.
 	jamBody := body
-	if mm.BodyTransform != nil {
+	if !private && mm.BodyTransform != nil {
 		jamBody = mm.BodyTransform(areaID, body)
 	}
 

--- a/internal/message/manager.go
+++ b/internal/message/manager.go
@@ -604,6 +604,7 @@ func (mm *MessageManager) addMessage(areaID int, from, to, subject, body, replyT
 	if private {
 		msg.Header = &jam.MessageHeader{Attribute: jam.MsgPrivate | jam.MsgLocal}
 	}
+	// replyToNum is a 1-based JAM message number; 0 means "no parent".
 	if replyToNum > 0 {
 		msg.ReplyTo = uint32(replyToNum)
 	}

--- a/internal/message/manager.go
+++ b/internal/message/manager.go
@@ -674,6 +674,13 @@ func (mm *MessageManager) AddReply(areaID int, from, to, subject, body, replyToM
 	return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, replyToNum, time.Now(), false)
 }
 
+// AddPrivateReply is AddReply for private mail: it records the parent pointer
+// while preserving the MSG_PRIVATE flag, so a reply to a private message stays
+// private (and therefore visible to its recipient).
+func (mm *MessageManager) AddPrivateReply(areaID int, from, to, subject, body, replyToMsgID string, replyToNum int) (int, error) {
+	return mm.addMessage(areaID, from, to, subject, body, replyToMsgID, replyToNum, time.Now(), true)
+}
+
 // GetMessage reads a single message by area ID and 1-based message number.
 func (mm *MessageManager) GetMessage(areaID, msgNum int) (*DisplayMessage, error) {
 	b, _, err := mm.openBase(areaID)

--- a/internal/message/reply_test.go
+++ b/internal/message/reply_test.go
@@ -140,3 +140,25 @@ func TestAddReply_AlsoSetsReplyID(t *testing.T) {
 		t.Errorf("ReplyToNum: want %d, got %d", parent, dm.ReplyToNum)
 	}
 }
+
+func TestAddPrivateReply_StaysPrivateAndThreads(t *testing.T) {
+	mm := newReplyTestManager(t) // area 2 is PRIVMAIL
+	parent, err := mm.AddPrivateMessage(2, "alice", "bob", "Topic", "first", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	reply, err := mm.AddPrivateReply(2, "bob", "alice", "Re: Topic", "second", "", parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dm, err := mm.GetMessage(2, reply)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !dm.IsPrivate {
+		t.Error("AddPrivateReply should keep the reply private")
+	}
+	if dm.ReplyToNum != parent {
+		t.Errorf("ReplyToNum: want %d, got %d", parent, dm.ReplyToNum)
+	}
+}

--- a/internal/message/reply_test.go
+++ b/internal/message/reply_test.go
@@ -121,7 +121,10 @@ func TestAddReply_SetsReplyTo(t *testing.T) {
 
 func TestAddReply_AlsoSetsReplyID(t *testing.T) {
 	mm := newReplyTestManager(t)
-	parent, _ := mm.AddMessage(1, "alice", "All", "Topic", "first", "")
+	parent, err := mm.AddMessage(1, "alice", "All", "Topic", "first", "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	reply, err := mm.AddReply(1, "bob", "alice", "Re: Topic", "second", "PARENTMSGID", parent)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/message/reply_test.go
+++ b/internal/message/reply_test.go
@@ -3,6 +3,7 @@ package message
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -66,6 +67,35 @@ func TestAddFamily_Characterization(t *testing.T) {
 	}
 	if !dmsg.DateTime.Equal(when) {
 		t.Errorf("AddMessageWithDate: want %v, got %v", when, dmsg.DateTime)
+	}
+}
+
+func TestAddPrivateMessage_SkipsBodyTransform(t *testing.T) {
+	mm := newReplyTestManager(t)
+	mm.BodyTransform = func(areaID int, body string) string { return body + "\n[TRANSFORMED]" }
+
+	pubNum, err := mm.AddMessage(1, "a", "All", "s", "public body", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub, err := mm.GetMessage(1, pubNum)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(pub.Body, "[TRANSFORMED]") {
+		t.Errorf("AddMessage should apply BodyTransform; body=%q", pub.Body)
+	}
+
+	privNum, err := mm.AddPrivateMessage(2, "a", "b", "s", "private body", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	priv, err := mm.GetMessage(2, privNum)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(priv.Body, "[TRANSFORMED]") {
+		t.Errorf("AddPrivateMessage must NOT apply BodyTransform; body=%q", priv.Body)
 	}
 }
 

--- a/internal/message/reply_test.go
+++ b/internal/message/reply_test.go
@@ -1,0 +1,109 @@
+package message
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newReplyTestManager(t *testing.T) *MessageManager {
+	t.Helper()
+	tmp := t.TempDir()
+	cfg := filepath.Join(tmp, "config")
+	if err := os.MkdirAll(cfg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	areas := `[{"id":1,"tag":"GENERAL","name":"General","base_path":"general","area_type":"local"},
+	           {"id":2,"tag":"PRIVMAIL","name":"Private Mail","base_path":"privmail","area_type":"local"}]`
+	if err := os.WriteFile(filepath.Join(cfg, "message_areas.json"), []byte(areas), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mm, err := NewMessageManager(tmp, cfg, "TestBBS", nil)
+	if err != nil {
+		t.Fatalf("NewMessageManager: %v", err)
+	}
+	return mm
+}
+
+// Characterization: lock the existing Add* behavior before consolidating.
+func TestAddFamily_Characterization(t *testing.T) {
+	mm := newReplyTestManager(t)
+
+	posted := 0
+	mm.OnMessagePosted = func(area *MessageArea, msgNum int, from, to, subject, body string) { posted++ }
+
+	if _, err := mm.AddMessage(1, "a", "All", "s", "b", ""); err != nil {
+		t.Fatal(err)
+	}
+	if posted != 1 {
+		t.Errorf("AddMessage should fire OnMessagePosted once, got %d", posted)
+	}
+
+	pn, err := mm.AddPrivateMessage(2, "a", "b", "s", "b", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if posted != 1 {
+		t.Errorf("AddPrivateMessage must NOT fire OnMessagePosted; count=%d", posted)
+	}
+	pm, err := mm.GetMessage(2, pn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pm.IsPrivate {
+		t.Error("AddPrivateMessage should set IsPrivate")
+	}
+
+	when := time.Date(2020, 1, 2, 3, 4, 0, 0, time.UTC)
+	dn, err := mm.AddMessageWithDate(1, "a", "All", "s3", "b3", "", when)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dmsg, err := mm.GetMessage(1, dn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !dmsg.DateTime.Equal(when) {
+		t.Errorf("AddMessageWithDate: want %v, got %v", when, dmsg.DateTime)
+	}
+}
+
+func TestAddReply_SetsReplyTo(t *testing.T) {
+	mm := newReplyTestManager(t)
+
+	parent, err := mm.AddMessage(1, "alice", "All", "Topic", "first", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	reply, err := mm.AddReply(1, "bob", "alice", "Re: Topic", "second", "", parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dm, err := mm.GetMessage(1, reply)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dm.ReplyToNum != parent {
+		t.Errorf("ReplyToNum: want %d, got %d", parent, dm.ReplyToNum)
+	}
+}
+
+func TestAddReply_AlsoSetsReplyID(t *testing.T) {
+	mm := newReplyTestManager(t)
+	parent, _ := mm.AddMessage(1, "alice", "All", "Topic", "first", "")
+	reply, err := mm.AddReply(1, "bob", "alice", "Re: Topic", "second", "PARENTMSGID", parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dm, err := mm.GetMessage(1, reply)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dm.ReplyID != "PARENTMSGID" {
+		t.Errorf("ReplyID: want PARENTMSGID, got %q", dm.ReplyID)
+	}
+	if dm.ReplyToNum != parent {
+		t.Errorf("ReplyToNum: want %d, got %d", parent, dm.ReplyToNum)
+	}
+}


### PR DESCRIPTION
Record a parent-message pointer when a user replies, so the reader shows `Reply#: N` for local message areas (and echomail replies link immediately).

Design: `docs/superpowers/specs/2026-06-30-local-reply-threading-design.md`
Plan: `docs/superpowers/plans/2026-06-30-local-reply-threading.md`

## Why
Local areas (GENERAL, PRIVMAIL) had no reply-chain linkage: JAM threads on FTN `MSGID`↔`ReplyID`, but local messages have no MSGID, so `Header.ReplyTo` stayed 0 and the reader could only group by subject. The display side was already wired (`ReplyToNum` → substitution key `P`; the default `MSGHDR.1.ans` already shows `Reply#: @P@`) — the gap was purely the write path. This also unblocks QWK Phase 4 (which previously had no reply data to preserve).

## What changed
- **`internal/jam`** — new `Message.ReplyTo uint32` convenience field; `WriteMessage`/`WriteMessageExt` persist it to the header. (Routed via a convenience field, NOT `msg.Header`, because `GetAttribute()` returns `Header.Attribute` when `Header != nil` — using Header would corrupt message attributes.)
- **`internal/message`** — consolidated the near-duplicate `AddMessage`/`AddMessageWithDate`/`AddPrivateMessage` into one internal `addMessage(...)` with thin wrappers, plus a new `AddReply(...)` that sets the parent number (`ReplyTo`) and the FTN `ReplyID`. Behavior is preserved exactly (characterization tests), including the private-mail `BodyTransform` skip and `OnMessagePosted` semantics.
- **`internal/menu`** — `handleReply` passes `currentMsg.MsgNum`; because `READPRIVMAIL` and public reading share `runMessageReader → handleReply`, this covers public **and** private-mail replies.

## Backward compatibility
`msg.ReplyTo` defaults to 0, so every existing caller writes `ReplyTo == 0` (unchanged). The three existing `Add*` signatures and behaviors are identical. No template/display changes.

## Out of scope (deferred)
Thread navigation commands; QWK export/import of the reference (now unblocked); backfilling existing messages.

## Verification
- `go test ./...` → 1631 pass (54 packages); `-race` clean on `internal/jam` + `internal/message`; changed files gofmt/vet clean.
- Tests: JAM `ReplyTo` write/read round-trip (incl. zero); manager characterization (OnMessagePosted fires for public not private; private flag; date preserved; private skips BodyTransform); `AddReply` sets ReplyTo + ReplyID.

Developed via TDD with per-task spec+quality reviews and a final whole-branch review (no Critical/Important findings; the consolidation's one latent behavior risk — applying BodyTransform to private mail — was caught and fixed mid-flight).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replies in local message areas now keep track of the parent message, improving threaded conversation display.
  * Reply details are now preserved when composing both public and private messages.

* **Bug Fixes**
  * Message replies now show the correct “Reply to” reference after saving and reopening messages.
  * Existing message posting behavior remains consistent while adding reply threading support.

* **Documentation**
  * Added design and implementation notes for local reply threading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->