### PR TITLE
test: coverage floor for zero-test packages + configeditor/menu seams

### DIFF
--- a/internal/conference/conference_test.go
+++ b/internal/conference/conference_test.go
@@ -1,0 +1,154 @@
+package conference
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeConferences writes a conferences.json fixture into dir.
+func writeConferences(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, conferencesFile), []byte(content), 0644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}
+
+func TestNewConferenceManager_MissingFile(t *testing.T) {
+	cm, err := NewConferenceManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("missing file should not error: %v", err)
+	}
+	if got := cm.ListConferences(); len(got) != 0 {
+		t.Errorf("want 0 conferences, got %d", len(got))
+	}
+}
+
+func TestNewConferenceManager_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	writeConferences(t, dir, "")
+	cm, err := NewConferenceManager(dir)
+	if err != nil {
+		t.Fatalf("empty file should not error: %v", err)
+	}
+	if got := cm.ListConferences(); len(got) != 0 {
+		t.Errorf("want 0 conferences, got %d", len(got))
+	}
+}
+
+func TestNewConferenceManager_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeConferences(t, dir, "{not json")
+	if _, err := NewConferenceManager(dir); err == nil {
+		t.Fatal("invalid JSON should return an error")
+	}
+}
+
+func TestConferenceManager_Lookups(t *testing.T) {
+	dir := t.TempDir()
+	writeConferences(t, dir, `[
+		{"id": 1, "position": 2, "tag": "LOCAL", "name": "Local"},
+		{"id": 2, "position": 1, "tag": "FSXNET", "name": "fsxNet"},
+		null,
+		{"id": 1, "position": 3, "tag": "DUPID", "name": "Duplicate ID"},
+		{"id": 3, "position": 4, "tag": "LOCAL", "name": "Duplicate Tag"}
+	]`)
+	cm, err := NewConferenceManager(dir)
+	if err != nil {
+		t.Fatalf("NewConferenceManager: %v", err)
+	}
+
+	// Duplicates and nulls are skipped: only 2 loaded.
+	list := cm.ListConferences()
+	if len(list) != 2 {
+		t.Fatalf("want 2 conferences, got %d", len(list))
+	}
+	// Sorted by Position: FSXNET (pos 1) before LOCAL (pos 2).
+	if list[0].Tag != "FSXNET" || list[1].Tag != "LOCAL" {
+		t.Errorf("list order = %s, %s; want FSXNET, LOCAL", list[0].Tag, list[1].Tag)
+	}
+
+	if c, ok := cm.GetByID(1); !ok || c.Name != "Local" {
+		t.Errorf("GetByID(1) = %+v, %v; want Local", c, ok)
+	}
+	if _, ok := cm.GetByID(99); ok {
+		t.Error("GetByID(99) should not exist")
+	}
+	if c, ok := cm.GetByTag("FSXNET"); !ok || c.ID != 2 {
+		t.Errorf("GetByTag(FSXNET) = %+v, %v; want ID 2", c, ok)
+	}
+	if _, ok := cm.GetByTag("NOPE"); ok {
+		t.Error("GetByTag(NOPE) should not exist")
+	}
+}
+
+func TestConferenceManager_PositionMigration(t *testing.T) {
+	dir := t.TempDir()
+	// Conference 5 has an explicit position; 2 and 7 need migration.
+	writeConferences(t, dir, `[
+		{"id": 7, "position": 0, "tag": "C7", "name": "Seven"},
+		{"id": 5, "position": 3, "tag": "C5", "name": "Five"},
+		{"id": 2, "position": 0, "tag": "C2", "name": "Two"}
+	]`)
+	cm, err := NewConferenceManager(dir)
+	if err != nil {
+		t.Fatalf("NewConferenceManager: %v", err)
+	}
+
+	// Unset positions are assigned after the current max (3), ordered by ID:
+	// C2 -> 4, C7 -> 5.
+	c2, _ := cm.GetByID(2)
+	c7, _ := cm.GetByID(7)
+	if c2.Position != 4 {
+		t.Errorf("C2 position = %d, want 4", c2.Position)
+	}
+	if c7.Position != 5 {
+		t.Errorf("C7 position = %d, want 5", c7.Position)
+	}
+
+	list := cm.ListConferences()
+	wantOrder := []string{"C5", "C2", "C7"}
+	for i, tag := range wantOrder {
+		if list[i].Tag != tag {
+			t.Errorf("list[%d] = %s, want %s", i, list[i].Tag, tag)
+		}
+	}
+}
+
+func TestGetSortedConferenceIDs(t *testing.T) {
+	dir := t.TempDir()
+	writeConferences(t, dir, `[
+		{"id": 1, "position": 3, "tag": "A", "name": "A"},
+		{"id": 2, "position": 1, "tag": "B", "name": "B"}
+	]`)
+	cm, err := NewConferenceManager(dir)
+	if err != nil {
+		t.Fatalf("NewConferenceManager: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		in   map[int]bool
+		want []int
+	}{
+		{"empty", map[int]bool{}, nil},
+		{"zero first", map[int]bool{0: true, 1: true, 2: true}, []int{0, 2, 1}},
+		{"by position", map[int]bool{1: true, 2: true}, []int{2, 1}},
+		// ID 9 is unknown: falls back to its ID (9) as position, sorting
+		// after B (pos 1) and A (pos 3).
+		{"unknown falls back to ID", map[int]bool{1: true, 9: true, 2: true}, []int{2, 1, 9}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cm.GetSortedConferenceIDs(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("got %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/configeditor/fields_helpers_test.go
+++ b/internal/configeditor/fields_helpers_test.go
@@ -1,0 +1,184 @@
+package configeditor
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+)
+
+func TestCSVSliceRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    string
+		want  []string
+		asCSV string
+	}{
+		{"empty", "", nil, ""},
+		{"whitespace only", "   ", nil, ""},
+		{"single", "a", []string{"a"}, "a"},
+		{"trims entries", " a , b ,c ", []string{"a", "b", "c"}, "a, b, c"},
+		{"drops empty entries", "a,,b,", []string{"a", "b"}, "a, b"},
+		{"all empty entries", ",,,", nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := csvToSlice(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("csvToSlice(%q) = %#v, want %#v", tt.in, got, tt.want)
+			}
+			if s := sliceToCSV(got); s != tt.asCSV {
+				t.Errorf("sliceToCSV = %q, want %q", s, tt.asCSV)
+			}
+		})
+	}
+}
+
+func TestDoorCommandsGetSet(t *testing.T) {
+	tests := []struct {
+		name     string
+		isDOS    bool
+		val      string
+		wantCmds []string
+		wantGet  string
+	}{
+		{"native empty", false, "", nil, ""},
+		{"native command only", false, "lord", []string{"lord"}, "lord"},
+		{"native with args", false, "lord /n1, /p2", []string{"lord", "/n1", "/p2"}, "lord /n1, /p2"},
+		{"dos batch lines", true, "cd door, run.bat", []string{"cd door", "run.bat"}, "cd door, run.bat"},
+		{"dos empty", true, "", nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &doorEditProxy{IsDOS: tt.isDOS}
+			doorCommandsSet(d, tt.val)
+			if !reflect.DeepEqual(d.Commands, tt.wantCmds) {
+				t.Errorf("Commands = %#v, want %#v", d.Commands, tt.wantCmds)
+			}
+			if got := doorCommandsGet(d); got != tt.wantGet {
+				t.Errorf("doorCommandsGet = %q, want %q", got, tt.wantGet)
+			}
+		})
+	}
+}
+
+func TestEnvMapCSVRoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    map[string]string
+		wantErr bool
+	}{
+		{"empty", "", nil, false},
+		{"single", "A=1", map[string]string{"A": "1"}, false},
+		{"multiple sorted", "B=2, A=1", map[string]string{"A": "1", "B": "2"}, false},
+		{"value with equals", "URL=http://x?a=b", map[string]string{"URL": "http://x?a=b"}, false},
+		{"missing value", "JUSTKEY", nil, true},
+		{"empty key", "=v", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := csvToEnvMap(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("csvToEnvMap(%q) err = %v, wantErr %v", tt.in, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("csvToEnvMap(%q) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+
+	// envMapToCSV sorts keys for stable output.
+	if got := envMapToCSV(map[string]string{"B": "2", "A": "1"}); got != "A=1, B=2" {
+		t.Errorf("envMapToCSV = %q, want A=1, B=2", got)
+	}
+	if got := envMapToCSV(nil); got != "" {
+		t.Errorf("envMapToCSV(nil) = %q, want empty", got)
+	}
+}
+
+func TestDoorTypeLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		door config.DoorConfig
+		want string
+	}{
+		{"syncjs", config.DoorConfig{Type: "synchronet_js"}, "SyncJS"},
+		{"vpl", config.DoorConfig{Type: "v3_script"}, "VPL"},
+		{"dos", config.DoorConfig{IsDOS: true}, "DOS"},
+		{"native", config.DoorConfig{}, "Native"},
+	}
+	for _, tt := range tests {
+		if got := doorTypeLabel(&tt.door); got != tt.want {
+			t.Errorf("%s: doorTypeLabel = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+	if !isSyncJS(&doorEditProxy{Type: "synchronet_js"}) || isSyncJS(&doorEditProxy{}) {
+		t.Error("isSyncJS misclassified")
+	}
+	if !isV3Script(&doorEditProxy{Type: "v3_script"}) || isV3Script(&doorEditProxy{}) {
+		t.Error("isV3Script misclassified")
+	}
+}
+
+func TestJoinSplitArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    []string
+		wantErr bool
+	}{
+		{"empty", "", []string{}, false},
+		{"json array", `["a","b c"]`, []string{"a", "b c"}, false},
+		{"legacy space split", "a b c", []string{"a", "b", "c"}, false},
+		{"malformed json rejected", `["a",`, nil, true},
+		{"stray quote rejected", `"abc`, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := splitArgs(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("splitArgs(%q) err = %v, wantErr %v", tt.in, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("splitArgs(%q) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+
+	// joinArgs -> splitArgs is lossless, including spaces and quotes.
+	args := []string{"-v", "arg with space", `quo"ted`}
+	back, err := splitArgs(joinArgs(args))
+	if err != nil {
+		t.Fatalf("round-trip: %v", err)
+	}
+	if !reflect.DeepEqual(back, args) {
+		t.Errorf("round-trip = %#v, want %#v", back, args)
+	}
+	if joinArgs(nil) != "" {
+		t.Error("joinArgs(nil) should be empty")
+	}
+}
+
+func TestSkipToColAndMaxInt(t *testing.T) {
+	if got := skipToCol("abcdef", 2); got != "cdef" {
+		t.Errorf("skipToCol plain = %q, want cdef", got)
+	}
+	if got := skipToCol("ab", 5); got != "" {
+		t.Errorf("skipToCol past end = %q, want empty", got)
+	}
+	// ANSI escapes are replayed so styling survives the split point.
+	styled := "\x1b[31mred\x1b[0mplain"
+	if got := skipToCol(styled, 3); got != "\x1b[0mplain" {
+		t.Errorf("skipToCol styled = %q, want %q", got, "\x1b[0mplain")
+	}
+	if maxInt(2, 3) != 3 || maxInt(5, -1) != 5 {
+		t.Error("maxInt wrong")
+	}
+}

--- a/internal/configeditor/fields_records_test.go
+++ b/internal/configeditor/fields_records_test.go
@@ -1,0 +1,246 @@
+package configeditor
+
+import (
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/archiver"
+	"github.com/ViSiON-3/vision-3-bbs/internal/conference"
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+	"github.com/ViSiON-3/vision-3-bbs/internal/file"
+	"github.com/ViSiON-3/vision-3-bbs/internal/message"
+	"github.com/ViSiON-3/vision-3-bbs/internal/transfer"
+)
+
+// newRecordModel builds a Model seeded with one record of every editable type.
+func newRecordModel() *Model {
+	return &Model{
+		configs: &allConfigs{
+			Conferences: []conference.Conference{
+				{ID: 1, Position: 1, Tag: "LOCAL", Name: "Local Conferences"},
+			},
+			MsgAreas: []message.MessageArea{
+				{ID: 1, Position: 1, Tag: "GENERAL", Name: "General", AreaType: "local",
+					ACSRead: "s10", ACSWrite: "s10", BasePath: "msgbases/general", ConferenceID: 1},
+			},
+			FileAreas: []file.FileArea{
+				{ID: 1, Tag: "UTILS", Name: "Utilities", Path: "utils", ConferenceID: 1},
+			},
+			Protocols: []transfer.ProtocolConfig{
+				{Key: "Z", Name: "Zmodem", SendCmd: "sz", SendArgs: []string{"-b"}, RecvCmd: "rz"},
+			},
+			Archivers: archiver.Config{Archivers: []archiver.Archiver{
+				{ID: "zip", Name: "ZIP Archive", Extension: ".zip", Magic: "504B0304"},
+			}},
+			LoginSeq: []config.LoginItem{
+				{Command: "DISPLAY", Data: "WELCOME.ANS"},
+			},
+			Events: config.EventsConfig{Events: []config.EventConfig{
+				{ID: "nightly", Name: "Nightly", Command: "true", Enabled: true},
+			}},
+		},
+		recordEditIdx: 0,
+	}
+}
+
+// TestRecordFieldGetSetIdempotence sweeps every record screen and verifies
+// that for each editable non-lookup field, Set(Get()) succeeds and Get is
+// stable afterwards (the editor must be able to re-save what it displays).
+func TestRecordFieldGetSetIdempotence(t *testing.T) {
+	screens := []string{
+		"msgarea", "filearea", "conference", "protocol", "archiver", "login", "event",
+	}
+	for _, screen := range screens {
+		t.Run(screen, func(t *testing.T) {
+			m := newRecordModel()
+			m.recordType = screen
+			fields := m.buildRecordFields()
+			if len(fields) == 0 {
+				t.Fatalf("no fields for screen %s", screen)
+			}
+			for _, f := range fields {
+				if f.Get == nil {
+					t.Errorf("field %q has no Get", f.Label)
+					continue
+				}
+				v1 := f.Get()
+				if f.Set == nil || f.Type == ftLookup || f.Type == ftDisplay {
+					continue
+				}
+				if err := f.Set(v1); err != nil {
+					t.Errorf("field %q: Set(Get()) = %v", f.Label, err)
+					continue
+				}
+				if v2 := f.Get(); v2 != v1 {
+					t.Errorf("field %q: Get after Set = %q, want %q", f.Label, v2, v1)
+				}
+			}
+		})
+	}
+}
+
+// TestSysFieldGetSetIdempotence sweeps all system-config sub-screens.
+func TestSysFieldGetSetIdempotence(t *testing.T) {
+	m := newRecordModel()
+	m.configs.Server = config.ServerConfig{
+		BoardName: "Test BBS", SysOpName: "sysop", QWKID: "TEST",
+	}
+	for screen := 0; screen <= 9; screen++ {
+		fields := m.buildSysFields(screen)
+		if len(fields) == 0 {
+			t.Errorf("no fields for sys screen %d", screen)
+			continue
+		}
+		for _, f := range fields {
+			if f.Get == nil {
+				t.Errorf("screen %d field %q has no Get", screen, f.Label)
+				continue
+			}
+			v1 := f.Get()
+			if f.Set == nil || f.Type == ftLookup || f.Type == ftDisplay {
+				continue
+			}
+			if err := f.Set(v1); err != nil {
+				t.Errorf("screen %d field %q: Set(Get()) = %v", screen, f.Label, err)
+				continue
+			}
+			if v2 := f.Get(); v2 != v1 {
+				t.Errorf("screen %d field %q: Get after Set = %q, want %q", screen, f.Label, v2, v1)
+			}
+		}
+	}
+}
+
+func findField(t *testing.T, fields []fieldDef, label string) *fieldDef {
+	t.Helper()
+	for i := range fields {
+		if fields[i].Label == label {
+			return &fields[i]
+		}
+	}
+	t.Fatalf("field %q not found", label)
+	return nil
+}
+
+func TestFieldsMsgAreaConditionalNetworkFields(t *testing.T) {
+	tests := []struct {
+		areaType   string
+		wantLabels []string
+	}{
+		{"local", nil},
+		{"echomail", []string{"Network", "Echo Tag", "Origin Addr", "Sponsor"}},
+		{"netmail", []string{"Network"}},
+		{"v3net", []string{"Network", "Echo Tag"}},
+	}
+	base := len(newRecordModel().fieldsMsgArea()) // local variant
+	for _, tt := range tests {
+		t.Run(tt.areaType, func(t *testing.T) {
+			m := newRecordModel()
+			m.configs.MsgAreas[0].AreaType = tt.areaType
+			fields := m.fieldsMsgArea()
+			if got, want := len(fields), base+len(tt.wantLabels); got != want {
+				t.Fatalf("field count = %d, want %d", got, want)
+			}
+			for _, label := range tt.wantLabels {
+				findField(t, fields, label)
+			}
+		})
+	}
+}
+
+func TestFieldsMsgAreaValidation(t *testing.T) {
+	m := newRecordModel()
+	m.recordType = "msgarea"
+	fields := m.buildRecordFields()
+
+	maxMsgs := findField(t, fields, "Max Messages")
+	if err := maxMsgs.Set("not-a-number"); err == nil {
+		t.Error("Max Messages should reject non-numeric input")
+	}
+	if err := maxMsgs.Set("500"); err != nil {
+		t.Fatalf("Set(500): %v", err)
+	}
+	if m.configs.MsgAreas[0].MaxMessages != 500 {
+		t.Errorf("MaxMessages = %d, want 500", m.configs.MsgAreas[0].MaxMessages)
+	}
+
+	autoJoin := findField(t, fields, "Auto Join")
+	if err := autoJoin.Set("Y"); err != nil {
+		t.Fatalf("Set(Y): %v", err)
+	}
+	if !m.configs.MsgAreas[0].AutoJoin {
+		t.Error("AutoJoin should be true after Set(Y)")
+	}
+
+	// Conference lookup: Get shows display name, Set takes the ID value.
+	conf := findField(t, fields, "Conference")
+	if got := conf.Get(); got != "Local Conferences (ID: 1)" {
+		t.Errorf("Conference Get = %q", got)
+	}
+	if err := conf.Set("0"); err != nil {
+		t.Fatalf("Set(0): %v", err)
+	}
+	if got := conf.Get(); got != "Ungrouped (ID: 0)" {
+		t.Errorf("Conference Get after Set(0) = %q", got)
+	}
+	if err := conf.Set("bogus"); err == nil {
+		t.Error("Conference Set should reject non-numeric ID")
+	}
+	items := conf.LookupItems()
+	if len(items) != 2 || items[0].Value != "0" || items[1].Value != "1" {
+		t.Errorf("lookup items = %+v", items)
+	}
+}
+
+func TestFieldsEventNameSetSanitizesID(t *testing.T) {
+	m := newRecordModel()
+	m.recordType = "event"
+	fields := m.buildRecordFields()
+
+	name := findField(t, fields, "Name")
+	if err := name.Set("New Cool Event!"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	e := m.configs.Events.Events[0]
+	if e.Name != "New Cool Event!" {
+		t.Errorf("Name = %q", e.Name)
+	}
+	if e.ID != "new_cool_event" {
+		t.Errorf("ID = %q, want new_cool_event", e.ID)
+	}
+	if err := name.Set("!!!"); err == nil {
+		t.Error("Set with no alphanumerics should error")
+	}
+}
+
+func TestFieldsProtocolArgsRoundTrip(t *testing.T) {
+	m := newRecordModel()
+	m.recordType = "protocol"
+	fields := m.buildRecordFields()
+
+	sendArgs := findField(t, fields, "Send Args")
+	if got := sendArgs.Get(); got != `["-b"]` {
+		t.Errorf("Send Args Get = %q, want [\"-b\"]", got)
+	}
+	if err := sendArgs.Set(`["-b","--tcp"]`); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if got := m.configs.Protocols[0].SendArgs; len(got) != 2 || got[1] != "--tcp" {
+		t.Errorf("SendArgs = %#v", got)
+	}
+	if err := sendArgs.Set(`["broken`); err == nil {
+		t.Error("Set with malformed JSON should error")
+	}
+}
+
+func TestBuildRecordFields_UnknownAndOutOfRange(t *testing.T) {
+	m := newRecordModel()
+	m.recordType = "nonsense"
+	if fields := m.buildRecordFields(); fields != nil {
+		t.Errorf("unknown record type should yield nil fields, got %d", len(fields))
+	}
+	m.recordType = "msgarea"
+	m.recordEditIdx = 42
+	if fields := m.buildRecordFields(); fields != nil {
+		t.Error("out-of-range index should yield nil fields")
+	}
+}

--- a/internal/configeditor/model_test.go
+++ b/internal/configeditor/model_test.go
@@ -103,7 +103,7 @@ func TestExitConfirmFlow(t *testing.T) {
 
 	// Clean model quits immediately on Escape.
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEscape})
-	m = updated.(Model)
+	_ = updated.(Model) // type-assert only; m is not read afterwards
 	if cmd == nil {
 		t.Error("clean exit should return Quit")
 	}

--- a/internal/configeditor/model_test.go
+++ b/internal/configeditor/model_test.go
@@ -26,14 +26,22 @@ func newTUIModel(t *testing.T) Model {
 	return m
 }
 
+// asModel asserts that a tea.Model returned by Update is this package's
+// Model, failing the test instead of panicking on a mismatch.
+func asModel(t *testing.T, m tea.Model) Model {
+	t.Helper()
+	got, ok := m.(Model)
+	if !ok {
+		t.Fatalf("Update returned %T, want Model", m)
+	}
+	return got
+}
+
+// hit sends a key message and returns the updated Model.
 func hit(t *testing.T, m Model, msg tea.KeyMsg) Model {
 	t.Helper()
 	updated, _ := m.Update(msg)
-	got, ok := updated.(Model)
-	if !ok {
-		t.Fatalf("Update returned %T, want Model", updated)
-	}
-	return got
+	return asModel(t, updated)
 }
 
 func TestTopMenuNavigationAndSelect(t *testing.T) {
@@ -103,9 +111,12 @@ func TestExitConfirmFlow(t *testing.T) {
 
 	// Clean model quits immediately on Escape.
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEscape})
-	_ = updated.(Model) // type-assert only; m is not read afterwards
+	asModel(t, updated) // m is not read afterwards; assert the type only
 	if cmd == nil {
-		t.Error("clean exit should return Quit")
+		t.Fatal("clean exit should return Quit")
+	}
+	if msg := cmd(); msg != (tea.QuitMsg{}) {
+		t.Errorf("clean exit cmd returned %T, want tea.QuitMsg", msg)
 	}
 
 	// Dirty model prompts first; Escape on the dialog cancels back to top menu.
@@ -128,7 +139,7 @@ func TestExitConfirmFlow(t *testing.T) {
 func TestConfigEditorViewSmoke(t *testing.T) {
 	m := newTUIModel(t)
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 32})
-	m = updated.(Model)
+	m = asModel(t, updated)
 
 	// Prepare state for the record screens.
 	m.recordType = "msgarea"

--- a/internal/configeditor/model_test.go
+++ b/internal/configeditor/model_test.go
@@ -1,0 +1,152 @@
+package configeditor
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/conference"
+	"github.com/ViSiON-3/vision-3-bbs/internal/message"
+)
+
+// newTUIModel builds an editor Model over an empty temp config dir and seeds
+// it with a conference and message area so record screens have data.
+func newTUIModel(t *testing.T) Model {
+	t.Helper()
+	m, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	m.configs.Conferences = []conference.Conference{
+		{ID: 1, Position: 1, Tag: "LOCAL", Name: "Local"},
+	}
+	m.configs.MsgAreas = []message.MessageArea{
+		{ID: 1, Position: 1, Tag: "GENERAL", Name: "General", AreaType: "local", ConferenceID: 1},
+	}
+	return m
+}
+
+func hit(t *testing.T, m Model, msg tea.KeyMsg) Model {
+	t.Helper()
+	updated, _ := m.Update(msg)
+	got, ok := updated.(Model)
+	if !ok {
+		t.Fatalf("Update returned %T, want Model", updated)
+	}
+	return got
+}
+
+func TestTopMenuNavigationAndSelect(t *testing.T) {
+	m := newTUIModel(t)
+	if m.mode != modeTopMenu {
+		t.Fatalf("initial mode = %v, want topMenu", m.mode)
+	}
+
+	m = hit(t, m, tea.KeyMsg{Type: tea.KeyDown})
+	if m.topCursor != 1 {
+		t.Errorf("cursor = %d, want 1", m.topCursor)
+	}
+	m = hit(t, m, tea.KeyMsg{Type: tea.KeyEnd})
+	if m.topCursor != len(m.topItems)-1 {
+		t.Errorf("cursor = %d, want last", m.topCursor)
+	}
+	m = hit(t, m, tea.KeyMsg{Type: tea.KeyHome})
+	m = hit(t, m, tea.KeyMsg{Type: tea.KeyUp}) // clamped at 0
+	if m.topCursor != 0 {
+		t.Errorf("cursor = %d, want 0", m.topCursor)
+	}
+
+	// Enter on item 0 opens the system-config submenu.
+	m = hit(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeSysConfigMenu {
+		t.Fatalf("mode = %v, want sysConfigMenu", m.mode)
+	}
+
+	// Hotkey selection: "6" jumps straight to the protocols record list.
+	m.mode = modeTopMenu
+	m = hit(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("6")})
+	if m.mode != modeRecordList || m.recordType != "protocol" {
+		t.Errorf("mode/type = %v/%q, want recordList/protocol", m.mode, m.recordType)
+	}
+	// Escape returns to the top menu.
+	m = hit(t, m, tea.KeyMsg{Type: tea.KeyEscape})
+	if m.mode != modeTopMenu {
+		t.Errorf("mode = %v, want topMenu", m.mode)
+	}
+}
+
+func TestCategoryMenuToRecordEdit(t *testing.T) {
+	m := newTUIModel(t)
+
+	// Item 1: Areas and Conferences → category menu.
+	m.topCursor = 1
+	m = hit(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeCategoryMenu || len(m.catMenuItems) != 3 {
+		t.Fatalf("mode/items = %v/%d, want categoryMenu/3", m.mode, len(m.catMenuItems))
+	}
+
+	// Select "Message Areas" → record list of msgareas.
+	m = hit(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeRecordList || m.recordType != "msgarea" {
+		t.Fatalf("mode/type = %v/%q, want recordList/msgarea", m.mode, m.recordType)
+	}
+
+	// Enter opens the record editor with built fields.
+	m = hit(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeRecordEdit || len(m.recordFields) == 0 {
+		t.Fatalf("mode/fields = %v/%d, want recordEdit with fields", m.mode, len(m.recordFields))
+	}
+}
+
+func TestExitConfirmFlow(t *testing.T) {
+	m := newTUIModel(t)
+
+	// Clean model quits immediately on Escape.
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	m = updated.(Model)
+	if cmd == nil {
+		t.Error("clean exit should return Quit")
+	}
+
+	// Dirty model prompts first; Escape on the dialog cancels back to top menu.
+	m = newTUIModel(t)
+	m.dirty = true
+	m = hit(t, m, tea.KeyMsg{Type: tea.KeyEscape})
+	if m.mode != modeExitConfirm || !m.confirmYes {
+		t.Fatalf("mode/yes = %v/%v, want exitConfirm/true", m.mode, m.confirmYes)
+	}
+	m = hit(t, m, tea.KeyMsg{Type: tea.KeyLeft}) // toggle to No
+	if m.confirmYes {
+		t.Error("left/right should toggle confirmYes")
+	}
+	m = hit(t, m, tea.KeyMsg{Type: tea.KeyEscape})
+	if m.mode != modeTopMenu {
+		t.Errorf("mode = %v, want topMenu after cancel", m.mode)
+	}
+}
+
+func TestConfigEditorViewSmoke(t *testing.T) {
+	m := newTUIModel(t)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 32})
+	m = updated.(Model)
+
+	// Prepare state for the record screens.
+	m.recordType = "msgarea"
+	m.recordEditIdx = 0
+	m.recordFields = m.buildRecordFields()
+	m.sysFields = m.buildSysFields(0)
+	m.catMenuTitle = "Areas and Conferences"
+	m.catMenuItems = []categoryMenuItem{{Label: "Message Areas", RecordType: "msgarea"}}
+
+	modes := []editorMode{
+		modeTopMenu, modeCategoryMenu, modeSysConfigMenu, modeSysConfigEdit,
+		modeRecordList, modeRecordEdit, modeExitConfirm, modeDeleteConfirm, modeHelp,
+	}
+	for _, mode := range modes {
+		mm := m
+		mm.mode = mode
+		if out := mm.View(); out == "" {
+			t.Errorf("View() in mode %v returned empty output", mode)
+		}
+	}
+}

--- a/internal/menu/executor_displayfile_test.go
+++ b/internal/menu/executor_displayfile_test.go
@@ -56,12 +56,20 @@ func TestDisplayFile(t *testing.T) {
 	})
 
 	t.Run("CP437 mode writes raw bytes", func(t *testing.T) {
+		// Pipe codes are expanded in every mode; what CP437 mode guarantees
+		// is that the resulting bytes — including high CP437 bytes like
+		// 0xB1 (▒) — are written verbatim, with no UTF-8 translation.
+		raw := append([]byte("Raw |15Block "), 0xB1)
+		if err := os.WriteFile(filepath.Join(e.MenuSetPath, "ansi", "RAW.ANS"), raw, 0644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
 		ts := newTestSession("")
-		if err := e.displayFile(newTestTerminal(ts), "WELCOME.ANS", ansi.OutputModeCP437); err != nil {
+		if err := e.displayFile(newTestTerminal(ts), "RAW.ANS", ansi.OutputModeCP437); err != nil {
 			t.Fatalf("displayFile: %v", err)
 		}
-		if !strings.Contains(ts.output(), "Hello") {
-			t.Errorf("output missing content: %q", ts.output())
+		want := string(ansi.ReplacePipeCodes(raw))
+		if got := ts.output(); got != want {
+			t.Errorf("output = %q, want raw %q", got, want)
 		}
 	})
 

--- a/internal/menu/executor_displayfile_test.go
+++ b/internal/menu/executor_displayfile_test.go
@@ -1,0 +1,78 @@
+package menu
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+)
+
+// newDisplayExecutor builds an executor over a temp menu set with an ansi/ dir.
+func newDisplayExecutor(t *testing.T) *MenuExecutor {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "ansi"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	return &MenuExecutor{
+		MenuSetPath:    root,
+		RootConfigPath: root,
+		LoadedStrings:  config.StringsConfig{ExecFileLoadError: "Cannot load %s"},
+	}
+}
+
+func TestDisplayFile(t *testing.T) {
+	e := newDisplayExecutor(t)
+	content := "Hello |15World"
+	if err := os.WriteFile(filepath.Join(e.MenuSetPath, "ansi", "WELCOME.ANS"), []byte(content), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	t.Run("renders file with pipe codes translated", func(t *testing.T) {
+		ts := newTestSession("")
+		if err := e.displayFile(newTestTerminal(ts), "WELCOME.ANS", ansi.OutputModeAuto); err != nil {
+			t.Fatalf("displayFile: %v", err)
+		}
+		out := ts.output()
+		if !strings.Contains(out, "Hello") || !strings.Contains(out, "World") {
+			t.Errorf("output missing content: %q", out)
+		}
+		if strings.Contains(out, "|15") {
+			t.Errorf("pipe code not translated: %q", out)
+		}
+	})
+
+	t.Run("clearFirst prepends clear sequence", func(t *testing.T) {
+		ts := newTestSession("")
+		if err := e.displayFile(newTestTerminal(ts), "WELCOME.ANS", ansi.OutputModeAuto, true); err != nil {
+			t.Fatalf("displayFile: %v", err)
+		}
+		if !strings.HasPrefix(ts.output(), ansi.ClearScreen()) {
+			t.Errorf("output should start with clear sequence: %q", ts.output())
+		}
+	})
+
+	t.Run("CP437 mode writes raw bytes", func(t *testing.T) {
+		ts := newTestSession("")
+		if err := e.displayFile(newTestTerminal(ts), "WELCOME.ANS", ansi.OutputModeCP437); err != nil {
+			t.Fatalf("displayFile: %v", err)
+		}
+		if !strings.Contains(ts.output(), "Hello") {
+			t.Errorf("output missing content: %q", ts.output())
+		}
+	})
+
+	t.Run("missing file returns error and shows load-error string", func(t *testing.T) {
+		ts := newTestSession("")
+		err := e.displayFile(newTestTerminal(ts), "NOPE.ANS", ansi.OutputModeAuto)
+		if err == nil {
+			t.Fatal("missing file should return an error")
+		}
+		if !strings.Contains(ts.output(), "Cannot load NOPE.ANS") {
+			t.Errorf("user-facing error not written: %q", ts.output())
+		}
+	})
+}

--- a/internal/menu/executor_tokens_test.go
+++ b/internal/menu/executor_tokens_test.go
@@ -1,0 +1,143 @@
+package menu
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/conference"
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+// newConfMgr builds a ConferenceManager over a temp conferences.json.
+func newConfMgr(t *testing.T) *conference.ConferenceManager {
+	t.Helper()
+	dir := t.TempDir()
+	data := `[
+		{"id": 1, "position": 1, "tag": "LOCAL", "name": "Local Confs"},
+		{"id": 2, "position": 2, "tag": "FSXNET", "name": "fsxNet"}
+	]`
+	if err := os.WriteFile(filepath.Join(dir, "conferences.json"), []byte(data), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cm, err := conference.NewConferenceManager(dir)
+	if err != nil {
+		t.Fatalf("NewConferenceManager: %v", err)
+	}
+	return cm
+}
+
+func TestResolveCurrentAreaTokens(t *testing.T) {
+	e := &MenuExecutor{}
+
+	// Nil user: tag None, name falls back to the passed-in name or None.
+	tag, name := e.resolveCurrentAreaTokens(nil, "")
+	if tag != "None" || name != "None" {
+		t.Errorf("nil user = %q/%q, want None/None", tag, name)
+	}
+	tag, name = e.resolveCurrentAreaTokens(nil, "Lobby")
+	if tag != "None" || name != "Lobby" {
+		t.Errorf("nil user with name = %q/%q, want None/Lobby", tag, name)
+	}
+
+	// User with a tag but no MessageMgr: tag from user, name None.
+	u := &user.User{CurrentMessageAreaTag: "GENERAL"}
+	tag, name = e.resolveCurrentAreaTokens(u, "")
+	if tag != "GENERAL" || name != "None" {
+		t.Errorf("user tag = %q/%q, want GENERAL/None", tag, name)
+	}
+}
+
+func TestResolveCurrentFileAreaTokens(t *testing.T) {
+	e := &MenuExecutor{}
+	tag, name := e.resolveCurrentFileAreaTokens(nil)
+	if tag != "None" || name != "None" {
+		t.Errorf("nil user = %q/%q, want None/None", tag, name)
+	}
+	u := &user.User{CurrentFileAreaTag: "UTILS"}
+	tag, name = e.resolveCurrentFileAreaTokens(u)
+	if tag != "UTILS" || name != "None" {
+		t.Errorf("user tag = %q/%q, want UTILS/None", tag, name)
+	}
+}
+
+func TestResolveFileConferencePath_Defaults(t *testing.T) {
+	e := &MenuExecutor{}
+	if got := e.resolveFileConferencePath(nil); got != "Local > None" {
+		t.Errorf("nil user = %q, want Local > None", got)
+	}
+	// FileMgr nil: same default even with a user.
+	if got := e.resolveFileConferencePath(&user.User{CurrentFileAreaID: 3}); got != "Local > None" {
+		t.Errorf("nil FileMgr = %q, want Local > None", got)
+	}
+}
+
+func TestApplyCommonTemplateTokens_GuestDefaults(t *testing.T) {
+	e := &MenuExecutor{}
+	in := "user=|UH alias=|ALIAS lvl=|LEVEL node=|NODE cc=|CC ccn=|CCN fc=|FC fcn=|FCN"
+	got := string(e.applyCommonTemplateTokens([]byte(in), nil, 3))
+	want := "user=Guest alias=Guest lvl=0 node=3 cc=None ccn=None fc=None fcn=None"
+	if got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+func TestApplyCommonTemplateTokens_UserAndConferences(t *testing.T) {
+	e := &MenuExecutor{ConferenceMgr: newConfMgr(t)}
+	u := &user.User{
+		Handle:                  "Felonius",
+		AccessLevel:             250,
+		CurrentMsgConferenceID:  1,
+		CurrentFileConferenceID: 2,
+	}
+	in := "|HANDLE l|LEVEL cc=|CC ccn=|CCN fc=|FC fcn=|FCN"
+	got := string(e.applyCommonTemplateTokens([]byte(in), u, 1))
+	want := "Felonius l250 cc=LOCAL ccn=Local Confs fc=FSXNET fcn=fsxNet"
+	if got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+
+	// Explicit user tags win over conference-derived tags.
+	u.CurrentMsgConferenceTag = "MYTAG"
+	got = string(e.applyCommonTemplateTokens([]byte("|CC"), u, 1))
+	if got != "MYTAG" {
+		t.Errorf("|CC = %q, want MYTAG", got)
+	}
+}
+
+// TestApplyCommonTemplateTokens_PrefixCollisions verifies longer tokens are
+// substituted before their shorter prefixes (|CFAN vs |CFA, |CAN vs |CA).
+func TestApplyCommonTemplateTokens_PrefixCollisions(t *testing.T) {
+	e := &MenuExecutor{}
+	u := &user.User{
+		CurrentMessageAreaTag: "MSGTAG",
+		CurrentFileAreaTag:    "FILETAG",
+	}
+	got := string(e.applyCommonTemplateTokens([]byte("|CFAN;|CFA;|CAN;|CA"), u, 1))
+	// File area name unknown (None), file tag FILETAG, msg name None, msg tag MSGTAG.
+	want := "None;FILETAG;None;MSGTAG"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestApplyCommonTemplateTokens_NodeAndDate(t *testing.T) {
+	e := &MenuExecutor{}
+	got := string(e.applyCommonTemplateTokens([]byte("|NODE |DATE |TIME"), nil, 42))
+	parts := strings.SplitN(got, " ", 3)
+	if len(parts) != 3 {
+		t.Fatalf("unexpected output %q", got)
+	}
+	if parts[0] != strconv.Itoa(42) {
+		t.Errorf("|NODE = %q, want 42", parts[0])
+	}
+	// Date format is MM/DD/YY.
+	if len(parts[1]) != 8 || parts[1][2] != '/' || parts[1][5] != '/' {
+		t.Errorf("|DATE = %q, want MM/DD/YY", parts[1])
+	}
+	if !strings.HasSuffix(parts[2], "am") && !strings.HasSuffix(parts[2], "pm") {
+		t.Errorf("|TIME = %q, want h:mm am/pm", parts[2])
+	}
+}

--- a/internal/menu/loader_test.go
+++ b/internal/menu/loader_test.go
@@ -1,0 +1,95 @@
+package menu
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadMenu(t *testing.T) {
+	dir := t.TempDir()
+	mnu := `{"CLR": true, "PROMPT1": "Cmd: ", "FALLBACK": "MAIN"}`
+	if err := os.WriteFile(filepath.Join(dir, "MAIN.MNU"), []byte(mnu), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "BAD.MNU"), []byte("{nope"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	rec, err := LoadMenu("MAIN", dir)
+	if err != nil {
+		t.Fatalf("LoadMenu: %v", err)
+	}
+	if !rec.GetClrScrBefore() || rec.Prompt1 != "Cmd: " || rec.Fallback != "MAIN" {
+		t.Errorf("record = %+v", rec)
+	}
+
+	if _, err := LoadMenu("MISSING", dir); err == nil {
+		t.Error("missing menu should error")
+	}
+	if _, err := LoadMenu("BAD", dir); err == nil {
+		t.Error("malformed JSON should error")
+	}
+}
+
+func TestLoadCommandsFile(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `[
+		{"KEYS": "M", "CMD": "GOTO:MSG", "ACS": "s10", "HIDDEN": false},
+		{"KEYS": "G", "CMD": "LOGOFF", "ACS": "", "HIDDEN": true}
+	]`
+	if err := os.WriteFile(filepath.Join(dir, "MAIN.CFG"), []byte(cfg), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "EMPTY.CFG"), nil, 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "BAD.CFG"), []byte("nope"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cmds, err := LoadCommands("MAIN", dir)
+	if err != nil {
+		t.Fatalf("LoadCommands: %v", err)
+	}
+	if len(cmds) != 2 {
+		t.Fatalf("want 2 commands, got %d", len(cmds))
+	}
+	if cmds[0].Keys != "M" || cmds[0].Command != "GOTO:MSG" || cmds[0].ACS != "s10" {
+		t.Errorf("cmd[0] = %+v", cmds[0])
+	}
+	if !cmds[1].Hidden {
+		t.Error("cmd[1] should be hidden")
+	}
+
+	// Missing file: valid, no commands.
+	cmds, err = LoadCommands("NOPE", dir)
+	if err != nil || len(cmds) != 0 {
+		t.Errorf("missing cfg: cmds=%d err=%v, want 0/nil", len(cmds), err)
+	}
+	// Empty file: valid, no commands.
+	cmds, err = LoadCommands("EMPTY", dir)
+	if err != nil || len(cmds) != 0 {
+		t.Errorf("empty cfg: cmds=%d err=%v, want 0/nil", len(cmds), err)
+	}
+	// Malformed JSON: error.
+	if _, err := LoadCommands("BAD", dir); err == nil {
+		t.Error("malformed cfg should error")
+	}
+}
+
+func TestHasBarFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "bar"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "bar", "MAIN.BAR"), []byte("x"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if !HasBarFile("MAIN", dir) {
+		t.Error("MAIN.BAR should be detected")
+	}
+	if HasBarFile("OTHER", dir) {
+		t.Error("OTHER.BAR should not be detected")
+	}
+}

--- a/internal/menueditor/fileio_test.go
+++ b/internal/menueditor/fileio_test.go
@@ -1,0 +1,235 @@
+package menueditor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newMenuBase creates a menu base directory with mnu/ and cfg/ subdirs.
+func newMenuBase(t *testing.T) string {
+	t.Helper()
+	base := t.TempDir()
+	for _, d := range []string{"mnu", "cfg"} {
+		if err := os.MkdirAll(filepath.Join(base, d), 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	return base
+}
+
+func TestNormalizeMenuName(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"upper passthrough", "MAIN", "MAIN", false},
+		{"lowercase normalized", "main", "MAIN", false},
+		{"trims whitespace", "  main ", "MAIN", false},
+		{"underscore and digits", "MENU_2", "MENU_2", false},
+		{"max length", "ABCDEFGH", "ABCDEFGH", false},
+		{"too long", "ABCDEFGHI", "", true},
+		{"empty", "", "", true},
+		{"path traversal", "../MAIN", "", true},
+		{"slash", "A/B", "", true},
+		{"dot", "A.B", "", true},
+		{"space inside", "A B", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeMenuName(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("normalizeMenuName(%q) err = %v, wantErr %v", tt.in, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("normalizeMenuName(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSaveAndLoadMenuRoundTrip(t *testing.T) {
+	base := newMenuBase(t)
+	want := MenuData{
+		Title:    "Main Menu",
+		CLR:      true,
+		Prompt1:  "Cmd: ",
+		Fallback: "MAIN",
+		ACS:      "s10",
+		MesConf:  2,
+	}
+	if err := SaveMenu(base, "main", want); err != nil {
+		t.Fatalf("SaveMenu: %v", err)
+	}
+
+	menus, err := LoadMenus(base)
+	if err != nil {
+		t.Fatalf("LoadMenus: %v", err)
+	}
+	if len(menus) != 1 {
+		t.Fatalf("want 1 menu, got %d", len(menus))
+	}
+	if menus[0].Name != "MAIN" {
+		t.Errorf("name = %q, want MAIN", menus[0].Name)
+	}
+	if menus[0].Data != want {
+		t.Errorf("data = %+v, want %+v", menus[0].Data, want)
+	}
+
+	// No temp files should remain after the atomic write.
+	entries, err := os.ReadDir(filepath.Join(base, "mnu"))
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp") {
+			t.Errorf("leftover temp file: %s", e.Name())
+		}
+	}
+}
+
+func TestLoadMenus_SkipsNonMenuFiles(t *testing.T) {
+	base := newMenuBase(t)
+	if err := SaveMenu(base, "B", MenuData{Title: "B"}); err != nil {
+		t.Fatalf("SaveMenu: %v", err)
+	}
+	if err := SaveMenu(base, "A", MenuData{Title: "A"}); err != nil {
+		t.Fatalf("SaveMenu: %v", err)
+	}
+	// Non-.MNU file and a subdirectory must be skipped.
+	if err := os.WriteFile(filepath.Join(base, "mnu", "README.txt"), []byte("x"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(base, "mnu", "sub"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	menus, err := LoadMenus(base)
+	if err != nil {
+		t.Fatalf("LoadMenus: %v", err)
+	}
+	if len(menus) != 2 {
+		t.Fatalf("want 2 menus, got %d", len(menus))
+	}
+	// Sorted alphabetically.
+	if menus[0].Name != "A" || menus[1].Name != "B" {
+		t.Errorf("order = %s, %s; want A, B", menus[0].Name, menus[1].Name)
+	}
+}
+
+func TestLoadMenus_MissingDir(t *testing.T) {
+	if _, err := LoadMenus(filepath.Join(t.TempDir(), "nope")); err == nil {
+		t.Fatal("missing mnu dir should error")
+	}
+}
+
+func TestSaveAndLoadCommands(t *testing.T) {
+	base := newMenuBase(t)
+
+	// Missing .CFG returns an empty slice, not an error.
+	cmds, err := LoadCommands(base, "MAIN")
+	if err != nil {
+		t.Fatalf("LoadCommands missing: %v", err)
+	}
+	if len(cmds) != 0 {
+		t.Errorf("want 0 commands, got %d", len(cmds))
+	}
+
+	want := []CmdData{
+		{Keys: "M", Command: "GOTO:MSGMENU", ACS: "s10"},
+		{Keys: "G", Command: "LOGOFF", Hidden: true},
+	}
+	if err := SaveCommands(base, "main", want); err != nil {
+		t.Fatalf("SaveCommands: %v", err)
+	}
+	got, err := LoadCommands(base, "MAIN")
+	if err != nil {
+		t.Fatalf("LoadCommands: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("want %d commands, got %d", len(want), len(got))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("cmd[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+
+	// Empty .CFG file also yields an empty slice.
+	if err := os.WriteFile(filepath.Join(base, "cfg", "EMPTY.CFG"), nil, 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cmds, err = LoadCommands(base, "EMPTY")
+	if err != nil {
+		t.Fatalf("LoadCommands empty: %v", err)
+	}
+	if len(cmds) != 0 {
+		t.Errorf("want 0 commands from empty file, got %d", len(cmds))
+	}
+
+	// Invalid names are rejected.
+	if _, err := LoadCommands(base, "../etc"); err == nil {
+		t.Error("LoadCommands with traversal name should error")
+	}
+	if err := SaveCommands(base, "bad name", nil); err == nil {
+		t.Error("SaveCommands with invalid name should error")
+	}
+	if err := SaveMenu(base, "toolongname", MenuData{}); err == nil {
+		t.Error("SaveMenu with invalid name should error")
+	}
+}
+
+func TestCreateDeleteExists(t *testing.T) {
+	base := newMenuBase(t)
+
+	if MenuExists(base, "NEW") {
+		t.Fatal("NEW should not exist yet")
+	}
+	if err := CreateMenu(base, "new"); err != nil {
+		t.Fatalf("CreateMenu: %v", err)
+	}
+	if !MenuExists(base, "new") {
+		t.Error("MenuExists should be true after CreateMenu (case-insensitive)")
+	}
+
+	// CreateMenu seeds UsePrompt=true and Fallback=self.
+	menus, err := LoadMenus(base)
+	if err != nil {
+		t.Fatalf("LoadMenus: %v", err)
+	}
+	if len(menus) != 1 || !menus[0].Data.UsePrompt || menus[0].Data.Fallback != "NEW" {
+		t.Errorf("created menu = %+v; want UsePrompt=true, Fallback=NEW", menus[0])
+	}
+	// An empty .CFG is created alongside.
+	if _, err := os.Stat(filepath.Join(base, "cfg", "NEW.CFG")); err != nil {
+		t.Errorf("expected NEW.CFG to exist: %v", err)
+	}
+
+	if err := DeleteMenu(base, "NEW"); err != nil {
+		t.Fatalf("DeleteMenu: %v", err)
+	}
+	if MenuExists(base, "NEW") {
+		t.Error("NEW should be gone after DeleteMenu")
+	}
+	if _, err := os.Stat(filepath.Join(base, "cfg", "NEW.CFG")); !os.IsNotExist(err) {
+		t.Errorf("NEW.CFG should be removed, stat err = %v", err)
+	}
+
+	// Deleting a nonexistent menu is not an error.
+	if err := DeleteMenu(base, "GHOST"); err != nil {
+		t.Errorf("DeleteMenu(nonexistent) = %v, want nil", err)
+	}
+	// Invalid names.
+	if err := CreateMenu(base, "../X"); err == nil {
+		t.Error("CreateMenu with traversal name should error")
+	}
+	if err := DeleteMenu(base, "../X"); err == nil {
+		t.Error("DeleteMenu with traversal name should error")
+	}
+	if MenuExists(base, "../X") {
+		t.Error("MenuExists with invalid name should be false")
+	}
+}

--- a/internal/menueditor/harness_test.go
+++ b/internal/menueditor/harness_test.go
@@ -1,0 +1,47 @@
+package menueditor
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// newTestEditor builds a Model over a menu base seeded with menus ALPHA and BETA.
+func newTestEditor(t *testing.T) Model {
+	t.Helper()
+	base := newMenuBase(t)
+	for _, name := range []string{"ALPHA", "BETA"} {
+		if err := CreateMenu(base, name); err != nil {
+			t.Fatalf("CreateMenu(%s): %v", name, err)
+		}
+	}
+	m, err := New(base)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return m
+}
+
+// asModel asserts that a tea.Model returned by Update is this package's
+// Model, failing the test instead of panicking on a mismatch.
+func asModel(t *testing.T, m tea.Model) Model {
+	t.Helper()
+	got, ok := m.(Model)
+	if !ok {
+		t.Fatalf("Update returned %T, want Model", m)
+	}
+	return got
+}
+
+// press sends a key message and returns the updated Model.
+func press(t *testing.T, m Model, msg tea.KeyMsg) Model {
+	t.Helper()
+	updated, _ := m.Update(msg)
+	return asModel(t, updated)
+}
+
+// typeText sends s as a runes key message and returns the updated Model.
+func typeText(t *testing.T, m Model, s string) Model {
+	t.Helper()
+	return press(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)})
+}

--- a/internal/menueditor/model_test.go
+++ b/internal/menueditor/model_test.go
@@ -282,7 +282,7 @@ func TestExitFlow(t *testing.T) {
 	// Clean model: Escape quits immediately.
 	m := newTestEditor(t)
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEscape})
-	m = updated.(Model)
+	_ = updated.(Model) // type-assert only; m is not read afterwards
 	if cmd == nil {
 		t.Error("clean exit should return a Quit command")
 	}

--- a/internal/menueditor/model_test.go
+++ b/internal/menueditor/model_test.go
@@ -1,0 +1,335 @@
+package menueditor
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// newTestEditor builds a Model over a menu base seeded with menus ALPHA and BETA.
+func newTestEditor(t *testing.T) Model {
+	t.Helper()
+	base := newMenuBase(t)
+	for _, name := range []string{"ALPHA", "BETA"} {
+		if err := CreateMenu(base, name); err != nil {
+			t.Fatalf("CreateMenu(%s): %v", name, err)
+		}
+	}
+	m, err := New(base)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return m
+}
+
+// press sends a key message and returns the updated Model.
+func press(t *testing.T, m Model, msg tea.KeyMsg) Model {
+	t.Helper()
+	updated, _ := m.Update(msg)
+	got, ok := updated.(Model)
+	if !ok {
+		t.Fatalf("Update returned %T, want Model", updated)
+	}
+	return got
+}
+
+func typeText(t *testing.T, m Model, s string) Model {
+	t.Helper()
+	return press(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)})
+}
+
+func TestMenuListNavigation(t *testing.T) {
+	m := newTestEditor(t)
+	if m.mode != modeMenuList || m.menuCursor != 0 {
+		t.Fatalf("initial mode/cursor = %v/%d", m.mode, m.menuCursor)
+	}
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyDown})
+	if m.menuCursor != 1 {
+		t.Errorf("after down: cursor = %d, want 1", m.menuCursor)
+	}
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyDown}) // clamped at last
+	if m.menuCursor != 1 {
+		t.Errorf("down at end: cursor = %d, want 1", m.menuCursor)
+	}
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyHome})
+	if m.menuCursor != 0 {
+		t.Errorf("after home: cursor = %d, want 0", m.menuCursor)
+	}
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnd})
+	if m.menuCursor != 1 {
+		t.Errorf("after end: cursor = %d, want 1", m.menuCursor)
+	}
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyPgUp})
+	if m.menuCursor != 0 {
+		t.Errorf("after pgup: cursor = %d, want 0", m.menuCursor)
+	}
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyPgDown})
+	if m.menuCursor != 1 {
+		t.Errorf("after pgdown: cursor = %d, want 1 (clamped)", m.menuCursor)
+	}
+}
+
+func TestMenuEditFieldFlow(t *testing.T) {
+	m := newTestEditor(t)
+
+	// Enter opens the menu editor on ALPHA.
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeMenuEdit || m.menuEditIdx != 0 {
+		t.Fatalf("mode/idx = %v/%d, want menuEdit/0", m.mode, m.menuEditIdx)
+	}
+
+	// Edit the Title field (field 0).
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeMenuEditField {
+		t.Fatalf("mode = %v, want menuEditField", m.mode)
+	}
+	m = typeText(t, m, "Main Menu")
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeMenuEdit {
+		t.Fatalf("mode = %v, want menuEdit after apply", m.mode)
+	}
+	if got := m.menus[0].Data.Title; got != "Main Menu" {
+		t.Errorf("title = %q, want Main Menu", got)
+	}
+	if !m.dirtyMenus["ALPHA"] {
+		t.Error("ALPHA should be marked dirty")
+	}
+	if m.menuEditFld != 1 {
+		t.Errorf("field cursor = %d, want 1 (advanced)", m.menuEditFld)
+	}
+
+	// Field 1 is Clear Screen (Y/N): Enter toggles in place.
+	wasCLR := m.menus[0].Data.CLR
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeMenuEdit || m.menus[0].Data.CLR == wasCLR {
+		t.Errorf("Y/N toggle: mode = %v, CLR = %v (was %v)", m.mode, m.menus[0].Data.CLR, wasCLR)
+	}
+
+	// Escape saves the dirty menu to disk and returns to the list.
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEscape})
+	if m.mode != modeMenuList {
+		t.Fatalf("mode = %v, want menuList", m.mode)
+	}
+	if m.dirtyMenus["ALPHA"] {
+		t.Error("ALPHA should be clean after save-on-escape")
+	}
+	menus, err := LoadMenus(m.menuBase)
+	if err != nil {
+		t.Fatalf("LoadMenus: %v", err)
+	}
+	if menus[0].Data.Title != "Main Menu" {
+		t.Errorf("persisted title = %q, want Main Menu", menus[0].Data.Title)
+	}
+}
+
+func TestMenuEditFieldValidation(t *testing.T) {
+	m := newTestEditor(t)
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // edit ALPHA
+
+	// Navigate to "Force Hlp Lvl" (field index 9) and enter a non-number.
+	for m.menuEditFld < 9 {
+		m = press(t, m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeMenuEditField {
+		t.Fatalf("mode = %v, want menuEditField", m.mode)
+	}
+	m.textInput.SetValue("abc")
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeMenuEditField {
+		t.Errorf("invalid value should keep edit mode, got %v", m.mode)
+	}
+	if m.message == "" {
+		t.Error("expected an invalid-value flash message")
+	}
+	// Escape abandons the field edit.
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEscape})
+	if m.mode != modeMenuEdit {
+		t.Errorf("mode = %v, want menuEdit", m.mode)
+	}
+}
+
+func TestAddMenuDialog(t *testing.T) {
+	m := newTestEditor(t)
+
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyF5})
+	if m.mode != modeAddMenu {
+		t.Fatalf("mode = %v, want addMenu", m.mode)
+	}
+	m = typeText(t, m, "gamma")
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeMenuEdit {
+		t.Fatalf("mode = %v, want menuEdit after create", m.mode)
+	}
+	if !MenuExists(m.menuBase, "GAMMA") {
+		t.Error("GAMMA should exist on disk")
+	}
+	if m.menus[m.menuEditIdx].Name != "GAMMA" {
+		t.Errorf("editing %q, want GAMMA", m.menus[m.menuEditIdx].Name)
+	}
+
+	// Creating a duplicate is rejected with a message.
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyF5})
+	m = typeText(t, m, "GAMMA")
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeMenuList || m.message == "" {
+		t.Errorf("duplicate create: mode = %v, message = %q", m.mode, m.message)
+	}
+
+	// Invalid characters are rejected.
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyF5})
+	m = typeText(t, m, "BAD-NAME")
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeMenuList || m.message == "" {
+		t.Errorf("invalid create: mode = %v, message = %q", m.mode, m.message)
+	}
+}
+
+func TestDeleteMenuConfirm(t *testing.T) {
+	m := newTestEditor(t)
+
+	// F2 then N cancels.
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyF2})
+	if m.mode != modeDeleteMenuConfirm {
+		t.Fatalf("mode = %v, want deleteMenuConfirm", m.mode)
+	}
+	m = typeText(t, m, "n")
+	if m.mode != modeMenuList || len(m.menus) != 2 {
+		t.Fatalf("cancel delete: mode = %v, menus = %d", m.mode, len(m.menus))
+	}
+
+	// F2 then Y deletes ALPHA from disk and the list.
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyF2})
+	m = typeText(t, m, "y")
+	if len(m.menus) != 1 || m.menus[0].Name != "BETA" {
+		t.Fatalf("after delete: menus = %+v, want just BETA", m.menus)
+	}
+	if MenuExists(m.menuBase, "ALPHA") {
+		t.Error("ALPHA should be deleted from disk")
+	}
+}
+
+func TestCommandListAndEditFlow(t *testing.T) {
+	m := newTestEditor(t)
+
+	// F10 opens the (empty) command list for ALPHA.
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyF10})
+	if m.mode != modeCommandList || len(m.cmds) != 0 {
+		t.Fatalf("mode/cmds = %v/%d, want commandList/0", m.mode, len(m.cmds))
+	}
+
+	// F5 appends a new command and opens the editor.
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyF5})
+	if m.mode != modeCommandEdit || len(m.cmds) != 1 {
+		t.Fatalf("mode/cmds = %v/%d, want commandEdit/1", m.mode, len(m.cmds))
+	}
+
+	// Edit Keystroke(s) (field 1): value is uppercased on apply.
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyDown})
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeCommandEditField {
+		t.Fatalf("mode = %v, want commandEditField", m.mode)
+	}
+	m = typeText(t, m, "q")
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.cmds[0].Keys != "Q" {
+		t.Errorf("keys = %q, want Q (uppercased)", m.cmds[0].Keys)
+	}
+
+	// Hidden? (field 4) toggles Y/N in place.
+	for m.cmdEditFld < 4 {
+		m = press(t, m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if !m.cmds[0].Hidden {
+		t.Error("Hidden should toggle to true")
+	}
+
+	// Escape back to list, then Escape saves commands and returns to menu edit.
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEscape})
+	if m.mode != modeCommandList {
+		t.Fatalf("mode = %v, want commandList", m.mode)
+	}
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEscape})
+	if m.mode != modeMenuEdit {
+		t.Fatalf("mode = %v, want menuEdit", m.mode)
+	}
+	cmds, err := LoadCommands(m.menuBase, "ALPHA")
+	if err != nil {
+		t.Fatalf("LoadCommands: %v", err)
+	}
+	if len(cmds) != 1 || cmds[0].Keys != "Q" || !cmds[0].Hidden {
+		t.Errorf("persisted cmds = %+v", cmds)
+	}
+}
+
+func TestDeleteCommandConfirm(t *testing.T) {
+	m := newTestEditor(t)
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyF10}) // command list
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyF5})  // add
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEscape})
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyF2}) // delete highlighted
+	if m.mode != modeDeleteCmdConfirm {
+		t.Fatalf("mode = %v, want deleteCmdConfirm", m.mode)
+	}
+	m = typeText(t, m, "y")
+	if len(m.cmds) != 0 || m.mode != modeCommandList {
+		t.Errorf("after delete: cmds = %d, mode = %v", len(m.cmds), m.mode)
+	}
+}
+
+func TestExitFlow(t *testing.T) {
+	// Clean model: Escape quits immediately.
+	m := newTestEditor(t)
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	m = updated.(Model)
+	if cmd == nil {
+		t.Error("clean exit should return a Quit command")
+	}
+
+	// Dirty model: Escape opens the exit confirm; Enter (Yes) saves all and quits.
+	m = newTestEditor(t)
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // edit ALPHA
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // edit Title
+	m = typeText(t, m, "Dirty")
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEscape}) // saves + back to list (clean)
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})  // re-enter edit
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})  // edit Title again
+	m = typeText(t, m, "2")
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	m.mode = modeMenuList // exit from list with dirty state
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEscape})
+	if m.mode != modeExitConfirm || !m.confirmYes {
+		t.Fatalf("mode/confirmYes = %v/%v, want exitConfirm/true", m.mode, m.confirmYes)
+	}
+	updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	if cmd == nil {
+		t.Error("confirmed exit should return a Quit command")
+	}
+	if len(m.dirtyMenus) != 0 {
+		t.Errorf("dirtyMenus = %v, want empty after saveAll", m.dirtyMenus)
+	}
+}
+
+func TestViewSmokeAllModes(t *testing.T) {
+	m := newTestEditor(t)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = updated.(Model)
+
+	modes := []editorMode{
+		modeMenuList, modeMenuEdit, modeDeleteMenuConfirm, modeAddMenu,
+		modeCommandList, modeCommandEdit, modeExitConfirm, modeHelp,
+	}
+	for _, mode := range modes {
+		mm := m
+		mm.mode = mode
+		if mode == modeCommandList || mode == modeCommandEdit {
+			mm.cmds = []CmdData{{Keys: "Q", Command: "LOGOFF"}}
+		}
+		if out := mm.View(); out == "" {
+			t.Errorf("View() in mode %v returned empty output", mode)
+		}
+	}
+}

