### PR TITLE
fix: resource-safety hardening (JAM recovery/lock, bounded network reads)

### DIFF
--- a/cmd/v3net-bootstrap/main.go
+++ b/cmd/v3net-bootstrap/main.go
@@ -114,7 +114,8 @@ func main() {
 	}
 	defer resp.Body.Close()
 
-	respBody, _ := io.ReadAll(resp.Body)
+	// Diagnostic output only: cap the read; truncation is acceptable.
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	fmt.Printf("Response: %d %s\n", resp.StatusCode, string(respBody))
 
 	if resp.StatusCode != http.StatusOK {

--- a/internal/ftn/packet.go
+++ b/internal/ftn/packet.go
@@ -23,11 +23,18 @@ const CWValidation = 0x0100
 // MaxFieldLen limits null-terminated string fields.
 const MaxFieldLen = 256
 
+// maxPacketBytes caps how much of a .PKT stream ReadPacket will buffer.
+// Typical packets are well under 1MB (arcmail bundles are split by mailers);
+// 16MB is far beyond any legitimate packet and guards against memory
+// exhaustion from a malformed or hostile input.
+const maxPacketBytes = 16 * 1024 * 1024
+
 // Errors
 var (
 	ErrInvalidPacketType = errors.New("ftn: invalid packet type (expected 2)")
 	ErrTruncatedPacket   = errors.New("ftn: truncated packet data")
 	ErrTruncatedMessage  = errors.New("ftn: truncated message in packet")
+	ErrPacketTooLarge    = errors.New("ftn: packet exceeds size limit")
 )
 
 // PacketHeader represents an FTN Type-2+ packet header (58 bytes).
@@ -159,9 +166,12 @@ func ReadPacketHeaderFromFile(path string) (*PacketHeader, error) {
 
 // ReadPacket parses a complete .PKT file from the reader.
 func ReadPacket(r io.Reader) (*PacketHeader, []*PackedMessage, error) {
-	data, err := io.ReadAll(r)
+	data, err := io.ReadAll(io.LimitReader(r, maxPacketBytes+1))
 	if err != nil {
 		return nil, nil, fmt.Errorf("ftn: read packet: %w", err)
+	}
+	if len(data) > maxPacketBytes {
+		return nil, nil, ErrPacketTooLarge
 	}
 
 	if len(data) < PacketHeaderSize+2 { // Header + terminator

--- a/internal/ftn/packet_test.go
+++ b/internal/ftn/packet_test.go
@@ -2,6 +2,8 @@ package ftn
 
 import (
 	"bytes"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -320,3 +322,20 @@ func TestParseLocalMessageBody(t *testing.T) {
 		t.Error("Text should contain message body")
 	}
 }
+
+func TestReadPacketRejectsOversizedInput(t *testing.T) {
+	// A reader that produces more than the packet size cap without
+	// allocating it all up front.
+	r := io.LimitReader(zeroReader{}, maxPacketBytes+2)
+	_, _, err := ReadPacket(r)
+	if err == nil {
+		t.Fatal("expected error for oversized packet, got nil")
+	}
+	if !errors.Is(err, ErrPacketTooLarge) {
+		t.Fatalf("want ErrPacketTooLarge, got: %v", err)
+	}
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) { return len(p), nil }

--- a/internal/jam/base.go
+++ b/internal/jam/base.go
@@ -142,6 +142,19 @@ func (b *Base) create() error {
 	return nil
 }
 
+// closeHandles closes and clears every base file handle and marks the base
+// closed. Used on unrecoverable failure paths so no handle leaks behind a
+// closed base. Callers must hold b.mu.
+func (b *Base) closeHandles() {
+	for _, f := range []*os.File{b.jhrFile, b.jdtFile, b.jdxFile, b.jlrFile} {
+		if f != nil {
+			_ = f.Close()
+		}
+	}
+	b.jhrFile, b.jdtFile, b.jdxFile, b.jlrFile = nil, nil, nil, nil
+	b.isOpen = false
+}
+
 // Close closes all file handles for the message base.
 func (b *Base) Close() error {
 	b.mu.Lock()

--- a/internal/jam/lock.go
+++ b/internal/jam/lock.go
@@ -44,8 +44,12 @@ func (b *Base) acquireFileLock() (func(), error) {
 
 		if info, statErr := os.Stat(lockPath); statErr == nil {
 			if time.Since(info.ModTime()) > staleAfter {
-				_ = os.Remove(lockPath)
-				continue
+				if rmErr := os.Remove(lockPath); rmErr == nil {
+					continue
+				}
+				// Couldn't remove the stale lock (permissions, or it's a
+				// directory); fall through to the deadline check so we time
+				// out instead of spinning forever.
 			}
 		}
 

--- a/internal/jam/lock_test.go
+++ b/internal/jam/lock_test.go
@@ -64,6 +64,53 @@ func TestAcquireFileLockTimeout(t *testing.T) {
 	}
 }
 
+func TestAcquireFileLockUnremovableStaleReturnsError(t *testing.T) {
+	lockMu.Lock()
+	origRetry := lockRetryDelay
+	origTimeout := lockTimeout
+	origStale := lockStaleAfter
+	lockRetryDelay = 5 * time.Millisecond
+	lockTimeout = 100 * time.Millisecond
+	lockStaleAfter = 10 * time.Millisecond
+	lockMu.Unlock()
+	defer func() {
+		lockMu.Lock()
+		lockRetryDelay = origRetry
+		lockTimeout = origTimeout
+		lockStaleAfter = origStale
+		lockMu.Unlock()
+	}()
+
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "lock-unremovable")
+	lockPath := basePath + ".bsy"
+
+	// A stale lock that os.Remove cannot delete: a non-empty directory.
+	if err := os.MkdirAll(filepath.Join(lockPath, "child"), 0755); err != nil {
+		t.Fatalf("mkdir unremovable lock: %v", err)
+	}
+	old := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(lockPath, old, old); err != nil {
+		t.Fatalf("set stale lock mtime: %v", err)
+	}
+
+	b := &Base{BasePath: basePath}
+	done := make(chan error, 1)
+	go func() {
+		_, err := b.acquireFileLock()
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected error for unremovable stale lock, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("acquireFileLock spun forever on unremovable stale lock; want timeout error")
+	}
+}
+
 func TestAcquireFileLockRemovesStaleLock(t *testing.T) {
 	lockMu.Lock()
 	origRetry := lockRetryDelay

--- a/internal/jam/pack.go
+++ b/internal/jam/pack.go
@@ -315,31 +315,32 @@ func (b *Base) packWithReplyIDCleanup(cleanReplyIDs bool) (PackResult, error) {
 			b.jdtFile, jdtErr = os.OpenFile(b.BasePath+".jdt", os.O_RDWR, 0644)
 			b.jdxFile, jdxErr = os.OpenFile(b.BasePath+".jdx", os.O_RDWR, 0644)
 			if reopenErr := errors.Join(jhrErr, jdtErr, jdxErr); reopenErr != nil {
-				b.isOpen = false
+				b.closeHandles()
 				return result, fmt.Errorf("jam: rename failed: %w; base could not be reopened (%w) — manual recovery required", err, reopenErr)
 			}
 			if hdrErr := b.readFixedHeader(); hdrErr != nil {
-				b.isOpen = false
+				b.closeHandles()
 				return result, fmt.Errorf("jam: rename failed: %w; header unreadable after reopen (%w) — manual recovery required", err, hdrErr)
 			}
 			return result, fmt.Errorf("jam: rename failed: %w — base may need manual recovery", err)
 		}
 	}
 
-	// Reopen files
+	// Reopen files. On any failure, close whatever did reopen so a failed
+	// pack never leaks handles behind a closed base.
 	b.jhrFile, err = os.OpenFile(b.BasePath+".jhr", os.O_RDWR, 0644)
 	if err != nil {
-		b.isOpen = false
+		b.closeHandles()
 		return result, fmt.Errorf("jam: failed to reopen .jhr after pack: %w", err)
 	}
 	b.jdtFile, err = os.OpenFile(b.BasePath+".jdt", os.O_RDWR, 0644)
 	if err != nil {
-		b.isOpen = false
+		b.closeHandles()
 		return result, fmt.Errorf("jam: failed to reopen .jdt after pack: %w", err)
 	}
 	b.jdxFile, err = os.OpenFile(b.BasePath+".jdx", os.O_RDWR, 0644)
 	if err != nil {
-		b.isOpen = false
+		b.closeHandles()
 		return result, fmt.Errorf("jam: failed to reopen .jdx after pack: %w", err)
 	}
 

--- a/internal/jam/pack.go
+++ b/internal/jam/pack.go
@@ -2,6 +2,7 @@ package jam
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -296,29 +297,33 @@ func (b *Base) packWithReplyIDCleanup(cleanReplyIDs bool) (PackResult, error) {
 	b.jdxFile.Close()
 
 	// Atomic rename
-	renameFailed := false
 	for _, pair := range [][2]string{
 		{tmpJhr, b.BasePath + ".jhr"},
 		{tmpJdt, b.BasePath + ".jdt"},
 		{tmpJdx, b.BasePath + ".jdx"},
 	} {
 		if err := os.Rename(pair[0], pair[1]); err != nil {
-			renameFailed = true
 			// Try to clean up remaining temp files
 			os.Remove(tmpJhr)
 			os.Remove(tmpJdt)
 			os.Remove(tmpJdx)
-			// Attempt to reopen original files
-			b.jhrFile, _ = os.OpenFile(b.BasePath+".jhr", os.O_RDWR, 0644)
-			b.jdtFile, _ = os.OpenFile(b.BasePath+".jdt", os.O_RDWR, 0644)
-			b.jdxFile, _ = os.OpenFile(b.BasePath+".jdx", os.O_RDWR, 0644)
-			b.readFixedHeader()
+			// Attempt to reopen original files; if any reopen fails the
+			// base is unusable and must not claim to be open with nil
+			// handles.
+			var jhrErr, jdtErr, jdxErr error
+			b.jhrFile, jhrErr = os.OpenFile(b.BasePath+".jhr", os.O_RDWR, 0644)
+			b.jdtFile, jdtErr = os.OpenFile(b.BasePath+".jdt", os.O_RDWR, 0644)
+			b.jdxFile, jdxErr = os.OpenFile(b.BasePath+".jdx", os.O_RDWR, 0644)
+			if reopenErr := errors.Join(jhrErr, jdtErr, jdxErr); reopenErr != nil {
+				b.isOpen = false
+				return result, fmt.Errorf("jam: rename failed: %w; base could not be reopened (%w) — manual recovery required", err, reopenErr)
+			}
+			if hdrErr := b.readFixedHeader(); hdrErr != nil {
+				b.isOpen = false
+				return result, fmt.Errorf("jam: rename failed: %w; header unreadable after reopen (%w) — manual recovery required", err, hdrErr)
+			}
 			return result, fmt.Errorf("jam: rename failed: %w — base may need manual recovery", err)
 		}
-	}
-
-	if renameFailed {
-		return result, fmt.Errorf("jam: pack failed during rename")
 	}
 
 	// Reopen files

--- a/internal/jam/pack_test.go
+++ b/internal/jam/pack_test.go
@@ -256,3 +256,45 @@ func TestPackPreservesFixedHeader(t *testing.T) {
 		t.Errorf("Serial changed: %d -> %d", serialBefore, serialAfter)
 	}
 }
+
+func TestPackRenameFailureMarksBaseClosed(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "renamefail")
+
+	b, err := Open(basePath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer b.Close()
+
+	msg := NewMessage()
+	msg.From = "Sender"
+	msg.To = "All"
+	msg.Subject = "Test"
+	msg.Text = "Body"
+	if _, err := b.WriteMessage(msg); err != nil {
+		t.Fatalf("WriteMessage: %v", err)
+	}
+
+	// Force the atomic rename to fail: replace the .jhr file with a
+	// non-empty directory. The open handle still reads the unlinked file,
+	// but os.Rename onto a non-empty directory fails, and the recovery
+	// reopen of the original path fails too.
+	jhrPath := basePath + ".jhr"
+	if err := os.Remove(jhrPath); err != nil {
+		t.Fatalf("remove .jhr: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(jhrPath, "child"), 0755); err != nil {
+		t.Fatalf("mkdir over .jhr: %v", err)
+	}
+
+	if _, err := b.Pack(); err == nil {
+		t.Fatal("expected Pack to fail when rename target is a directory")
+	}
+
+	// The base could not be recovered (reopen failed), so it must not
+	// claim to be open with nil file handles.
+	if b.IsOpen() {
+		t.Error("base claims open after failed rename recovery; want IsOpen() == false")
+	}
+}

--- a/internal/v3net/leaf/chat.go
+++ b/internal/v3net/leaf/chat.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"sync"
 	"time"
 
@@ -175,7 +174,7 @@ func (s *ChatSession) Join(room string) ([]chat.RoomInfo, []chat.ChatMessage, er
 	if resp.StatusCode/100 != 2 {
 		return nil, nil, fmt.Errorf("join chat: hub returned status %d", resp.StatusCode)
 	}
-	respBytes, err := io.ReadAll(resp.Body)
+	respBytes, err := readBody(resp.Body, maxRespBytes)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/v3net/leaf/chat.go
+++ b/internal/v3net/leaf/chat.go
@@ -176,7 +176,7 @@ func (s *ChatSession) Join(room string) ([]chat.RoomInfo, []chat.ChatMessage, er
 	}
 	respBytes, err := readBody(resp.Body, maxRespBytes)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("join chat: %w", err)
 	}
 	var joinResp protocol.ChatJoinResponse
 	if err := json.Unmarshal(respBytes, &joinResp); err != nil {

--- a/internal/v3net/leaf/leaf_test.go
+++ b/internal/v3net/leaf/leaf_test.go
@@ -286,3 +286,22 @@ func TestSSE_ReconnectsOnDisconnect(t *testing.T) {
 		}
 	}
 }
+
+func TestGetRejectsOversizedResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		big := make([]byte, 64*1024)
+		// Stream well past the response cap.
+		for written := 0; written <= maxRespBytes; written += len(big) {
+			if _, err := w.Write(big); err != nil {
+				return
+			}
+		}
+	}))
+	defer ts.Close()
+
+	l, _ := setupLeaf(t, ts.URL, &mockJAMWriter{})
+	if _, err := l.get("/v3net/v1/testnet/info"); err == nil {
+		t.Fatal("expected error for oversized response body, got nil")
+	}
+}

