### PR TITLE
feat(configeditor): add QWK Mobile API sub-screen to system config TUI

### DIFF
--- a/internal/configeditor/fields_qwkapi.go
+++ b/internal/configeditor/fields_qwkapi.go
@@ -1,0 +1,73 @@
+package configeditor
+
+import (
+	"strconv"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
+)
+
+// sysFieldsQWKAPI returns fields for the QWK Mobile API sub-screen.
+func sysFieldsQWKAPI(cfg *config.ServerConfig) []fieldDef {
+	api := &cfg.QWKAPI
+	return []fieldDef{
+		{
+			Label: "Enabled", Help: "Enable the QWK mobile app HTTP API", Type: ftYesNo, Col: 3, Row: 1, Width: 1,
+			Get: func() string { return uitext.BoolToYN(api.Enabled) },
+			Set: func(val string) error { api.Enabled = uitext.YNToBool(val); return nil },
+		},
+		{
+			Label: "Host", Help: "Listen address (blank=all interfaces)", Type: ftString, Col: 3, Row: 2, Width: 20,
+			Get: func() string { return api.Host },
+			Set: func(val string) error { api.Host = val; return nil },
+		},
+		{
+			Label: "Port", Help: "API listen port (default: 8666)", Type: ftInteger, Col: 3, Row: 3, Width: 5, Min: 1, Max: 65535,
+			Get: func() string {
+				p := api.Port
+				if p == 0 {
+					p = 8666
+				}
+				return strconv.Itoa(p)
+			},
+			Set: func(val string) error {
+				n, err := strconv.Atoi(val)
+				if err != nil {
+					return err
+				}
+				api.Port = n
+				return nil
+			},
+		},
+		{
+			Label: "Cert File", Help: "TLS certificate path (blank=auto self-signed)", Type: ftString, Col: 3, Row: 4, Width: 45,
+			Get: func() string { return api.CertFile },
+			Set: func(val string) error { api.CertFile = val; return nil },
+		},
+		{
+			Label: "Key File", Help: "TLS private key path (blank=auto self-signed)", Type: ftString, Col: 3, Row: 5, Width: 45,
+			Get: func() string { return api.KeyFile },
+			Set: func(val string) error { api.KeyFile = val; return nil },
+		},
+		{
+			Label: "Token TTL Hrs", Help: "Bearer token lifetime in hours (default: 24)", Type: ftInteger, Col: 3, Row: 6, Width: 5, Min: 1, Max: 8760,
+			Get: func() string {
+				// Match QWKAPIConfig.TokenTTL, which defaults every
+				// non-positive value to 24h.
+				h := api.TokenTTLHours
+				if h <= 0 {
+					h = 24
+				}
+				return strconv.Itoa(h)
+			},
+			Set: func(val string) error {
+				n, err := strconv.Atoi(val)
+				if err != nil {
+					return err
+				}
+				api.TokenTTLHours = n
+				return nil
+			},
+		},
+	}
+}

--- a/internal/configeditor/fields_system.go
+++ b/internal/configeditor/fields_system.go
@@ -97,6 +97,8 @@ func (m *Model) buildSysFields(screen int) []fieldDef {
 		return sysFieldsDOS(cfg)
 	case 8:
 		return sysFieldsLogging(cfg)
+	case 9:
+		return sysFieldsQWKAPI(cfg)
 	}
 	return nil
 }
