### PR TITLE
feat(qwk): Phase 4 — reply threading in packets

### DIFF
--- a/docs/superpowers/plans/2026-06-30-qwk-phase4-reply-threading.md
+++ b/docs/superpowers/plans/2026-06-30-qwk-phase4-reply-threading.md
@@ -1,0 +1,404 @@
+# QWK Phase 4 — Reply Threading in Packets — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Round-trip a message's parent pointer through the base-QWK reference field (header positions 108–115), so reply chains survive QWK download and REP upload.
+
+**Architecture:** The codec carries the reference: `PacketMessage`/`REPMessage` gain `ReplyToNumber`, `formatMessage` writes it, `parseREPMessages` reads it. The service copies it on export (`BuildPacket`) and, on import, posts via `AddReply`/`AddPrivateReply` with the parsed number (`replyToNum == 0` reproduces the old non-reply post).
+
+**Tech Stack:** Go (stdlib `archive/zip`, `strconv`, `testing`); existing `internal/qwk`, `internal/qwkservice`, `internal/message`.
+
+## Global Constraints
+
+- No new dependencies; `slog` for logging; Go files under 300 lines.
+- TDD: failing test first → red → minimal implementation → green → commit.
+- Reference field = header positions 108–115 (8 chars); the value is the parent's QWK message number, which equals its local JAM `MsgNum` in our export. `ReplyToNumber == 0` means "no parent" and writes the same `"       0"` bytes as today (backward compatible).
+- Import uses server-receive time (no authored-date preservation) and sets the reference as-is (no validation / degraded-thread reporting).
+- `AddReply`/`AddPrivateReply` with `replyToNum == 0` behave exactly like `AddMessage`/`AddPrivateMessage` (the manager's `replyToNum > 0` guard skips the pointer).
+- Spec: `docs/superpowers/specs/2026-06-30-qwk-phase4-reply-threading-design.md`.
+
+---
+
+## File Structure
+
+- Modify: `internal/qwk/types.go` — `PacketMessage.ReplyToNumber`, `REPMessage.ReplyToNumber`.
+- Modify: `internal/qwk/writer.go` — `formatMessage` writes the reference.
+- Modify: `internal/qwk/reader.go` — `parseREPMessages` reads the reference.
+- Modify: `internal/qwk/rep_writer_test.go` / `internal/qwk/writer_test.go` — codec tests.
+- Modify: `internal/qwkservice/service.go` — `BuildPacket` copy; `MessageStore` swap.
+- Modify: `internal/qwkservice/service_import.go` — route via `AddReply`/`AddPrivateReply`.
+- Modify: `internal/qwkservice/fakestore_test.go` — `AddReply`/`AddPrivateReply` + `replyToNum`.
+- Modify: `internal/qwkservice/service_export_test.go`, `service_import_test.go` — tests.
+- Modify: `docs/sysop/messages/qwk.md` — one-line note.
+
+---
+
+## Task 1: Codec carries the reference field
+
+**Files:**
+- Modify: `internal/qwk/types.go`, `internal/qwk/writer.go`, `internal/qwk/reader.go`
+- Test: `internal/qwk/rep_writer_test.go` (add), `internal/qwk/writer_test.go` (add)
+
+**Interfaces:**
+- Produces: `PacketMessage.ReplyToNumber int`, `REPMessage.ReplyToNumber int`; `formatMessage` writes/`parseREPMessages` reads positions 108–115.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/qwk/writer_test.go`:
+
+```go
+func TestFormatMessage_ReplyToNumber(t *testing.T) {
+	data := formatMessage(PacketMessage{
+		Conference: 1, Number: 2, To: "All", Subject: "Re",
+		DateTime: time.Date(2026, 3, 5, 14, 30, 0, 0, time.UTC), Body: "x",
+		ReplyToNumber: 7,
+	})
+	ref := strings.TrimSpace(string(data[108:116]))
+	if ref != "7" {
+		t.Errorf("reference field (108-115): want 7, got %q", ref)
+	}
+}
+```
+
+Add to `internal/qwk/rep_writer_test.go`:
+
+```go
+func TestREP_RoundTripReplyToNumber(t *testing.T) {
+	in := []PacketMessage{
+		{Conference: 1, Number: 1, From: "a", To: "b", Subject: "First",
+			DateTime: time.Date(2026, 3, 5, 10, 0, 0, 0, time.UTC), Body: "root"},
+		{Conference: 1, Number: 2, From: "a", To: "b", Subject: "Re: First",
+			DateTime: time.Date(2026, 3, 5, 11, 0, 0, 0, time.UTC), Body: "reply",
+			ReplyToNumber: 1},
+	}
+	data := buildREP(t, "VISION3", in)
+	out, err := ReadREP(bytes.NewReader(data), int64(len(data)), "VISION3")
+	if err != nil {
+		t.Fatalf("ReadREP: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("want 2 messages, got %d", len(out))
+	}
+	if out[0].ReplyToNumber != 0 {
+		t.Errorf("root ReplyToNumber: want 0, got %d", out[0].ReplyToNumber)
+	}
+	if out[1].ReplyToNumber != 1 {
+		t.Errorf("reply ReplyToNumber: want 1, got %d", out[1].ReplyToNumber)
+	}
+}
+```
+
+(`buildREP` already exists in `rep_writer_test.go`; `strings`/`time` are already imported in `writer_test.go`.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/qwk/ -run 'TestFormatMessage_ReplyToNumber|TestREP_RoundTripReplyToNumber' -v`
+Expected: FAIL — `ReplyToNumber` is not a field of `PacketMessage`/`REPMessage` (compile error).
+
+- [ ] **Step 3: Add the struct fields**
+
+In `internal/qwk/types.go`, add to `PacketMessage` (after `Private bool`):
+
+```go
+	ReplyToNumber int // QWK reference: parent message number (0 = none)
+```
+
+And to `REPMessage` (after `Body string`):
+
+```go
+	ReplyToNumber int // QWK reference: parent message number (0 = none)
+```
+
+- [ ] **Step 4: Write the reference in formatMessage**
+
+In `internal/qwk/writer.go`, replace the hardcoded reference line (currently
+`copyPadded(header[108:116], fmt.Sprintf("%8d", 0), 8)`):
+
+```go
+	// Reference number: positions 108-115 (8 chars) — parent message number.
+	copyPadded(header[108:116], fmt.Sprintf("%8d", msg.ReplyToNumber), 8)
+```
+
+- [ ] **Step 5: Parse the reference in parseREPMessages**
+
+In `internal/qwk/reader.go`, in the per-message loop, parse the reference
+alongside the other fields and include it in the `REPMessage`. After the
+`subject := ...` line, add:
+
+```go
+		refStr := strings.TrimSpace(string(header[108:116]))
+		refNum, _ := strconv.Atoi(refStr) // 0 / unparsable => no parent
+```
+
+and add the field to the appended struct:
+
+```go
+		messages = append(messages, REPMessage{
+			Conference:    confNum,
+			To:            to,
+			Subject:       subject,
+			Body:          body,
+			ReplyToNumber: refNum,
+		})
+```
+
+(`strconv` and `strings` are already imported in `reader.go`.)
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test ./internal/qwk/ 2>&1 | tail -5`
+Expected: PASS — the two new tests plus all existing `internal/qwk` tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+gofmt -w internal/qwk/types.go internal/qwk/writer.go internal/qwk/reader.go internal/qwk/writer_test.go internal/qwk/rep_writer_test.go
+go vet ./internal/qwk/
+git add internal/qwk/
+git commit -m "feat(qwk): carry parent message number in the QWK reference field"
+```
+
+---
+
+## Task 2: Service exports + imports the reference
+
+**Files:**
+- Modify: `internal/qwkservice/service.go` (`BuildPacket` copy; `MessageStore` swap)
+- Modify: `internal/qwkservice/service_import.go` (route via reply methods)
+- Modify: `internal/qwkservice/fakestore_test.go`
+- Test: `internal/qwkservice/service_export_test.go`, `internal/qwkservice/service_import_test.go`
+
+**Interfaces:**
+- Consumes: `PacketMessage.ReplyToNumber`, `REPMessage.ReplyToNumber` (Task 1); `MessageManager.AddReply`/`AddPrivateReply` (already implemented).
+- Produces: `MessageStore` declares `AddReply`/`AddPrivateReply` (replacing `AddMessage`/`AddPrivateMessage`).
+
+- [ ] **Step 1: Update the fake store and write the failing tests**
+
+In `internal/qwkservice/fakestore_test.go`, add `replyToNum` to the record and
+replace the two `Add*` fakes with reply variants:
+
+```go
+type postedMessage struct {
+	areaID                       int
+	from, to, subject, body, rep string
+	replyToNum                   int
+}
+```
+
+```go
+func (f *fakeStore) AddReply(areaID int, from, to, subject, body, replyToMsgID string, replyToNum int) (int, error) {
+	if err := f.addErr[areaID]; err != nil {
+		return 0, err
+	}
+	f.posted = append(f.posted, postedMessage{areaID, from, to, subject, body, replyToMsgID, replyToNum})
+	return len(f.posted), nil
+}
+
+func (f *fakeStore) AddPrivateReply(areaID int, from, to, subject, body, replyToMsgID string, replyToNum int) (int, error) {
+	if err := f.addErr[areaID]; err != nil {
+		return 0, err
+	}
+	f.privPosted = append(f.privPosted, postedMessage{areaID, from, to, subject, body, replyToMsgID, replyToNum})
+	return len(f.privPosted), nil
+}
+```
+
+(Delete the old `AddMessage`/`AddPrivateMessage` fake methods. Existing import
+tests assert on `store.posted`/`store.privPosted` lengths and the `from`/`to`/
+`body` fields, which are unchanged.)
+
+Add the export test to `internal/qwkservice/service_export_test.go` (add `io`,
+`strconv`, `strings` to its imports):
+
+```go
+// firstMsgReplyRef parses the QWK reference field (positions 108-115) of the
+// first message in a packet's MESSAGES.DAT.
+func firstMsgReplyRef(t *testing.T, packet []byte) int {
+	t.Helper()
+	zr, err := zip.NewReader(bytes.NewReader(packet), int64(len(packet)))
+	if err != nil {
+		t.Fatalf("zip: %v", err)
+	}
+	for _, f := range zr.File {
+		if f.Name != "MESSAGES.DAT" {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Block 1 is the spacer; the first message header starts at offset 128.
+		hdr := data[128:256]
+		ref, _ := strconv.Atoi(strings.TrimSpace(string(hdr[108:116])))
+		return ref
+	}
+	t.Fatal("MESSAGES.DAT not found")
+	return 0
+}
+
+func TestBuildPacket_WritesReplyReference(t *testing.T) {
+	store := newFakeStore()
+	store.addArea(&message.MessageArea{ID: 1, Tag: "GENERAL", Name: "General"})
+	m := dm(1, "a", "All", "s", "b")
+	m.ReplyToNum = 7
+	store.seed(1, m)
+
+	svc := newTestService(t, store)
+	res, err := svc.BuildPacket(ExportOptions{Handle: "tester", TaggedTags: []string{"GENERAL"}})
+	if err != nil {
+		t.Fatalf("BuildPacket: %v", err)
+	}
+	if got := firstMsgReplyRef(t, res.Packet); got != 7 {
+		t.Errorf("exported reply reference: want 7, got %d", got)
+	}
+}
+```
+
+Add the import tests to `internal/qwkservice/service_import_test.go`:
+
+```go
+func TestImportREP_SetsReplyPointer(t *testing.T) {
+	store := newFakeStore()
+	store.addArea(&message.MessageArea{ID: 1, Tag: "GENERAL", Name: "General"})
+	rep := makeREP(t, "VISION3", []qwk.PacketMessage{
+		{Conference: 1, Number: 1, To: "SysOp", Subject: "Re", DateTime: time.Now(), Body: "reply", ReplyToNumber: 5},
+	})
+
+	svc := newTestService(t, store)
+	if _, err := svc.ImportREP(rep, ImportOptions{Handle: "tester"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.posted) != 1 || store.posted[0].replyToNum != 5 {
+		t.Errorf("want AddReply with replyToNum 5, got %+v", store.posted)
+	}
+}
+
+func TestImportREP_PrivateReplyPointer(t *testing.T) {
+	store := newFakeStore()
+	store.addArea(&message.MessageArea{ID: 3, Tag: "PRIVMAIL", Name: "Private Mail"})
+	rep := makeREP(t, "VISION3", []qwk.PacketMessage{
+		{Conference: 0, Number: 1, To: "friend", Subject: "Re", DateTime: time.Now(), Body: "x", ReplyToNumber: 4},
+	})
+
+	svc := newTestService(t, store)
+	if _, err := svc.ImportREP(rep, ImportOptions{Handle: "tester"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.privPosted) != 1 || store.privPosted[0].replyToNum != 4 {
+		t.Errorf("want AddPrivateReply with replyToNum 4, got %+v", store.privPosted)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/qwkservice/ -run 'TestBuildPacket_WritesReplyReference|TestImportREP_SetsReplyPointer|TestImportREP_PrivateReplyPointer' -v`
+Expected: FAIL — `MessageStore` has no `AddReply`/`AddPrivateReply` and `BuildPacket` does not set the reference, so the fake no longer satisfies the interface / the assertions fail.
+
+- [ ] **Step 3: Swap the `MessageStore` interface**
+
+In `internal/qwkservice/service.go`, replace the two interface lines:
+
+```go
+	AddReply(areaID int, from, to, subject, body, replyToMsgID string, replyToNum int) (int, error)
+	AddPrivateReply(areaID int, from, to, subject, body, replyToMsgID string, replyToNum int) (int, error)
+```
+
+(removing the old `AddMessage`/`AddPrivateMessage` declarations).
+
+- [ ] **Step 4: Copy the reference on export**
+
+In `internal/qwkservice/service.go` `BuildPacket`, add the field to the
+`qwk.PacketMessage` literal (after `Private: msg.IsPrivate,`):
+
+```go
+				ReplyToNumber: msg.ReplyToNum,
+```
+
+- [ ] **Step 5: Route import through the reply methods**
+
+In `internal/qwkservice/service_import.go`, replace the post block:
+
+```go
+		var perr error
+		if kind == KindPrivateMail {
+			_, perr = s.store.AddPrivateReply(area.ID, opts.Handle, msg.To, msg.Subject, body, "", msg.ReplyToNumber)
+		} else {
+			_, perr = s.store.AddReply(area.ID, opts.Handle, msg.To, msg.Subject, body, "", msg.ReplyToNumber)
+		}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test ./internal/qwkservice/ 2>&1 | tail -5`
+Expected: PASS — the three new tests plus all existing `internal/qwkservice` tests (existing import tests still pass: `AddReply`/`AddPrivateReply` append to the same `posted`/`privPosted` slices, and non-reply REPs carry `ReplyToNumber == 0`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+gofmt -w internal/qwkservice/service.go internal/qwkservice/service_import.go internal/qwkservice/fakestore_test.go internal/qwkservice/service_export_test.go internal/qwkservice/service_import_test.go
+go vet ./internal/qwkservice/
+git add internal/qwkservice/
+git commit -m "feat(qwk): export and import the reply reference, threading REP replies"
+```
+
+---
+
+## Task 3: Docs + full verification
+
+**Files:**
+- Modify: `docs/sysop/messages/qwk.md`
+
+- [ ] **Step 1: Add a one-line note**
+
+In `docs/sysop/messages/qwk.md`, near the conference-numbering / upload section,
+add:
+
+```markdown
+## Reply threading
+
+Reply relationships are preserved across packets: a reply's parent message number
+travels in the QWK reference field, so a reply read or composed in an offline
+reader keeps its "Reply#: N" linkage when it is downloaded or uploaded.
+```
+
+- [ ] **Step 2: Commit the docs**
+
+```bash
+git add docs/sysop/messages/qwk.md
+git commit -m "docs(qwk): document reply threading across packets"
+```
+
+- [ ] **Step 3: Full verification**
+
+Run: `gofmt -l internal/qwk internal/qwkservice`
+Expected: no output.
+
+Run: `go vet ./... 2>&1 | tail -5`
+Expected: no issues.
+
+Run: `go test ./... 2>&1 | tail -10`
+Expected: all packages PASS.
+
+Run: `go test -race ./internal/qwk ./internal/qwkservice 2>&1 | tail -5`
+Expected: PASS, no races.
+
+- [ ] **Step 4: Final commit (only if cleanup was needed)**
+
+```bash
+git add -A
+git commit -m "chore(qwk): Phase 4 cleanup and verification"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+- **Spec coverage:** reference field round-trip (struct fields + write + parse) → Task 1; `BuildPacket` export copy + `MessageStore` swap + `ImportREP` routing via `AddReply`/`AddPrivateReply` + fake store → Task 2; docs + verification → Task 3. All spec sections covered.
+- **Placeholder scan:** no TBD/TODO; every code step shows full code.
+- **Type consistency:** `ReplyToNumber int` on both `PacketMessage` and `REPMessage`; `AddReply`/`AddPrivateReply(... replyToMsgID string, replyToNum int)` match `*message.MessageManager` and the fake; `BuildPacket` reads `DisplayMessage.ReplyToNum`; import passes `msg.ReplyToNumber`. Consistent across tasks.

--- a/docs/superpowers/specs/2026-06-30-qwk-phase4-reply-threading-design.md
+++ b/docs/superpowers/specs/2026-06-30-qwk-phase4-reply-threading-design.md
@@ -1,0 +1,169 @@
+# QWK Phase 4 — Reply Threading in Packets
+
+**Date:** 2026-06-30
+**Status:** Approved design
+**Branch:** `qwk-phase4-reply-metadata`
+**Parent plan:** `docs-internal/plans/2026-06-29-qwk-rep-sync-mobile-design.md` (Phase 4)
+
+---
+
+## Problem
+
+Local messages now carry a reply pointer (`Header.ReplyTo`, set by `AddReply`),
+but QWK packets discard it. The base-QWK message header has a "reference number"
+field (positions 108–115) meant to hold the parent message's number — ViSiON/3
+hardcodes it to `0` on export (`internal/qwk/writer.go:231`) and never parses it
+on import (`internal/qwk/reader.go`). So a reply downloaded in a `.QWK`, or
+uploaded in a `.REP`, loses its thread linkage.
+
+Now that `DisplayMessage.ReplyToNum` is populated and the reader displays
+"Reply#: N", there is real data to carry. This phase round-trips it through the
+base-QWK reference field.
+
+## Goals
+
+- Export each message's parent number into the QWK reference field.
+- Parse the reference field on REP import and set the reply pointer on the posted
+  message, so reply chains survive the offline-reader round trip.
+
+## Non-goals (later phases)
+
+- `HEADERS.DAT` / Synchronet `@` tags (Phase 5; and see the project note dropping
+  the `@` tags).
+- MSGID / network-address fields — local areas (the QWK use case) have no MSGID;
+  those belong to echomail / `HEADERS.DAT`.
+- Preserving the reader's authored compose date (decided: use server-receive
+  time; a small follow-up could add it).
+- Validating the reference / reporting degraded threads (decided: set it as-is;
+  readers produce valid references for messages we exported, and a dangling
+  reference is harmless — the reader tolerates it).
+
+## Decisions (confirmed)
+
+| Decision | Choice |
+| --- | --- |
+| Threading channel | Base-QWK reference field (positions 108–115); the parent's QWK number, which equals its local JAM message number in our export |
+| Import timestamp | Server-receive time (no authored-date preservation) |
+| Bad/dangling reference | Set as-is, no validation, no degraded-thread reporting |
+| Import posting API | Always use `AddReply`/`AddPrivateReply`; `replyToNum == 0` means "no parent" (behaves exactly like the non-reply post) |
+
+---
+
+## Design
+
+### 1. Export — `internal/qwk` + `qwkservice`
+
+- `PacketMessage` (`internal/qwk/types.go`) gains `ReplyToNumber int`.
+- `formatMessage` (`internal/qwk/writer.go:231`) writes it into positions
+  108–115 instead of `0`:
+
+  ```go
+  copyPadded(header[108:116], fmt.Sprintf("%8d", msg.ReplyToNumber), 8)
+  ```
+
+  `ReplyToNumber == 0` writes the same `"       0"` as today, so non-replies are
+  unchanged and existing readers see no difference.
+- `BuildPacket` (`internal/qwkservice/service.go:180`) copies it from the
+  `DisplayMessage`:
+
+  ```go
+  pw.AddMessage(qwk.PacketMessage{
+      ...
+      ReplyToNumber: msg.ReplyToNum,
+  })
+  ```
+
+  Because exported QWK message numbers equal the local JAM `MsgNum`, the
+  reference field is the parent's local number directly — no remapping.
+
+### 2. Import — `internal/qwk` + `qwkservice`
+
+- `REPMessage` (`internal/qwk/types.go`) gains `ReplyToNumber int`.
+- `parseREPMessages` (`internal/qwk/reader.go`) parses positions 108–115
+  alongside the existing To/Subject/conference fields:
+
+  ```go
+  refStr := strings.TrimSpace(string(header[108:116]))
+  refNum, _ := strconv.Atoi(refStr) // 0 / unparsable => no parent
+  ```
+
+  (`strconv` is already imported.) Set `REPMessage.ReplyToNumber = refNum`.
+- `ImportREP` (`internal/qwkservice/service_import.go`) posts through the reply
+  methods, passing the parsed number:
+
+  ```go
+  if kind == KindPrivateMail {
+      _, perr = s.store.AddPrivateReply(area.ID, opts.Handle, msg.To, msg.Subject, body, "", msg.ReplyToNumber)
+  } else {
+      _, perr = s.store.AddReply(area.ID, opts.Handle, msg.To, msg.Subject, body, "", msg.ReplyToNumber)
+  }
+  ```
+
+  A reference from an incoming `.REP` is the parent's local message number (it is
+  a message ViSiON/3 exported), so the reply threads against the right parent.
+  When `ReplyToNumber == 0`, `AddReply`/`AddPrivateReply` behave exactly like
+  `AddMessage`/`AddPrivateMessage` (the manager's `replyToNum > 0` guard skips the
+  pointer), so non-reply imports are unchanged.
+
+### 3. `MessageStore` interface
+
+`internal/qwkservice/service.go`'s `MessageStore` currently declares
+`AddMessage` and `AddPrivateMessage`. Since import is their only caller and it
+now uses the reply variants, replace them:
+
+```go
+- AddMessage(areaID int, from, to, subject, body, replyToMsgID string) (int, error)
+- AddPrivateMessage(areaID int, from, to, subject, body, replyToMsgID string) (int, error)
++ AddReply(areaID int, from, to, subject, body, replyToMsgID string, replyToNum int) (int, error)
++ AddPrivateReply(areaID int, from, to, subject, body, replyToMsgID string, replyToNum int) (int, error)
+```
+
+`*message.MessageManager` already implements both. The test `fakeStore` is
+updated to match (recording the `replyToNum` so import tests can assert it).
+
+### 4. `WriteREP` (test helper) parity
+
+`WriteREP` builds the `.MSG` via `formatMessage`, so it carries `ReplyToNumber`
+automatically once `formatMessage` writes it — no change needed beyond passing
+`ReplyToNumber` in the `PacketMessage`s a test constructs.
+
+---
+
+## Testing
+
+**`internal/qwk`:**
+- `formatMessage` writes `ReplyToNumber` into positions 108–115 (parse the bytes
+  back).
+- `parseREPMessages` reads the reference field into `REPMessage.ReplyToNumber`.
+- `WriteREP` → `ReadREP` round-trip preserves `ReplyToNumber` (incl. 0).
+
+**`internal/qwkservice`:**
+- Export: `BuildPacket` from a `DisplayMessage` with `ReplyToNum = N` produces a
+  packet whose message reference is `N` (read it back via `ReadREP`).
+- Import (public): a REP message with `ReplyToNumber = N` calls `AddReply` with
+  `replyToNum = N` (fake records it); `ReplyToNumber = 0` calls `AddReply` with 0.
+- Import (private): conference 0 routes to `AddPrivateReply` with the number.
+- Existing import tests updated for the `AddReply`/`AddPrivateReply` fake methods;
+  their behavior (posted/skipped/duplicate, ACS, signature) is unchanged.
+
+---
+
+## Risks / notes
+
+- **Partial packets:** a newscan packet may omit the parent (read earlier); the
+  reference still points at the parent's number, which the reader resolves
+  against its own accumulated store — standard QWK behavior.
+- **Reference width:** positions 108–115 hold 8 digits — ample for JAM message
+  numbers.
+- **Backward compatible:** `ReplyToNumber` defaults to 0 → identical bytes to
+  today's hardcoded `0`; import of older packets (no reference) yields 0 → no
+  parent.
+
+## Acceptance criteria
+
+- A reply exported in a `.QWK` carries its parent number in the reference field.
+- A reply uploaded in a `.REP` is posted with its parent pointer set (verifiable
+  via `GetMessage(...).ReplyToNum`), threading public and private replies.
+- Non-reply messages and older packets behave exactly as before.
+- Tests cover export reference-field write, import reference parse + routing, and
+  the round-trip.

--- a/docs/sysop/messages/qwk.md
+++ b/docs/sysop/messages/qwk.md
@@ -75,6 +75,12 @@ QWK download and upload use the same file transfer subsystem as file areas. Any 
 
 When processing a REP upload, ViSiON/3 checks `acs_write` on the destination message area for each reply. Replies to areas where the user lacks write access are silently skipped and logged at `WARN` level.
 
+## Reply threading
+
+Reply relationships are preserved across packets: a reply's parent message number
+travels in the QWK reference field, so a reply read or composed in an offline
+reader keeps its "Reply#: N" linkage when it is downloaded or uploaded.
+
 ## Conference numbering and private mail
 
 ViSiON/3 assigns each exported message area a **stable QWK conference number**

--- a/internal/qwk/reader.go
+++ b/internal/qwk/reader.go
@@ -129,16 +129,19 @@ func parseREPMessages(data []byte) ([]REPMessage, error) {
 		// Parse fields
 		to := strings.TrimSpace(string(header[21:46]))
 		subject := strings.TrimSpace(string(header[71:96]))
+		refStr := strings.TrimSpace(string(header[108:116]))
+		refNum, _ := strconv.Atoi(refStr) // 0 / unparsable => no parent
 
 		// Extract body (starts after header block)
 		bodyBytes := data[pos+BlockSize : pos+totalBytes]
 		body := decodeQWKBody(bodyBytes)
 
 		messages = append(messages, REPMessage{
-			Conference: confNum,
-			To:         to,
-			Subject:    subject,
-			Body:       body,
+			Conference:    confNum,
+			To:            to,
+			Subject:       subject,
+			Body:          body,
+			ReplyToNumber: refNum,
 		})
 
 		pos += totalBytes

--- a/internal/qwk/rep_writer_test.go
+++ b/internal/qwk/rep_writer_test.go
@@ -225,3 +225,27 @@ func TestWriteREP_CapsBBSIDToEightChars(t *testing.T) {
 		t.Errorf("first-block BBSID = %q, want LONGERNA", p.BBSID)
 	}
 }
+
+func TestREP_RoundTripReplyToNumber(t *testing.T) {
+	in := []PacketMessage{
+		{Conference: 1, Number: 1, From: "a", To: "b", Subject: "First",
+			DateTime: time.Date(2026, 3, 5, 10, 0, 0, 0, time.UTC), Body: "root"},
+		{Conference: 1, Number: 2, From: "a", To: "b", Subject: "Re: First",
+			DateTime: time.Date(2026, 3, 5, 11, 0, 0, 0, time.UTC), Body: "reply",
+			ReplyToNumber: 1},
+	}
+	data := buildREP(t, "VISION3", in)
+	out, err := ReadREP(bytes.NewReader(data), int64(len(data)), "VISION3")
+	if err != nil {
+		t.Fatalf("ReadREP: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("want 2 messages, got %d", len(out))
+	}
+	if out[0].ReplyToNumber != 0 {
+		t.Errorf("root ReplyToNumber: want 0, got %d", out[0].ReplyToNumber)
+	}
+	if out[1].ReplyToNumber != 1 {
+		t.Errorf("reply ReplyToNumber: want 1, got %d", out[1].ReplyToNumber)
+	}
+}

--- a/internal/qwk/types.go
+++ b/internal/qwk/types.go
@@ -20,20 +20,22 @@ type ConferenceInfo struct {
 
 // PacketMessage is a message to be packed into a QWK MESSAGES.DAT.
 type PacketMessage struct {
-	Conference int
-	Number     int // Message number in the base
-	From       string
-	To         string
-	Subject    string
-	DateTime   time.Time
-	Body       string
-	Private    bool
+	Conference    int
+	Number        int // Message number in the base
+	From          string
+	To            string
+	Subject       string
+	DateTime      time.Time
+	Body          string
+	Private       bool
+	ReplyToNumber int // QWK reference: parent message number (0 = none)
 }
 
 // REPMessage is a message extracted from an uploaded REP packet.
 type REPMessage struct {
-	Conference int
-	To         string
-	Subject    string
-	Body       string
+	Conference    int
+	To            string
+	Subject       string
+	Body          string
+	ReplyToNumber int // QWK reference: parent message number (0 = none)
 }

--- a/internal/qwk/writer.go
+++ b/internal/qwk/writer.go
@@ -227,8 +227,8 @@ func formatMessage(msg PacketMessage) []byte {
 
 	// Password: positions 96-107 (12 chars) — blank
 
-	// Reference number: positions 108-115 (8 chars)
-	copyPadded(header[108:116], fmt.Sprintf("%8d", 0), 8)
+	// Reference number: positions 108-115 (8 chars) — parent message number.
+	copyPadded(header[108:116], fmt.Sprintf("%8d", msg.ReplyToNumber), 8)
 
 	// Body with QWK line ending (0xE3)
 	body := strings.ReplaceAll(msg.Body, "\r\n", "\xe3")

--- a/internal/qwk/writer.go
+++ b/internal/qwk/writer.go
@@ -227,7 +227,7 @@ func formatMessage(msg PacketMessage) []byte {
 
 	// Password: positions 96-107 (12 chars) — blank
 
-	// Reference number: positions 108-115 (8 chars) — parent message number.
+	// Reference number: positions 108-115 (8 bytes) — parent message number.
 	copyPadded(header[108:116], fmt.Sprintf("%8d", msg.ReplyToNumber), 8)
 
 	// Body with QWK line ending (0xE3)

--- a/internal/qwk/writer_test.go
+++ b/internal/qwk/writer_test.go
@@ -269,3 +269,15 @@ func TestPacketWriter_BBSID_Truncation(t *testing.T) {
 		t.Errorf("bbsID truncation: want 'LONGERNA', got %q", pw.bbsID)
 	}
 }
+
+func TestFormatMessage_ReplyToNumber(t *testing.T) {
+	data := formatMessage(PacketMessage{
+		Conference: 1, Number: 2, To: "All", Subject: "Re",
+		DateTime: time.Date(2026, 3, 5, 14, 30, 0, 0, time.UTC), Body: "x",
+		ReplyToNumber: 7,
+	})
+	ref := strings.TrimSpace(string(data[108:116]))
+	if ref != "7" {
+		t.Errorf("reference field (108-115): want 7, got %q", ref)
+	}
+}

--- a/internal/qwkservice/fakestore_test.go
+++ b/internal/qwkservice/fakestore_test.go
@@ -27,6 +27,7 @@ type fakeStore struct {
 type postedMessage struct {
 	areaID                       int
 	from, to, subject, body, rep string
+	replyToNum                   int
 }
 
 type setRead struct {
@@ -85,19 +86,19 @@ func (f *fakeStore) GetMessage(areaID, msgNum int) (*message.DisplayMessage, err
 	return list[msgNum-1], nil
 }
 
-func (f *fakeStore) AddMessage(areaID int, from, to, subject, body, replyToMsgID string) (int, error) {
+func (f *fakeStore) AddReply(areaID int, from, to, subject, body, replyToMsgID string, replyToNum int) (int, error) {
 	if err := f.addErr[areaID]; err != nil {
 		return 0, err
 	}
-	f.posted = append(f.posted, postedMessage{areaID, from, to, subject, body, replyToMsgID})
+	f.posted = append(f.posted, postedMessage{areaID, from, to, subject, body, replyToMsgID, replyToNum})
 	return len(f.posted), nil
 }
 
-func (f *fakeStore) AddPrivateMessage(areaID int, from, to, subject, body, replyToMsgID string) (int, error) {
+func (f *fakeStore) AddPrivateReply(areaID int, from, to, subject, body, replyToMsgID string, replyToNum int) (int, error) {
 	if err := f.addErr[areaID]; err != nil {
 		return 0, err
 	}
-	f.privPosted = append(f.privPosted, postedMessage{areaID, from, to, subject, body, replyToMsgID})
+	f.privPosted = append(f.privPosted, postedMessage{areaID, from, to, subject, body, replyToMsgID, replyToNum})
 	return len(f.privPosted), nil
 }
 

--- a/internal/qwkservice/fakestore_test.go
+++ b/internal/qwkservice/fakestore_test.go
@@ -21,7 +21,7 @@ type fakeStore struct {
 	posted     []postedMessage
 	privPosted []postedMessage
 	setReads   []setRead
-	addErr     map[int]error // areaID -> error to return from AddMessage
+	addErr     map[int]error // areaID -> error to return from AddReply/AddPrivateReply
 }
 
 type postedMessage struct {

--- a/internal/qwkservice/service.go
+++ b/internal/qwkservice/service.go
@@ -30,8 +30,8 @@ type MessageStore interface {
 	SetLastRead(areaID int, username string, msgNum int) error
 	GetMessageCountForArea(areaID int) (int, error)
 	GetMessage(areaID, msgNum int) (*message.DisplayMessage, error)
-	AddMessage(areaID int, from, to, subject, body, replyToMsgID string) (int, error)
-	AddPrivateMessage(areaID int, from, to, subject, body, replyToMsgID string) (int, error)
+	AddReply(areaID int, from, to, subject, body, replyToMsgID string, replyToNum int) (int, error)
+	AddPrivateReply(areaID int, from, to, subject, body, replyToMsgID string, replyToNum int) (int, error)
 }
 
 // Service orchestrates QWK packet export and REP import for a single BBS
@@ -178,14 +178,15 @@ func (s *Service) BuildPacket(opts ExportOptions) (*ExportResult, error) {
 			}
 
 			pw.AddMessage(qwk.PacketMessage{
-				Conference: entry.QWKNumber,
-				Number:     msg.MsgNum,
-				From:       msg.From,
-				To:         msg.To,
-				Subject:    msg.Subject,
-				DateTime:   msg.DateTime,
-				Body:       msg.Body,
-				Private:    msg.IsPrivate,
+				Conference:    entry.QWKNumber,
+				Number:        msg.MsgNum,
+				From:          msg.From,
+				To:            msg.To,
+				Subject:       msg.Subject,
+				DateTime:      msg.DateTime,
+				Body:          msg.Body,
+				Private:       msg.IsPrivate,
+				ReplyToNumber: msg.ReplyToNum,
 			})
 			packed++
 			res.MessageCount++

--- a/internal/qwkservice/service_export_test.go
+++ b/internal/qwkservice/service_export_test.go
@@ -3,6 +3,9 @@ package qwkservice
 import (
 	"archive/zip"
 	"bytes"
+	"io"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/message"
@@ -260,5 +263,52 @@ func TestCommitExport_AppliesLastRead(t *testing.T) {
 	}
 	if store.setReads[0] != (setRead{1, "tester", 7}) {
 		t.Errorf("first commit: got %+v", store.setReads[0])
+	}
+}
+
+// firstMsgReplyRef parses the QWK reference field (positions 108-115) of the
+// first message in a packet's MESSAGES.DAT.
+func firstMsgReplyRef(t *testing.T, packet []byte) int {
+	t.Helper()
+	zr, err := zip.NewReader(bytes.NewReader(packet), int64(len(packet)))
+	if err != nil {
+		t.Fatalf("zip: %v", err)
+	}
+	for _, f := range zr.File {
+		if f.Name != "MESSAGES.DAT" {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Block 1 is the spacer; the first message header starts at offset 128.
+		hdr := data[128:256]
+		ref, _ := strconv.Atoi(strings.TrimSpace(string(hdr[108:116])))
+		return ref
+	}
+	t.Fatal("MESSAGES.DAT not found")
+	return 0
+}
+
+func TestBuildPacket_WritesReplyReference(t *testing.T) {
+	store := newFakeStore()
+	store.addArea(&message.MessageArea{ID: 1, Tag: "GENERAL", Name: "General"})
+	m := dm(1, "a", "All", "s", "b")
+	m.ReplyToNum = 7
+	store.seed(1, m)
+
+	svc := newTestService(t, store)
+	res, err := svc.BuildPacket(ExportOptions{Handle: "tester", TaggedTags: []string{"GENERAL"}})
+	if err != nil {
+		t.Fatalf("BuildPacket: %v", err)
+	}
+	if got := firstMsgReplyRef(t, res.Packet); got != 7 {
+		t.Errorf("exported reply reference: want 7, got %d", got)
 	}
 }

--- a/internal/qwkservice/service_import.go
+++ b/internal/qwkservice/service_import.go
@@ -100,9 +100,9 @@ func (s *Service) ImportREP(data []byte, opts ImportOptions) (*ImportResult, err
 
 		var perr error
 		if kind == KindPrivateMail {
-			_, perr = s.store.AddPrivateMessage(area.ID, opts.Handle, msg.To, msg.Subject, body, "")
+			_, perr = s.store.AddPrivateReply(area.ID, opts.Handle, msg.To, msg.Subject, body, "", msg.ReplyToNumber)
 		} else {
-			_, perr = s.store.AddMessage(area.ID, opts.Handle, msg.To, msg.Subject, body, "")
+			_, perr = s.store.AddReply(area.ID, opts.Handle, msg.To, msg.Subject, body, "", msg.ReplyToNumber)
 		}
 		if perr != nil {
 			slog.Error("qwk import: failed to post", "area", area.ID, "error", perr)

--- a/internal/qwkservice/service_import_test.go
+++ b/internal/qwkservice/service_import_test.go
@@ -236,3 +236,35 @@ func TestImportREP_MappedButStaleAreaSkipped(t *testing.T) {
 		t.Errorf("nothing should be posted for a stale mapped conference: public=%d priv=%d", len(store.posted), len(store.privPosted))
 	}
 }
+
+func TestImportREP_SetsReplyPointer(t *testing.T) {
+	store := newFakeStore()
+	store.addArea(&message.MessageArea{ID: 1, Tag: "GENERAL", Name: "General"})
+	rep := makeREP(t, "VISION3", []qwk.PacketMessage{
+		{Conference: 1, Number: 1, To: "SysOp", Subject: "Re", DateTime: time.Now(), Body: "reply", ReplyToNumber: 5},
+	})
+
+	svc := newTestService(t, store)
+	if _, err := svc.ImportREP(rep, ImportOptions{Handle: "tester"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.posted) != 1 || store.posted[0].replyToNum != 5 {
+		t.Errorf("want AddReply with replyToNum 5, got %+v", store.posted)
+	}
+}
+
+func TestImportREP_PrivateReplyPointer(t *testing.T) {
+	store := newFakeStore()
+	store.addArea(&message.MessageArea{ID: 3, Tag: "PRIVMAIL", Name: "Private Mail"})
+	rep := makeREP(t, "VISION3", []qwk.PacketMessage{
+		{Conference: 0, Number: 1, To: "friend", Subject: "Re", DateTime: time.Now(), Body: "x", ReplyToNumber: 4},
+	})
+
+	svc := newTestService(t, store)
+	if _, err := svc.ImportREP(rep, ImportOptions{Handle: "tester"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.privPosted) != 1 || store.privPosted[0].replyToNum != 4 {
+		t.Errorf("want AddPrivateReply with replyToNum 4, got %+v", store.privPosted)
+	}
+}


### PR DESCRIPTION
Implements **QWK Phase 4**: reply chains now round-trip through QWK download and REP upload. Builds on the local reply-threading feature ([#66](https://github.com/ViSiON-3/vision-3-bbs/pull/66)), which gave messages a parent pointer to preserve.

Design: `docs/superpowers/specs/2026-06-30-qwk-phase4-reply-threading-design.md`
Plan: `docs/superpowers/plans/2026-06-30-qwk-phase4-reply-threading.md`

## What changed
- **Codec (`internal/qwk`)** — `PacketMessage`/`REPMessage` gain `ReplyToNumber`. `formatMessage` writes it into the base-QWK message header **reference field** (positions 108–115, previously hardcoded `0`); `parseREPMessages` reads it back. The reference is the parent's QWK message number, which equals its local JAM `MsgNum` in our export — no remapping.
- **Service (`internal/qwkservice`)** — `BuildPacket` copies `msg.ReplyToNum` into the exported message. `ImportREP` posts through `AddReply`/`AddPrivateReply` (the `MessageStore` interface swaps `AddMessage`/`AddPrivateMessage` for these), passing the parsed reference: private conference → `AddPrivateReply`, public → `AddReply`.

## Behavior / scope
- **Backward compatible:** `ReplyToNumber == 0` writes byte-identical to today's hardcoded `0`, and the manager's `replyToNum > 0` guard means a 0 reference reproduces the prior non-reply post. Non-replies and older packets are unchanged.
- **Decided (per design):** imported replies use **server-receive time** (no authored-date preservation), and the reference is set **as-is** (no validation / degraded-thread reporting) — readers produce valid references for messages we exported, and a dangling reference is harmless.
- **Deferred:** MSGID / network-address fields (echomail / `HEADERS.DAT`, Phase 5).

## Verification
- `go test ./...` → 1637 pass (54 packages); `-race` clean on `internal/qwk` + `internal/qwkservice`; gofmt/vet clean.
- New tests: reference-field write; `WriteREP`→`ReadREP` round-trip (incl. 0); `BuildPacket` writes the reference (parses real MESSAGES.DAT bytes); import sets the pointer for public + private replies.

Developed via TDD with per-task spec+quality reviews and a final whole-branch review (no Critical/Important findings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preserving reply threading in QWK packets, so replies can keep their parent message link when exported and imported.
  * Private and public replies now retain their reply reference during packet processing.

* **Bug Fixes**
  * Improved packet handling to read and write reply reference values consistently, including round-trip support.

* **Documentation**
  * Added updated guidance for reply threading behavior in QWK packet workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->