### PR TITLE
feat(qwk): Phase 5 — HEADERS.DAT extended headers (long To/From/Subject)

### DIFF
--- a/docs/superpowers/plans/2026-06-30-qwk-phase5-headers-dat.md
+++ b/docs/superpowers/plans/2026-06-30-qwk-phase5-headers-dat.md
@@ -1,0 +1,600 @@
+# QWK Phase 5 — HEADERS.DAT Extended Headers — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Write and read a `HEADERS.DAT` file so full `To`/`From`/`Subject` (plus `Message-ID` and `WhenWritten`) round-trip through QWK packets, lifting the 25-char base-header limit.
+
+**Architecture:** A new `internal/qwk/headers.go` encodes/parses the Synchronet INI form (`[<hex-offset>]` sections keyed by each message's `MESSAGES.DAT` header offset). The packet writer and REP writer emit `HEADERS.DAT`; the REP reader parses it and overrides the truncated `Subject`/`To`. Codec-only — no `qwkservice` change (full fields already flow through `PacketMessage`/`REPMessage`).
+
+**Tech Stack:** Go (stdlib `archive/zip`, `strconv`, `strings`, `time`, `testing`); `internal/qwk` only.
+
+## Global Constraints
+
+- No new dependencies; Go files under 300 lines; `slog` for logging.
+- TDD: failing test first → red → minimal implementation → green → commit.
+- Format (Synchronet `ref:qwk`): INI; section `[<hexoffset>]` (lowercase hex, no `0x`); offset = the message header's byte offset in `MESSAGES.DAT` (first message at 128, after the 128-byte spacer); fields `Message-ID`, `Subject`, `To`, `From`, `WhenWritten`; `HEADERS.DAT` overrides the base header. CRLF line endings.
+- `WhenWritten` = `YYYYMMDDhhmmss±hhmm` then two spaces then the SMB timezone as lowercase hex; SMB tz = `0x2000|absMinutes` (west) or `0x1000|absMinutes` (east), US/daylight flags NOT set.
+- `Message-ID` synthesized deterministically: `<{number}.{conference}@{lowercased-bbsID}>`.
+- Emit one `HEADERS.DAT` section per message, always. Adding the file is non-breaking (plain readers ignore it).
+- Spec: `docs/superpowers/specs/2026-06-30-qwk-phase5-headers-dat-design.md`.
+
+---
+
+## File Structure
+
+- Create: `internal/qwk/headers.go` — encode/parse + `smbTimezone`/`synthMessageID`/`formatWhenWritten`/`extHeadersFor`.
+- Create: `internal/qwk/headers_test.go` — unit tests for the above.
+- Modify: `internal/qwk/writer.go` — `writeMessagesDAT` returns offsets; `WritePacket` writes `HEADERS.DAT`.
+- Modify: `internal/qwk/rep_writer.go` — `WriteREP` writes `HEADERS.DAT`.
+- Modify: `internal/qwk/reader.go` — `ReadREPPacket` parses `HEADERS.DAT`; `parseREPMessages` applies the override.
+- Modify: `internal/qwk/rep_writer_test.go` / `writer_test.go` — round-trip + emit tests.
+- Modify: `docs/sysop/messages/qwk.md` — one-line note.
+
+---
+
+## Task 1: `headers.go` — encode/parse + helpers
+
+**Files:**
+- Create: `internal/qwk/headers.go`
+- Test: `internal/qwk/headers_test.go`
+
+**Interfaces:**
+- Produces: `type ExtHeader struct { Offset int; MessageID, Subject, To, From, WhenWritten string }`; `encodeHeadersDAT([]ExtHeader) []byte`; `parseHeadersDAT([]byte) map[int]ExtHeader`; `smbTimezone(offsetSeconds int) string`; `synthMessageID(bbsID string, conference, number int) string`; `formatWhenWritten(t time.Time) string`; `extHeadersFor(msgs []PacketMessage, offsets []int, bbsID string) []ExtHeader`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/qwk/headers_test.go`:
+
+```go
+package qwk
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSynthMessageID(t *testing.T) {
+	if got := synthMessageID("VISION3", 1, 2); got != "<2.1@vision3>" {
+		t.Errorf("synthMessageID = %q, want <2.1@vision3>", got)
+	}
+}
+
+func TestSmbTimezone(t *testing.T) {
+	if got := smbTimezone(-8 * 3600); got != "21e0" { // 480 min west
+		t.Errorf("smbTimezone(-0800) = %q, want 21e0", got)
+	}
+	if got := smbTimezone(1 * 3600); got != "103c" { // 60 min east
+		t.Errorf("smbTimezone(+0100) = %q, want 103c", got)
+	}
+}
+
+func TestHeadersDAT_RoundTrip(t *testing.T) {
+	in := []ExtHeader{
+		{Offset: 384, MessageID: "<2.1@v>", Subject: "Second", To: "Bob", From: "Al", WhenWritten: "20260305150000-0800  21e0"},
+		{Offset: 128, MessageID: "<1.1@v>", Subject: "First: with a colon", To: "Al", From: "Bob", WhenWritten: "20260305143000-0800  21e0"},
+	}
+	data := encodeHeadersDAT(in)
+	out := parseHeadersDAT(data)
+
+	if len(out) != 2 {
+		t.Fatalf("want 2 sections, got %d", len(out))
+	}
+	h := out[128]
+	if h.Subject != "First: with a colon" {
+		t.Errorf("subject with colon not preserved: %q", h.Subject)
+	}
+	if h.To != "Al" || h.From != "Bob" || h.MessageID != "<1.1@v>" {
+		t.Errorf("fields not preserved: %+v", h)
+	}
+	if _, ok := out[384]; !ok {
+		t.Error("second section (offset 384) missing")
+	}
+}
+
+func TestParseHeadersDAT_LenientOnGarbage(t *testing.T) {
+	if got := parseHeadersDAT(nil); len(got) != 0 {
+		t.Errorf("nil input: want empty map, got %v", got)
+	}
+	if got := parseHeadersDAT([]byte("not ini\nmore junk\n")); len(got) != 0 {
+		t.Errorf("garbage input: want empty map, got %v", got)
+	}
+}
+
+func TestFormatWhenWritten(t *testing.T) {
+	tt := time.Date(2026, 3, 5, 14, 30, 0, 0, time.FixedZone("PST", -8*3600))
+	if got := formatWhenWritten(tt); got != "20260305143000-0800  21e0" {
+		t.Errorf("formatWhenWritten = %q, want 20260305143000-0800  21e0", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/qwk/ -run 'TestSynthMessageID|TestSmbTimezone|TestHeadersDAT_RoundTrip|TestParseHeadersDAT_LenientOnGarbage|TestFormatWhenWritten' -v`
+Expected: FAIL — the functions/types are undefined (compile error).
+
+- [ ] **Step 3: Implement `internal/qwk/headers.go`**
+
+```go
+package qwk
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ExtHeader is the subset of HEADERS.DAT fields ViSiON/3 emits and consumes.
+type ExtHeader struct {
+	Offset      int // byte offset of the message header in MESSAGES.DAT / .MSG
+	MessageID   string
+	Subject     string
+	To          string
+	From        string
+	WhenWritten string
+}
+
+// encodeHeadersDAT renders HEADERS.DAT sections (ordered by offset) as INI bytes.
+func encodeHeadersDAT(hs []ExtHeader) []byte {
+	sorted := make([]ExtHeader, len(hs))
+	copy(sorted, hs)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Offset < sorted[j].Offset })
+
+	var buf bytes.Buffer
+	for i, h := range sorted {
+		if i > 0 {
+			buf.WriteString("\r\n")
+		}
+		fmt.Fprintf(&buf, "[%x]\r\n", h.Offset)
+		writeHeaderField(&buf, "Message-ID", h.MessageID)
+		writeHeaderField(&buf, "Subject", h.Subject)
+		writeHeaderField(&buf, "To", h.To)
+		writeHeaderField(&buf, "From", h.From)
+		writeHeaderField(&buf, "WhenWritten", h.WhenWritten)
+	}
+	return buf.Bytes()
+}
+
+func writeHeaderField(buf *bytes.Buffer, key, val string) {
+	if val == "" {
+		return
+	}
+	buf.WriteString(key)
+	buf.WriteString(": ")
+	buf.WriteString(val)
+	buf.WriteString("\r\n")
+}
+
+// parseHeadersDAT parses HEADERS.DAT into a map keyed by message byte offset.
+// Malformed lines and unknown keys are ignored; empty/garbage input yields an
+// empty map.
+func parseHeadersDAT(data []byte) map[int]ExtHeader {
+	out := make(map[int]ExtHeader)
+	var cur ExtHeader
+	have := false
+	flush := func() {
+		if have {
+			out[cur.Offset] = cur
+		}
+	}
+	for _, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(strings.TrimRight(raw, "\r"))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			flush()
+			off, err := strconv.ParseInt(line[1:len(line)-1], 16, 64)
+			if err != nil {
+				have = false
+				continue
+			}
+			cur = ExtHeader{Offset: int(off)}
+			have = true
+			continue
+		}
+		if !have {
+			continue
+		}
+		key, val, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		val = strings.TrimSpace(val)
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "message-id":
+			cur.MessageID = val
+		case "subject":
+			cur.Subject = val
+		case "to":
+			cur.To = val
+		case "from":
+			cur.From = val
+		case "whenwritten":
+			cur.WhenWritten = val
+		}
+	}
+	flush()
+	return out
+}
+
+// smbTimezone encodes a UTC offset (in seconds) as the SMB hex timezone. Bits
+// 0-11 hold the absolute minutes; 0x2000 marks west of UTC, 0x1000 east. The US
+// and daylight flag bits are intentionally not set (they cannot be reliably
+// inferred; the ISO-8601 offset carries the real offset).
+func smbTimezone(offsetSeconds int) string {
+	mins := offsetSeconds / 60
+	var v uint16
+	if mins < 0 {
+		v = 0x2000 | uint16(-mins)
+	} else {
+		v = 0x1000 | uint16(mins)
+	}
+	return fmt.Sprintf("%x", v)
+}
+
+// synthMessageID builds a deterministic RFC822-style Message-ID for a local
+// message, which has no FTN MSGID.
+func synthMessageID(bbsID string, conference, number int) string {
+	return fmt.Sprintf("<%d.%d@%s>", number, conference, strings.ToLower(bbsID))
+}
+
+// formatWhenWritten renders a timestamp as ISO-8601 with offset plus the SMB
+// hex timezone.
+func formatWhenWritten(t time.Time) string {
+	_, off := t.Zone()
+	return t.Format("20060102150405-0700") + "  " + smbTimezone(off)
+}
+
+// extHeadersFor builds the HEADERS.DAT entries for a set of packet messages
+// given their byte offsets in MESSAGES.DAT / .MSG.
+func extHeadersFor(msgs []PacketMessage, offsets []int, bbsID string) []ExtHeader {
+	hs := make([]ExtHeader, 0, len(msgs))
+	for i, m := range msgs {
+		hs = append(hs, ExtHeader{
+			Offset:      offsets[i],
+			MessageID:   synthMessageID(bbsID, m.Conference, m.Number),
+			Subject:     m.Subject,
+			To:          m.To,
+			From:        m.From,
+			WhenWritten: formatWhenWritten(m.DateTime),
+		})
+	}
+	return hs
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/qwk/ -run 'TestSynthMessageID|TestSmbTimezone|TestHeadersDAT_RoundTrip|TestParseHeadersDAT_LenientOnGarbage|TestFormatWhenWritten' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/qwk/headers.go internal/qwk/headers_test.go
+go vet ./internal/qwk/
+git add internal/qwk/headers.go internal/qwk/headers_test.go
+git commit -m "feat(qwk): add HEADERS.DAT encode/parse and helpers"
+```
+
+---
+
+## Task 2: Writers emit `HEADERS.DAT`
+
+**Files:**
+- Modify: `internal/qwk/writer.go` (`writeMessagesDAT` returns offsets; `WritePacket` writes `HEADERS.DAT`)
+- Modify: `internal/qwk/rep_writer.go` (`WriteREP` writes `HEADERS.DAT`)
+- Test: `internal/qwk/rep_writer_test.go`
+
+**Interfaces:**
+- Consumes: `encodeHeadersDAT`, `extHeadersFor` (Task 1).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/qwk/rep_writer_test.go`:
+
+```go
+func TestWriteREP_EmitsHeadersDAT(t *testing.T) {
+	longSubject := "A very long subject line beyond the 25-character base limit"
+	data := buildREP(t, "VISION3", []PacketMessage{
+		{Conference: 1, Number: 1, From: "SysOp", To: "SomebodyWithALongHandle",
+			Subject: longSubject, DateTime: time.Date(2026, 3, 5, 14, 30, 0, 0, time.UTC), Body: "x"},
+	})
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("zip: %v", err)
+	}
+	var hdr []byte
+	for _, f := range zr.File {
+		if f.Name == "HEADERS.DAT" {
+			rc, _ := f.Open()
+			hdr, _ = io.ReadAll(rc)
+			rc.Close()
+		}
+	}
+	if hdr == nil {
+		t.Fatal("REP packet missing HEADERS.DAT")
+	}
+	// First message header is at offset 128 -> section [80].
+	got := parseHeadersDAT(hdr)
+	h, ok := got[128]
+	if !ok {
+		t.Fatalf("no section at offset 128; sections=%v", got)
+	}
+	if h.Subject != longSubject {
+		t.Errorf("HEADERS.DAT subject: want full, got %q", h.Subject)
+	}
+	if h.To != "SomebodyWithALongHandle" {
+		t.Errorf("HEADERS.DAT to: want full, got %q", h.To)
+	}
+}
+```
+
+(`io` is already imported in the qwk package tests via other files; if not, add
+`"io"` to `rep_writer_test.go` imports.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/qwk/ -run TestWriteREP_EmitsHeadersDAT -v`
+Expected: FAIL — no `HEADERS.DAT` entry in the REP zip.
+
+- [ ] **Step 3: Track offsets and emit in `writeMessagesDAT` / `WritePacket`**
+
+In `internal/qwk/writer.go`, change `writeMessagesDAT` to also return the
+per-message offsets. Update its signature and body:
+
+```go
+func (pw *PacketWriter) writeMessagesDAT(zw *zip.Writer) (map[int][]byte, []byte, []int, error) {
+```
+
+Inside the message loop, record the offset **before** advancing `currentBlock`
+(add right after `msgBytes := formatMessage(msg)` / before writing, e.g. just
+before `msgBuf.Write(padded)`):
+
+```go
+		offsets = append(offsets, (currentBlock-1)*BlockSize)
+```
+
+Declare `var offsets []int` next to `ndxData`, and change the two `return`
+statements to include it (`return ndxData, personalNDX, offsets, nil` and the
+error return `return nil, nil, nil, err`).
+
+In `WritePacket`, update the call and write `HEADERS.DAT` after `PERSONAL.NDX`:
+
+```go
+	ndxData, personalNDX, offsets, err := pw.writeMessagesDAT(zw)
+	if err != nil {
+		return fmt.Errorf("MESSAGES.DAT: %w", err)
+	}
+```
+
+```go
+	if hdrs := encodeHeadersDAT(extHeadersFor(pw.messages, offsets, pw.bbsID)); len(hdrs) > 0 {
+		if err := writeZipEntry(zw, "HEADERS.DAT", hdrs); err != nil {
+			return fmt.Errorf("HEADERS.DAT: %w", err)
+		}
+	}
+```
+
+- [ ] **Step 4: Emit in `WriteREP`**
+
+In `internal/qwk/rep_writer.go`, collect offsets in the message loop and write a
+`HEADERS.DAT` entry. Before the loop add `var offsets []int`; inside the loop,
+capture the offset before appending the message's blocks:
+
+```go
+	for _, msg := range msgs {
+		offsets = append(offsets, msgBuf.Len())
+		msgBytes := formatMessage(msg)
+		numBlocks := (len(msgBytes) + BlockSize - 1) / BlockSize
+
+		padded := make([]byte, numBlocks*BlockSize)
+		for i := range padded {
+			padded[i] = ' '
+		}
+		copy(padded, msgBytes)
+		msgBuf.Write(padded)
+	}
+```
+
+After the `<bbsID>.MSG` zip entry is written successfully (before `zw.Close()`),
+add:
+
+```go
+	if hdrs := encodeHeadersDAT(extHeadersFor(msgs, offsets, bbsID)); len(hdrs) > 0 {
+		if err := writeZipEntry(zw, "HEADERS.DAT", hdrs); err != nil {
+			zw.Close()
+			return fmt.Errorf("HEADERS.DAT: %w", err)
+		}
+	}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/qwk/ 2>&1 | tail -5`
+Expected: PASS — the new emit test plus all existing `internal/qwk` tests (the
+extra zip entry does not affect `ReadREP`, which reads only `<bbsID>.MSG`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+gofmt -w internal/qwk/writer.go internal/qwk/rep_writer.go internal/qwk/rep_writer_test.go
+go vet ./internal/qwk/
+git add internal/qwk/writer.go internal/qwk/rep_writer.go internal/qwk/rep_writer_test.go
+git commit -m "feat(qwk): emit HEADERS.DAT from the packet and REP writers"
+```
+
+---
+
+## Task 3: Reader parses `HEADERS.DAT` and applies precedence
+
+**Files:**
+- Modify: `internal/qwk/reader.go` (`ReadREPPacket` reads `HEADERS.DAT`; `parseREPMessages` overrides)
+- Test: `internal/qwk/rep_writer_test.go`
+
+**Interfaces:**
+- Consumes: `parseHeadersDAT` (Task 1), the `HEADERS.DAT` written by Task 2.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/qwk/rep_writer_test.go`:
+
+```go
+func TestREP_RoundTripLongSubjectViaHeaders(t *testing.T) {
+	longSubject := "A very long subject line beyond the 25-character base limit"
+	data := buildREP(t, "VISION3", []PacketMessage{
+		{Conference: 1, Number: 1, From: "SysOp", To: "SomebodyWithALongHandle",
+			Subject: longSubject, DateTime: time.Date(2026, 3, 5, 14, 30, 0, 0, time.UTC), Body: "x"},
+	})
+
+	out, err := ReadREP(bytes.NewReader(data), int64(len(data)), "VISION3")
+	if err != nil {
+		t.Fatalf("ReadREP: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("want 1 message, got %d", len(out))
+	}
+	if out[0].Subject != longSubject {
+		t.Errorf("subject not restored from HEADERS.DAT: got %q (len %d)", out[0].Subject, len(out[0].Subject))
+	}
+	if out[0].To != "SomebodyWithALongHandle" {
+		t.Errorf("to not restored from HEADERS.DAT: got %q", out[0].To)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/qwk/ -run TestREP_RoundTripLongSubjectViaHeaders -v`
+Expected: FAIL — `Subject` comes back truncated to 25 chars (no override yet).
+
+- [ ] **Step 3: Read `HEADERS.DAT` in `ReadREPPacket` and pass it to `parseREPMessages`**
+
+In `internal/qwk/reader.go` `ReadREPPacket`, after `data` is read and before
+calling `parseREPMessages`, locate and parse the (optional) `HEADERS.DAT` entry:
+
+```go
+	headers := map[int]ExtHeader{}
+	for _, f := range zr.File {
+		if strings.EqualFold(f.Name, "HEADERS.DAT") {
+			hrc, err := f.Open()
+			if err == nil {
+				hdata, _ := io.ReadAll(hrc)
+				hrc.Close()
+				headers = parseHeadersDAT(hdata)
+			}
+			break
+		}
+	}
+
+	msgs, err := parseREPMessages(data, headers)
+	if err != nil {
+		return nil, err
+	}
+```
+
+Change `parseREPMessages` to accept the headers map and apply the override. Its
+signature becomes:
+
+```go
+func parseREPMessages(data []byte, headers map[int]ExtHeader) ([]REPMessage, error) {
+```
+
+Inside the loop, after computing `to` and `subject` (and before building the
+`REPMessage`), apply the precedence:
+
+```go
+		if h, ok := headers[pos]; ok {
+			if h.Subject != "" {
+				subject = h.Subject
+			}
+			if h.To != "" {
+				to = h.To
+			}
+		}
+```
+
+`From` is not surfaced on import; `Message-ID`/`WhenWritten` are parsed but not
+consumed (import uses server-receive time).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/qwk/ 2>&1 | tail -5`
+Expected: PASS — the new round-trip test plus all existing `internal/qwk` tests.
+The existing REP tests build zips without a `HEADERS.DAT`, so `parseREPMessages`
+receives an empty map and behaves exactly as before (base-header fallback).
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/qwk/reader.go internal/qwk/rep_writer_test.go
+go vet ./internal/qwk/
+git add internal/qwk/reader.go internal/qwk/rep_writer_test.go
+git commit -m "feat(qwk): apply HEADERS.DAT precedence on REP import (full To/Subject)"
+```
+
+---
+
+## Task 4: Docs + full verification
+
+**Files:**
+- Modify: `docs/sysop/messages/qwk.md`
+
+- [ ] **Step 1: Add a note**
+
+In `docs/sysop/messages/qwk.md`, near the packet-format / reply-threading section,
+add:
+
+```markdown
+## Long headers (HEADERS.DAT)
+
+The base QWK message header limits To/From/Subject to 25 characters. ViSiON/3 also
+writes a `HEADERS.DAT` file carrying the full-length fields (and a Message-ID and
+timestamp) per the Synchronet extended-header format, and reads it back on REP
+upload — so long subjects survive the round trip. Readers that don't understand
+`HEADERS.DAT` simply ignore the extra file.
+
+(Interoperability with third-party readers such as MultiMail follows the
+documented format but has not yet been validated against a real reader.)
+```
+
+- [ ] **Step 2: Commit the docs**
+
+```bash
+git add docs/sysop/messages/qwk.md
+git commit -m "docs(qwk): document HEADERS.DAT long-header support"
+```
+
+- [ ] **Step 3: Full verification**
+
+Run: `gofmt -l internal/qwk`
+Expected: no output.
+
+Run: `go vet ./... 2>&1 | tail -5`
+Expected: no issues.
+
+Run: `go test ./... 2>&1 | tail -10`
+Expected: all packages PASS.
+
+Run: `go test -race ./internal/qwk ./internal/qwkservice 2>&1 | tail -5`
+Expected: PASS, no race warnings.
+
+- [ ] **Step 4: Final commit (only if cleanup was needed)**
+
+```bash
+git add -A
+git commit -m "chore(qwk): Phase 5 cleanup and verification"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+- **Spec coverage:** encode/parse + helpers (`smbTimezone`, `synthMessageID`, `formatWhenWritten`, `extHeadersFor`) → Task 1; writer emit (`WritePacket` + `WriteREP`, offset tracking) → Task 2; reader parse + `Subject`/`To` override with precedence → Task 3; docs + verification → Task 4. Codec-only, no service change — matches the spec. All sections covered.
+- **Placeholder scan:** no TBD/TODO; every code step shows full code; the unchanged parts of the writer/reader loops are shown in context.
+- **Type consistency:** `ExtHeader{Offset,MessageID,Subject,To,From,WhenWritten}`, `encodeHeadersDAT`/`parseHeadersDAT`, `extHeadersFor(msgs, offsets, bbsID)`, `parseREPMessages(data, headers)` and the `writeMessagesDAT` 4-value return are used consistently across tasks. Offsets: write `(currentBlock-1)*128` / `msgBuf.Len()`, read `pos` — both the message-header start, asserted by the round-trip at offset 128.

--- a/docs/superpowers/specs/2026-06-30-qwk-phase5-headers-dat-design.md
+++ b/docs/superpowers/specs/2026-06-30-qwk-phase5-headers-dat-design.md
@@ -1,0 +1,217 @@
+# QWK Phase 5 — HEADERS.DAT Extended Headers
+
+**Date:** 2026-06-30
+**Status:** Approved design
+**Branch:** `qwk-phase5-headers-dat` (stacked on `qwk-phase4-reply-metadata` / PR #67)
+**Parent plan:** `docs-internal/plans/2026-06-29-qwk-rep-sync-mobile-design.md` (Phase 5)
+
+---
+
+## Problem
+
+The base QWK message header truncates `To`/`From`/`Subject` to **25 characters**
+(`internal/qwk/writer.go:220-226`), so long subjects are lost in a packet. The
+QWKE/Synchronet `HEADERS.DAT` file carries full-length header fields (and more)
+without kludge lines, and takes precedence over the base header. Adding it lets
+long subjects survive a QWK download / REP upload and moves ViSiON/3 toward
+mainstream reader (MultiMail/Synchronet) interoperability.
+
+## Goal
+
+Write and read a `HEADERS.DAT` file so full `To`/`From`/`Subject` (plus a
+`Message-ID` and `WhenWritten` timestamp) round-trip through QWK packets.
+
+## Scope decisions (confirmed)
+
+| Decision | Choice |
+| --- | --- |
+| Fields per section | `Message-ID`, `Subject`, `To`, `From`, `WhenWritten` |
+| Emit policy | One `HEADERS.DAT` section per message, always |
+| Layer | Codec only (`internal/qwk`); no `qwkservice` change (full fields already flow through `PacketMessage`/`REPMessage`) |
+| Interop | **Unverified** — implemented to the documented Synchronet format; validated only by a ViSiON/3 write→read round-trip. Real MultiMail/Synchronet validation is deferred until captured fixtures exist (`testdata/external/`). |
+
+## Non-goals
+
+- Synchronet legacy `@`-tag parsing (dropped from the roadmap — see the project
+  note; QWK-networking is the future trigger).
+- `In-Reply-To` / network-address / netmail fields (threading is already handled
+  by the Phase 4 reference field; net-addr is echomail-only).
+- Any `qwkservice` change (the service already carries full `Subject`/`To`).
+- A config gate (readers that don't understand `HEADERS.DAT` ignore the extra
+  zip entry — adding it is non-breaking).
+
+---
+
+## Format (authoritative — Synchronet `ref:qwk`)
+
+`HEADERS.DAT` is an INI-style text file. Each section corresponds to one message
+in `MESSAGES.DAT` (or `<bbsID>.MSG` for a REP). The section name is the message
+header block's **byte offset into `MESSAGES.DAT`, in lowercase hexadecimal,
+without a `0x` prefix**. The first message begins at offset 128 (after the
+128-byte spacer block).
+
+Example:
+
+```
+[80]
+Message-ID: <1.1@vision3>
+Subject: A very long subject line that exceeds the 25-character base limit
+To: SomebodyWithARatherLongHandle
+From: SysOp
+WhenWritten: 20260305143000-0800  21e0
+
+[180]
+Message-ID: <2.1@vision3>
+Subject: Re: A very long subject line that exceeds the 25-character base limit
+To: SysOp
+From: SomebodyWithARatherLongHandle
+WhenWritten: 20260305150000-0800  21e0
+```
+
+- **`Message-ID`** — RFC822-style. Local messages have no MSGID, so synthesize a
+  deterministic one: `<{number}.{conference}@{lowercased-bbsID}>`.
+- **`Subject`/`To`/`From`** — full, untruncated values.
+- **`WhenWritten`** — `YYYYMMDDhhmmss±hhmm` (ISO-8601, from the message
+  timestamp) then two spaces then the SMB timezone as lowercase hex (see below).
+
+### SMB timezone hex
+
+The SMB timezone is a 16-bit value: bits 0–11 hold the absolute minutes offset
+from UTC; bit `0x2000` marks *west* of UTC (non-US), bit `0x1000` marks *east*
+of UTC (non-US); bits `0x4000` (US) and `0x8000` (daylight) are additional flags.
+
+We emit the non-US west/east form and do **not** set the US or daylight flags —
+they cannot be reliably inferred for an arbitrary BBS, and the ISO-8601 offset
+already conveys the actual offset:
+
+```go
+func smbTimezone(offsetSeconds int) string {
+    mins := offsetSeconds / 60
+    var v uint16
+    if mins < 0 {
+        v = 0x2000 | uint16(-mins) // west of UTC
+    } else {
+        v = 0x1000 | uint16(mins)  // east of UTC
+    }
+    return fmt.Sprintf("%x", v)
+}
+```
+
+(e.g. UTC-0800 → 480 min west → `0x2000|0x1E0 = 0x21E0` → `"21e0"`.)
+
+---
+
+## Design
+
+### 1. `internal/qwk/headers.go` (new)
+
+Pure encode/parse plus the two helpers, all unit-testable in isolation:
+
+```go
+// ExtHeader is the subset of HEADERS.DAT fields ViSiON/3 emits/consumes.
+type ExtHeader struct {
+    Offset      int    // byte offset of the message header in MESSAGES.DAT
+    MessageID   string
+    Subject     string
+    To          string
+    From        string
+    WhenWritten string
+}
+
+// encodeHeadersDAT renders sections (ordered by offset) to INI bytes.
+func encodeHeadersDAT(hs []ExtHeader) []byte
+
+// parseHeadersDAT parses HEADERS.DAT into a map keyed by byte offset. Unknown
+// keys and malformed lines are ignored (lenient); a missing file is handled by
+// the caller (empty map).
+func parseHeadersDAT(data []byte) map[int]ExtHeader
+
+func smbTimezone(offsetSeconds int) string
+func synthMessageID(bbsID string, conference, number int) string // "<num.conf@bbsid>"
+```
+
+Encoding rules: `[<hex offset>]` section line; `Key: Value` field lines
+(`strings.SplitN(line, ":", 2)` on read; only the first `:` splits, so subjects
+containing `:` are preserved); blank line between sections. CRLF line endings to
+match the other packet text files.
+
+### 2. Writer emits `HEADERS.DAT` — `internal/qwk/writer.go`, `rep_writer.go`
+
+- `writeMessagesDAT` already tracks `currentBlock` (block 1 = spacer, messages
+  from block 2). Record each message's header offset as `(currentBlock-1)*128`
+  and return the per-message offsets alongside the NDX data.
+- `WritePacket` builds `[]ExtHeader` from `pw.messages` + offsets (full
+  `Subject`/`To`/`From`; `synthMessageID(pw.bbsID, msg.Conference, msg.Number)`;
+  `WhenWritten` from `msg.DateTime`) and writes a `HEADERS.DAT` zip entry.
+- `WriteREP` (the REP builder) computes the same offsets for its single `.MSG`
+  and writes a `HEADERS.DAT` entry into the `.REP` zip too, so the write→read
+  round trip carries the extended headers.
+
+The base header still writes the 25-char-truncated `To`/`From`/`Subject`
+(`formatMessage` unchanged) — plain readers keep working; `HEADERS.DAT` is
+purely additive.
+
+### 3. Reader parses + applies precedence — `internal/qwk/reader.go`
+
+- `ReadREPPacket` locates a `HEADERS.DAT` entry in the zip (case-insensitive; may
+  be absent) and parses it into `map[int]ExtHeader`.
+- `parseREPMessages` gains the headers map. It already tracks each message's
+  byte offset (`pos`); when a section exists for that offset, it **overrides**
+  the block-header `Subject` and `To` with the full `HEADERS.DAT` values
+  (precedence per spec). `From` is not surfaced on import (a REP's author is the
+  uploading user, applied by the service); `Message-ID`/`WhenWritten` are parsed
+  but not consumed (import uses server-receive time, per Phase 4).
+
+No `internal/qwkservice` change: `BuildPacket` already sets the full
+`PacketMessage.Subject`/`To`/`From`, and `ImportREP` already posts
+`REPMessage.Subject`/`To`, so overridden (full) values flow through
+automatically.
+
+---
+
+## Testing
+
+**`internal/qwk` (unit — headers.go):**
+- `synthMessageID` → `<2.1@vision3>` form.
+- `smbTimezone`: UTC-0800 → `"21e0"`, UTC+0100 → `"103c"` (60 min east → `0x1000|0x3C`).
+- `encodeHeadersDAT`→`parseHeadersDAT` round-trip preserves offset + all fields;
+  a `Subject` containing `:` survives.
+- `parseHeadersDAT` on malformed/empty input returns an empty map (no panic).
+
+**`internal/qwk` (round-trip — the headline verification):**
+- A packet/REP written with a `>25`-char `Subject` reads back the **full**
+  subject via `HEADERS.DAT` override (and the base block still holds the 25-char
+  form).
+- `HEADERS.DAT` section offsets match message positions for a multi-message
+  packet (second message keyed at `[180]` etc.).
+- A REP with **no** `HEADERS.DAT` still reads (falls back to block header) — the
+  existing REP tests continue to pass unchanged.
+
+**`internal/qwkservice`:** existing tests unchanged (no service change); a
+long-subject export→import round trip is covered at the codec layer.
+
+---
+
+## Risks / notes
+
+- **Interop is unverified.** The format follows the Synchronet reference, but has
+  not been checked against a real MultiMail/Synchronet packet. `testdata/external/`
+  remains the slot for captured fixtures; a follow-up should validate and, if the
+  format needs adjustment, correct it before claiming MultiMail interop.
+- **SMB tz flags:** the US and daylight-savings flag bits are intentionally not
+  set (cannot be reliably inferred); the ISO-8601 offset carries the real offset.
+- **Synthesized Message-ID:** deterministic per `(bbsID, conference, number)`;
+  not globally unique across BBSes, which is acceptable for local packets.
+- **Offset agreement:** the write-side offset `(currentBlock-1)*128` and the
+  read-side `pos` must reference the same thing (the message's header block start
+  in `MESSAGES.DAT`/`.MSG`). Tests assert the multi-message offsets to lock this.
+
+## Acceptance criteria
+
+- ViSiON/3 packets include a `HEADERS.DAT` with a section per message.
+- A long (`>25`-char) `Subject` (and `To`) survives a ViSiON/3 write→read round
+  trip via `HEADERS.DAT`; the base header still carries the truncated form.
+- REP packets without `HEADERS.DAT` still import (base-header fallback);
+  existing codec/service tests pass unchanged.
+- The format is documented as following the Synchronet reference with real-reader
+  interop flagged unverified.

--- a/docs/sysop/messages/qwk.md
+++ b/docs/sysop/messages/qwk.md
@@ -81,6 +81,17 @@ Reply relationships are preserved across packets: a reply's parent message numbe
 travels in the QWK reference field, so a reply read or composed in an offline
 reader keeps its "Reply#: N" linkage when it is downloaded or uploaded.
 
+## Long headers (HEADERS.DAT)
+
+The base QWK message header limits To/From/Subject to 25 characters. ViSiON/3 also
+writes a `HEADERS.DAT` file carrying the full-length fields (and a Message-ID and
+timestamp) per the Synchronet extended-header format, and reads it back on REP
+upload — so long subjects survive the round trip. Readers that don't understand
+`HEADERS.DAT` simply ignore the extra file.
+
+(Interoperability with third-party readers such as MultiMail follows the
+documented format but has not yet been validated against a real reader.)
+
 ## Conference numbering and private mail
 
 ViSiON/3 assigns each exported message area a **stable QWK conference number**

--- a/internal/qwk/headers.go
+++ b/internal/qwk/headers.go
@@ -1,0 +1,149 @@
+package qwk
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ExtHeader is the subset of HEADERS.DAT fields ViSiON/3 emits and consumes.
+type ExtHeader struct {
+	Offset      int // byte offset of the message header in MESSAGES.DAT / .MSG
+	MessageID   string
+	Subject     string
+	To          string
+	From        string
+	WhenWritten string
+}
+
+// encodeHeadersDAT renders HEADERS.DAT sections (ordered by offset) as INI bytes.
+func encodeHeadersDAT(hs []ExtHeader) []byte {
+	sorted := make([]ExtHeader, len(hs))
+	copy(sorted, hs)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Offset < sorted[j].Offset })
+
+	var buf bytes.Buffer
+	for i, h := range sorted {
+		if i > 0 {
+			buf.WriteString("\r\n")
+		}
+		fmt.Fprintf(&buf, "[%x]\r\n", h.Offset)
+		writeHeaderField(&buf, "Message-ID", h.MessageID)
+		writeHeaderField(&buf, "Subject", h.Subject)
+		writeHeaderField(&buf, "To", h.To)
+		writeHeaderField(&buf, "From", h.From)
+		writeHeaderField(&buf, "WhenWritten", h.WhenWritten)
+	}
+	return buf.Bytes()
+}
+
+func writeHeaderField(buf *bytes.Buffer, key, val string) {
+	if val == "" {
+		return
+	}
+	buf.WriteString(key)
+	buf.WriteString(": ")
+	buf.WriteString(val)
+	buf.WriteString("\r\n")
+}
+
+// parseHeadersDAT parses HEADERS.DAT into a map keyed by message byte offset.
+// Malformed lines and unknown keys are ignored; empty/garbage input yields an
+// empty map.
+func parseHeadersDAT(data []byte) map[int]ExtHeader {
+	out := make(map[int]ExtHeader)
+	var cur ExtHeader
+	have := false
+	flush := func() {
+		if have {
+			out[cur.Offset] = cur
+		}
+	}
+	for _, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(strings.TrimRight(raw, "\r"))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			flush()
+			off, err := strconv.ParseInt(line[1:len(line)-1], 16, 64)
+			if err != nil {
+				have = false
+				continue
+			}
+			cur = ExtHeader{Offset: int(off)}
+			have = true
+			continue
+		}
+		if !have {
+			continue
+		}
+		key, val, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		val = strings.TrimSpace(val)
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "message-id":
+			cur.MessageID = val
+		case "subject":
+			cur.Subject = val
+		case "to":
+			cur.To = val
+		case "from":
+			cur.From = val
+		case "whenwritten":
+			cur.WhenWritten = val
+		}
+	}
+	flush()
+	return out
+}
+
+// smbTimezone encodes a UTC offset (in seconds) as the SMB hex timezone. Bits
+// 0-11 hold the absolute minutes; 0x2000 marks west of UTC, 0x1000 east. The US
+// and daylight flag bits are intentionally not set (they cannot be reliably
+// inferred; the ISO-8601 offset carries the real offset).
+func smbTimezone(offsetSeconds int) string {
+	mins := offsetSeconds / 60
+	var v uint16
+	if mins < 0 {
+		v = 0x2000 | uint16(-mins)
+	} else {
+		v = 0x1000 | uint16(mins)
+	}
+	return fmt.Sprintf("%x", v)
+}
+
+// synthMessageID builds a deterministic RFC822-style Message-ID for a local
+// message, which has no FTN MSGID.
+func synthMessageID(bbsID string, conference, number int) string {
+	return fmt.Sprintf("<%d.%d@%s>", number, conference, strings.ToLower(bbsID))
+}
+
+// formatWhenWritten renders a timestamp as ISO-8601 with offset plus the SMB
+// hex timezone.
+func formatWhenWritten(t time.Time) string {
+	_, off := t.Zone()
+	return t.Format("20060102150405-0700") + "  " + smbTimezone(off)
+}
+
+// extHeadersFor builds the HEADERS.DAT entries for a set of packet messages
+// given their byte offsets in MESSAGES.DAT / .MSG.
+func extHeadersFor(msgs []PacketMessage, offsets []int, bbsID string) []ExtHeader {
+	hs := make([]ExtHeader, 0, len(msgs))
+	for i, m := range msgs {
+		hs = append(hs, ExtHeader{
+			Offset:      offsets[i],
+			MessageID:   synthMessageID(bbsID, m.Conference, m.Number),
+			Subject:     m.Subject,
+			To:          m.To,
+			From:        m.From,
+			WhenWritten: formatWhenWritten(m.DateTime),
+		})
+	}
+	return hs
+}

--- a/internal/qwk/headers_test.go
+++ b/internal/qwk/headers_test.go
@@ -1,0 +1,60 @@
+package qwk
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSynthMessageID(t *testing.T) {
+	if got := synthMessageID("VISION3", 1, 2); got != "<2.1@vision3>" {
+		t.Errorf("synthMessageID = %q, want <2.1@vision3>", got)
+	}
+}
+
+func TestSmbTimezone(t *testing.T) {
+	if got := smbTimezone(-8 * 3600); got != "21e0" { // 480 min west
+		t.Errorf("smbTimezone(-0800) = %q, want 21e0", got)
+	}
+	if got := smbTimezone(1 * 3600); got != "103c" { // 60 min east
+		t.Errorf("smbTimezone(+0100) = %q, want 103c", got)
+	}
+}
+
+func TestHeadersDAT_RoundTrip(t *testing.T) {
+	in := []ExtHeader{
+		{Offset: 384, MessageID: "<2.1@v>", Subject: "Second", To: "Bob", From: "Al", WhenWritten: "20260305150000-0800  21e0"},
+		{Offset: 128, MessageID: "<1.1@v>", Subject: "First: with a colon", To: "Al", From: "Bob", WhenWritten: "20260305143000-0800  21e0"},
+	}
+	data := encodeHeadersDAT(in)
+	out := parseHeadersDAT(data)
+
+	if len(out) != 2 {
+		t.Fatalf("want 2 sections, got %d", len(out))
+	}
+	h := out[128]
+	if h.Subject != "First: with a colon" {
+		t.Errorf("subject with colon not preserved: %q", h.Subject)
+	}
+	if h.To != "Al" || h.From != "Bob" || h.MessageID != "<1.1@v>" {
+		t.Errorf("fields not preserved: %+v", h)
+	}
+	if _, ok := out[384]; !ok {
+		t.Error("second section (offset 384) missing")
+	}
+}
+
+func TestParseHeadersDAT_LenientOnGarbage(t *testing.T) {
+	if got := parseHeadersDAT(nil); len(got) != 0 {
+		t.Errorf("nil input: want empty map, got %v", got)
+	}
+	if got := parseHeadersDAT([]byte("not ini\nmore junk\n")); len(got) != 0 {
+		t.Errorf("garbage input: want empty map, got %v", got)
+	}
+}
+
+func TestFormatWhenWritten(t *testing.T) {
+	tt := time.Date(2026, 3, 5, 14, 30, 0, 0, time.FixedZone("PST", -8*3600))
+	if got := formatWhenWritten(tt); got != "20260305143000-0800  21e0" {
+		t.Errorf("formatWhenWritten = %q, want 20260305143000-0800  21e0", got)
+	}
+}

--- a/internal/qwk/ndx.go
+++ b/internal/qwk/ndx.go
@@ -1,0 +1,33 @@
+package qwk
+
+import "math"
+
+// makeNDXRecord creates a 5-byte NDX index record.
+// offset is the 1-based block number; conf is the conference number.
+//
+// The QWK spec requires offsets encoded as Microsoft BASIC single-precision
+// float (MSBIN4 / MBF4), not IEEE 754. MBF4 layout (little-endian in file):
+//
+//	byte[0] = mantissa bits 7-0
+//	byte[1] = mantissa bits 15-8
+//	byte[2] = sign (bit 7) | mantissa bits 22-16
+//	byte[3] = exponent (bias 128; 0 means zero)
+//
+// Conversion from IEEE 754: same mantissa/sign bits; MBF exponent = IEEE exponent + 2.
+func makeNDXRecord(offset int, conf int) []byte {
+	rec := make([]byte, 5)
+	f := float32(offset)
+	if f != 0 {
+		ieee := math.Float32bits(f)
+		sign := byte(ieee >> 31)
+		ieeeExp := (ieee >> 23) & 0xFF
+		mantissa := ieee & 0x7FFFFF
+		mbfExp := ieeeExp + 2 // adjust bias: 127 → 128, plus implicit-bit shift
+		rec[0] = byte(mantissa & 0xFF)
+		rec[1] = byte((mantissa >> 8) & 0xFF)
+		rec[2] = (sign << 7) | byte((mantissa>>16)&0x7F)
+		rec[3] = byte(mbfExp & 0xFF)
+	}
+	rec[4] = byte(conf & 0xFF)
+	return rec
+}

--- a/internal/qwk/reader.go
+++ b/internal/qwk/reader.go
@@ -70,7 +70,20 @@ func ReadREPPacket(r io.ReaderAt, size int64, bbsID string) (*REPPacket, error) 
 		return nil, fmt.Errorf("failed to read %s: %w", msgFile.Name, err)
 	}
 
-	msgs, err := parseREPMessages(data)
+	headers := map[int]ExtHeader{}
+	for _, f := range zr.File {
+		if strings.EqualFold(f.Name, "HEADERS.DAT") {
+			hrc, err := f.Open()
+			if err == nil {
+				hdata, _ := io.ReadAll(hrc)
+				hrc.Close()
+				headers = parseHeadersDAT(hdata)
+			}
+			break
+		}
+	}
+
+	msgs, err := parseREPMessages(data, headers)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +109,10 @@ func firstBlockID(data []byte) string {
 	return strings.ToUpper(string(block[start:end]))
 }
 
-// parseREPMessages extracts messages from the raw block data.
-func parseREPMessages(data []byte) ([]REPMessage, error) {
+// parseREPMessages extracts messages from the raw block data. The headers map
+// (keyed by byte offset) is used to apply HEADERS.DAT precedence for Subject
+// and To fields that exceed the 25-character base-header limit.
+func parseREPMessages(data []byte, headers map[int]ExtHeader) ([]REPMessage, error) {
 	if len(data) < BlockSize {
 		return nil, fmt.Errorf("REP data too short (%d bytes)", len(data))
 	}
@@ -131,6 +146,17 @@ func parseREPMessages(data []byte) ([]REPMessage, error) {
 		subject := strings.TrimSpace(string(header[71:96]))
 		refStr := strings.TrimSpace(string(header[108:116]))
 		refNum, _ := strconv.Atoi(refStr) // 0 / unparsable => no parent
+
+		// Apply HEADERS.DAT precedence: full-length Subject/To override the
+		// truncated base-header values when present.
+		if h, ok := headers[pos]; ok {
+			if h.Subject != "" {
+				subject = h.Subject
+			}
+			if h.To != "" {
+				to = h.To
+			}
+		}
 
 		// Extract body (starts after header block)
 		bodyBytes := data[pos+BlockSize : pos+totalBytes]

--- a/internal/qwk/reader.go
+++ b/internal/qwk/reader.go
@@ -75,9 +75,11 @@ func ReadREPPacket(r io.ReaderAt, size int64, bbsID string) (*REPPacket, error) 
 		if strings.EqualFold(f.Name, "HEADERS.DAT") {
 			hrc, err := f.Open()
 			if err == nil {
-				hdata, _ := io.ReadAll(hrc)
+				hdata, rerr := io.ReadAll(hrc)
 				hrc.Close()
-				headers = parseHeadersDAT(hdata)
+				if rerr == nil {
+					headers = parseHeadersDAT(hdata)
+				}
 			}
 			break
 		}

--- a/internal/qwk/rep_writer.go
+++ b/internal/qwk/rep_writer.go
@@ -36,7 +36,9 @@ func WriteREP(w io.Writer, bbsID string, msgs []PacketMessage) error {
 	copy(spacer, bbsID)
 	msgBuf.Write(spacer)
 
+	var offsets []int
 	for _, msg := range msgs {
+		offsets = append(offsets, msgBuf.Len())
 		msgBytes := formatMessage(msg)
 		numBlocks := (len(msgBytes) + BlockSize - 1) / BlockSize
 
@@ -53,6 +55,14 @@ func WriteREP(w io.Writer, bbsID string, msgs []PacketMessage) error {
 		zw.Close()
 		return fmt.Errorf("%s: %w", name, err)
 	}
+
+	if hdrs := encodeHeadersDAT(extHeadersFor(msgs, offsets, bbsID)); len(hdrs) > 0 {
+		if err := writeZipEntry(zw, "HEADERS.DAT", hdrs); err != nil {
+			zw.Close()
+			return fmt.Errorf("HEADERS.DAT: %w", err)
+		}
+	}
+
 	// Close explicitly so a central-directory flush failure is reported rather
 	// than silently producing a truncated archive.
 	if err := zw.Close(); err != nil {

--- a/internal/qwk/rep_writer_test.go
+++ b/internal/qwk/rep_writer_test.go
@@ -287,6 +287,62 @@ func TestREP_RoundTripLongSubjectViaHeaders(t *testing.T) {
 	}
 }
 
+// TestREP_HeadersDATMultiMessageOffsets locks the offset-accumulation logic: a
+// first message whose body spans multiple blocks must push the second message's
+// HEADERS.DAT section to the correct accumulated byte offset, and the full
+// second subject must survive the round trip.
+func TestREP_HeadersDATMultiMessageOffsets(t *testing.T) {
+	// 200-byte body: header(128) + body(200) = 328 -> 3 blocks -> 384 bytes.
+	// So message 2's header starts at 128 (spacer) + 384 = 512 (hex 200).
+	subj1 := "First message with a subject longer than twenty-five characters"
+	subj2 := "Second message also with a subject longer than the base limit"
+	data := buildREP(t, "VISION3", []PacketMessage{
+		{Conference: 1, Number: 1, From: "SysOp", To: "AlphaWithALongHandle",
+			Subject: subj1, DateTime: time.Date(2026, 3, 5, 14, 30, 0, 0, time.UTC),
+			Body: strings.Repeat("x", 200)},
+		{Conference: 1, Number: 2, From: "SysOp", To: "BravoWithALongHandle",
+			Subject: subj2, DateTime: time.Date(2026, 3, 5, 15, 0, 0, 0, time.UTC), Body: "y"},
+	})
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("zip: %v", err)
+	}
+	var hdr []byte
+	for _, f := range zr.File {
+		if f.Name == "HEADERS.DAT" {
+			rc, _ := f.Open()
+			hdr, _ = io.ReadAll(rc)
+			rc.Close()
+		}
+	}
+	if hdr == nil {
+		t.Fatal("REP packet missing HEADERS.DAT")
+	}
+	got := parseHeadersDAT(hdr)
+	if h, ok := got[128]; !ok || h.Subject != subj1 {
+		t.Errorf("section [80] (offset 128): ok=%v subject=%q, want %q", ok, h.Subject, subj1)
+	}
+	if h, ok := got[512]; !ok || h.Subject != subj2 {
+		t.Errorf("section [200] (offset 512): ok=%v subject=%q, want %q; sections=%v", ok, h.Subject, subj2, got)
+	}
+
+	// Read side must agree on the accumulated offset and restore the full subject.
+	out, err := ReadREP(bytes.NewReader(data), int64(len(data)), "VISION3")
+	if err != nil {
+		t.Fatalf("ReadREP: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("want 2 messages, got %d", len(out))
+	}
+	if out[1].Subject != subj2 {
+		t.Errorf("second subject not restored: got %q", out[1].Subject)
+	}
+	if out[1].To != "BravoWithALongHandle" {
+		t.Errorf("second To not restored: got %q", out[1].To)
+	}
+}
+
 func TestREP_RoundTripReplyToNumber(t *testing.T) {
 	in := []PacketMessage{
 		{Conference: 1, Number: 1, From: "a", To: "b", Subject: "First",

--- a/internal/qwk/rep_writer_test.go
+++ b/internal/qwk/rep_writer_test.go
@@ -265,6 +265,28 @@ func TestWriteREP_EmitsHeadersDAT(t *testing.T) {
 	}
 }
 
+func TestREP_RoundTripLongSubjectViaHeaders(t *testing.T) {
+	longSubject := "A very long subject line beyond the 25-character base limit"
+	data := buildREP(t, "VISION3", []PacketMessage{
+		{Conference: 1, Number: 1, From: "SysOp", To: "SomebodyWithALongHandle",
+			Subject: longSubject, DateTime: time.Date(2026, 3, 5, 14, 30, 0, 0, time.UTC), Body: "x"},
+	})
+
+	out, err := ReadREP(bytes.NewReader(data), int64(len(data)), "VISION3")
+	if err != nil {
+		t.Fatalf("ReadREP: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("want 1 message, got %d", len(out))
+	}
+	if out[0].Subject != longSubject {
+		t.Errorf("subject not restored from HEADERS.DAT: got %q (len %d)", out[0].Subject, len(out[0].Subject))
+	}
+	if out[0].To != "SomebodyWithALongHandle" {
+		t.Errorf("to not restored from HEADERS.DAT: got %q", out[0].To)
+	}
+}
+
 func TestREP_RoundTripReplyToNumber(t *testing.T) {
 	in := []PacketMessage{
 		{Conference: 1, Number: 1, From: "a", To: "b", Subject: "First",

--- a/internal/qwk/rep_writer_test.go
+++ b/internal/qwk/rep_writer_test.go
@@ -3,6 +3,7 @@ package qwk
 import (
 	"archive/zip"
 	"bytes"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -209,12 +210,14 @@ func TestWriteREP_CapsBBSIDToEightChars(t *testing.T) {
 	if err != nil {
 		t.Fatalf("zip: %v", err)
 	}
-	var name string
+	var msgName string
 	for _, f := range zr.File {
-		name = f.Name
+		if strings.HasSuffix(f.Name, ".MSG") {
+			msgName = f.Name
+		}
 	}
-	if name != "LONGERNA.MSG" {
-		t.Errorf("REP .MSG filename = %q, want LONGERNA.MSG", name)
+	if msgName != "LONGERNA.MSG" {
+		t.Errorf("REP .MSG filename = %q, want LONGERNA.MSG", msgName)
 	}
 
 	p, err := ReadREPPacket(bytes.NewReader(data), int64(len(data)), "LONGERNA")
@@ -223,6 +226,42 @@ func TestWriteREP_CapsBBSIDToEightChars(t *testing.T) {
 	}
 	if p.BBSID != "LONGERNA" {
 		t.Errorf("first-block BBSID = %q, want LONGERNA", p.BBSID)
+	}
+}
+
+func TestWriteREP_EmitsHeadersDAT(t *testing.T) {
+	longSubject := "A very long subject line beyond the 25-character base limit"
+	data := buildREP(t, "VISION3", []PacketMessage{
+		{Conference: 1, Number: 1, From: "SysOp", To: "SomebodyWithALongHandle",
+			Subject: longSubject, DateTime: time.Date(2026, 3, 5, 14, 30, 0, 0, time.UTC), Body: "x"},
+	})
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("zip: %v", err)
+	}
+	var hdr []byte
+	for _, f := range zr.File {
+		if f.Name == "HEADERS.DAT" {
+			rc, _ := f.Open()
+			hdr, _ = io.ReadAll(rc)
+			rc.Close()
+		}
+	}
+	if hdr == nil {
+		t.Fatal("REP packet missing HEADERS.DAT")
+	}
+	// First message header is at offset 128 -> section [80].
+	got := parseHeadersDAT(hdr)
+	h, ok := got[128]
+	if !ok {
+		t.Fatalf("no section at offset 128; sections=%v", got)
+	}
+	if h.Subject != longSubject {
+		t.Errorf("HEADERS.DAT subject: want full, got %q", h.Subject)
+	}
+	if h.To != "SomebodyWithALongHandle" {
+		t.Errorf("HEADERS.DAT to: want full, got %q", h.To)
 	}
 }
 

--- a/internal/qwk/writer.go
+++ b/internal/qwk/writer.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math"
 	"strings"
 	"time"
 )
@@ -264,36 +263,6 @@ func formatMessage(msg PacketMessage) []byte {
 	result = append(result, []byte(body)...)
 
 	return result
-}
-
-// makeNDXRecord creates a 5-byte NDX index record.
-// offset is the 1-based block number; conf is the conference number.
-//
-// The QWK spec requires offsets encoded as Microsoft BASIC single-precision
-// float (MSBIN4 / MBF4), not IEEE 754. MBF4 layout (little-endian in file):
-//
-//	byte[0] = mantissa bits 7-0
-//	byte[1] = mantissa bits 15-8
-//	byte[2] = sign (bit 7) | mantissa bits 22-16
-//	byte[3] = exponent (bias 128; 0 means zero)
-//
-// Conversion from IEEE 754: same mantissa/sign bits; MBF exponent = IEEE exponent + 2.
-func makeNDXRecord(offset int, conf int) []byte {
-	rec := make([]byte, 5)
-	f := float32(offset)
-	if f != 0 {
-		ieee := math.Float32bits(f)
-		sign := byte(ieee >> 31)
-		ieeeExp := (ieee >> 23) & 0xFF
-		mantissa := ieee & 0x7FFFFF
-		mbfExp := ieeeExp + 2 // adjust bias: 127 → 128, plus implicit-bit shift
-		rec[0] = byte(mantissa & 0xFF)
-		rec[1] = byte((mantissa >> 8) & 0xFF)
-		rec[2] = (sign << 7) | byte((mantissa>>16)&0x7F)
-		rec[3] = byte(mbfExp & 0xFF)
-	}
-	rec[4] = byte(conf & 0xFF)
-	return rec
 }
 
 func copyPadded(dst []byte, src string, maxLen int) {

--- a/internal/qwk/writer.go
+++ b/internal/qwk/writer.go
@@ -70,7 +70,7 @@ func (pw *PacketWriter) WritePacket(w io.Writer) error {
 		return fmt.Errorf("DOOR.ID: %w", err)
 	}
 
-	ndxData, personalNDX, err := pw.writeMessagesDAT(zw)
+	ndxData, personalNDX, offsets, err := pw.writeMessagesDAT(zw)
 	if err != nil {
 		return fmt.Errorf("MESSAGES.DAT: %w", err)
 	}
@@ -85,6 +85,12 @@ func (pw *PacketWriter) WritePacket(w io.Writer) error {
 	if len(personalNDX) > 0 {
 		if err := writeZipEntry(zw, "PERSONAL.NDX", personalNDX); err != nil {
 			return fmt.Errorf("PERSONAL.NDX: %w", err)
+		}
+	}
+
+	if hdrs := encodeHeadersDAT(extHeadersFor(pw.messages, offsets, pw.bbsID)); len(hdrs) > 0 {
+		if err := writeZipEntry(zw, "HEADERS.DAT", hdrs); err != nil {
+			return fmt.Errorf("HEADERS.DAT: %w", err)
 		}
 	}
 
@@ -143,9 +149,9 @@ func (pw *PacketWriter) writeDoorID(zw *zip.Writer) error {
 	return writeZipEntry(zw, "DOOR.ID", buf.Bytes())
 }
 
-// writeMessagesDAT writes all messages and returns NDX data per conference
-// and PERSONAL.NDX data.
-func (pw *PacketWriter) writeMessagesDAT(zw *zip.Writer) (map[int][]byte, []byte, error) {
+// writeMessagesDAT writes all messages and returns NDX data per conference,
+// PERSONAL.NDX data, and the per-message byte offsets into MESSAGES.DAT.
+func (pw *PacketWriter) writeMessagesDAT(zw *zip.Writer) (map[int][]byte, []byte, []int, error) {
 	var msgBuf bytes.Buffer
 
 	// First block is a copyright/spacer block (128 bytes of spaces)
@@ -159,6 +165,7 @@ func (pw *PacketWriter) writeMessagesDAT(zw *zip.Writer) (map[int][]byte, []byte
 	currentBlock := 2 // Block 1 is the spacer; messages start at block 2
 	ndxData := make(map[int][]byte)
 	var personalNDX []byte
+	var offsets []int
 
 	for _, msg := range pw.messages {
 		msgBytes := formatMessage(msg)
@@ -179,16 +186,19 @@ func (pw *PacketWriter) writeMessagesDAT(zw *zip.Writer) (map[int][]byte, []byte
 			personalNDX = append(personalNDX, ndxRecord...)
 		}
 
+		// Record the byte offset of this message before advancing currentBlock.
+		offsets = append(offsets, (currentBlock-1)*BlockSize)
+
 		msgBuf.Write(padded)
 		currentBlock += numBlocks
 	}
 
 	if err := writeZipEntry(zw, "MESSAGES.DAT", msgBuf.Bytes()); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	slog.Info("QWK packet written", "messages", len(pw.messages), "blocks", currentBlock-1)
-	return ndxData, personalNDX, nil
+	return ndxData, personalNDX, offsets, nil
 }
 
 // formatMessage encodes a single message in QWK format.


### PR DESCRIPTION
## Summary

QWK Phase 5 adds Synchronet-format **HEADERS.DAT** support so full-length `To`/`From`/`Subject` (plus a synthesized `Message-ID` and a `WhenWritten` timestamp) survive a QWK download / REP upload — lifting the base header's 25-character limit. Codec-only (`internal/qwk`); no `qwkservice` change, because the full fields already flow through `PacketMessage`/`REPMessage`.

> Rebased onto `main` after Phase 4 (#67) merged. Supersedes the closed #68 (whose base branch was deleted on merge).

## What changed

- **`headers.go`** (new) — INI encode/parse of `HEADERS.DAT` (`[<hex-offset>]` sections keyed by each message's byte offset in `MESSAGES.DAT`/`.MSG`), plus `smbTimezone`, `synthMessageID`, `formatWhenWritten`, `extHeadersFor`.
- **Writers** (`writer.go`, `rep_writer.go`) — `WritePacket` and `WriteREP` emit a `HEADERS.DAT` zip entry. The base header keeps its 25-char truncation (plain readers unaffected); `HEADERS.DAT` is purely additive.
- **`ndx.go`** (new) — extracted the MBF4 NDX record encoder out of `writer.go` to stay under the 300-line ceiling.
- **Reader** (`reader.go`) — `ReadREPPacket` parses `HEADERS.DAT` (case-insensitive; absent/corrupt → base-header fallback) and `parseREPMessages` overrides the truncated `Subject`/`To` by byte offset (spec precedence).
- **Docs** — `docs/sysop/messages/qwk.md` documents the feature and flags real-reader interop as unverified.

## Format fidelity

- Section `[<lowercase-hex>]`; `Key: Value` lines; CRLF. Subjects containing `:` survive (first-colon split).
- `smbTimezone`: `0x2000|min` west / `0x1000|min` east; US/DST flags omitted (can't infer for an arbitrary BBS; ISO-8601 offset carries the real offset).
- `synthMessageID` → `<num.conf@lowercased-bbsid>` (local messages have no FTN MSGID).

## Testing

- Unit: encode/parse round-trip (incl. colon subjects), `smbTimezone` (`-0800`→`21e0`, `+0100`→`103c`), `synthMessageID`, lenient parse (garbage/empty → empty map, no panic).
- Round-trip: a >25-char Subject/To survives write→read via `HEADERS.DAT`; base header still truncated.
- **Multi-message offset accumulation**: second section lands at the accumulated offset (512 / `[200]`) after a 3-block first message; read side agrees.
- Full suite green, `go vet`/`gofmt` clean, race clean (`qwk` + `qwkservice`).

## Not in scope / disclosed

- Real MultiMail/Synchronet interop is **unverified** — implemented to the documented format; validated only by a ViSiON/3 round-trip. `testdata/external/` reserved for captured fixtures.
- Synchronet `@`-tags dropped from the roadmap (QWK-net is the future trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preserving long message headers during QWK download and REP upload, including full Subject and To fields.
  * Extended message packet handling so header details can round-trip more reliably across compatible clients.

* **Bug Fixes**
  * Improved handling of messages that exceed standard QWK header length limits.
  * Restored full header values when available, instead of keeping truncated versions.

* **Documentation**
  * Added guidance about long headers and how extended header support behaves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->