### PR TITLE
perf(menu): hoist include-tag regex out of the render path

### DIFF
--- a/internal/menu/executor.go
+++ b/internal/menu/executor.go
@@ -2235,6 +2235,10 @@ func (e *MenuExecutor) displayPrompt(terminal *term.Terminal, menu *MenuRecord, 
 	return nil
 }
 
+// includeTagRe matches %%filename.ext%% include tags. Package-level so menu
+// renders don't recompile it on every call and recursion level.
+var includeTagRe = regexp.MustCompile(`%%([a-zA-Z0-9_\-]+\.[a-zA-Z0-9]+)%%`)
+
 // processFileIncludes recursively replaces %%filename.ans tags with file content.
 // It now looks for included files within the MENU SET's ansi directory.
 func (e *MenuExecutor) processFileIncludes(prompt string, depth int) (string, error) {
@@ -2244,11 +2248,11 @@ func (e *MenuExecutor) processFileIncludes(prompt string, depth int) (string, er
 		return prompt, nil
 	}
 
-	re := regexp.MustCompile(`%%([a-zA-Z0-9_\-]+\.[a-zA-Z0-9]+)%%`)
 	processedAny := false
-	result := re.ReplaceAllStringFunc(prompt, func(match string) string {
+	result := includeTagRe.ReplaceAllStringFunc(prompt, func(match string) string {
 		processedAny = true
-		fileName := re.FindStringSubmatch(match)[1]
+		// match is "%%name.ext%%"; strip the delimiters instead of re-matching.
+		fileName := strings.TrimSuffix(strings.TrimPrefix(match, "%%"), "%%")
 		// Look for included file in MenuSetPath/ansi
 		filePath := filepath.Join(e.MenuSetPath, "ansi", fileName)
 

--- a/internal/menu/executor.go
+++ b/internal/menu/executor.go
@@ -2237,7 +2237,7 @@ func (e *MenuExecutor) displayPrompt(terminal *term.Terminal, menu *MenuRecord, 
 
 // includeTagRe matches %%filename.ext%% include tags. Package-level so menu
 // renders don't recompile it on every call and recursion level.
-var includeTagRe = regexp.MustCompile(`%%([a-zA-Z0-9_\-]+\.[a-zA-Z0-9]+)%%`)
+var includeTagRe = regexp.MustCompile(`%%[a-zA-Z0-9_\-]+\.[a-zA-Z0-9]+%%`)
 
 // processFileIncludes recursively replaces %%filename.ans tags with file content.
 // It now looks for included files within the MENU SET's ansi directory.

--- a/internal/menu/executor_includes_test.go
+++ b/internal/menu/executor_includes_test.go
@@ -1,0 +1,66 @@
+package menu
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newIncludeExecutor(t *testing.T) *MenuExecutor {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "ansi"), 0755); err != nil {
+		t.Fatalf("mkdir ansi: %v", err)
+	}
+	return &MenuExecutor{MenuSetPath: root}
+}
+
+func writeInclude(t *testing.T, e *MenuExecutor, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(e.MenuSetPath, "ansi", name), []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func TestProcessFileIncludes(t *testing.T) {
+	e := newIncludeExecutor(t)
+	writeInclude(t, e, "header.ans", "HEADER")
+	writeInclude(t, e, "outer.ans", "[%%inner.ans%%]")
+	writeInclude(t, e, "inner.ans", "NESTED")
+	writeInclude(t, e, "loop.ans", "%%loop.ans%%")
+
+	tests := []struct {
+		name   string
+		prompt string
+		want   string
+	}{
+		{"no includes", "plain text", "plain text"},
+		{"single include", "a %%header.ans%% b", "a HEADER b"},
+		{"two includes", "%%header.ans%%+%%header.ans%%", "HEADER+HEADER"},
+		{"nested include", "x %%outer.ans%% y", "x [NESTED] y"},
+		{"missing file removed", "a %%nope.ans%% b", "a  b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := e.processFileIncludes(tt.prompt, 0)
+			if err != nil {
+				t.Fatalf("processFileIncludes: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("self-referential include stops at depth cap", func(t *testing.T) {
+		got, err := e.processFileIncludes("%%loop.ans%%", 0)
+		if err != nil {
+			t.Fatalf("processFileIncludes: %v", err)
+		}
+		// Must terminate; the unresolved tag from the final depth remains.
+		if !strings.Contains(got, "%%loop.ans%%") {
+			t.Errorf("expected unresolved tag after depth cap, got %q", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Step 2 of the approved refactoring plan (docs-internal/plans/2026-07-15-audit-scorecard.md): `processFileIncludes` ran `regexp.MustCompile` on **every menu/prompt render and every recursion level**, plus a second regex execution per match just to extract the filename. The pattern is now a package-level var and the filename is extracted by trimming the `%%` delimiters (the match is by construction `%%name.ext%%`).

## Testing
- TDD: `TestProcessFileIncludes` characterization tests written first against the old implementation (flat include, repeated, nested, missing-file, self-referential depth cap), then the change applied — behavior identical.
- Full menu package: 305 tests pass; gofmt/vet clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt file inclusion handling for nested and multiple includes.
  * Missing include files are removed cleanly from prompts.
  * Self-referential includes now stop safely instead of causing endless processing.

* **Tests**
  * Added coverage for standard, nested, multiple, missing, and self-referential file includes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->