--- a/internal/menueditor/model_test.go
+++ b/internal/menueditor/model_test.go
@@ -6,38 +6,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// newTestEditor builds a Model over a menu base seeded with menus ALPHA and BETA.
-func newTestEditor(t *testing.T) Model {
-	t.Helper()
-	base := newMenuBase(t)
-	for _, name := range []string{"ALPHA", "BETA"} {
-		if err := CreateMenu(base, name); err != nil {
-			t.Fatalf("CreateMenu(%s): %v", name, err)
-		}
-	}
-	m, err := New(base)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-	return m
-}
-
-// press sends a key message and returns the updated Model.
-func press(t *testing.T, m Model, msg tea.KeyMsg) Model {
-	t.Helper()
-	updated, _ := m.Update(msg)
-	got, ok := updated.(Model)
-	if !ok {
-		t.Fatalf("Update returned %T, want Model", updated)
-	}
-	return got
-}
-
-func typeText(t *testing.T, m Model, s string) Model {
-	t.Helper()
-	return press(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)})
-}
-
 func TestMenuListNavigation(t *testing.T) {
 	m := newTestEditor(t)
 	if m.mode != modeMenuList || m.menuCursor != 0 {
@@ -282,7 +250,7 @@ func TestExitFlow(t *testing.T) {
 	// Clean model: Escape quits immediately.
 	m := newTestEditor(t)
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEscape})
-	_ = updated.(Model) // type-assert only; m is not read afterwards
+	asModel(t, updated) // m is not read afterwards; assert the type only
 	if cmd == nil {
 		t.Error("clean exit should return a Quit command")
 	}
@@ -304,32 +272,11 @@ func TestExitFlow(t *testing.T) {
 		t.Fatalf("mode/confirmYes = %v/%v, want exitConfirm/true", m.mode, m.confirmYes)
 	}
 	updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	m = updated.(Model)
+	m = asModel(t, updated)
 	if cmd == nil {
 		t.Error("confirmed exit should return a Quit command")
 	}
 	if len(m.dirtyMenus) != 0 {
 		t.Errorf("dirtyMenus = %v, want empty after saveAll", m.dirtyMenus)
-	}
-}
-
-func TestViewSmokeAllModes(t *testing.T) {
-	m := newTestEditor(t)
-	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
-	m = updated.(Model)
-
-	modes := []editorMode{
-		modeMenuList, modeMenuEdit, modeDeleteMenuConfirm, modeAddMenu,
-		modeCommandList, modeCommandEdit, modeExitConfirm, modeHelp,
-	}
-	for _, mode := range modes {
-		mm := m
-		mm.mode = mode
-		if mode == modeCommandList || mode == modeCommandEdit {
-			mm.cmds = []CmdData{{Keys: "Q", Command: "LOGOFF"}}
-		}
-		if out := mm.View(); out == "" {
-			t.Errorf("View() in mode %v returned empty output", mode)
-		}
 	}
 }

