### PR TITLE
refactor(menu): consolidate duplicated lightbar handlers into generic picker

### DIFF
--- a/internal/menu/area_lightbar.go
+++ b/internal/menu/area_lightbar.go
@@ -1,0 +1,263 @@
+package menu
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/editor"
+	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+	"github.com/gliderlabs/ssh"
+)
+
+// areaLightbarPicker is a generic full-screen lightbar list picker shared by
+// the conference (CHANGEMSGCONF) and message-area (SELECTMSGAREA) selection
+// screens. It owns terminal layout, template-based rendering, the diff-based
+// redraw loop, and key handling; variant-specific behavior is injected via
+// the callback fields. Rendering methods live in area_lightbar_render.go.
+type areaLightbarPicker[T any] struct {
+	e           *MenuExecutor
+	terminal    io.Writer
+	outputMode  ansi.OutputMode
+	currentUser *user.User
+	nodeNumber  int
+
+	items []T
+	// buildItemLine renders one item row from the MID template. displayIdx
+	// is 1-based.
+	buildItemLine func(item T, displayIdx int) string
+	hint          string // pipe-coded hint line rendered at hintRow
+	headerName    string // value substituted for ^CN in the TOP template
+	topBytes      []byte // raw TOP template bytes
+	hiColorSeq    string // ANSI sequence for the highlighted (selected) row
+
+	termWidth        int
+	termHeight       int
+	itemAreaStartRow int
+	separatorRow     int
+	hintRow          int
+	visibleRows      int
+
+	selectedIndex  int
+	topIndex       int
+	needFullRedraw bool
+
+	// onSelect handles Enter on items[idx]. When done is false the loop
+	// continues (e.g. an ACS check failed); otherwise run returns its values.
+	onSelect func(idx int) (done bool, u *user.User, next string, err error)
+	// onSideNav handles left/right arrows; nil means the keys are ignored.
+	onSideNav func(left bool)
+}
+
+// resolveTermDims resolves terminal dimensions: prefer passed values, then
+// user preferences, then 80x24 defaults.
+func resolveTermDims(currentUser *user.User, termWidth, termHeight int) (int, int) {
+	if termWidth <= 0 && currentUser != nil {
+		termWidth = currentUser.ScreenWidth
+	}
+	if termWidth <= 0 {
+		termWidth = 80
+	}
+	if termHeight <= 0 && currentUser != nil {
+		termHeight = currentUser.ScreenHeight
+	}
+	if termHeight <= 0 {
+		termHeight = 24
+	}
+	return termWidth, termHeight
+}
+
+// measureAreaHeaderRows counts the rows the TOP template occupies, using the
+// same pipeline as renderTop so the count is accurate even when
+// applyCommonTemplateTokens expands multi-line tokens.
+func measureAreaHeaderRows(e *MenuExecutor, topBytes []byte, currentUser *user.User, nodeNumber int) int {
+	sampleTop := strings.ReplaceAll(string(topBytes), "^CN", "")
+	sampleWithTokens := e.applyCommonTemplateTokens([]byte(sampleTop), currentUser, nodeNumber)
+	processedSample := string(ansi.ReplacePipeCodes(sampleWithTokens))
+	headerLines := strings.Count(processedSample, "\n")
+	// If the template's last row has no trailing \n, the cursor stays on that
+	// row and headerLines is undercounted by 1 — causing itemAreaStartRow to
+	// land on the separator line, which renderItemArea then overwrites.
+	// Detect visible content after the last \n and bump headerLines if found.
+	lastNL := strings.LastIndex(processedSample, "\n")
+	tail := processedSample
+	if lastNL >= 0 {
+		tail = processedSample[lastNL+1:]
+	}
+	tail = areaLightbarAnsiRe.ReplaceAllString(tail, "")
+	tail = strings.Trim(tail, "\r")
+	if len(tail) > 0 {
+		headerLines++
+	}
+	if headerLines < 1 {
+		headerLines = 1
+	}
+	return headerLines
+}
+
+// resolveAreaHiColor returns the highlight ANSI sequence, preferring the
+// optional BAR file (same pattern as FILELISTHI.BAR) over the theme default.
+func resolveAreaHiColor(e *MenuExecutor, barName string, nodeNumber int) string {
+	hiBarOptions, err := loadBarFile(barName, e)
+	if err != nil {
+		slog.Warn("failed to load "+barName+".BAR", "node", nodeNumber, "error", err)
+	}
+	if len(hiBarOptions) > 0 {
+		return colorCodeToAnsi(hiBarOptions[0].HighlightColor)
+	}
+	return colorCodeToAnsi(e.Theme.YesNoHighlightColor)
+}
+
+// computeLayout derives the item-area, separator, and hint rows from the
+// header height and terminal height.
+func (p *areaLightbarPicker[T]) computeLayout(headerLines int) {
+	p.itemAreaStartRow = headerLines + 1
+	p.separatorRow = p.termHeight - 1
+	p.hintRow = p.termHeight
+	if p.separatorRow <= p.itemAreaStartRow {
+		p.separatorRow = p.itemAreaStartRow + 1
+	}
+	p.visibleRows = p.separatorRow - p.itemAreaStartRow
+	if p.visibleRows < 3 {
+		p.visibleRows = 3
+	}
+}
+
+// clampSelection keeps selectedIndex within the item list and scrolls
+// topIndex so the selection stays visible.
+func (p *areaLightbarPicker[T]) clampSelection() {
+	if len(p.items) == 0 {
+		p.selectedIndex, p.topIndex = 0, 0
+		return
+	}
+	if p.selectedIndex < 0 {
+		p.selectedIndex = 0
+	}
+	if p.selectedIndex >= len(p.items) {
+		p.selectedIndex = len(p.items) - 1
+	}
+	if p.selectedIndex < p.topIndex {
+		p.topIndex = p.selectedIndex
+	}
+	if p.selectedIndex >= p.topIndex+p.visibleRows {
+		p.topIndex = p.selectedIndex - p.visibleRows + 1
+	}
+	if p.topIndex < 0 {
+		p.topIndex = 0
+	}
+}
+
+// moveSelection applies navigation keys that only change the selection or
+// scroll position. Other keys are ignored.
+func (p *areaLightbarPicker[T]) moveSelection(keyInt int) {
+	switch keyInt {
+	case editor.KeyArrowUp:
+		p.selectedIndex--
+	case editor.KeyArrowDown:
+		p.selectedIndex++
+	case editor.KeyPageUp, editor.KeyCtrlR:
+		p.selectedIndex -= p.visibleRows
+		p.topIndex -= p.visibleRows
+		if p.topIndex < 0 {
+			p.topIndex = 0
+		}
+	case editor.KeyPageDown, editor.KeyCtrlC:
+		p.selectedIndex += p.visibleRows
+		p.topIndex += p.visibleRows
+	case editor.KeyHome:
+		p.selectedIndex = 0
+	case editor.KeyEnd:
+		if len(p.items) > 0 {
+			p.selectedIndex = len(p.items) - 1
+		}
+	default:
+		if keyInt >= 32 && keyInt < 127 {
+			ch := rune(keyInt)
+			switch {
+			case ch >= '1' && ch <= '9':
+				idx := int(ch - '1')
+				if idx < len(p.items) {
+					p.selectedIndex = idx
+				}
+			case ch == '0':
+				if 9 < len(p.items) {
+					p.selectedIndex = 9
+				}
+			}
+		}
+	}
+}
+
+// run hides the cursor, drives the diff-based redraw loop, and dispatches
+// keys until a selection is made or the user quits or disconnects.
+func (p *areaLightbarPicker[T]) run(s ssh.Session) (*user.User, string, error) {
+	ih := getSessionIH(s)
+	_ = terminalio.WriteProcessedBytes(p.terminal, []byte("\x1b[?25l"), p.outputMode)
+	defer terminalio.WriteProcessedBytes(p.terminal, []byte("\x1b[?25h"), p.outputMode)
+
+	prevSelectedIndex := -1
+	prevTopIndex := -1
+	p.needFullRedraw = true
+
+	for {
+		p.clampSelection()
+
+		if p.needFullRedraw {
+			if err := p.renderFull(); err != nil {
+				return nil, "", err
+			}
+			p.needFullRedraw = false
+		} else if p.topIndex != prevTopIndex {
+			if err := p.renderItemArea(); err != nil {
+				return nil, "", err
+			}
+		} else if p.selectedIndex != prevSelectedIndex {
+			if err := p.redrawChangedRows(prevSelectedIndex); err != nil {
+				return nil, "", err
+			}
+		}
+
+		prevSelectedIndex = p.selectedIndex
+		prevTopIndex = p.topIndex
+
+		keyInt, err := ih.ReadKey()
+		if err != nil {
+			if errors.Is(err, editor.ErrIdleTimeout) {
+				return nil, "LOGOFF", editor.ErrIdleTimeout
+			}
+			if errors.Is(err, io.EOF) {
+				return nil, "LOGOFF", io.EOF
+			}
+			return nil, "", err
+		}
+
+		switch keyInt {
+		case editor.KeyArrowLeft:
+			if p.onSideNav != nil {
+				p.onSideNav(true)
+			}
+		case editor.KeyArrowRight:
+			if p.onSideNav != nil {
+				p.onSideNav(false)
+			}
+		case editor.KeyEnter:
+			if len(p.items) == 0 {
+				continue
+			}
+			done, u, next, err := p.onSelect(p.selectedIndex)
+			if done {
+				return u, next, err
+			}
+		case editor.KeyEsc:
+			return p.currentUser, "", nil
+		default:
+			if keyInt == 'q' || keyInt == 'Q' {
+				return p.currentUser, "", nil
+			}
+			p.moveSelection(keyInt)
+		}
+	}
+}