@@ -582,6 +584,69 @@ func sysFieldsDOS(cfg *config.ServerConfig) []fieldDef {
 			Label: "DOSemu Path", Help: "Path to dosemu2 binary (blank=auto-detect)", Type: ftString, Col: 3, Row: 1, Width: 45,
 			Get: func() string { return cfg.DosemuPath },
 			Set: func(val string) error { cfg.DosemuPath = val; return nil },
+		},
+	}
+}
+
+// sysFieldsQWKAPI returns fields for the QWK Mobile API sub-screen.
+func sysFieldsQWKAPI(cfg *config.ServerConfig) []fieldDef {
+	api := &cfg.QWKAPI
+	return []fieldDef{
+		{
+			Label: "Enabled", Help: "Enable the QWK mobile app HTTP API", Type: ftYesNo, Col: 3, Row: 1, Width: 1,
+			Get: func() string { return uitext.BoolToYN(api.Enabled) },
+			Set: func(val string) error { api.Enabled = uitext.YNToBool(val); return nil },
+		},
+		{
+			Label: "Host", Help: "Listen address (blank=all interfaces)", Type: ftString, Col: 3, Row: 2, Width: 20,
+			Get: func() string { return api.Host },
+			Set: func(val string) error { api.Host = val; return nil },
+		},
+		{
+			Label: "Port", Help: "API listen port (default: 8666)", Type: ftInteger, Col: 3, Row: 3, Width: 5, Min: 1, Max: 65535,
+			Get: func() string {
+				p := api.Port
+				if p == 0 {
+					p = 8666
+				}
+				return strconv.Itoa(p)
+			},
+			Set: func(val string) error {
+				n, err := strconv.Atoi(val)
+				if err != nil {
+					return err
+				}
+				api.Port = n
+				return nil
+			},
+		},
+		{
+			Label: "Cert File", Help: "TLS certificate path (blank=auto self-signed)", Type: ftString, Col: 3, Row: 4, Width: 45,
+			Get: func() string { return api.CertFile },
+			Set: func(val string) error { api.CertFile = val; return nil },
+		},
+		{
+			Label: "Key File", Help: "TLS private key path (blank=auto self-signed)", Type: ftString, Col: 3, Row: 5, Width: 45,
+			Get: func() string { return api.KeyFile },
+			Set: func(val string) error { api.KeyFile = val; return nil },
+		},
+		{
+			Label: "Token TTL Hrs", Help: "Bearer token lifetime in hours (default: 24)", Type: ftInteger, Col: 3, Row: 6, Width: 5, Min: 1, Max: 8760,
+			Get: func() string {
+				h := api.TokenTTLHours
+				if h == 0 {
+					h = 24
+				}
+				return strconv.Itoa(h)
+			},
+			Set: func(val string) error {
+				n, err := strconv.Atoi(val)
+				if err != nil {
+					return err
+				}
+				api.TokenTTLHours = n
+				return nil
+			},
 		},
 	}
 }

--- a/internal/configeditor/fields_system.go
+++ b/internal/configeditor/fields_system.go
@@ -588,69 +588,6 @@ func sysFieldsDOS(cfg *config.ServerConfig) []fieldDef {
 	}
 }
 
-// sysFieldsQWKAPI returns fields for the QWK Mobile API sub-screen.
-func sysFieldsQWKAPI(cfg *config.ServerConfig) []fieldDef {
-	api := &cfg.QWKAPI
-	return []fieldDef{
-		{
-			Label: "Enabled", Help: "Enable the QWK mobile app HTTP API", Type: ftYesNo, Col: 3, Row: 1, Width: 1,
-			Get: func() string { return uitext.BoolToYN(api.Enabled) },
-			Set: func(val string) error { api.Enabled = uitext.YNToBool(val); return nil },
-		},
-		{
-			Label: "Host", Help: "Listen address (blank=all interfaces)", Type: ftString, Col: 3, Row: 2, Width: 20,
-			Get: func() string { return api.Host },
-			Set: func(val string) error { api.Host = val; return nil },
-		},
-		{
-			Label: "Port", Help: "API listen port (default: 8666)", Type: ftInteger, Col: 3, Row: 3, Width: 5, Min: 1, Max: 65535,
-			Get: func() string {
-				p := api.Port
-				if p == 0 {
-					p = 8666
-				}
-				return strconv.Itoa(p)
-			},
-			Set: func(val string) error {
-				n, err := strconv.Atoi(val)
-				if err != nil {
-					return err
-				}
-				api.Port = n
-				return nil
-			},
-		},
-		{
-			Label: "Cert File", Help: "TLS certificate path (blank=auto self-signed)", Type: ftString, Col: 3, Row: 4, Width: 45,
-			Get: func() string { return api.CertFile },
-			Set: func(val string) error { api.CertFile = val; return nil },
-		},
-		{
-			Label: "Key File", Help: "TLS private key path (blank=auto self-signed)", Type: ftString, Col: 3, Row: 5, Width: 45,
-			Get: func() string { return api.KeyFile },
-			Set: func(val string) error { api.KeyFile = val; return nil },
-		},
-		{
-			Label: "Token TTL Hrs", Help: "Bearer token lifetime in hours (default: 24)", Type: ftInteger, Col: 3, Row: 6, Width: 5, Min: 1, Max: 8760,
-			Get: func() string {
-				h := api.TokenTTLHours
-				if h == 0 {
-					h = 24
-				}
-				return strconv.Itoa(h)
-			},
-			Set: func(val string) error {
-				n, err := strconv.Atoi(val)
-				if err != nil {
-					return err
-				}
-				api.TokenTTLHours = n
-				return nil
-			},
-		},
-	}
-}
-
 // logRollingTypes is the single source of truth for the Rolling Type lookup:
 // the persisted LoggingConfig.Type, the short label shown in the form, and the
 // picker description. logTypeToLabel / logLabelToType convert against it.