--- a/internal/menueditor/view_test.go
+++ b/internal/menueditor/view_test.go
@@ -1,0 +1,30 @@
+package menueditor
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// TestViewSmokeAllModes checks that View renders non-empty output in every
+// editor mode.
+func TestViewSmokeAllModes(t *testing.T) {
+	m := newTestEditor(t)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = asModel(t, updated)
+
+	modes := []editorMode{
+		modeMenuList, modeMenuEdit, modeDeleteMenuConfirm, modeAddMenu,
+		modeCommandList, modeCommandEdit, modeExitConfirm, modeHelp,
+	}
+	for _, mode := range modes {
+		mm := m
+		mm.mode = mode
+		if mode == modeCommandList || mode == modeCommandEdit {
+			mm.cmds = []CmdData{{Keys: "Q", Command: "LOGOFF"}}
+		}
+		if out := mm.View(); out == "" {
+			t.Errorf("View() in mode %v returned empty output", mode)
+		}
+	}
+}

--- a/internal/stringeditor/colors_test.go
+++ b/internal/stringeditor/colors_test.go
@@ -1,7 +1,11 @@
 package stringeditor
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
+// TestParseColorCodes covers pipe/dollar color code parsing into styled spans.
 func TestParseColorCodes(t *testing.T) {
 	tests := []struct {
 		name string
@@ -38,6 +42,7 @@ func TestParseColorCodes(t *testing.T) {
 	}
 }
 
+// TestDollarColorIndex covers the $-code letter to color index mapping.
 func TestDollarColorIndex(t *testing.T) {
 	tests := []struct {
 		ch   byte
@@ -54,6 +59,7 @@ func TestDollarColorIndex(t *testing.T) {
 	}
 }
 
+// TestPlainTextLength covers visible-length computation with codes stripped.
 func TestPlainTextLength(t *testing.T) {
 	tests := []struct {
 		name string
@@ -75,11 +81,16 @@ func TestPlainTextLength(t *testing.T) {
 	}
 }
 
+// TestRenderColorString_TruncatesWithOverflowMarker covers truncation to
+// maxWidth with the "»" overflow marker.
 func TestRenderColorString_TruncatesWithOverflowMarker(t *testing.T) {
 	// 10 visible chars, maxWidth 5: output visible content is 4 chars + "»".
 	out := RenderColorString("0123456789", 5)
 	if visualLen(out) != 5 {
 		t.Errorf("visible len = %d, want 5 (4 chars + overflow marker)", visualLen(out))
+	}
+	if !strings.Contains(out, "»") {
+		t.Errorf("truncated output missing overflow marker: %q", out)
 	}
 	// Fits: no marker.
 	out = RenderColorString("abc", 10)

--- a/internal/stringeditor/colors_test.go
+++ b/internal/stringeditor/colors_test.go
@@ -1,0 +1,89 @@
+package stringeditor
+
+import "testing"
+
+func TestParseColorCodes(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []styledSpan
+	}{
+		{"plain text single span", "hello", []styledSpan{{text: "hello", fg: dosColors[9]}}},
+		{"pipe fg splits spans", "a|04b", []styledSpan{
+			{text: "a", fg: dosColors[9]},
+			{text: "b", fg: dosColors[4]},
+		}},
+		{"pipe fg 15", "|15x", []styledSpan{{text: "x", fg: dosColors[15]}}},
+		{"background code", "|B1x", []styledSpan{{text: "x", fg: dosColors[9], bg: dosBgColors[1]}}},
+		{"CR becomes space", "a|CRb", []styledSpan{{text: "a b", fg: dosColors[9]}}},
+		{"CL is stripped", "a|CLb", []styledSpan{{text: "ab", fg: dosColors[9]}}},
+		{"dollar lowercase", "$rx", []styledSpan{{text: "x", fg: dosColors[4]}}},
+		{"dollar uppercase", "$Wx", []styledSpan{{text: "x", fg: dosColors[15]}}},
+		{"unknown dollar literal", "$zx", []styledSpan{{text: "$zx", fg: dosColors[9]}}},
+		{"unknown pipe literal", "|ZZx", []styledSpan{{text: "|ZZx", fg: dosColors[9]}}},
+		{"empty", "", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseColorCodes(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("spans = %+v, want %+v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("span[%d] = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDollarColorIndex(t *testing.T) {
+	tests := []struct {
+		ch   byte
+		want int
+	}{
+		{'a', 0}, {'b', 1}, {'g', 2}, {'c', 3}, {'r', 4}, {'p', 5}, {'y', 6}, {'w', 7},
+		{'A', 8}, {'B', 9}, {'G', 10}, {'C', 11}, {'R', 12}, {'P', 13}, {'Y', 14}, {'W', 15},
+		{'z', -1}, {'0', -1}, {' ', -1},
+	}
+	for _, tt := range tests {
+		if got := dollarColorIndex(tt.ch); got != tt.want {
+			t.Errorf("dollarColorIndex(%q) = %d, want %d", tt.ch, got, tt.want)
+		}
+	}
+}
+
+func TestPlainTextLength(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{"plain", "hello", 5},
+		{"pipe codes stripped", "|04red|15white", 8},
+		{"dollar codes stripped", "$rab$Wcd", 4},
+		{"CR counts as space", "a|CRb", 3},
+		{"empty", "", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PlainTextLength(tt.in); got != tt.want {
+				t.Errorf("PlainTextLength(%q) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderColorString_TruncatesWithOverflowMarker(t *testing.T) {
+	// 10 visible chars, maxWidth 5: output visible content is 4 chars + "»".
+	out := RenderColorString("0123456789", 5)
+	if visualLen(out) != 5 {
+		t.Errorf("visible len = %d, want 5 (4 chars + overflow marker)", visualLen(out))
+	}
+	// Fits: no marker.
+	out = RenderColorString("abc", 10)
+	if visualLen(out) != 3 {
+		t.Errorf("visible len = %d, want 3", visualLen(out))
+	}
+}

--- a/internal/stringeditor/fileio_test.go
+++ b/internal/stringeditor/fileio_test.go
@@ -1,0 +1,116 @@
+package stringeditor
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadStrings_MissingFileCreatesDefaults(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "strings.json")
+	got, err := LoadStrings(path)
+	if err != nil {
+		t.Fatalf("LoadStrings: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("expected non-empty defaults map")
+	}
+	// The file must now exist and be valid JSON.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("defaults file not created: %v", err)
+	}
+	var onDisk map[string]string
+	if err := json.Unmarshal(data, &onDisk); err != nil {
+		t.Fatalf("created file is not valid JSON: %v", err)
+	}
+	// No internal placeholder keys are persisted.
+	for k := range onDisk {
+		if strings.HasPrefix(k, "_") {
+			t.Errorf("placeholder key %q should not be persisted", k)
+		}
+	}
+}
+
+func TestLoadStrings_InvalidJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "strings.json")
+	if err := os.WriteFile(path, []byte("{broken"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := LoadStrings(path); err == nil {
+		t.Fatal("invalid JSON should return an error")
+	}
+}
+
+func TestSaveStrings_RoundTripSortedAndFiltered(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "strings.json")
+	in := map[string]string{
+		"zebra":     "last",
+		"alpha":     "first",
+		"_reserved": "must not persist",
+		"mid":       `has "quotes" and |07 codes`,
+	}
+	if err := SaveStrings(path, in); err != nil {
+		t.Fatalf("SaveStrings: %v", err)
+	}
+
+	got, err := LoadStrings(path)
+	if err != nil {
+		t.Fatalf("LoadStrings: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("want 3 keys (placeholder dropped), got %d: %v", len(got), got)
+	}
+	if _, ok := got["_reserved"]; ok {
+		t.Error("_reserved should have been filtered out")
+	}
+	if got["mid"] != in["mid"] {
+		t.Errorf("mid = %q, want %q", got["mid"], in["mid"])
+	}
+
+	// Keys are written in sorted order.
+	raw, _ := os.ReadFile(path)
+	ia := strings.Index(string(raw), `"alpha"`)
+	im := strings.Index(string(raw), `"mid"`)
+	iz := strings.Index(string(raw), `"zebra"`)
+	if ia < 0 || im < 0 || iz < 0 || !(ia < im && im < iz) {
+		t.Errorf("keys not sorted on disk: alpha@%d mid@%d zebra@%d", ia, im, iz)
+	}
+}
+
+func TestMarshalOrdered_Empty(t *testing.T) {
+	data, err := marshalOrdered(nil)
+	if err != nil {
+		t.Fatalf("marshalOrdered: %v", err)
+	}
+	var m map[string]string
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("empty output not valid JSON: %v (data=%q)", err, data)
+	}
+	if len(m) != 0 {
+		t.Errorf("want empty object, got %v", m)
+	}
+}
+
+func TestDefaultStrings_SkipsPlaceholders(t *testing.T) {
+	defaults := DefaultStrings()
+	if len(defaults) == 0 {
+		t.Fatal("expected non-empty defaults")
+	}
+	for k := range defaults {
+		if strings.HasPrefix(k, "_") {
+			t.Errorf("placeholder key %q should not be in defaults", k)
+		}
+	}
+	// Every non-placeholder metadata entry must have a default.
+	for _, e := range StringEntries() {
+		if strings.HasPrefix(e.Key, "_") {
+			continue
+		}
+		if _, ok := defaults[e.Key]; !ok {
+			t.Errorf("metadata key %q missing from defaults", e.Key)
+		}
+	}
+}

--- a/internal/stringeditor/fileio_test.go
+++ b/internal/stringeditor/fileio_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 )
 
+// TestLoadStrings_MissingFileCreatesDefaults checks that a missing file is
+// created with default strings and no placeholder keys.
 func TestLoadStrings_MissingFileCreatesDefaults(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "strings.json")
 	got, err := LoadStrings(path)
@@ -34,6 +36,7 @@ func TestLoadStrings_MissingFileCreatesDefaults(t *testing.T) {
 	}
 }
 
+// TestLoadStrings_InvalidJSON checks that malformed JSON returns an error.
 func TestLoadStrings_InvalidJSON(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "strings.json")
 	if err := os.WriteFile(path, []byte("{broken"), 0644); err != nil {
@@ -44,6 +47,8 @@ func TestLoadStrings_InvalidJSON(t *testing.T) {
 	}
 }
 
+// TestSaveStrings_RoundTripSortedAndFiltered checks the save/load round trip
+// filters placeholder keys and writes keys in sorted order.
 func TestSaveStrings_RoundTripSortedAndFiltered(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "strings.json")
 	in := map[string]string{
@@ -80,6 +85,7 @@ func TestSaveStrings_RoundTripSortedAndFiltered(t *testing.T) {
 	}
 }
 
+// TestMarshalOrdered_Empty checks that a nil map marshals to an empty object.
 func TestMarshalOrdered_Empty(t *testing.T) {
 	data, err := marshalOrdered(nil)
 	if err != nil {
@@ -94,6 +100,8 @@ func TestMarshalOrdered_Empty(t *testing.T) {
 	}
 }
 
+// TestDefaultStrings_SkipsPlaceholders checks defaults exclude placeholder
+// keys but cover every non-placeholder metadata entry.
 func TestDefaultStrings_SkipsPlaceholders(t *testing.T) {
 	defaults := DefaultStrings()
 	if len(defaults) == 0 {

--- a/internal/stringeditor/fileio_test.go
+++ b/internal/stringeditor/fileio_test.go
@@ -75,7 +75,7 @@ func TestSaveStrings_RoundTripSortedAndFiltered(t *testing.T) {
 	ia := strings.Index(string(raw), `"alpha"`)
 	im := strings.Index(string(raw), `"mid"`)
 	iz := strings.Index(string(raw), `"zebra"`)
-	if ia < 0 || im < 0 || iz < 0 || !(ia < im && im < iz) {
+	if ia < 0 || im < 0 || iz < 0 || ia >= im || im >= iz {
 		t.Errorf("keys not sorted on disk: alpha@%d mid@%d zebra@%d", ia, im, iz)
 	}
 }

--- a/internal/stringeditor/model_test.go
+++ b/internal/stringeditor/model_test.go
@@ -1,0 +1,204 @@
+package stringeditor
+
+import (
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// newTestModel builds a Model over a temp strings.json.
+func newTestModel(t *testing.T) Model {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "strings.json")
+	m, err := New(path, map[string]string{"defPrompt": "factory"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return m
+}
+
+// key sends a key message and returns the updated Model.
+func key(t *testing.T, m Model, msg tea.KeyMsg) Model {
+	t.Helper()
+	updated, _ := m.Update(msg)
+	got, ok := updated.(Model)
+	if !ok {
+		t.Fatalf("Update returned %T, want Model", updated)
+	}
+	return got
+}
+
+func TestModelNavigation(t *testing.T) {
+	m := newTestModel(t)
+	if m.cursor != 0 || m.page != 0 {
+		t.Fatalf("initial cursor/page = %d/%d, want 0/0", m.cursor, m.page)
+	}
+
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyDown})
+	if m.cursor != 1 {
+		t.Errorf("after down: cursor = %d, want 1", m.cursor)
+	}
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyUp})
+	if m.cursor != 0 {
+		t.Errorf("after up: cursor = %d, want 0", m.cursor)
+	}
+	// Up at top is a no-op.
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyUp})
+	if m.cursor != 0 {
+		t.Errorf("up at top: cursor = %d, want 0", m.cursor)
+	}
+
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyPgDown})
+	if m.page != 1 || m.cursor != itemsPerPage {
+		t.Errorf("after pgdown: page/cursor = %d/%d, want 1/%d", m.page, m.cursor, itemsPerPage)
+	}
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyPgUp})
+	if m.page != 0 || m.cursor != 0 {
+		t.Errorf("after pgup: page/cursor = %d/%d, want 0/0", m.page, m.cursor)
+	}
+
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyEnd})
+	if m.cursor != len(m.entries)-1 || m.page != m.numPages-1 {
+		t.Errorf("after end: cursor/page = %d/%d, want %d/%d",
+			m.cursor, m.page, len(m.entries)-1, m.numPages-1)
+	}
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyHome})
+	if m.cursor != 0 || m.page != 0 {
+		t.Errorf("after home: cursor/page = %d/%d, want 0/0", m.cursor, m.page)
+	}
+}
+
+func TestModelEditFlow(t *testing.T) {
+	m := newTestModel(t)
+	keyName := m.entries[0].Key
+
+	// Enter starts editing the first entry.
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeEdit || m.editKey != keyName {
+		t.Fatalf("mode/editKey = %v/%q, want edit/%q", m.mode, m.editKey, keyName)
+	}
+
+	// Type a value and confirm.
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("hi")})
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeNavigate {
+		t.Fatalf("mode = %v, want navigate", m.mode)
+	}
+	if m.values[keyName] != "hi" {
+		t.Errorf("value = %q, want hi", m.values[keyName])
+	}
+	if !m.dirty {
+		t.Error("model should be dirty after an edit")
+	}
+
+	// Escape cancels an edit without changing the value.
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("junk")})
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyEscape})
+	if m.values[keyName] != "hi" {
+		t.Errorf("cancelled edit changed value to %q", m.values[keyName])
+	}
+
+	// Typing a printable char in navigate mode starts an edit prefilled with it.
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	if m.mode != modeEdit || m.textInput.Value() != "x" {
+		t.Errorf("mode/prefill = %v/%q, want edit/x", m.mode, m.textInput.Value())
+	}
+}
+
+func TestModelAbortAndRevertConfirm(t *testing.T) {
+	m := newTestModel(t)
+	keyName := m.entries[0].Key
+
+	// Escape opens the abort dialog; N returns to navigation.
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyEscape})
+	if m.mode != modeAbortConfirm {
+		t.Fatalf("mode = %v, want abort confirm", m.mode)
+	}
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	if m.mode != modeNavigate {
+		t.Fatalf("mode = %v, want navigate after N", m.mode)
+	}
+
+	// Edit a value, then F3 + Y reverts it to the on-disk original.
+	orig := m.origValues[keyName]
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("changed")})
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyF3})
+	if m.mode != modeRevertConfirm {
+		t.Fatalf("mode = %v, want revert confirm", m.mode)
+	}
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	if m.values[keyName] != orig {
+		t.Errorf("value = %q, want reverted %q", m.values[keyName], orig)
+	}
+	if m.dirty {
+		t.Error("dirty should be false after reverting the only change")
+	}
+}
+
+func TestModelRestoreDefault(t *testing.T) {
+	m := newTestModel(t)
+
+	// Find the entry index for the key with a shipped default.
+	idx := -1
+	for i, e := range m.entries {
+		if e.Key == "defPrompt" {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		t.Fatal("defPrompt entry not found in metadata")
+	}
+	m.cursor = idx
+	m.page = idx / itemsPerPage
+
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyF4})
+	if m.mode != modeDefaultConfirm {
+		t.Fatalf("mode = %v, want default confirm", m.mode)
+	}
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	if m.values["defPrompt"] != "factory" {
+		t.Errorf("value = %q, want shipped default", m.values["defPrompt"])
+	}
+}
+
+func TestModelSearch(t *testing.T) {
+	m := newTestModel(t)
+
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/")})
+	if m.mode != modeSearch {
+		t.Fatalf("mode = %v, want search", m.mode)
+	}
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("pause")})
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.mode != modeNavigate {
+		t.Fatalf("mode = %v, want navigate after search", m.mode)
+	}
+	if m.entries[m.cursor].Key != "pauseString" {
+		t.Errorf("cursor on %q, want pauseString", m.entries[m.cursor].Key)
+	}
+	// Escape leaves search mode.
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/")})
+	m = key(t, m, tea.KeyMsg{Type: tea.KeyEscape})
+	if m.mode != modeNavigate {
+		t.Errorf("mode = %v, want navigate after escape", m.mode)
+	}
+}
+
+func TestModelViewSmoke(t *testing.T) {
+	m := newTestModel(t)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = updated.(Model)
+	if out := m.View(); out == "" {
+		t.Error("View() returned empty output")
+	}
+	// Dialog views render too.
+	m.mode = modeAbortConfirm
+	if out := m.View(); out == "" {
+		t.Error("View() in confirm mode returned empty output")
+	}
+}