--- a/internal/menu/area_lightbar_conf.go
+++ b/internal/menu/area_lightbar_conf.go
@@ -1,8 +1,6 @@
 package menu
 
 import (
-	"errors"
-	"io"
 	"log/slog"
 	"path/filepath"
 	"strconv"
@@ -10,10 +8,16 @@ import (
 	"time"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
-	"github.com/ViSiON-3/vision-3-bbs/internal/editor"
 	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 )
+
+// confPickItem is one selectable conference row in the lightbar picker.
+type confPickItem struct {
+	id          int
+	name        string
+	description string
+}
 
 // runChangeMsgConferenceLightbar is the lightbar version of runChangeMsgConference.
 func runChangeMsgConferenceLightbar(c *cmdCtx, args string) (*user.User, string, error) {
@@ -25,24 +29,10 @@ func runChangeMsgConferenceLightbar(c *cmdCtx, args string) (*user.User, string,
 	nodeNumber := c.nodeNumber
 	sessionStartTime := c.sessionStartTime
 	outputMode := c.outputMode
-	termWidth := c.termWidth
-	termHeight := c.termHeight
 
 	slog.Debug("running CHANGEMSGCONF (lightbar)", "node", nodeNumber)
 
-	// Resolve terminal dimensions: prefer passed values, then user prefs, then defaults.
-	if termWidth <= 0 && currentUser != nil {
-		termWidth = currentUser.ScreenWidth
-	}
-	if termWidth <= 0 {
-		termWidth = 80
-	}
-	if termHeight <= 0 && currentUser != nil {
-		termHeight = currentUser.ScreenHeight
-	}
-	if termHeight <= 0 {
-		termHeight = 24
-	}
+	termWidth, termHeight := resolveTermDims(currentUser, c.termWidth, c.termHeight)
 
 	if currentUser == nil {
 		_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ConfLoginRequired)), outputMode)
@@ -67,28 +57,14 @@ func runChangeMsgConferenceLightbar(c *cmdCtx, args string) (*user.User, string,
 
 	processedMidTemplate := string(ansi.ReplacePipeCodes(midBytes))
 
-	buildItemLine := func(name, description string, displayIdx int) string {
-		line := processedMidTemplate
-		line = strings.ReplaceAll(line, "^CI", padRight(strconv.Itoa(displayIdx), 3))
-		line = strings.ReplaceAll(line, "^CN", padRight(truncateStr(name, 20), 20))
-		line = strings.ReplaceAll(line, "^CD", truncateStr(description, 53))
-		return strings.TrimRight(line, "\r\n")
-	}
-
-	type confItem struct {
-		id          int
-		name        string
-		description string
-	}
-
 	// Build the accessible conference list.
-	var confs []confItem
+	var confs []confPickItem
 	currentConfName := "None"
 	for _, conf := range e.ConferenceMgr.ListConferences() {
 		if !checkACS(conf.ACS, currentUser, s, terminal, sessionStartTime) {
 			continue
 		}
-		confs = append(confs, confItem{id: conf.ID, name: conf.Name, description: conf.Description})
+		confs = append(confs, confPickItem{id: conf.ID, name: conf.Name, description: conf.Description})
 		if conf.ID == currentUser.CurrentMsgConferenceID {
 			currentConfName = conf.Name
 		}
@@ -100,294 +76,67 @@ func runChangeMsgConferenceLightbar(c *cmdCtx, args string) (*user.User, string,
 		return currentUser, "", nil
 	}
 
-	// Load optional highlight BAR file (MSGCONFHI.BAR) — same pattern as FILELISTHI.BAR.
-	hiBarOptions, hiBarErr := loadBarFile("MSGCONFHI", e)
-	if hiBarErr != nil {
-		slog.Warn("failed to load MSGCONFHI.BAR", "node", nodeNumber, "error", hiBarErr)
+	p := &areaLightbarPicker[confPickItem]{
+		e:           e,
+		terminal:    terminal,
+		outputMode:  outputMode,
+		currentUser: currentUser,
+		nodeNumber:  nodeNumber,
+		items:       confs,
+		buildItemLine: func(item confPickItem, displayIdx int) string {
+			line := processedMidTemplate
+			line = strings.ReplaceAll(line, "^CI", padRight(strconv.Itoa(displayIdx), 3))
+			line = strings.ReplaceAll(line, "^CN", padRight(truncateStr(item.name, 20), 20))
+			line = strings.ReplaceAll(line, "^CD", truncateStr(item.description, 53))
+			return strings.TrimRight(line, "\r\n")
+		},
+		hint:       "|08[ |15Up|08/|15Dn|08 ] Navigate  [ |15PgUp|08/|15PgDn|08 ] Page  [ |15Enter|08 ] Select  [ |15Q|08 ] Quit",
+		headerName: currentConfName,
+		topBytes:   topBytes,
+		hiColorSeq: resolveAreaHiColor(e, "MSGCONFHI", nodeNumber),
+		termWidth:  termWidth,
+		termHeight: termHeight,
 	}
-
-	// Measure header rows using the same pipeline as renderTop.
-	sampleTop := strings.ReplaceAll(string(topBytes), "^CN", "")
-	sampleWithTokens := e.applyCommonTemplateTokens([]byte(sampleTop), currentUser, nodeNumber)
-	processedSample := string(ansi.ReplacePipeCodes(sampleWithTokens))
-	headerLines := strings.Count(processedSample, "\n")
-	// If the template's last row has no trailing \n, bump headerLines so
-	// itemAreaStartRow is placed past the separator, not on it.
-	{
-		lastNL := strings.LastIndex(processedSample, "\n")
-		tail := processedSample
-		if lastNL >= 0 {
-			tail = processedSample[lastNL+1:]
-		}
-		tail = areaLightbarAnsiRe.ReplaceAllString(tail, "")
-		tail = strings.Trim(tail, "\r")
-		if len(tail) > 0 {
-			headerLines++
-		}
-	}
-	if headerLines < 1 {
-		headerLines = 1
-	}
-
-	itemAreaStartRow := headerLines + 1
-	separatorRow := termHeight - 1
-	hintRow := termHeight
-	if separatorRow <= itemAreaStartRow {
-		separatorRow = itemAreaStartRow + 1
-	}
-	visibleRows := separatorRow - itemAreaStartRow
-	if visibleRows < 3 {
-		visibleRows = 3
-	}
-
-	hiColorSeq := colorCodeToAnsi(e.Theme.YesNoHighlightColor)
-	if len(hiBarOptions) > 0 {
-		hiColorSeq = colorCodeToAnsi(hiBarOptions[0].HighlightColor)
-	}
-
-	renderTop := func(confName string) error {
-		topStr := strings.ReplaceAll(string(topBytes), "^CN", confName)
-		withTokens := e.applyCommonTemplateTokens([]byte(topStr), currentUser, nodeNumber)
-		processed := ansi.ReplacePipeCodes(withTokens)
-		if err := terminalio.WriteProcessedBytes(terminal, []byte(ansi.MoveCursor(1, 1)), outputMode); err != nil {
-			return err
-		}
-		return terminalio.WriteProcessedBytes(terminal, processed, outputMode)
-	}
-
-	renderSeparator := func() error {
-		count := termWidth - 2
-		if count < 0 {
-			count = 0
-		}
-		sep := strings.Repeat("\xc4", count)
-		line := ansi.MoveCursor(separatorRow, 1) + "\x1b[2K" + string(ansi.ReplacePipeCodes([]byte("|08\xfa"+sep+"\xfa|07")))
-		return terminalio.WriteProcessedBytes(terminal, []byte(line), outputMode)
-	}
-
-	renderHint := func() error {
-		hint := "|08[ |15Up|08/|15Dn|08 ] Navigate  [ |15PgUp|08/|15PgDn|08 ] Page  [ |15Enter|08 ] Select  [ |15Q|08 ] Quit"
-		line := ansi.MoveCursor(hintRow, 1) + "\x1b[2K" + string(ansi.ReplacePipeCodes([]byte(hint)))
-		return terminalio.WriteProcessedBytes(terminal, []byte(line), outputMode)
-	}
-
-	renderItemArea := func(topIndex, selectedIndex int) error {
-		for row := 0; row < visibleRows; row++ {
-			absRow := itemAreaStartRow + row
-			if err := terminalio.WriteProcessedBytes(terminal, []byte(ansi.MoveCursor(absRow, 1)+"\x1b[2K"), outputMode); err != nil {
-				return err
-			}
-			idx := topIndex + row
-			if idx >= len(confs) {
-				continue
-			}
-			line := buildItemLine(confs[idx].name, confs[idx].description, idx+1)
-			if idx == selectedIndex {
-				stripped := stripAreaAnsi(line)
-				if len(stripped) > termWidth {
-					stripped = stripped[:termWidth]
-				}
-				rendered := hiColorSeq + padRight(stripped, termWidth) + "\x1b[0m"
-				if err := terminalio.WriteProcessedBytes(terminal, []byte(rendered), outputMode); err != nil {
-					return err
-				}
-			} else {
-				if err := terminalio.WriteProcessedBytes(terminal, []byte(line), outputMode); err != nil {
-					return err
-				}
-			}
-		}
-		return nil
-	}
-
-	renderFull := func(topIndex, selectedIndex int) error {
-		if err := terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode); err != nil {
-			return err
-		}
-		if err := renderTop(currentConfName); err != nil {
-			return err
-		}
-		if err := renderItemArea(topIndex, selectedIndex); err != nil {
-			return err
-		}
-		if err := renderSeparator(); err != nil {
-			return err
-		}
-		return renderHint()
-	}
-
-	ih := getSessionIH(s)
-	_ = terminalio.WriteProcessedBytes(terminal, []byte("\x1b[?25l"), outputMode)
-	defer terminalio.WriteProcessedBytes(terminal, []byte("\x1b[?25h"), outputMode)
+	p.computeLayout(measureAreaHeaderRows(e, topBytes, currentUser, nodeNumber))
 
 	// Pre-select the current conference.
-	selectedIndex := 0
-	for i, c := range confs {
-		if c.id == currentUser.CurrentMsgConferenceID {
-			selectedIndex = i
+	for i, cf := range confs {
+		if cf.id == currentUser.CurrentMsgConferenceID {
+			p.selectedIndex = i
 			break
 		}
 	}
-	topIndex := 0
 
-	clampSelection := func() {
-		if len(confs) == 0 {
-			selectedIndex, topIndex = 0, 0
-			return
+	p.onSelect = func(idx int) (bool, *user.User, string, error) {
+		chosen := confs[idx]
+		e.setUserMsgConference(currentUser, chosen.id)
+
+		firstArea := findFirstAccessibleAreaInConference(e, s, terminal, currentUser, chosen.id, sessionStartTime)
+		if firstArea != nil {
+			currentUser.CurrentMessageAreaID = firstArea.ID
+			currentUser.CurrentMessageAreaTag = firstArea.Tag
+		} else {
+			currentUser.CurrentMessageAreaID = 0
+			currentUser.CurrentMessageAreaTag = ""
 		}
-		if selectedIndex < 0 {
-			selectedIndex = 0
+
+		if err := userManager.UpdateUser(currentUser); err != nil {
+			slog.Error("failed to save user after conference change", "node", nodeNumber, "error", err)
 		}
-		if selectedIndex >= len(confs) {
-			selectedIndex = len(confs) - 1
+
+		confName := chosen.name
+		confTag := ""
+		if conf, ok := e.ConferenceMgr.GetByID(chosen.id); ok {
+			confName = conf.Name
+			confTag = conf.Tag
 		}
-		if selectedIndex < topIndex {
-			topIndex = selectedIndex
-		}
-		if selectedIndex >= topIndex+visibleRows {
-			topIndex = selectedIndex - visibleRows + 1
-		}
-		if topIndex < 0 {
-			topIndex = 0
-		}
+
+		p.showConfirm("|08[ |15" + confName + " |08] |15Conference Joined!|07")
+
+		slog.Info("user changed conference",
+			"node", nodeNumber, "handle", currentUser.Handle, "id", chosen.id, "tag", confTag, "area", currentUser.CurrentMessageAreaTag)
+		return true, currentUser, "", nil
 	}
 
-	prevSelectedIndex := -1
-	prevTopIndex := -1
-	needFullRedraw := true
-
-	for {
-		clampSelection()
-
-		if needFullRedraw {
-			if err := renderFull(topIndex, selectedIndex); err != nil {
-				return nil, "", err
-			}
-			needFullRedraw = false
-		} else if topIndex != prevTopIndex {
-			if err := renderItemArea(topIndex, selectedIndex); err != nil {
-				return nil, "", err
-			}
-		} else if selectedIndex != prevSelectedIndex {
-			if prevSelectedIndex >= topIndex && prevSelectedIndex < topIndex+visibleRows {
-				oldRow := itemAreaStartRow + (prevSelectedIndex - topIndex)
-				oldLine := buildItemLine(confs[prevSelectedIndex].name, confs[prevSelectedIndex].description, prevSelectedIndex+1)
-				if err := terminalio.WriteProcessedBytes(terminal, []byte(ansi.MoveCursor(oldRow, 1)+"\x1b[2K"), outputMode); err != nil {
-					return nil, "", err
-				}
-				if err := terminalio.WriteProcessedBytes(terminal, []byte(oldLine), outputMode); err != nil {
-					return nil, "", err
-				}
-			}
-			if selectedIndex >= topIndex && selectedIndex < topIndex+visibleRows {
-				newRow := itemAreaStartRow + (selectedIndex - topIndex)
-				newLine := buildItemLine(confs[selectedIndex].name, confs[selectedIndex].description, selectedIndex+1)
-				rendered := hiColorSeq + padRight(stripAreaAnsi(newLine), termWidth) + "\x1b[0m"
-				if err := terminalio.WriteProcessedBytes(terminal, []byte(ansi.MoveCursor(newRow, 1)+"\x1b[2K"), outputMode); err != nil {
-					return nil, "", err
-				}
-				if err := terminalio.WriteProcessedBytes(terminal, []byte(rendered), outputMode); err != nil {
-					return nil, "", err
-				}
-			}
-		}
-
-		prevSelectedIndex = selectedIndex
-		prevTopIndex = topIndex
-
-		keyInt, err := ih.ReadKey()
-		if err != nil {
-			if errors.Is(err, editor.ErrIdleTimeout) {
-				return nil, "LOGOFF", editor.ErrIdleTimeout
-			}
-			if errors.Is(err, io.EOF) {
-				return nil, "LOGOFF", io.EOF
-			}
-			return nil, "", err
-		}
-
-		switch keyInt {
-		case editor.KeyArrowUp:
-			selectedIndex--
-
-		case editor.KeyArrowDown:
-			selectedIndex++
-
-		case editor.KeyPageUp, editor.KeyCtrlR:
-			selectedIndex -= visibleRows
-			topIndex -= visibleRows
-			if topIndex < 0 {
-				topIndex = 0
-			}
-
-		case editor.KeyPageDown, editor.KeyCtrlC:
-			selectedIndex += visibleRows
-			topIndex += visibleRows
-
-		case editor.KeyHome:
-			selectedIndex = 0
-
-		case editor.KeyEnd:
-			if len(confs) > 0 {
-				selectedIndex = len(confs) - 1
-			}
-
-		case editor.KeyEnter:
-			if len(confs) == 0 {
-				continue
-			}
-			chosen := confs[selectedIndex]
-			e.setUserMsgConference(currentUser, chosen.id)
-
-			firstArea := findFirstAccessibleAreaInConference(e, s, terminal, currentUser, chosen.id, sessionStartTime)
-			if firstArea != nil {
-				currentUser.CurrentMessageAreaID = firstArea.ID
-				currentUser.CurrentMessageAreaTag = firstArea.Tag
-			} else {
-				currentUser.CurrentMessageAreaID = 0
-				currentUser.CurrentMessageAreaTag = ""
-			}
-
-			if err := userManager.UpdateUser(currentUser); err != nil {
-				slog.Error("failed to save user after conference change", "node", nodeNumber, "error", err)
-			}
-
-			confName := chosen.name
-			confTag := ""
-			if conf, ok := e.ConferenceMgr.GetByID(chosen.id); ok {
-				confName = conf.Name
-				confTag = conf.Tag
-			}
-
-			confirmMsg := "|08[ |15" + confName + " |08] |15Conference Joined!|07"
-			hintLine := ansi.MoveCursor(hintRow, 1) + "\x1b[2K" + string(ansi.ReplacePipeCodes([]byte(confirmMsg)))
-			_ = terminalio.WriteProcessedBytes(terminal, []byte(hintLine), outputMode)
-			time.Sleep(1 * time.Second)
-
-			slog.Info("user changed conference",
-				"node", nodeNumber, "handle", currentUser.Handle, "id", chosen.id, "tag", confTag, "area", currentUser.CurrentMessageAreaTag)
-			return currentUser, "", nil
-
-		case editor.KeyEsc:
-			return currentUser, "", nil
-
-		default:
-			if keyInt >= 32 && keyInt < 127 {
-				ch := rune(keyInt)
-				switch {
-				case ch == 'q' || ch == 'Q':
-					return currentUser, "", nil
-				case ch >= '1' && ch <= '9':
-					idx := int(ch - '1')
-					if idx < len(confs) {
-						selectedIndex = idx
-					}
-				case ch == '0':
-					if 9 < len(confs) {
-						selectedIndex = 9
-					}
-				}
-			}
-		}
-	}
+	return p.run(s)
 }

--- a/internal/menu/area_lightbar_render.go
+++ b/internal/menu/area_lightbar_render.go
@@ -1,0 +1,120 @@
+package menu
+
+import (
+	"strings"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
+)
+
+// renderTop draws the TOP template at row 1, substituting ^CN with the
+// current header name.
+func (p *areaLightbarPicker[T]) renderTop() error {
+	topStr := strings.ReplaceAll(string(p.topBytes), "^CN", p.headerName)
+	withTokens := p.e.applyCommonTemplateTokens([]byte(topStr), p.currentUser, p.nodeNumber)
+	processed := ansi.ReplacePipeCodes(withTokens)
+	if err := terminalio.WriteProcessedBytes(p.terminal, []byte(ansi.MoveCursor(1, 1)), p.outputMode); err != nil {
+		return err
+	}
+	return terminalio.WriteProcessedBytes(p.terminal, processed, p.outputMode)
+}
+
+// renderSeparator draws the horizontal rule above the hint line.
+func (p *areaLightbarPicker[T]) renderSeparator() error {
+	count := p.termWidth - 2
+	if count < 0 {
+		count = 0
+	}
+	sep := strings.Repeat("\xc4", count)
+	line := ansi.MoveCursor(p.separatorRow, 1) + "\x1b[2K" + string(ansi.ReplacePipeCodes([]byte("|08\xfa"+sep+"\xfa|07")))
+	return terminalio.WriteProcessedBytes(p.terminal, []byte(line), p.outputMode)
+}
+
+// renderHint draws the key-hint line at the bottom row.
+func (p *areaLightbarPicker[T]) renderHint() error {
+	line := ansi.MoveCursor(p.hintRow, 1) + "\x1b[2K" + string(ansi.ReplacePipeCodes([]byte(p.hint)))
+	return terminalio.WriteProcessedBytes(p.terminal, []byte(line), p.outputMode)
+}
+
+// renderItemArea redraws every visible item row, highlighting the selection.
+func (p *areaLightbarPicker[T]) renderItemArea() error {
+	for row := 0; row < p.visibleRows; row++ {
+		absRow := p.itemAreaStartRow + row
+		if err := terminalio.WriteProcessedBytes(p.terminal, []byte(ansi.MoveCursor(absRow, 1)+"\x1b[2K"), p.outputMode); err != nil {
+			return err
+		}
+		idx := p.topIndex + row
+		if idx >= len(p.items) {
+			continue
+		}
+		line := p.buildItemLine(p.items[idx], idx+1)
+		if idx == p.selectedIndex {
+			stripped := stripAreaAnsi(line)
+			if len(stripped) > p.termWidth {
+				stripped = stripped[:p.termWidth]
+			}
+			rendered := p.hiColorSeq + padRight(stripped, p.termWidth) + "\x1b[0m"
+			if err := terminalio.WriteProcessedBytes(p.terminal, []byte(rendered), p.outputMode); err != nil {
+				return err
+			}
+		} else {
+			if err := terminalio.WriteProcessedBytes(p.terminal, []byte(line), p.outputMode); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// renderFull clears the screen and redraws header, items, separator, and hint.
+func (p *areaLightbarPicker[T]) renderFull() error {
+	if err := terminalio.WriteProcessedBytes(p.terminal, []byte(ansi.ClearScreen()), p.outputMode); err != nil {
+		return err
+	}
+	if err := p.renderTop(); err != nil {
+		return err
+	}
+	if err := p.renderItemArea(); err != nil {
+		return err
+	}
+	if err := p.renderSeparator(); err != nil {
+		return err
+	}
+	return p.renderHint()
+}
+
+// redrawChangedRows redraws only the previously selected and newly selected
+// rows after a selection move that did not scroll the window.
+func (p *areaLightbarPicker[T]) redrawChangedRows(prevSelectedIndex int) error {
+	if prevSelectedIndex >= p.topIndex && prevSelectedIndex < p.topIndex+p.visibleRows {
+		oldRow := p.itemAreaStartRow + (prevSelectedIndex - p.topIndex)
+		oldLine := p.buildItemLine(p.items[prevSelectedIndex], prevSelectedIndex+1)
+		if err := terminalio.WriteProcessedBytes(p.terminal, []byte(ansi.MoveCursor(oldRow, 1)+"\x1b[2K"), p.outputMode); err != nil {
+			return err
+		}
+		if err := terminalio.WriteProcessedBytes(p.terminal, []byte(oldLine), p.outputMode); err != nil {
+			return err
+		}
+	}
+	if p.selectedIndex >= p.topIndex && p.selectedIndex < p.topIndex+p.visibleRows {
+		newRow := p.itemAreaStartRow + (p.selectedIndex - p.topIndex)
+		newLine := p.buildItemLine(p.items[p.selectedIndex], p.selectedIndex+1)
+		rendered := p.hiColorSeq + padRight(stripAreaAnsi(newLine), p.termWidth) + "\x1b[0m"
+		if err := terminalio.WriteProcessedBytes(p.terminal, []byte(ansi.MoveCursor(newRow, 1)+"\x1b[2K"), p.outputMode); err != nil {
+			return err
+		}
+		if err := terminalio.WriteProcessedBytes(p.terminal, []byte(rendered), p.outputMode); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// showConfirm replaces the hint line with a pipe-coded confirmation message
+// and pauses briefly so the user can read it.
+func (p *areaLightbarPicker[T]) showConfirm(msg string) {
+	line := ansi.MoveCursor(p.hintRow, 1) + "\x1b[2K" + string(ansi.ReplacePipeCodes([]byte(msg)))
+	_ = terminalio.WriteProcessedBytes(p.terminal, []byte(line), p.outputMode)
+	time.Sleep(1 * time.Second)
+}

--- a/internal/menu/area_lightbar_select.go
+++ b/internal/menu/area_lightbar_select.go
@@ -1,8 +1,6 @@
 package menu
 
 import (
-	"errors"
-	"io"
 	"log/slog"
 	"path/filepath"
 	"sort"
@@ -11,14 +9,14 @@ import (
 	"time"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
-	"github.com/ViSiON-3/vision-3-bbs/internal/editor"
 	"github.com/ViSiON-3/vision-3-bbs/internal/message"
 	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 )
 
 // runSelectMessageAreaLightbar is the lightbar version of runSelectMessageArea.
-// It uses arrow-key navigation and paging for large area lists.
+// It uses arrow-key navigation and paging for large area lists, with left/right
+// arrows switching the conference filter.
 func runSelectMessageAreaLightbar(c *cmdCtx, args string) (*user.User, string, error) {
 	e := c.e
 	s := c.s
@@ -28,24 +26,10 @@ func runSelectMessageAreaLightbar(c *cmdCtx, args string) (*user.User, string, e
 	nodeNumber := c.nodeNumber
 	sessionStartTime := c.sessionStartTime
 	outputMode := c.outputMode
-	termWidth := c.termWidth
-	termHeight := c.termHeight
 
 	slog.Debug("running SELECTMSGAREA (lightbar)", "node", nodeNumber)
 
-	// Resolve terminal dimensions: prefer passed values, then user prefs, then defaults.
-	if termWidth <= 0 && currentUser != nil {
-		termWidth = currentUser.ScreenWidth
-	}
-	if termWidth <= 0 {
-		termWidth = 80
-	}
-	if termHeight <= 0 && currentUser != nil {
-		termHeight = currentUser.ScreenHeight
-	}
-	if termHeight <= 0 {
-		termHeight = 24
-	}
+	termWidth, termHeight := resolveTermDims(currentUser, c.termWidth, c.termHeight)
 
 	if currentUser == nil {
 		msg := "\r\n|01Error: You must be logged in to select a message area.|07\r\n"
@@ -94,16 +78,6 @@ func runSelectMessageAreaLightbar(c *cmdCtx, args string) (*user.User, string, e
 		return areas
 	}
 
-	buildItemLine := func(area *message.MessageArea, displayIdx int) string {
-		line := processedMidTemplate
-		line = strings.ReplaceAll(line, "^ID", padRight(strconv.Itoa(displayIdx), 3))
-		line = strings.ReplaceAll(line, "^TAG", padRight(truncateStr(area.Tag, 16), 16))
-		line = strings.ReplaceAll(line, "^NA", padRight(truncateStr(area.Name, 14), 14))
-		line = strings.ReplaceAll(line, "^DE", padRight(truncateStr(area.Description, 32), 32))
-		line = strings.ReplaceAll(line, "^DS", truncateStr(area.AreaType, 8))
-		return strings.TrimRight(line, "\r\n")
-	}
-
 	confNameFor := func(confID int) string {
 		if e.ConferenceMgr != nil {
 			if conf, ok := e.ConferenceMgr.GetByID(confID); ok {
@@ -113,295 +87,61 @@ func runSelectMessageAreaLightbar(c *cmdCtx, args string) (*user.User, string, e
 		return "None"
 	}
 
-	// Load optional highlight BAR file (MSGAREAHI.BAR) — same pattern as FILELISTHI.BAR.
-	hiBarOptions, hiBarErr := loadBarFile("MSGAREAHI", e)
-	if hiBarErr != nil {
-		slog.Warn("failed to load MSGAREAHI.BAR", "node", nodeNumber, "error", hiBarErr)
+	p := &areaLightbarPicker[*message.MessageArea]{
+		e:           e,
+		terminal:    terminal,
+		outputMode:  outputMode,
+		currentUser: currentUser,
+		nodeNumber:  nodeNumber,
+		items:       buildAreaList(filterConfID),
+		buildItemLine: func(area *message.MessageArea, displayIdx int) string {
+			line := processedMidTemplate
+			line = strings.ReplaceAll(line, "^ID", padRight(strconv.Itoa(displayIdx), 3))
+			line = strings.ReplaceAll(line, "^TAG", padRight(truncateStr(area.Tag, 16), 16))
+			line = strings.ReplaceAll(line, "^NA", padRight(truncateStr(area.Name, 14), 14))
+			line = strings.ReplaceAll(line, "^DE", padRight(truncateStr(area.Description, 32), 32))
+			line = strings.ReplaceAll(line, "^DS", truncateStr(area.AreaType, 8))
+			return strings.TrimRight(line, "\r\n")
+		},
+		hint:       "|08[ |15Up|08/|15Dn|08 ] Nav  [ |15Lt|08/|15Rt|08 ] Conf  [ |15PgUp|08/|15PgDn|08 ] Page  [ |15Enter|08 ] Select  [ |15Q|08 ] Quit",
+		headerName: confNameFor(filterConfID),
+		topBytes:   topBytes,
+		hiColorSeq: resolveAreaHiColor(e, "MSGAREAHI", nodeNumber),
+		termWidth:  termWidth,
+		termHeight: termHeight,
 	}
+	p.computeLayout(measureAreaHeaderRows(e, topBytes, currentUser, nodeNumber))
 
-	// Measure header rows using the same pipeline as renderTop so the count
-	// is accurate even when applyCommonTemplateTokens expands multi-line tokens.
-	sampleTop := strings.ReplaceAll(string(topBytes), "^CN", "")
-	sampleWithTokens := e.applyCommonTemplateTokens([]byte(sampleTop), currentUser, nodeNumber)
-	processedSample := string(ansi.ReplacePipeCodes(sampleWithTokens))
-	headerLines := strings.Count(processedSample, "\n")
-	// If the template's last row has no trailing \n, the cursor stays on that
-	// row and headerLines is undercounted by 1 — causing itemAreaStartRow to
-	// land on the separator line, which renderItemArea then overwrites.
-	// Detect visible content after the last \n and bump headerLines if found.
-	{
-		lastNL := strings.LastIndex(processedSample, "\n")
-		tail := processedSample
-		if lastNL >= 0 {
-			tail = processedSample[lastNL+1:]
-		}
-		tail = areaLightbarAnsiRe.ReplaceAllString(tail, "")
-		tail = strings.Trim(tail, "\r")
-		if len(tail) > 0 {
-			headerLines++
-		}
-	}
-	if headerLines < 1 {
-		headerLines = 1
-	}
-
-	itemAreaStartRow := headerLines + 1
-	separatorRow := termHeight - 1
-	hintRow := termHeight
-	if separatorRow <= itemAreaStartRow {
-		separatorRow = itemAreaStartRow + 1
-	}
-	visibleRows := separatorRow - itemAreaStartRow
-	if visibleRows < 3 {
-		visibleRows = 3
-	}
-
-	hiColorSeq := colorCodeToAnsi(e.Theme.YesNoHighlightColor)
-	if len(hiBarOptions) > 0 {
-		hiColorSeq = colorCodeToAnsi(hiBarOptions[0].HighlightColor)
-	}
-
-	renderTop := func(confName string) error {
-		topStr := strings.ReplaceAll(string(topBytes), "^CN", confName)
-		withTokens := e.applyCommonTemplateTokens([]byte(topStr), currentUser, nodeNumber)
-		processed := ansi.ReplacePipeCodes(withTokens)
-		if err := terminalio.WriteProcessedBytes(terminal, []byte(ansi.MoveCursor(1, 1)), outputMode); err != nil {
-			return err
-		}
-		return terminalio.WriteProcessedBytes(terminal, processed, outputMode)
-	}
-
-	renderSeparator := func() error {
-		count := termWidth - 2
-		if count < 0 {
-			count = 0
-		}
-		sep := strings.Repeat("\xc4", count)
-		line := ansi.MoveCursor(separatorRow, 1) + "\x1b[2K" + string(ansi.ReplacePipeCodes([]byte("|08\xfa"+sep+"\xfa|07")))
-		return terminalio.WriteProcessedBytes(terminal, []byte(line), outputMode)
-	}
-
-	renderHint := func() error {
-		hint := "|08[ |15Up|08/|15Dn|08 ] Nav  [ |15Lt|08/|15Rt|08 ] Conf  [ |15PgUp|08/|15PgDn|08 ] Page  [ |15Enter|08 ] Select  [ |15Q|08 ] Quit"
-		line := ansi.MoveCursor(hintRow, 1) + "\x1b[2K" + string(ansi.ReplacePipeCodes([]byte(hint)))
-		return terminalio.WriteProcessedBytes(terminal, []byte(line), outputMode)
-	}
-
-	renderItemArea := func(areas []*message.MessageArea, topIndex, selectedIndex int) error {
-		for row := 0; row < visibleRows; row++ {
-			absRow := itemAreaStartRow + row
-			if err := terminalio.WriteProcessedBytes(terminal, []byte(ansi.MoveCursor(absRow, 1)+"\x1b[2K"), outputMode); err != nil {
-				return err
-			}
-			idx := topIndex + row
-			if idx >= len(areas) {
-				continue
-			}
-			line := buildItemLine(areas[idx], idx+1)
-			if idx == selectedIndex {
-				stripped := stripAreaAnsi(line)
-				if len(stripped) > termWidth {
-					stripped = stripped[:termWidth]
-				}
-				rendered := hiColorSeq + padRight(stripped, termWidth) + "\x1b[0m"
-				if err := terminalio.WriteProcessedBytes(terminal, []byte(rendered), outputMode); err != nil {
-					return err
-				}
-			} else {
-				if err := terminalio.WriteProcessedBytes(terminal, []byte(line), outputMode); err != nil {
-					return err
-				}
-			}
-		}
-		return nil
-	}
-
-	renderFull := func(areas []*message.MessageArea, confName string, topIndex, selectedIndex int) error {
-		if err := terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode); err != nil {
-			return err
-		}
-		if err := renderTop(confName); err != nil {
-			return err
-		}
-		if err := renderItemArea(areas, topIndex, selectedIndex); err != nil {
-			return err
-		}
-		if err := renderSeparator(); err != nil {
-			return err
-		}
-		return renderHint()
-	}
-
-	ih := getSessionIH(s)
-	_ = terminalio.WriteProcessedBytes(terminal, []byte("\x1b[?25l"), outputMode)
-	defer terminalio.WriteProcessedBytes(terminal, []byte("\x1b[?25h"), outputMode)
-
-	areas := buildAreaList(filterConfID)
-	confName := confNameFor(filterConfID)
-	selectedIndex := 0
-	topIndex := 0
-
-	clampSelection := func() {
-		if len(areas) == 0 {
-			selectedIndex, topIndex = 0, 0
-			return
-		}
-		if selectedIndex < 0 {
-			selectedIndex = 0
-		}
-		if selectedIndex >= len(areas) {
-			selectedIndex = len(areas) - 1
-		}
-		if selectedIndex < topIndex {
-			topIndex = selectedIndex
-		}
-		if selectedIndex >= topIndex+visibleRows {
-			topIndex = selectedIndex - visibleRows + 1
-		}
-		if topIndex < 0 {
-			topIndex = 0
-		}
-	}
-
-	prevSelectedIndex := -1
-	prevTopIndex := -1
-	needFullRedraw := true
-
-	for {
-		clampSelection()
-
-		if needFullRedraw {
-			if err := renderFull(areas, confName, topIndex, selectedIndex); err != nil {
-				return nil, "", err
-			}
-			needFullRedraw = false
-		} else if topIndex != prevTopIndex {
-			if err := renderItemArea(areas, topIndex, selectedIndex); err != nil {
-				return nil, "", err
-			}
-		} else if selectedIndex != prevSelectedIndex {
-			// Redraw only the two changed rows.
-			if prevSelectedIndex >= topIndex && prevSelectedIndex < topIndex+visibleRows {
-				oldRow := itemAreaStartRow + (prevSelectedIndex - topIndex)
-				oldLine := buildItemLine(areas[prevSelectedIndex], prevSelectedIndex+1)
-				if err := terminalio.WriteProcessedBytes(terminal, []byte(ansi.MoveCursor(oldRow, 1)+"\x1b[2K"), outputMode); err != nil {
-					return nil, "", err
-				}
-				if err := terminalio.WriteProcessedBytes(terminal, []byte(oldLine), outputMode); err != nil {
-					return nil, "", err
-				}
-			}
-			if selectedIndex >= topIndex && selectedIndex < topIndex+visibleRows {
-				newRow := itemAreaStartRow + (selectedIndex - topIndex)
-				newLine := buildItemLine(areas[selectedIndex], selectedIndex+1)
-				rendered := hiColorSeq + padRight(stripAreaAnsi(newLine), termWidth) + "\x1b[0m"
-				if err := terminalio.WriteProcessedBytes(terminal, []byte(ansi.MoveCursor(newRow, 1)+"\x1b[2K"), outputMode); err != nil {
-					return nil, "", err
-				}
-				if err := terminalio.WriteProcessedBytes(terminal, []byte(rendered), outputMode); err != nil {
-					return nil, "", err
-				}
-			}
-		}
-
-		prevSelectedIndex = selectedIndex
-		prevTopIndex = topIndex
-
-		keyInt, err := ih.ReadKey()
-		if err != nil {
-			if errors.Is(err, editor.ErrIdleTimeout) {
-				return nil, "LOGOFF", editor.ErrIdleTimeout
-			}
-			if errors.Is(err, io.EOF) {
-				return nil, "LOGOFF", io.EOF
-			}
-			return nil, "", err
-		}
-
-		switch keyInt {
-		case editor.KeyArrowUp:
-			selectedIndex--
-
-		case editor.KeyArrowDown:
-			selectedIndex++
-
-		case editor.KeyPageUp, editor.KeyCtrlR:
-			selectedIndex -= visibleRows
-			topIndex -= visibleRows
-			if topIndex < 0 {
-				topIndex = 0
-			}
-
-		case editor.KeyPageDown, editor.KeyCtrlC:
-			selectedIndex += visibleRows
-			topIndex += visibleRows
-
-		case editor.KeyHome:
-			selectedIndex = 0
-
-		case editor.KeyEnd:
-			if len(areas) > 0 {
-				selectedIndex = len(areas) - 1
-			}
-
-		case editor.KeyArrowLeft:
+	p.onSideNav = func(left bool) {
+		if left {
 			filterConfID = prevConf(accessibleConfs, filterConfID)
-			areas = buildAreaList(filterConfID)
-			confName = confNameFor(filterConfID)
-			selectedIndex, topIndex = 0, 0
-			needFullRedraw = true
-
-		case editor.KeyArrowRight:
+		} else {
 			filterConfID = nextConf(accessibleConfs, filterConfID)
-			areas = buildAreaList(filterConfID)
-			confName = confNameFor(filterConfID)
-			selectedIndex, topIndex = 0, 0
-			needFullRedraw = true
-
-		case editor.KeyEnter:
-			if len(areas) == 0 {
-				continue
-			}
-			area := areas[selectedIndex]
-			if !checkACS(area.ACSRead, currentUser, s, terminal, sessionStartTime) {
-				continue
-			}
-			currentUser.CurrentMessageAreaID = area.ID
-			currentUser.CurrentMessageAreaTag = area.Tag
-			e.setUserMsgConference(currentUser, area.ConferenceID)
-			if err := userManager.UpdateUser(currentUser); err != nil {
-				slog.Error("failed to save user after area change", "node", nodeNumber, "error", err)
-			}
-
-			confirmMsg := "|08[ |15" + area.Name + " |08] |15Area Joined!|07"
-			hintLine := ansi.MoveCursor(hintRow, 1) + "\x1b[2K" + string(ansi.ReplacePipeCodes([]byte(confirmMsg)))
-			_ = terminalio.WriteProcessedBytes(terminal, []byte(hintLine), outputMode)
-			time.Sleep(1 * time.Second)
-
-			slog.Info("user changed message area",
-				"node", nodeNumber, "handle", currentUser.Handle, "id", area.ID, "tag", area.Tag)
-			return currentUser, "", nil
-
-		case editor.KeyEsc:
-			return currentUser, "", nil
-
-		default:
-			if keyInt >= 32 && keyInt < 127 {
-				ch := rune(keyInt)
-				switch {
-				case ch == 'q' || ch == 'Q':
-					return currentUser, "", nil
-				case ch >= '1' && ch <= '9':
-					idx := int(ch - '1')
-					if idx < len(areas) {
-						selectedIndex = idx
-					}
-				case ch == '0':
-					if 9 < len(areas) {
-						selectedIndex = 9
-					}
-				}
-			}
 		}
+		p.items = buildAreaList(filterConfID)
+		p.headerName = confNameFor(filterConfID)
+		p.selectedIndex, p.topIndex = 0, 0
+		p.needFullRedraw = true
 	}
+
+	p.onSelect = func(idx int) (bool, *user.User, string, error) {
+		area := p.items[idx]
+		if !checkACS(area.ACSRead, currentUser, s, terminal, sessionStartTime) {
+			return false, nil, "", nil
+		}
+		currentUser.CurrentMessageAreaID = area.ID
+		currentUser.CurrentMessageAreaTag = area.Tag
+		e.setUserMsgConference(currentUser, area.ConferenceID)
+		if err := userManager.UpdateUser(currentUser); err != nil {
+			slog.Error("failed to save user after area change", "node", nodeNumber, "error", err)
+		}
+
+		p.showConfirm("|08[ |15" + area.Name + " |08] |15Area Joined!|07")
+
+		slog.Info("user changed message area",
+			"node", nodeNumber, "handle", currentUser.Handle, "id", area.ID, "tag", area.Tag)
+		return true, currentUser, "", nil
+	}
+
+	return p.run(s)
 }

--- a/internal/menu/area_lightbar_test.go
+++ b/internal/menu/area_lightbar_test.go
@@ -1,0 +1,183 @@
+package menu
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/editor"
+)
+
+// newTestPicker builds a picker over n string items with a simple item-line
+// builder that records invocations, using a bytes.Buffer as the terminal.
+func newTestPicker(n, visibleRows int) (*areaLightbarPicker[string], *bytes.Buffer, *[]string) {
+	items := make([]string, n)
+	for i := range items {
+		items[i] = fmt.Sprintf("item-%d", i)
+	}
+	var out bytes.Buffer
+	calls := &[]string{}
+	p := &areaLightbarPicker[string]{
+		terminal:   &out,
+		outputMode: ansi.OutputModeCP437,
+		items:      items,
+		buildItemLine: func(item string, displayIdx int) string {
+			*calls = append(*calls, fmt.Sprintf("%s:%d", item, displayIdx))
+			return item
+		},
+		termWidth:        80,
+		termHeight:       24,
+		itemAreaStartRow: 5,
+		visibleRows:      visibleRows,
+	}
+	return p, &out, calls
+}
+
+func TestClampSelectionBounds(t *testing.T) {
+	p, _, _ := newTestPicker(10, 5)
+
+	p.selectedIndex = -3
+	p.clampSelection()
+	if p.selectedIndex != 0 {
+		t.Errorf("negative selection: got %d, want 0", p.selectedIndex)
+	}
+
+	p.selectedIndex = 42
+	p.clampSelection()
+	if p.selectedIndex != 9 {
+		t.Errorf("overshoot selection: got %d, want 9", p.selectedIndex)
+	}
+	// Selection past the window must scroll topIndex down.
+	if p.topIndex != 5 {
+		t.Errorf("topIndex after scroll down: got %d, want 5", p.topIndex)
+	}
+
+	// Selection above the window must scroll topIndex up.
+	p.selectedIndex = 2
+	p.clampSelection()
+	if p.topIndex != 2 {
+		t.Errorf("topIndex after scroll up: got %d, want 2", p.topIndex)
+	}
+}
+
+func TestClampSelectionEmptyList(t *testing.T) {
+	p, _, _ := newTestPicker(0, 5)
+	p.selectedIndex, p.topIndex = 7, 3
+	p.clampSelection()
+	if p.selectedIndex != 0 || p.topIndex != 0 {
+		t.Errorf("empty list: got (%d,%d), want (0,0)", p.selectedIndex, p.topIndex)
+	}
+}
+
+func TestMoveSelection(t *testing.T) {
+	p, _, _ := newTestPicker(20, 5)
+
+	p.moveSelection(editor.KeyArrowDown)
+	if p.selectedIndex != 1 {
+		t.Errorf("arrow down: got %d, want 1", p.selectedIndex)
+	}
+	p.moveSelection(editor.KeyArrowUp)
+	if p.selectedIndex != 0 {
+		t.Errorf("arrow up: got %d, want 0", p.selectedIndex)
+	}
+
+	p.moveSelection(editor.KeyPageDown)
+	if p.selectedIndex != 5 || p.topIndex != 5 {
+		t.Errorf("page down: got (%d,%d), want (5,5)", p.selectedIndex, p.topIndex)
+	}
+	p.moveSelection(editor.KeyPageUp)
+	if p.selectedIndex != 0 || p.topIndex != 0 {
+		t.Errorf("page up: got (%d,%d), want (0,0)", p.selectedIndex, p.topIndex)
+	}
+	// Page up at the top must not push topIndex negative.
+	p.moveSelection(editor.KeyPageUp)
+	if p.topIndex != 0 {
+		t.Errorf("page up at top: topIndex got %d, want 0", p.topIndex)
+	}
+
+	p.moveSelection(editor.KeyEnd)
+	if p.selectedIndex != 19 {
+		t.Errorf("end: got %d, want 19", p.selectedIndex)
+	}
+	p.moveSelection(editor.KeyHome)
+	if p.selectedIndex != 0 {
+		t.Errorf("home: got %d, want 0", p.selectedIndex)
+	}
+
+	// Digit shortcuts: '3' selects index 2, '0' selects index 9.
+	p.moveSelection('3')
+	if p.selectedIndex != 2 {
+		t.Errorf("digit 3: got %d, want 2", p.selectedIndex)
+	}
+	p.moveSelection('0')
+	if p.selectedIndex != 9 {
+		t.Errorf("digit 0: got %d, want 9", p.selectedIndex)
+	}
+
+	// Digit beyond list length is ignored.
+	short, _, _ := newTestPicker(2, 5)
+	short.moveSelection('9')
+	if short.selectedIndex != 0 {
+		t.Errorf("digit beyond list: got %d, want 0", short.selectedIndex)
+	}
+}
+
+func TestRenderItemAreaInvokesBuilder(t *testing.T) {
+	p, out, calls := newTestPicker(3, 5)
+	p.topIndex, p.selectedIndex = 0, 1
+	p.hiColorSeq = "\x1b[44m"
+
+	if err := p.renderItemArea(); err != nil {
+		t.Fatalf("renderItemArea: %v", err)
+	}
+
+	// Builder is called once per visible item with 1-based display index.
+	want := []string{"item-0:1", "item-1:2", "item-2:3"}
+	if len(*calls) != len(want) {
+		t.Fatalf("builder calls: got %v, want %v", *calls, want)
+	}
+	for i, w := range want {
+		if (*calls)[i] != w {
+			t.Errorf("call %d: got %q, want %q", i, (*calls)[i], w)
+		}
+	}
+
+	// The selected row is rendered with the highlight sequence and reset.
+	rendered := out.String()
+	if !strings.Contains(rendered, "\x1b[44m"+padRight("item-1", 80)+"\x1b[0m") {
+		t.Errorf("selected row not highlighted; output: %q", rendered)
+	}
+	if !strings.Contains(rendered, "item-0") || !strings.Contains(rendered, "item-2") {
+		t.Errorf("unselected rows missing; output: %q", rendered)
+	}
+}
+
+func TestComputeLayout(t *testing.T) {
+	p, _, _ := newTestPicker(1, 0)
+	p.termHeight = 24
+	p.computeLayout(4)
+	if p.itemAreaStartRow != 5 || p.separatorRow != 23 || p.hintRow != 24 || p.visibleRows != 18 {
+		t.Errorf("layout 24-row: got start=%d sep=%d hint=%d vis=%d",
+			p.itemAreaStartRow, p.separatorRow, p.hintRow, p.visibleRows)
+	}
+
+	// Tiny terminal: separator pushed below header, visibleRows floored at 3.
+	p.termHeight = 5
+	p.computeLayout(10)
+	if p.separatorRow != 12 || p.visibleRows != 3 {
+		t.Errorf("layout tiny: got sep=%d vis=%d, want sep=12 vis=3", p.separatorRow, p.visibleRows)
+	}
+}
+
+func TestResolveTermDims(t *testing.T) {
+	w, h := resolveTermDims(nil, 0, 0)
+	if w != 80 || h != 24 {
+		t.Errorf("defaults: got %dx%d, want 80x24", w, h)
+	}
+	w, h = resolveTermDims(nil, 132, 50)
+	if w != 132 || h != 50 {
+		t.Errorf("explicit: got %dx%d, want 132x50", w, h)
+	}
+}


### PR DESCRIPTION
## Summary
Step 1 of the approved refactoring plan (docs-internal/plans/2026-07-15-audit-scorecard.md): the conference and area lightbar handlers were ~85% structurally identical (393 + 407 LOC). They're now thin wrappers (142 + 147 LOC) around a shared generic `areaLightbarPicker[T]`:

- `area_lightbar.go` (263 LOC) — dimension resolution, header measurement, BAR-file highlight resolution, layout, selection clamping/movement, and the diff-redraw run loop; variant behavior injected via `buildItemLine`, `onSelect`, and optional `onSideNav` callbacks.
- `area_lightbar_render.go` (120 LOC) — the render helpers.
- Net **−128 production LOC** with every duplicated block eliminated; all files under 300 lines.

## Behavior preservation
Terminal output is unchanged by construction — escape sequences, write ordering, and even the original highlight asymmetry between full render (truncate-then-pad) and diff redraw (pad-only) are preserved verbatim. Two neutral ordering notes are in the commit message.

## Testing
- New `area_lightbar_test.go` (first tests for this UI): clampSelection bounds/scroll, moveSelection across arrows/paging/home-end/digit shortcuts, layout at normal and tiny terminal sizes, and render-callback invocation with highlight verification against a fake terminal.
- `go test -race ./internal/menu/` — 304 pass; full suite 1684 pass in 55 packages; gofmt/vet clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full-screen lightbar pickers for selecting conferences and message areas.
  * Added keyboard navigation with arrows, paging, Home/End, and numeric shortcuts.
  * Added scrolling, highlighted selections, terminal-aware layouts, and confirmation messages.
  * Added side navigation to switch conference filters while choosing message areas.

* **Bug Fixes**
  * Improved handling of terminal dimensions, narrow screens, and empty lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->