--- a/internal/configeditor/fields_system_test.go
+++ b/internal/configeditor/fields_system_test.go
@@ -62,4 +62,11 @@ func TestSysFieldsQWKAPI(t *testing.T) {
 	if got := find("Token TTL Hrs").Get(); got != "24" {
 		t.Errorf("Token TTL default: want 24, got %q", got)
 	}
+
+	// Runtime (TokenTTL) treats any non-positive value as 24h; the editor
+	// must display the same for hand-edited negative values.
+	cfg.QWKAPI.TokenTTLHours = -5
+	if got := find("Token TTL Hrs").Get(); got != "24" {
+		t.Errorf("Token TTL for negative value: want 24, got %q", got)
+	}
 }

--- a/internal/configeditor/fields_system_test.go
+++ b/internal/configeditor/fields_system_test.go
@@ -30,3 +30,36 @@ func TestSysFieldsRegistration_QWKIDNormalizesOnSet(t *testing.T) {
 		t.Errorf("Get: want MYID, got %q", got)
 	}
 }
+
+func TestSysFieldsQWKAPI(t *testing.T) {
+	cfg := &config.ServerConfig{}
+	fields := sysFieldsQWKAPI(cfg)
+
+	find := func(label string) *fieldDef {
+		for i := range fields {
+			if fields[i].Label == label {
+				return &fields[i]
+			}
+		}
+		t.Fatalf("%s field not found in QWK API screen", label)
+		return nil
+	}
+
+	enabled := find("Enabled")
+	if got := enabled.Get(); got != "N" {
+		t.Errorf("Enabled default: want N, got %q", got)
+	}
+	if err := enabled.Set("Y"); err != nil {
+		t.Fatalf("Set Enabled: %v", err)
+	}
+	if !cfg.QWKAPI.Enabled {
+		t.Error("Set(Y) should enable cfg.QWKAPI.Enabled")
+	}
+
+	if got := find("Port").Get(); got != "8666" {
+		t.Errorf("Port default: want 8666, got %q", got)
+	}
+	if got := find("Token TTL Hrs").Get(); got != "24" {
+		t.Errorf("Token TTL default: want 24, got %q", got)
+	}
+}

--- a/internal/configeditor/model.go
+++ b/internal/configeditor/model.go
@@ -297,6 +297,7 @@ func New(configPath string) (Model, error) {
 		{"New User Voting (NUV)"},
 		{"DOS Emulation"},
 		{"Logging"},
+		{"QWK Mobile API"},
 	}
 
 	return Model{

--- a/internal/configeditor/update_syscfg.go
+++ b/internal/configeditor/update_syscfg.go
@@ -41,8 +41,12 @@ func (m Model) updateSysConfigMenu(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.mode = modeTopMenu
 			return m, nil
 		}
-		if len(key) == 1 && key[0] >= '1' && key[0] <= '9' {
+		if len(key) == 1 && key[0] >= '0' && key[0] <= '9' {
+			// '1'-'9' select items 1-9; '0' selects item 10.
 			idx := int(key[0] - '1')
+			if key[0] == '0' {
+				idx = 9
+			}
 			if idx < len(m.sysMenuItems) {
 				m.sysMenuCursor = idx
 				m.sysSubScreen = idx

--- a/internal/configeditor/view.go
+++ b/internal/configeditor/view.go
@@ -247,7 +247,9 @@ func (m Model) viewSysConfigMenu() string {
 
 	// Menu items
 	for i, item := range m.sysMenuItems {
-		content := fmt.Sprintf("  %d. %s", i+1, item.Label)
+		// Hotkey display matches input mapping: items 1-9 use their digit,
+		// item 10 uses '0'.
+		content := fmt.Sprintf("  %d. %s", (i+1)%10, item.Label)
 		content = padRight(content, boxW)
 
 		var styled string


### PR DESCRIPTION
## Summary
- The `qwkAPI` settings block existed in `config.json` (and `config.QWKAPIConfig`) but could only be edited by hand — the config TUI had no screen for it.
- Adds a **QWK Mobile API** sub-screen (item 10) under System Configuration exposing Enabled, Host, Port, Cert File, Key File, and Token TTL Hours, showing the 8666/24h defaults when unset.
- Maps the `0` hotkey to menu item 10 (single-digit hotkeys previously stopped at 9); arrow keys and PgUp/PgDn paging already work since navigation is length-driven.
- Saving needs no extra wiring — the editor persists the whole `ServerConfig` via `config.SaveServerConfig`.

## Testing
- Added `TestSysFieldsQWKAPI` covering the Enabled toggle wiring and Port/TTL default display.
- `go vet` clean; all configeditor tests pass (28).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a QWK Mobile API section to system configuration.
  * Added settings for enabling the API, host, port, TLS certificates, and token expiration.
  * Added support for selecting the new configuration screen with the `0` key.
* **Bug Fixes**
  * Added sensible defaults for the API port and token lifetime when unspecified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->