### PR TITLE
test(file): pagination sort-consistency coverage + stale TODO cleanup

### DIFF
--- a/internal/file/manager_test.go
+++ b/internal/file/manager_test.go
@@ -257,22 +257,46 @@ func TestGetFilesForAreaPaginated(t *testing.T) {
 		})
 	}
 
-	// Page 1, size 2
+	// All records, in the order GetFilesForArea provides (pagination must match it).
+	all := fm.GetFilesForArea(1)
+	if len(all) != 5 {
+		t.Fatalf("expected 5 records total, got %d", len(all))
+	}
+
+	// Page 1, size 2 (first page)
 	page, err := fm.GetFilesForAreaPaginated(1, 1, 2)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(page) != 2 {
-		t.Errorf("expected 2 records on page 1, got %d", len(page))
+		t.Fatalf("expected 2 records on page 1, got %d", len(page))
+	}
+	if page[0].ID != all[0].ID || page[1].ID != all[1].ID {
+		t.Error("page 1 does not match first two records of GetFilesForArea")
 	}
 
-	// Page 3, size 2 (only 1 record left)
+	// Page 2, size 2 (middle page)
+	page, err = fm.GetFilesForAreaPaginated(1, 2, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(page) != 2 {
+		t.Fatalf("expected 2 records on page 2, got %d", len(page))
+	}
+	if page[0].ID != all[2].ID || page[1].ID != all[3].ID {
+		t.Error("page 2 does not match middle records of GetFilesForArea")
+	}
+
+	// Page 3, size 2 (last, partial page: only 1 record left)
 	page, err = fm.GetFilesForAreaPaginated(1, 3, 2)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(page) != 1 {
-		t.Errorf("expected 1 record on last page, got %d", len(page))
+		t.Fatalf("expected 1 record on last page, got %d", len(page))
+	}
+	if page[0].ID != all[4].ID {
+		t.Error("last page does not match final record of GetFilesForArea")
 	}
 
 	// Page beyond range
@@ -285,9 +309,22 @@ func TestGetFilesForAreaPaginated(t *testing.T) {
 	}
 
 	// Invalid page
-	_, err = fm.GetFilesForAreaPaginated(1, 0, 2)
-	if err == nil {
+	if _, err = fm.GetFilesForAreaPaginated(1, 0, 2); err == nil {
 		t.Error("expected error for page 0")
+	}
+
+	// Invalid page size
+	if _, err = fm.GetFilesForAreaPaginated(1, 1, 0); err == nil {
+		t.Error("expected error for pageSize 0")
+	}
+
+	// Nonexistent area
+	page, err = fm.GetFilesForAreaPaginated(999, 1, 2)
+	if err != nil {
+		t.Fatalf("unexpected error for nonexistent area: %v", err)
+	}
+	if len(page) != 0 {
+		t.Errorf("expected 0 records for nonexistent area, got %d", len(page))
 	}
 }
 

--- a/internal/menu/executor_files.go
+++ b/internal/menu/executor_files.go
@@ -744,7 +744,6 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 	slog.Debug("file list pagination", "node", nodeNumber, "termHeight", termHeight, "fixedLines", fixedLines, "filesPerPage", filesPerPage)
 
 	// --- Get Total File Count ---
-	// TODO: Implement GetFileCountForArea in FileManager
 	totalFiles, err := e.FileMgr.GetFileCountForArea(currentAreaID)
 	if err != nil {
 		slog.Error("failed to get file count for area", "node", nodeNumber, "area", currentAreaID, "error", err)
@@ -769,7 +768,6 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 
 	// --- Fetch Initial Page ---
 	if totalFiles > 0 {
-		// TODO: Implement GetFilesForAreaPaginated in FileManager
 		filesOnPage, err = e.FileMgr.GetFilesForAreaPaginated(currentAreaID, currentPage, filesPerPage)
 		if err != nil {
 			slog.Error("failed to get files for area page", "node", nodeNumber, "area", currentAreaID, "page", currentPage, "error", err)


### PR DESCRIPTION
## Summary
Step 6 of the refactoring plan came back smaller than scoped: `GetFileCountForArea` and `GetFilesForAreaPaginated` **already exist** in FileManager with correct locking, clamping, and page copies, and the executor listing paths already use them — the audit item was driven by stale TODO comments at the call sites.

- Deleted the two stale TODOs in `executor_files.go`.
- Extended `TestGetFilesForAreaPaginated` with the missing cases: first/middle/last-partial page contents asserted against `GetFilesForArea` ordering (sort consistency), pageSize-0 error, nonexistent-area empty result.

Remaining whole-area callers were reviewed and legitimately need full lists (filename search, upload dup-check, lightbar scroll buffer, scripting API) — converting the lightbar to on-demand paging would be an architectural change, intentionally out of scope.

## Testing
`go test -race ./internal/file/ ./internal/menu/` — 346 pass; full suite 1692 pass; gofmt/vet clean.