--- a/internal/v3net/leaf/nal.go
+++ b/internal/v3net/leaf/nal.go
@@ -60,7 +60,8 @@ func (l *Leaf) ProposeArea(req protocol.AreaProposalRequest) (*protocol.Proposal
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		body, _ := io.ReadAll(resp.Body)
+		// Diagnostic error body: truncation at the cap is acceptable here.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxRespBytes))
 		var pr protocol.ProposalResponse
 		if json.Unmarshal(body, &pr) == nil && pr.Error != "" {
 			return nil, fmt.Errorf("hub: %s", pr.Error)

--- a/internal/v3net/leaf/poller.go
+++ b/internal/v3net/leaf/poller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"time"
 
@@ -31,7 +30,7 @@ func (l *Leaf) poll(ctx context.Context) (int, error) {
 			return total, fmt.Errorf("leaf: fetch messages: %w", err)
 		}
 
-		body, err := io.ReadAll(resp.Body)
+		body, err := readBody(resp.Body, maxPollRespBytes)
 		resp.Body.Close()
 
 		if err != nil {

--- a/internal/v3net/leaf/sender.go
+++ b/internal/v3net/leaf/sender.go
@@ -43,7 +43,10 @@ func (l *Leaf) subscribe(ctx context.Context) error {
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := readBody(resp.Body, maxRespBytes)
+	if err != nil {
+		return fmt.Errorf("leaf: read subscribe response: %w", err)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("leaf: subscribe returned %d: %s", resp.StatusCode, string(body))
 	}
@@ -202,6 +205,31 @@ func (l *Leaf) signedPostWithResponse(ctx context.Context, path string, body []b
 	return l.client.Do(req)
 }
 
+// Response-body size caps. Hub responses are JSON: subscribe/join/info
+// payloads are small, and a message page is at most 100 messages of ≤32KB
+// body each (~4MB). Reading is capped so a misbehaving or hostile hub
+// cannot exhaust leaf memory.
+const (
+	// maxRespBytes bounds small JSON responses (info, NAL, subscribe,
+	// chat join) and diagnostic error bodies.
+	maxRespBytes = 1 << 20 // 1MB
+	// maxPollRespBytes bounds a message-page response.
+	maxPollRespBytes = 8 << 20 // 8MB
+)
+
+// readBody reads an HTTP response body capped at limit bytes, erroring if
+// the body exceeds the cap (never parse truncated data as if complete).
+func readBody(body io.Reader, limit int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(body, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("leaf: response body exceeds %d byte limit", limit)
+	}
+	return data, nil
+}
+
 // get performs an unauthenticated GET and returns the response body.
 func (l *Leaf) get(path string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, l.cfg.HubURL+path, nil)
@@ -216,7 +244,7 @@ func (l *Leaf) get(path string) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GET %s: status %d", path, resp.StatusCode)
 	}
-	return io.ReadAll(resp.Body)
+	return readBody(resp.Body, maxRespBytes)
 }
 
 func (l *Leaf) signedGet(path string) (*http.Response, error) {

--- a/internal/v3net/leaf/sender.go
+++ b/internal/v3net/leaf/sender.go
@@ -219,13 +219,14 @@ const (
 
 // readBody reads an HTTP response body capped at limit bytes, erroring if
 // the body exceeds the cap (never parse truncated data as if complete).
+// Errors carry no "leaf:" prefix — call sites add their own context.
 func readBody(body io.Reader, limit int64) ([]byte, error) {
 	data, err := io.ReadAll(io.LimitReader(body, limit+1))
 	if err != nil {
 		return nil, err
 	}
 	if int64(len(data)) > limit {
-		return nil, fmt.Errorf("leaf: response body exceeds %d byte limit", limit)
+		return nil, fmt.Errorf("response body exceeds %d byte limit", limit)
 	}
 	return data, nil
 }
@@ -244,7 +245,11 @@ func (l *Leaf) get(path string) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GET %s: status %d", path, resp.StatusCode)
 	}
-	return readBody(resp.Body, maxRespBytes)
+	data, err := readBody(resp.Body, maxRespBytes)
+	if err != nil {
+		return nil, fmt.Errorf("leaf: GET %s: %w", path, err)
+	}
+	return data, nil
 }
 
 func (l *Leaf) signedGet(path string) (*http.Response, error) {


### PR DESCRIPTION
## Summary
Step 1b of the audit plan — the confirmed resource-safety defects.

### JAM message base (`internal/jam`)
- **pack.go**: in the rename-failure recovery path, `os.OpenFile` errors on the three index files were discarded (`_ =`), leaving an "open" base with nil handles. Now reopen errors mark the base closed and are wrapped into the returned error (`errors.Join`). Also removed the unreachable `renameFailed` block.
- **lock.go**: if a stale `.bsy` lock could not be removed (permissions, or it's a directory), the `continue` skipped the deadline check and the acquire loop **spun forever**. It now falls through to the deadline and times out.

### Bounded network reads (memory-exhaustion / DoS hardening)
Following the existing `io.LimitReader` pattern (`nal.go`, `qwkapi/handlers.go`, `echolist.go`):
- `internal/ftn.ReadPacket`: 16MB cap, new `ErrPacketTooLarge` sentinel (typical packets are <1MB).
- `internal/v3net/leaf`: new `readBody` helper; 1MB cap on JSON/diagnostic responses (`get`, subscribe, chat join, propose), 8MB on message pages (protocol max is 100 msgs × ≤32KB body/page).
- `cmd/v3net-bootstrap`: 1MB cap on the diagnostic response print.

Truncation-tolerant reads (error diagnostics) truncate at the cap; parse paths error out rather than parse truncated data.

## Testing (TDD — each test written first, failing)
- `TestAcquireFileLockUnremovableStaleReturnsError` — reproduced the infinite spin (test timed out pre-fix).
- `TestPackRenameFailureMarksBaseClosed` — reproduced the open-base-with-nil-handles state.
- `TestGetRejectsOversizedResponse`, `TestReadPacketRejectsOversizedInput` — oversized inputs now error.
- Full suite: 1671 tests pass in 55 packages. gofmt/vet clean on changed files.

V3Net note: no FTN behavior changed beyond the read cap; per-message limits already enforced by `protocol.Validate` are unaffected.