### PR TITLE
fix(v3net): wire NAL SSE events into the leaf event loop

### DIFF
--- a/internal/v3net/leaf/nal.go
+++ b/internal/v3net/leaf/nal.go
@@ -76,11 +76,16 @@ func (l *Leaf) ProposeArea(req protocol.AreaProposalRequest) (*protocol.Proposal
 	return &pr, nil
 }
 
+// nalRefetchBase is the base delay before re-fetching the NAL after an
+// nal_updated event (±10% jitter, per the protocol spec's thundering-herd
+// guidance). Variable so tests can shorten it.
+var nalRefetchBase = 60 * time.Second
+
 // handleNALUpdated schedules a NAL re-fetch after receiving an nal_updated SSE event.
 func (l *Leaf) handleNALUpdated(ctx context.Context) {
-	// Re-fetch within 60 seconds ±10% jitter.
+	// Re-fetch within nalRefetchBase ±10% jitter.
 	jitter := 1.0 + (rand.Float64()*2-1)*0.10
-	delay := time.Duration(float64(60*time.Second) * jitter)
+	delay := time.Duration(float64(nalRefetchBase) * jitter)
 
 	slog.Info("leaf: NAL updated, re-fetching", "network", l.cfg.Network, "delay", delay)
 

--- a/internal/v3net/leaf/nal_sse_test.go
+++ b/internal/v3net/leaf/nal_sse_test.go
@@ -1,0 +1,94 @@
+package leaf
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/keystore"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/nal"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+)
+
+// TestSSE_NALUpdatedTriggersRefetch verifies the nal_updated SSE event is
+// wired to the NAL re-fetch handler: when the hub announces a NAL update, the
+// leaf must re-fetch and verify the NAL from GET /{network}/nal (per the
+// protocol spec, within 60s ±10% jitter — shortened here via nalRefetchBase).
+func TestSSE_NALUpdatedTriggersRefetch(t *testing.T) {
+	origDelay := nalRefetchBase
+	nalRefetchBase = 20 * time.Millisecond
+	t.Cleanup(func() { nalRefetchBase = origDelay })
+
+	// Coordinator identity to sign the NAL the mock hub serves.
+	coordKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "coord.key"))
+	if err != nil {
+		t.Fatalf("load coord keystore: %v", err)
+	}
+	signed := &protocol.NAL{
+		V3NetNAL:    "1.0",
+		Network:     "testnet",
+		CoordNodeID: coordKS.NodeID(),
+	}
+	if err := nal.Sign(signed, coordKS); err != nil {
+		t.Fatalf("sign NAL: %v", err)
+	}
+	nalJSON, err := json.Marshal(signed)
+	if err != nil {
+		t.Fatalf("marshal NAL: %v", err)
+	}
+
+	var mu sync.Mutex
+	nalFetches := 0
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v3net/v1/testnet/events":
+			flusher, ok := w.(http.Flusher)
+			if !ok {
+				t.Error("no flusher")
+				return
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(200)
+			fmt.Fprint(w, "event: nal_updated\ndata: {\"network\":\"testnet\"}\n\n")
+			flusher.Flush()
+			<-r.Context().Done()
+		case "/v3net/v1/testnet/nal":
+			mu.Lock()
+			nalFetches++
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(nalJSON)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	l, _ := setupLeaf(t, ts.URL, &mockJAMWriter{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go l.runSSE(ctx)
+
+	deadline := time.After(2 * time.Second)
+	for {
+		mu.Lock()
+		n := nalFetches
+		mu.Unlock()
+		if n >= 1 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("nal_updated SSE event did not trigger a NAL re-fetch (wiring missing)")
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}

--- a/internal/v3net/leaf/sse.go
+++ b/internal/v3net/leaf/sse.go
@@ -93,6 +93,7 @@ func (l *Leaf) connectSSE(ctx context.Context, reconnect bool) error {
 				}
 				l.onEvent(ev)
 				l.chatSessions.dispatch(ev)
+				l.dispatchNALEvent(ctx, ev)
 			}
 			eventType = ""
 			continue


### PR DESCRIPTION
## Summary
Closes the wiring gap surfaced during the dead-code burn-down (PR #89 kept these symbols as staged-not-dead): `dispatchNALEvent`/`handleNALUpdated` implement the spec'd NAL SSE handling — re-fetch the NAL within 60s ±10% jitter on `nal_updated`, plus logging for area-access/proposal/subscription/coordinator events — but `connectSSE` never called them, so leaves ignored NAL updates until restart.

- `sse.go`: dispatch every parsed event to `dispatchNALEvent` alongside `onEvent` and chat dispatch (one line).
- `nal.go`: the 60s re-fetch base becomes package var `nalRefetchBase` so tests can shorten it (same precedent as `sseBackoffBase/Max`).

## Testing (TDD)
`TestSSE_NALUpdatedTriggersRefetch`: mock hub emits `nal_updated` over a live SSE stream and serves a coordinator-signed NAL; the test asserts the leaf re-fetches and verifies it. **Fails without the wiring (verified), passes with it.** `go test -race ./internal/v3net/...` — 159 pass across 8 packages; full suite 1693 pass; gofmt/vet clean.