### PR TITLE
chore: point dev-setup completion message at release-page binaries

### DIFF
--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -260,9 +260,10 @@ echo "  Login:  felonius / password"
 echo ""
 if [[ $SYMLINK -eq 1 ]]; then
     echo "Binaries are symlinked to $REPO_DIR"
-    echo "After rebuilding (go build -o vision3 ./cmd/vision3), the BBS"
-    echo "picks up the new binary automatically."
-    echo ""
+    echo "Download the external binaries separately"
+    echo "from the GitHub release page for your platform"
+    echo "and place in $REPO_DIR/bin"
+    echo " "
 fi
 echo "To start the BBS:"
 echo "  cd $TARGET && ./vision3"


### PR DESCRIPTION
## Summary
- Update the symlink-mode completion message in `dev-setup.sh`: instead of describing a local `go build` of `vision3`, tell users to download the external binaries from the GitHub release page for their platform and place them in `$REPO_DIR/bin`.

## Why
The previous message implied rebuilding locally would produce everything, but the external binaries aren't built that way — they need to be fetched from the release page.

## Testing
- Message-only change; ran `bash -n dev-setup.sh` to verify syntax.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the setup instructions shown after creating symlinks to point users to the correct release downloads for their platform.
  * Clarified where external binaries should be placed for local setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->