--- a/internal/stringeditor/model_test.go
+++ b/internal/stringeditor/model_test.go
@@ -18,17 +18,25 @@ func newTestModel(t *testing.T) Model {
 	return m
 }
 
-// key sends a key message and returns the updated Model.
-func key(t *testing.T, m Model, msg tea.KeyMsg) Model {
+// asModel asserts that a tea.Model returned by Update is this package's
+// Model, failing the test instead of panicking on a mismatch.
+func asModel(t *testing.T, m tea.Model) Model {
 	t.Helper()
-	updated, _ := m.Update(msg)
-	got, ok := updated.(Model)
+	got, ok := m.(Model)
 	if !ok {
-		t.Fatalf("Update returned %T, want Model", updated)
+		t.Fatalf("Update returned %T, want Model", m)
 	}
 	return got
 }
 
+// key sends a key message and returns the updated Model.
+func key(t *testing.T, m Model, msg tea.KeyMsg) Model {
+	t.Helper()
+	updated, _ := m.Update(msg)
+	return asModel(t, updated)
+}
+
+// TestModelNavigation exercises cursor and page movement keys.
 func TestModelNavigation(t *testing.T) {
 	m := newTestModel(t)
 	if m.cursor != 0 || m.page != 0 {
@@ -69,6 +77,7 @@ func TestModelNavigation(t *testing.T) {
 	}
 }
 
+// TestModelEditFlow covers entering, confirming, and cancelling an edit.
 func TestModelEditFlow(t *testing.T) {
 	m := newTestModel(t)
 	keyName := m.entries[0].Key
@@ -107,6 +116,7 @@ func TestModelEditFlow(t *testing.T) {
 	}
 }
 
+// TestModelAbortAndRevertConfirm covers the abort and revert dialogs.
 func TestModelAbortAndRevertConfirm(t *testing.T) {
 	m := newTestModel(t)
 	keyName := m.entries[0].Key
@@ -139,6 +149,7 @@ func TestModelAbortAndRevertConfirm(t *testing.T) {
 	}
 }
 
+// TestModelRestoreDefault covers F4 restoring a key's shipped default value.
 func TestModelRestoreDefault(t *testing.T) {
 	m := newTestModel(t)
 
@@ -166,6 +177,7 @@ func TestModelRestoreDefault(t *testing.T) {
 	}
 }
 
+// TestModelSearch covers entering search mode, matching a key, and escaping.
 func TestModelSearch(t *testing.T) {
 	m := newTestModel(t)
 
@@ -189,10 +201,11 @@ func TestModelSearch(t *testing.T) {
 	}
 }
 
+// TestModelViewSmoke checks that View renders non-empty output.
 func TestModelViewSmoke(t *testing.T) {
 	m := newTestModel(t)
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
-	m = updated.(Model)
+	m = asModel(t, updated)
 	if out := m.View(); out == "" {
 		t.Error("View() returned empty output")
 	}

--- a/internal/util/format_test.go
+++ b/internal/util/format_test.go
@@ -1,0 +1,28 @@
+package util
+
+import "testing"
+
+func TestFormatFileSize(t *testing.T) {
+	tests := []struct {
+		name string
+		size int64
+		want string
+	}{
+		{"zero", 0, "0"},
+		{"bytes", 1023, "1023"},
+		{"exactly 1K", 1024, "1.0K"},
+		{"kilobytes", 1536, "1.5K"},
+		{"just under 1M", 1024*1024 - 1, "1024.0K"},
+		{"exactly 1M", 1024 * 1024, "1.0M"},
+		{"megabytes", 5 * 1024 * 1024, "5.0M"},
+		{"exactly 1G", 1024 * 1024 * 1024, "1.0G"},
+		{"gigabytes", int64(2.5 * 1024 * 1024 * 1024), "2.5G"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatFileSize(tt.size); got != tt.want {
+				t.Errorf("FormatFileSize(%d) = %q, want %q", tt.size, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Step 7 of the refactoring plan: raise the coverage floor. **Tests only — zero production changes** (13 new test files, 2,059 lines).

| Package | Before | After |
|---|---|---|
| internal/util | 0% | **100%** |
| internal/conference | 0% | **98.9%** |
| internal/stringeditor | 0% | **79.5%** |
| internal/menueditor | 0% | **73.5%** |
| internal/configeditor | 5.5% | **26.6%** |
| internal/menu | 7.2% | 7.8% (targeted seams: loader, template tokens, displayFile) |

Highlights: path-traversal cases for menu-name normalization, atomic-write leftover-file checks, a generic Get→Set→Get idempotence sweep across all 17 configeditor screens, and TUI characterization flows for menueditor/stringeditor/configeditor. No latent bugs surfaced — all characterized behavior matched the implementations.

## Testing
Full suite: **1834 tests pass** in 55 packages (was 1692); `-race` clean on all six touched packages; gofmt/vet clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added conference manager tests covering missing/empty files, invalid JSON, null/duplicate skipping, position sorting, and deterministic position migration.
  * Added config editor unit tests for CSV parsing, door/environment handling, argument join/split, cursor utilities, record/system field idempotence, and editor UI-flow state transitions.
  * Added menu and menu editor tests for menu/command loading, display-file rendering, token/template substitution, persistence, and interactive edit/confirm flows.
  * Added string editor and utility tests for color parsing/rendering, JSON defaults/round-trips, model navigation/edit/search flows, and file-size formatting thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->