### PR TITLE
test: goroutine-lifecycle regression tests (scripting, syncjs, menu chat)

### DIFF
--- a/internal/menu/chat_lifecycle_test.go
+++ b/internal/menu/chat_lifecycle_test.go
@@ -1,0 +1,67 @@
+package menu
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/chat"
+)
+
+// TestChatEventPumpExitsOnClose demonstrates the shutdown contract runChat's
+// cleanup() relies on: the event-pump goroutine ranges over svc.Events(), and
+// cleanup() calls svc.Close() then blocks on <-done. If Close() did not close
+// the Events() channel, the range never ends, close(done) never runs, and the
+// session goroutine would hang forever on every chat exit (including abnormal
+// disconnect, which reaches cleanup() via the io.EOF path).
+//
+// This exercises the real LocalChatService using the same pump/cleanup shape
+// as runChat, and asserts no goroutine leak.
+func TestChatEventPumpExitsOnClose(t *testing.T) {
+	baseline := runtime.NumGoroutine()
+
+	dbPath := filepath.Join(t.TempDir(), "chat.db")
+	svc, err := chat.NewLocalChatService("tester", dbPath)
+	if err != nil {
+		t.Fatalf("NewLocalChatService: %v", err)
+	}
+	if _, _, err := svc.Join("lobby"); err != nil {
+		t.Fatalf("Join: %v", err)
+	}
+
+	// Mirror runChat's event pump goroutine.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range svc.Events() {
+			// Drain; runChat renders these to the session.
+		}
+	}()
+
+	// Mirror runChat's cleanup(): leave, close, wait for the pump.
+	svc.Leave("lobby") //nolint:errcheck
+	svc.Close()        //nolint:errcheck
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("event pump goroutine did not exit after svc.Close(); cleanup would hang")
+	}
+
+	waitChatNoGoroutineLeak(t, baseline)
+}
+
+func waitChatNoGoroutineLeak(t *testing.T, baseline int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if runtime.NumGoroutine() <= baseline {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("goroutine leak: have %d, baseline %d", runtime.NumGoroutine(), baseline)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/menu/chat_lifecycle_test.go
+++ b/internal/menu/chat_lifecycle_test.go
@@ -26,6 +26,15 @@ func TestChatEventPumpExitsOnClose(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewLocalChatService: %v", err)
 	}
+	// Fallback so an early Fatal can't leave the service (and its pump
+	// goroutines/DB handle) open for later tests. The closed flag prevents
+	// a double Close of the events channel.
+	closed := false
+	t.Cleanup(func() {
+		if !closed {
+			_ = svc.Close()
+		}
+	})
 	if _, _, err := svc.Join("lobby"); err != nil {
 		t.Fatalf("Join: %v", err)
 	}
@@ -40,8 +49,13 @@ func TestChatEventPumpExitsOnClose(t *testing.T) {
 	}()
 
 	// Mirror runChat's cleanup(): leave, close, wait for the pump.
-	svc.Leave("lobby") //nolint:errcheck
-	svc.Close()        //nolint:errcheck
+	if err := svc.Leave("lobby"); err != nil {
+		t.Errorf("Leave: %v", err)
+	}
+	closed = true
+	if err := svc.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
 
 	select {
 	case <-done:

--- a/internal/scripting/engine_lifecycle_test.go
+++ b/internal/scripting/engine_lifecycle_test.go
@@ -85,6 +85,19 @@ func TestEngineCloseStopsIOGoroutines(t *testing.T) {
 		ScreenHeight: 24,
 	}, ScriptConfig{}, nil)
 
+	// Door-handler cleanup sequence: interrupt the blocked Read, then Close.
+	// Registered with t.Cleanup so an early Fatal can't leak the pump
+	// goroutines into later tests; the explicit call below goes through the
+	// same once-guarded path.
+	var cleanupOnce sync.Once
+	cleanup := func() {
+		cleanupOnce.Do(func() {
+			sess.closeInterrupt()
+			eng.Close()
+		})
+	}
+	t.Cleanup(cleanup)
+
 	// Consume the one scripted byte the way a script's first key read would;
 	// this starts the I/O pump goroutines and then leaves the copier blocked
 	// in session.Read — the state at normal script end.
@@ -92,9 +105,7 @@ func TestEngineCloseStopsIOGoroutines(t *testing.T) {
 		t.Fatalf("readKey = %q, %v; want \"A\", nil", key, err)
 	}
 
-	// Door-handler cleanup sequence: interrupt the blocked Read, then Close.
-	sess.closeInterrupt()
-	eng.Close()
+	cleanup()
 
 	// The copier must have actually exited (not merely timed out in Close).
 	select {

--- a/internal/scripting/engine_lifecycle_test.go
+++ b/internal/scripting/engine_lifecycle_test.go
@@ -1,0 +1,125 @@
+package scripting
+
+import (
+	"context"
+	"io"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+)
+
+// interruptibleSession is a fake session that mimics a live SSH/telnet
+// connection. Read replays any scripted bytes, then blocks until the read
+// interrupt is closed — mirroring the real adapters' SetReadInterrupt — at
+// which point it returns an error WITHOUT consuming a keypress. This is the
+// exact contract the door handlers rely on to stop the copier goroutine.
+type interruptibleSession struct {
+	mu        sync.Mutex
+	data      []byte
+	interrupt chan struct{}
+	out       []byte
+}
+
+func newInterruptibleSession(data string) *interruptibleSession {
+	return &interruptibleSession{data: []byte(data), interrupt: make(chan struct{})}
+}
+
+func (s *interruptibleSession) Read(p []byte) (int, error) {
+	s.mu.Lock()
+	if len(s.data) > 0 {
+		n := copy(p, s.data)
+		s.data = s.data[n:]
+		s.mu.Unlock()
+		return n, nil
+	}
+	s.mu.Unlock()
+	<-s.interrupt
+	return 0, io.EOF
+}
+
+func (s *interruptibleSession) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	s.out = append(s.out, p...)
+	s.mu.Unlock()
+	return len(p), nil
+}
+
+// closeInterrupt mimics the door handler closing the SetReadInterrupt channel
+// after the script ends.
+func (s *interruptibleSession) closeInterrupt() { close(s.interrupt) }
+
+// waitNoGoroutineLeak polls until the goroutine count drops back to (or below)
+// the baseline, failing after 2s. Used to prove the engine's I/O pump and
+// context-watcher goroutines all exit on Close.
+func waitNoGoroutineLeak(t *testing.T, baseline int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if runtime.NumGoroutine() <= baseline {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("goroutine leak: have %d, baseline %d", runtime.NumGoroutine(), baseline)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestEngineCloseStopsIOGoroutines demonstrates that when a V3 script ends
+// normally while the user stays connected, the copier (session->pipe), reader
+// (pipe->channel) and context-watcher goroutines all exit once the door
+// handler closes the read interrupt and calls Close. A regression here would
+// leave the copier blocked in session.Read, stealing the next menu keypress
+// and leaking one goroutine per script run.
+func TestEngineCloseStopsIOGoroutines(t *testing.T) {
+	baseline := runtime.NumGoroutine()
+
+	sess := newInterruptibleSession("A")
+	eng := NewEngine(context.Background(), &SessionContext{
+		Session:      sess,
+		OutputMode:   ansi.OutputModeCP437,
+		ScreenWidth:  80,
+		ScreenHeight: 24,
+	}, ScriptConfig{}, nil)
+
+	// Consume the one scripted byte the way a script's first key read would;
+	// this starts the I/O pump goroutines and then leaves the copier blocked
+	// in session.Read — the state at normal script end.
+	if key, err := eng.readKey(2 * time.Second); err != nil || key != "A" {
+		t.Fatalf("readKey = %q, %v; want \"A\", nil", key, err)
+	}
+
+	// Door-handler cleanup sequence: interrupt the blocked Read, then Close.
+	sess.closeInterrupt()
+	eng.Close()
+
+	// The copier must have actually exited (not merely timed out in Close).
+	select {
+	case <-eng.copierDone:
+	default:
+		t.Fatal("copier goroutine did not exit before Close returned")
+	}
+
+	waitNoGoroutineLeak(t, baseline)
+}
+
+// TestEngineCloseWithoutInputIsClean verifies that a script which never reads
+// input starts no pump goroutines and closes cleanly.
+func TestEngineCloseWithoutInputIsClean(t *testing.T) {
+	baseline := runtime.NumGoroutine()
+
+	sess := newInterruptibleSession("")
+	eng := NewEngine(context.Background(), &SessionContext{
+		Session:    sess,
+		OutputMode: ansi.OutputModeCP437,
+	}, ScriptConfig{}, nil)
+	eng.Close()
+
+	if eng.copierDone != nil {
+		t.Fatal("copier goroutine started for a script that never read input")
+	}
+	waitNoGoroutineLeak(t, baseline)
+}

--- a/internal/syncjs/engine_lifecycle_test.go
+++ b/internal/syncjs/engine_lifecycle_test.go
@@ -86,6 +86,19 @@ func TestEngineCloseStopsIOGoroutines(t *testing.T) {
 	sess := newInterruptibleSession("A")
 	eng := newLifecycleEngine(sess)
 
+	// Door-handler cleanup sequence: interrupt the blocked Read, then Close.
+	// Registered with t.Cleanup so an early Fatal can't leak the pump
+	// goroutines into later tests; the explicit call below goes through the
+	// same once-guarded path.
+	var cleanupOnce sync.Once
+	cleanup := func() {
+		cleanupOnce.Do(func() {
+			sess.closeInterrupt()
+			eng.Close()
+		})
+	}
+	t.Cleanup(cleanup)
+
 	// Consume the one scripted byte the way a door's first key read would;
 	// this starts the I/O pump goroutines and then leaves the copier blocked
 	// in session.Read — the state at normal door end.
@@ -93,9 +106,7 @@ func TestEngineCloseStopsIOGoroutines(t *testing.T) {
 		t.Fatalf("readKey = %q, %v; want \"A\", nil", key, err)
 	}
 
-	// Door-handler cleanup sequence: interrupt the blocked Read, then Close.
-	sess.closeInterrupt()
-	eng.Close()
+	cleanup()
 
 	select {
 	case <-eng.copierDone:

--- a/internal/syncjs/engine_lifecycle_test.go
+++ b/internal/syncjs/engine_lifecycle_test.go
@@ -1,0 +1,121 @@
+package syncjs
+
+import (
+	"context"
+	"io"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+)
+
+// interruptibleSession is a fake session that mimics a live SSH/telnet
+// connection. Read replays any scripted bytes, then blocks until the read
+// interrupt is closed — mirroring the real adapters' SetReadInterrupt — at
+// which point it returns an error WITHOUT consuming a keypress. This is the
+// exact contract the door handler relies on to stop the copier goroutine.
+type interruptibleSession struct {
+	mu        sync.Mutex
+	data      []byte
+	interrupt chan struct{}
+	out       []byte
+}
+
+func newInterruptibleSession(data string) *interruptibleSession {
+	return &interruptibleSession{data: []byte(data), interrupt: make(chan struct{})}
+}
+
+func (s *interruptibleSession) Read(p []byte) (int, error) {
+	s.mu.Lock()
+	if len(s.data) > 0 {
+		n := copy(p, s.data)
+		s.data = s.data[n:]
+		s.mu.Unlock()
+		return n, nil
+	}
+	s.mu.Unlock()
+	<-s.interrupt
+	return 0, io.EOF
+}
+
+func (s *interruptibleSession) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	s.out = append(s.out, p...)
+	s.mu.Unlock()
+	return len(p), nil
+}
+
+func (s *interruptibleSession) closeInterrupt() { close(s.interrupt) }
+
+// waitNoGoroutineLeak polls until the goroutine count drops back to (or below)
+// the baseline, failing after 2s.
+func waitNoGoroutineLeak(t *testing.T, baseline int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if runtime.NumGoroutine() <= baseline {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("goroutine leak: have %d, baseline %d", runtime.NumGoroutine(), baseline)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func newLifecycleEngine(sess io.ReadWriter) *Engine {
+	return NewEngine(context.Background(), &SessionContext{
+		Session:      sess,
+		OutputMode:   ansi.OutputModeCP437,
+		ScreenWidth:  80,
+		ScreenHeight: 24,
+	}, SyncJSDoorConfig{WorkingDir: ".", ExecDir: ".", DataDir: ".", NodeDir: "."})
+}
+
+// TestEngineCloseStopsIOGoroutines demonstrates that when a SyncJS door ends
+// normally while the user stays connected, the copier (session->pipe), reader
+// (pipe->channel) and context-watcher goroutines all exit once the door
+// handler closes the read interrupt and calls Close. A regression here would
+// leave the copier blocked in session.Read, stealing the next menu keypress
+// and leaking one goroutine per door run.
+func TestEngineCloseStopsIOGoroutines(t *testing.T) {
+	baseline := runtime.NumGoroutine()
+
+	sess := newInterruptibleSession("A")
+	eng := newLifecycleEngine(sess)
+
+	// Consume the one scripted byte the way a door's first key read would;
+	// this starts the I/O pump goroutines and then leaves the copier blocked
+	// in session.Read — the state at normal door end.
+	if key, err := eng.readKey(2 * time.Second); err != nil || key != "A" {
+		t.Fatalf("readKey = %q, %v; want \"A\", nil", key, err)
+	}
+
+	// Door-handler cleanup sequence: interrupt the blocked Read, then Close.
+	sess.closeInterrupt()
+	eng.Close()
+
+	select {
+	case <-eng.copierDone:
+	default:
+		t.Fatal("copier goroutine did not exit before Close returned")
+	}
+
+	waitNoGoroutineLeak(t, baseline)
+}
+
+// TestEngineCloseWithoutInputIsClean verifies that a door which never reads
+// input starts no pump goroutines and closes cleanly.
+func TestEngineCloseWithoutInputIsClean(t *testing.T) {
+	baseline := runtime.NumGoroutine()
+
+	eng := newLifecycleEngine(newInterruptibleSession(""))
+	eng.Close()
+
+	if eng.copierDone != nil {
+		t.Fatal("copier goroutine started for a door that never read input")
+	}
+	waitNoGoroutineLeak(t, baseline)
+}


### PR DESCRIPTION
## Summary
Step 1c of the audit plan: audit the session-scoped goroutine loops flagged as potential leaks, fix any defects, and lock in the lifecycle behavior.

**Audit verdict: no leaks found — all flagged loops already shut down correctly.**

- `internal/tosser/runner.go`, `internal/v3net/leaf/{sse,leaf,poller}.go` — already ctx-cancelled (`select` on `ctx.Done()` / per-iteration `ctx.Err()` checks). False positives from the initial sweep; no changes.
- `internal/scripting/engine.go` + `internal/syncjs/engine.go` I/O pumps — the door wrappers close the `SetReadInterrupt` channel *before* `eng.Close()` (same pattern as the b418afa double-reader fix), so the copier exits without stealing a keypress; `io.Pipe` is synchronous so the pipe reader can send at most 2 items into a cap-4 channel after close, and `Close()` drains it. Both live transports (sshserver, telnetserver) implement `SetReadInterrupt`.
- `internal/menu/chat.go` — `cleanup()` closes the chat service, which closes the `Events()` channel the pump ranges over; all disconnect paths reach `cleanup()`; probe goroutines are `wg.Wait`-bounded with buffered result channels.

## Changes
Tests only — no production code:
- `internal/scripting/engine_lifecycle_test.go`, `internal/syncjs/engine_lifecycle_test.go` — engine Close stops the copier/reader/watchContext goroutines (goroutine-count returns to baseline; interruptible fake session). First tests in both packages.
- `internal/menu/chat_lifecycle_test.go` — the event pump exits when the chat service closes.

## Testing
- `go test -race` on the three packages: 348 tests pass; new tests pass with `-count=3` (no flakiness).
- Full suite: 1672 tests pass in 55 packages. gofmt/vet clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added lifecycle regression coverage for chat, scripting, and synchronization engines.
  - Verified clean shutdown of event and I/O processing.
  - Confirmed shutdown completes without leaving background goroutines running.
  - Covered both active sessions and sessions with no input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->