### PR TITLE
chore: errcheck burn-down 1092 → 0 (+ staticcheck 93 → 16)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
       exclude-functions:
         - github.com/ViSiON-3/vision-3-bbs/internal/terminalio.WriteProcessedBytes
         - github.com/ViSiON-3/vision-3-bbs/internal/terminalio.WriteString
+        - github.com/ViSiON-3/vision-3-bbs/internal/terminalio.WriteStringCP437
   exclusions:
     generated: lax
     paths:

--- a/cmd/ansitest/main.go
+++ b/cmd/ansitest/main.go
@@ -38,31 +38,31 @@ var cp437ToAscii = map[byte]string{
 
 // ANSI Test Server handler
 func handleAnsiTestSession(session ssh.Session) {
-	defer session.Close()
+	defer func() { _ = session.Close() }() // best-effort teardown
 	ptyReq, winCh, isPty := session.Pty()
 	if !isPty {
-		fmt.Fprintln(session, "No PTY requested. This test requires a terminal.")
+		_, _ = fmt.Fprintln(session, "No PTY requested. This test requires a terminal.")
 		return
 	}
 
 	term := terminal.NewTerminal(session, "TEST> ")
-	term.SetSize(ptyReq.Window.Width, ptyReq.Window.Height)
+	_ = term.SetSize(ptyReq.Window.Width, ptyReq.Window.Height) // best-effort display
 
 	go func() {
 		for win := range winCh {
-			term.SetSize(win.Width, win.Height)
+			_ = term.SetSize(win.Width, win.Height) // best-effort display
 		}
 	}()
 
-	fmt.Fprintln(session, "ANSI CP437 Character Display Test Suite")
-	fmt.Fprintln(session, "Terminal type:", ptyReq.Term)
-	fmt.Fprintln(session, "Size:", ptyReq.Window.Width, "x", ptyReq.Window.Height)
-	fmt.Fprintln(session)
-	fmt.Fprintln(session, "Type 'test' to run all display tests")
-	fmt.Fprintln(session, "Type 'test1' through 'test7' to run individual tests")
-	fmt.Fprintln(session, "Type 'file' to display a sample .ANS file with different methods")
-	fmt.Fprintln(session, "Type 'terminal' to print terminal information")
-	fmt.Fprintln(session, "Type 'exit' to quit")
+	_, _ = fmt.Fprintln(session, "ANSI CP437 Character Display Test Suite")
+	_, _ = fmt.Fprintln(session, "Terminal type:", ptyReq.Term)
+	_, _ = fmt.Fprintln(session, "Size:", ptyReq.Window.Width, "x", ptyReq.Window.Height)
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session, "Type 'test' to run all display tests")
+	_, _ = fmt.Fprintln(session, "Type 'test1' through 'test7' to run individual tests")
+	_, _ = fmt.Fprintln(session, "Type 'file' to display a sample .ANS file with different methods")
+	_, _ = fmt.Fprintln(session, "Type 'terminal' to print terminal information")
+	_, _ = fmt.Fprintln(session, "Type 'exit' to quit")
 
 	for {
 		line, err := term.ReadLine()
@@ -72,7 +72,7 @@ func handleAnsiTestSession(session ssh.Session) {
 
 		switch line {
 		case "exit", "quit":
-			fmt.Fprintln(session, "Goodbye!")
+			_, _ = fmt.Fprintln(session, "Goodbye!")
 			return
 		case "test":
 			runAllTests(session)
@@ -95,16 +95,16 @@ func handleAnsiTestSession(session ssh.Session) {
 		case "terminal":
 			printTerminalInfo(session)
 		default:
-			fmt.Fprintln(session, "Unknown command:", line)
+			_, _ = fmt.Fprintln(session, "Unknown command:", line)
 		}
 	}
 }
 
 // --- Test Functions (Moved from cmd/vision3/main.go) ---
 func runAllTests(session ssh.Session) {
-	fmt.Fprintln(session, "\x1B[2J\x1B[H") // Clear screen and home cursor
-	fmt.Fprintln(session, "Running all CP437 character display tests...")
-	fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session, "\x1B[2J\x1B[H") // Clear screen and home cursor
+	_, _ = fmt.Fprintln(session, "Running all CP437 character display tests...")
+	_, _ = fmt.Fprintln(session)
 
 	testRawBytes(session)
 	time.Sleep(500 * time.Millisecond)
@@ -120,186 +120,186 @@ func runAllTests(session ssh.Session) {
 	time.Sleep(500 * time.Millisecond)
 	testByteByByte(session)
 
-	fmt.Fprintln(session)
-	fmt.Fprintln(session, "All tests complete. Look for any method that displays the characters correctly.")
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session, "All tests complete. Look for any method that displays the characters correctly.")
 }
 
 func testRawBytes(session ssh.Session) {
-	fmt.Fprintln(session, "\x1B[1;37m=== Test 1: Raw CP437 Bytes ===\x1B[0m")
-	fmt.Fprintln(session, "Sending the raw CP437 bytes directly...")
-	fmt.Fprintln(session)
-	fmt.Fprint(session, "Raw CP437:  ")
-	session.Write(testChars)
-	fmt.Fprintln(session)
-	fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session, "\x1B[1;37m=== Test 1: Raw CP437 Bytes ===\x1B[0m")
+	_, _ = fmt.Fprintln(session, "Sending the raw CP437 bytes directly...")
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprint(session, "Raw CP437:  ")
+	_, _ = session.Write(testChars)
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session)
 }
 
 func testUnicodeEscapes(session ssh.Session) {
-	fmt.Fprintln(session, "\x1B[1;37m=== Test 2: Unicode Characters ===\x1B[0m")
-	fmt.Fprintln(session, "Using Go string literals with embedded Unicode characters...")
-	fmt.Fprintln(session)
-	fmt.Fprint(session, "Unicode:    ")
-	fmt.Fprint(session, "│─┌┐└┘├┤┬┴┼░▒▓█ßþ")
-	fmt.Fprintln(session)
-	fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session, "\x1B[1;37m=== Test 2: Unicode Characters ===\x1B[0m")
+	_, _ = fmt.Fprintln(session, "Using Go string literals with embedded Unicode characters...")
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprint(session, "Unicode:    ")
+	_, _ = fmt.Fprint(session, "│─┌┐└┘├┤┬┴┼░▒▓█ßþ")
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session)
 }
 
 func testUTF8Encoding(session ssh.Session) {
-	fmt.Fprintln(session, "\x1B[1;37m=== Test 3: CP437 Converted to UTF-8 ===\x1B[0m")
-	fmt.Fprintln(session, "Converting each CP437 character to its Unicode equivalent (using internal/ansi map)...")
-	fmt.Fprintln(session)
-	fmt.Fprint(session, "UTF-8:      ")
+	_, _ = fmt.Fprintln(session, "\x1B[1;37m=== Test 3: CP437 Converted to UTF-8 ===\x1B[0m")
+	_, _ = fmt.Fprintln(session, "Converting each CP437 character to its Unicode equivalent (using internal/ansi map)...")
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprint(session, "UTF-8:      ")
 	w := bufio.NewWriter(session)
 	for _, b := range testChars {
 		// Use the exported map from the ansi package
 		r := ansi.Cp437ToUnicode[b]
-		w.WriteRune(r)
+		_, _ = w.WriteRune(r) // best-effort display
 	}
-	w.Flush()
-	fmt.Fprintln(session)
-	fmt.Fprintln(session)
+	_ = w.Flush() // best-effort display
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session)
 }
 
 func testVT100LineDrawing(session ssh.Session) {
-	fmt.Fprintln(session, "\x1B[1;37m=== Test 4: VT100 Line Drawing Mode ===\x1B[0m")
-	fmt.Fprintln(session, "Using VT100/xterm line drawing character set...")
-	fmt.Fprintln(session)
-	fmt.Fprint(session, "VT100:      ")
+	_, _ = fmt.Fprintln(session, "\x1B[1;37m=== Test 4: VT100 Line Drawing Mode ===\x1B[0m")
+	_, _ = fmt.Fprintln(session, "Using VT100/xterm line drawing character set...")
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprint(session, "VT100:      ")
 	for _, b := range testChars {
 		if vt100Char, ok := cp437ToVT100[b]; ok {
-			fmt.Fprintf(session, "\x1B(0%c\x1B(B", vt100Char)
+			_, _ = fmt.Fprintf(session, "\x1B(0%c\x1B(B", vt100Char)
 		} else {
 			if fallback, ok := cp437ToAscii[b]; ok {
-				fmt.Fprint(session, fallback)
+				_, _ = fmt.Fprint(session, fallback)
 			} else {
-				fmt.Fprint(session, "?")
+				_, _ = fmt.Fprint(session, "?")
 			}
 		}
 	}
-	fmt.Fprintln(session)
-	fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session)
 }
 
 func testASCIIFallbacks(session ssh.Session) {
-	fmt.Fprintln(session, "\x1B[1;37m=== Test 5: ASCII Fallbacks ===\x1B[0m")
-	fmt.Fprintln(session, "Using pure ASCII approximations for CP437 characters...")
-	fmt.Fprintln(session)
-	fmt.Fprint(session, "ASCII:      ")
+	_, _ = fmt.Fprintln(session, "\x1B[1;37m=== Test 5: ASCII Fallbacks ===\x1B[0m")
+	_, _ = fmt.Fprintln(session, "Using pure ASCII approximations for CP437 characters...")
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprint(session, "ASCII:      ")
 	for _, b := range testChars {
 		if fallback, ok := cp437ToAscii[b]; ok {
-			fmt.Fprint(session, fallback)
+			_, _ = fmt.Fprint(session, fallback)
 		} else {
-			fmt.Fprint(session, "?")
+			_, _ = fmt.Fprint(session, "?")
 		}
 	}
-	fmt.Fprintln(session)
-	fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session)
 }
 
 func testCharacterSetSwitching(session ssh.Session) {
-	fmt.Fprintln(session, "\x1B[1;37m=== Test 6: Character Set Switching ===\x1B[0m")
-	fmt.Fprintln(session, "Trying different terminal character set switching sequences...")
-	fmt.Fprintln(session)
-	session.Write([]byte("ISO 8859-1: \x1B%@"))
-	session.Write(testChars)
-	session.Write([]byte("\x1B%G\n"))
-	fmt.Fprintln(session)
-	fmt.Fprint(session, "DEC Special: ")
+	_, _ = fmt.Fprintln(session, "\x1B[1;37m=== Test 6: Character Set Switching ===\x1B[0m")
+	_, _ = fmt.Fprintln(session, "Trying different terminal character set switching sequences...")
+	_, _ = fmt.Fprintln(session)
+	_, _ = session.Write([]byte("ISO 8859-1: \x1B%@"))
+	_, _ = session.Write(testChars)
+	_, _ = session.Write([]byte("\x1B%G\n"))
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprint(session, "DEC Special: ")
 	for _, b := range testChars {
 		if vt100Char, ok := cp437ToVT100[b]; ok {
-			fmt.Fprintf(session, "\x1B(0%c", vt100Char)
+			_, _ = fmt.Fprintf(session, "\x1B(0%c", vt100Char)
 		} else {
-			fmt.Fprint(session, "?")
+			_, _ = fmt.Fprint(session, "?")
 		}
 	}
-	fmt.Fprintln(session, "\x1B(B")
-	fmt.Fprintln(session)
-	session.Write([]byte("UTF-8:      \x1B%G"))
+	_, _ = fmt.Fprintln(session, "\x1B(B")
+	_, _ = fmt.Fprintln(session)
+	_, _ = session.Write([]byte("UTF-8:      \x1B%G"))
 	w := bufio.NewWriter(session)
 	for _, b := range testChars {
 		r := ansi.Cp437ToUnicode[b]
-		w.WriteRune(r)
+		_, _ = w.WriteRune(r) // best-effort display
 	}
-	w.Flush()
-	fmt.Fprintln(session)
-	fmt.Fprintln(session)
+	_ = w.Flush() // best-effort display
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session)
 }
 
 func testByteByByte(session ssh.Session) {
-	fmt.Fprintln(session, "\x1B[1;37m=== Test 7: Byte-by-Byte Testing ===\x1B[0m")
-	fmt.Fprintln(session, "Testing each character individually with different methods...")
-	fmt.Fprintln(session)
-	fmt.Fprintln(session, "CP437 Byte | Raw | UTF-8 | VT100 | ASCII")
-	fmt.Fprintln(session, "---------------------------------------")
+	_, _ = fmt.Fprintln(session, "\x1B[1;37m=== Test 7: Byte-by-Byte Testing ===\x1B[0m")
+	_, _ = fmt.Fprintln(session, "Testing each character individually with different methods...")
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session, "CP437 Byte | Raw | UTF-8 | VT100 | ASCII")
+	_, _ = fmt.Fprintln(session, "---------------------------------------")
 	w := bufio.NewWriter(session)
 	for _, b := range testChars {
-		fmt.Fprintf(w, "  0x%02X    |  ", b)
-		w.WriteByte(b)
-		fmt.Fprint(w, "  |  ")
+		_, _ = fmt.Fprintf(w, "  0x%02X    |  ", b)
+		_ = w.WriteByte(b) // best-effort display
+		_, _ = fmt.Fprint(w, "  |  ")
 		r := ansi.Cp437ToUnicode[b]
-		w.WriteRune(r)
-		fmt.Fprint(w, "  |  ")
+		_, _ = w.WriteRune(r) // best-effort display
+		_, _ = fmt.Fprint(w, "  |  ")
 		if vt100Char, ok := cp437ToVT100[b]; ok {
-			fmt.Fprintf(w, "\x1B(0%c\x1B(B", vt100Char)
+			_, _ = fmt.Fprintf(w, "\x1B(0%c\x1B(B", vt100Char)
 		} else {
-			fmt.Fprint(w, " ")
+			_, _ = fmt.Fprint(w, " ")
 		}
-		fmt.Fprint(w, "  |  ")
+		_, _ = fmt.Fprint(w, "  |  ")
 		if fallback, ok := cp437ToAscii[b]; ok {
-			fmt.Fprint(w, fallback)
+			_, _ = fmt.Fprint(w, fallback)
 		} else {
-			fmt.Fprint(w, "?")
+			_, _ = fmt.Fprint(w, "?")
 		}
-		fmt.Fprintln(w)
+		_, _ = fmt.Fprintln(w)
 	}
-	w.Flush()
-	fmt.Fprintln(session)
+	_ = w.Flush() // best-effort display
+	_, _ = fmt.Fprintln(session)
 }
 
 func testANSFile(session ssh.Session) {
-	fmt.Fprintln(session, "\x1B[2J\x1B[H")
-	fmt.Fprintln(session, "\x1B[1;37m=== Testing .ANS File Display Methods ===\x1B[0m")
+	_, _ = fmt.Fprintln(session, "\x1B[2J\x1B[H")
+	_, _ = fmt.Fprintln(session, "\x1B[1;37m=== Testing .ANS File Display Methods ===\x1B[0m")
 	// Assumes sample.ans is in a relative 'assets' dir; adjust if needed
 	filename := filepath.Join("..", "assets", "sample.ans") // Adjust path relative to cmd/ansitest
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
-		fmt.Fprintln(session, "Sample ANSI file not found at:", filename)
-		fmt.Fprintln(session, "Ensure sample.ans exists in the assets directory relative to the project root.")
+		_, _ = fmt.Fprintln(session, "Sample ANSI file not found at:", filename)
+		_, _ = fmt.Fprintln(session, "Ensure sample.ans exists in the assets directory relative to the project root.")
 		return
 	}
 	data, err := os.ReadFile(filename)
 	if err != nil {
-		fmt.Fprintln(session, "Error reading sample file:", err)
+		_, _ = fmt.Fprintln(session, "Error reading sample file:", err)
 		return
 	}
 	term := terminal.NewTerminal(session, "")
 
-	fmt.Fprintln(session, "Press Enter to see the file displayed with raw bytes...")
-	term.ReadLine()
-	fmt.Fprintln(session, "\x1B[2J\x1B[H\x1B[1;37m--- Raw Bytes Method --- \x1B[0m")
-	session.Write(data)
-	fmt.Fprintln(session)
-	fmt.Fprintln(session, "Press Enter to continue...")
-	term.ReadLine()
+	_, _ = fmt.Fprintln(session, "Press Enter to see the file displayed with raw bytes...")
+	_, _ = term.ReadLine() // wait for Enter; input discarded
+	_, _ = fmt.Fprintln(session, "\x1B[2J\x1B[H\x1B[1;37m--- Raw Bytes Method --- \x1B[0m")
+	_, _ = session.Write(data)
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session, "Press Enter to continue...")
+	_, _ = term.ReadLine() // wait for Enter; input discarded
 
-	fmt.Fprintln(session, "\x1B[2J\x1B[H\x1B[1;37m--- UTF-8 Conversion Method --- \x1B[0m")
+	_, _ = fmt.Fprintln(session, "\x1B[2J\x1B[H\x1B[1;37m--- UTF-8 Conversion Method --- \x1B[0m")
 	decoder := charmap.CodePage437.NewDecoder()
 	utf8Data, _ := decoder.Bytes(data)
-	session.Write(utf8Data)
-	fmt.Fprintln(session)
-	fmt.Fprintln(session, "Press Enter to continue...")
-	term.ReadLine()
+	_, _ = session.Write(utf8Data)
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session, "Press Enter to continue...")
+	_, _ = term.ReadLine() // wait for Enter; input discarded
 
-	fmt.Fprintln(session, "\x1B[2J\x1B[H\x1B[1;37m--- VT100 Line Drawing Method --- \x1B[0m")
+	_, _ = fmt.Fprintln(session, "\x1B[2J\x1B[H\x1B[1;37m--- VT100 Line Drawing Method --- \x1B[0m")
 	displayWithVT100(session, data)
-	fmt.Fprintln(session)
-	fmt.Fprintln(session, "Press Enter to continue...")
-	term.ReadLine()
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session, "Press Enter to continue...")
+	_, _ = term.ReadLine() // wait for Enter; input discarded
 
-	fmt.Fprintln(session, "\x1B[2J\x1B[H\x1B[1;37m--- ASCII Fallbacks Method --- \x1B[0m")
+	_, _ = fmt.Fprintln(session, "\x1B[2J\x1B[H\x1B[1;37m--- ASCII Fallbacks Method --- \x1B[0m")
 	displayWithAscii(session, data)
-	fmt.Fprintln(session)
-	fmt.Fprintln(session, "Press Enter to return to the main menu...")
-	term.ReadLine()
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session, "Press Enter to return to the main menu...")
+	_, _ = term.ReadLine() // wait for Enter; input discarded
 }
 
 func displayWithVT100(session ssh.Session, data []byte) {
@@ -307,26 +307,26 @@ func displayWithVT100(session ssh.Session, data []byte) {
 	for i := 0; i < len(data); i++ {
 		b := data[i]
 		if inEscape {
-			session.Write([]byte{b})
+			_, _ = session.Write([]byte{b})
 			if (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') {
 				inEscape = false
 			}
 			continue
 		}
 		if b == 0x1B {
-			session.Write([]byte{b})
+			_, _ = session.Write([]byte{b})
 			inEscape = true
 			continue
 		}
 		if b < 128 {
-			session.Write([]byte{b})
+			_, _ = session.Write([]byte{b})
 		} else if vt100Char, ok := cp437ToVT100[b]; ok {
-			fmt.Fprintf(session, "\x1B(0%c\x1B(B", vt100Char)
+			_, _ = fmt.Fprintf(session, "\x1B(0%c\x1B(B", vt100Char)
 		} else {
 			if fallback, ok := cp437ToAscii[b]; ok {
-				fmt.Fprint(session, fallback)
+				_, _ = fmt.Fprint(session, fallback)
 			} else {
-				session.Write([]byte{b}) // Pass through unknown bytes
+				_, _ = session.Write([]byte{b}) // Pass through unknown bytes
 			}
 		}
 	}
@@ -337,60 +337,60 @@ func displayWithAscii(session ssh.Session, data []byte) {
 	for i := 0; i < len(data); i++ {
 		b := data[i]
 		if inEscape {
-			session.Write([]byte{b})
+			_, _ = session.Write([]byte{b})
 			if (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') {
 				inEscape = false
 			}
 			continue
 		}
 		if b == 0x1B {
-			session.Write([]byte{b})
+			_, _ = session.Write([]byte{b})
 			inEscape = true
 			continue
 		}
 		if b < 128 {
-			session.Write([]byte{b})
+			_, _ = session.Write([]byte{b})
 		} else {
 			if fallback, ok := cp437ToAscii[b]; ok {
-				fmt.Fprint(session, fallback)
+				_, _ = fmt.Fprint(session, fallback)
 			} else {
-				fmt.Fprint(session, "?")
+				_, _ = fmt.Fprint(session, "?")
 			}
 		}
 	}
 }
 
 func printTerminalInfo(session ssh.Session) {
-	fmt.Fprintln(session, "\x1B[2J\x1B[H")
-	fmt.Fprintln(session, "\x1B[1;37m=== Terminal Information ===\x1B[0m")
+	_, _ = fmt.Fprintln(session, "\x1B[2J\x1B[H")
+	_, _ = fmt.Fprintln(session, "\x1B[1;37m=== Terminal Information ===\x1B[0m")
 	ptyReq, _, isPty := session.Pty()
 	if !isPty {
-		fmt.Fprintln(session, "No PTY requested. Terminal information unavailable.")
+		_, _ = fmt.Fprintln(session, "No PTY requested. Terminal information unavailable.")
 		return
 	}
-	fmt.Fprintln(session, "Terminal Type:", ptyReq.Term)
-	fmt.Fprintln(session, "Window Size:", ptyReq.Window.Width, "x", ptyReq.Window.Height)
-	fmt.Fprintln(session)
-	fmt.Fprintln(session, "Requesting terminal attributes...")
-	session.SendRequest("xterm-256color", false, []byte("TERM=xterm-256color"))
-	fmt.Fprintln(session, "Testing UTF-8 support:")
-	fmt.Fprintln(session, "  ASCII:  ABCDEFG123456!@#$")
-	fmt.Fprintln(session, "  Latin1: ñ é ü ß ö ø å")
-	fmt.Fprintln(session, "  CJK:    你好 こんにちは 안녕하세요")
-	fmt.Fprintln(session, "  Emoji:  🚀 💻 📦 🔥")
-	fmt.Fprintln(session)
-	fmt.Fprintln(session, "Testing line drawing modes:")
-	fmt.Fprintln(session, "  VT100:  \x1B(0lqwqk\x1B(B")
-	fmt.Fprintln(session, "          \x1B(0x x x\x1B(B")
-	fmt.Fprintln(session, "          \x1B(0mqjm\x1B(B")
-	fmt.Fprintln(session)
-	fmt.Fprintln(session, "Testing character set switching sequences:")
-	fmt.Fprintln(session, "  Default UTF-8")
-	session.Write([]byte("  Switch to ISO 8859-1: \x1B%@Test\x1B%G\n"))
-	session.Write([]byte("  Switch to UTF-8: \x1B%GTest\n"))
-	fmt.Fprintln(session)
-	fmt.Fprintln(session, "If you see boxes or question marks instead of special characters")
-	fmt.Fprintln(session, "above, your terminal may not support UTF-8 properly.")
+	_, _ = fmt.Fprintln(session, "Terminal Type:", ptyReq.Term)
+	_, _ = fmt.Fprintln(session, "Window Size:", ptyReq.Window.Width, "x", ptyReq.Window.Height)
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session, "Requesting terminal attributes...")
+	_, _ = session.SendRequest("xterm-256color", false, []byte("TERM=xterm-256color")) // best-effort probe
+	_, _ = fmt.Fprintln(session, "Testing UTF-8 support:")
+	_, _ = fmt.Fprintln(session, "  ASCII:  ABCDEFG123456!@#$")
+	_, _ = fmt.Fprintln(session, "  Latin1: ñ é ü ß ö ø å")
+	_, _ = fmt.Fprintln(session, "  CJK:    你好 こんにちは 안녕하세요")
+	_, _ = fmt.Fprintln(session, "  Emoji:  🚀 💻 📦 🔥")
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session, "Testing line drawing modes:")
+	_, _ = fmt.Fprintln(session, "  VT100:  \x1B(0lqwqk\x1B(B")
+	_, _ = fmt.Fprintln(session, "          \x1B(0x x x\x1B(B")
+	_, _ = fmt.Fprintln(session, "          \x1B(0mqjm\x1B(B")
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session, "Testing character set switching sequences:")
+	_, _ = fmt.Fprintln(session, "  Default UTF-8")
+	_, _ = session.Write([]byte("  Switch to ISO 8859-1: \x1B%@Test\x1B%G\n"))
+	_, _ = session.Write([]byte("  Switch to UTF-8: \x1B%GTest\n"))
+	_, _ = fmt.Fprintln(session)
+	_, _ = fmt.Fprintln(session, "If you see boxes or question marks instead of special characters")
+	_, _ = fmt.Fprintln(session, "above, your terminal may not support UTF-8 properly.")
 }
 
 // loadHostKey loads a private key for the SSH server.

--- a/cmd/ansitest/main.go
+++ b/cmd/ansitest/main.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gliderlabs/ssh"
 	gossh "golang.org/x/crypto/ssh"
-	terminal "golang.org/x/crypto/ssh/terminal"
+	terminal "golang.org/x/term"
 	"golang.org/x/text/encoding/charmap"
 
 	// Use the internal ansi package for Cp437ToUnicode

--- a/cmd/helper/files_import.go
+++ b/cmd/helper/files_import.go
@@ -44,7 +44,7 @@ func cmdFilesImport(args []string) {
 		fmt.Fprintf(os.Stderr, "  helper files import --dir ~/staging --area UTILS --preserve-dates --dry-run\n")
 		fmt.Fprintf(os.Stderr, "  helper files import --dir /tmp/incoming --area UPLOADS --move --uploader Admin\n")
 	}
-	fs.Parse(args)
+	_ = fs.Parse(args) // ExitOnError: Parse exits the program on failure
 
 	if *dir == "" || *areaTag == "" {
 		fmt.Fprintf(os.Stderr, "Error: --dir and --area are required\n\n")
@@ -314,13 +314,13 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer in.Close()
+	defer func() { _ = in.Close() }() // read-only
 
 	out, err := os.Create(dst)
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() { _ = out.Close() }() // error path cleanup; success path closes explicitly
 
 	if _, err := io.Copy(out, in); err != nil {
 		return err

--- a/cmd/helper/files_reextractdiz.go
+++ b/cmd/helper/files_reextractdiz.go
@@ -28,7 +28,7 @@ func cmdFilesReextractDIZ(args []string) {
 		fmt.Fprintf(os.Stderr, "  helper files reextractdiz --area GENERAL\n")
 		fmt.Fprintf(os.Stderr, "  helper files reextractdiz --dry-run\n")
 	}
-	fs.Parse(args)
+	_ = fs.Parse(args) // ExitOnError: Parse exits the program on failure
 
 	areas, err := loadFileAreas(*configDir)
 	if err != nil {

--- a/cmd/helper/main.go
+++ b/cmd/helper/main.go
@@ -50,9 +50,9 @@ const (
 )
 
 func printHeader() {
-	fmt.Fprintf(os.Stderr, "%sViSiON/3 Helper Utility v%s  ·  MIT License%s\n",
+	_, _ = fmt.Fprintf(os.Stderr, "%sViSiON/3 Helper Utility v%s  ·  MIT License%s\n",
 		clrBold, version.Number, clrReset)
-	fmt.Fprintln(os.Stderr, separator)
+	_, _ = fmt.Fprintln(os.Stderr, separator)
 }
 
 func bullet(msg string) string {
@@ -103,30 +103,30 @@ func main() {
 func printUsage(errMsg string) {
 	w := os.Stderr
 	printHeader()
-	fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w)
 	if errMsg != "" {
-		fmt.Fprintln(w, bullet(errMsg))
+		_, _ = fmt.Fprintln(w, bullet(errMsg))
 	}
-	fmt.Fprintln(w, bullet("helper needs a little more information!"))
-	fmt.Fprintln(w, bullet("Required Format: helper <command> [options]"))
-	fmt.Fprintln(w, bullet("Valid Commands Are As Follows..."))
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "  %sFTN Commands:%s\n", clrBold, clrReset)
-	fmt.Fprintln(w, helpcmd("FTNSETUP", "Import FTN echo areas from a FIDONET.NA file"))
-	fmt.Fprintln(w, helpcmd("AREAFIX", "Send an AreaFix netmail command to a network hub"))
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "  %sUser Commands:%s\n", clrBold, clrReset)
-	fmt.Fprintln(w, helpcmd("USERS PURGE", "Permanently remove soft-deleted users past retention"))
-	fmt.Fprintln(w, helpcmd("USERS LIST", "List user accounts"))
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "  %sFile Commands:%s\n", clrBold, clrReset)
-	fmt.Fprintln(w, helpcmd("FILES IMPORT", "Bulk import files from a directory into a file area"))
-	fmt.Fprintln(w, helpcmd("FILES REEXTRACTDIZ", "Re-extract FILE_ID.DIZ and update descriptions"))
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "  %sGlobal Options:%s\n", clrBold, clrReset)
-	fmt.Fprintln(w, helpopt("--config DIR", "Config directory (default: configs)"))
-	fmt.Fprintln(w, helpopt("--data DIR", "Data directory (default: data)"))
-	fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, bullet("helper needs a little more information!"))
+	_, _ = fmt.Fprintln(w, bullet("Required Format: helper <command> [options]"))
+	_, _ = fmt.Fprintln(w, bullet("Valid Commands Are As Follows..."))
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintf(w, "  %sFTN Commands:%s\n", clrBold, clrReset)
+	_, _ = fmt.Fprintln(w, helpcmd("FTNSETUP", "Import FTN echo areas from a FIDONET.NA file"))
+	_, _ = fmt.Fprintln(w, helpcmd("AREAFIX", "Send an AreaFix netmail command to a network hub"))
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintf(w, "  %sUser Commands:%s\n", clrBold, clrReset)
+	_, _ = fmt.Fprintln(w, helpcmd("USERS PURGE", "Permanently remove soft-deleted users past retention"))
+	_, _ = fmt.Fprintln(w, helpcmd("USERS LIST", "List user accounts"))
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintf(w, "  %sFile Commands:%s\n", clrBold, clrReset)
+	_, _ = fmt.Fprintln(w, helpcmd("FILES IMPORT", "Bulk import files from a directory into a file area"))
+	_, _ = fmt.Fprintln(w, helpcmd("FILES REEXTRACTDIZ", "Re-extract FILE_ID.DIZ and update descriptions"))
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintf(w, "  %sGlobal Options:%s\n", clrBold, clrReset)
+	_, _ = fmt.Fprintln(w, helpopt("--config DIR", "Config directory (default: configs)"))
+	_, _ = fmt.Fprintln(w, helpopt("--data DIR", "Data directory (default: data)"))
+	_, _ = fmt.Fprintln(w)
 }
 
 // --- users command group ---
@@ -134,27 +134,27 @@ func printUsage(errMsg string) {
 func printUsersHelp(errMsg string) {
 	w := os.Stderr
 	printHeader()
-	fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w)
 	if errMsg != "" {
-		fmt.Fprintln(w, bullet(errMsg))
+		_, _ = fmt.Fprintln(w, bullet(errMsg))
 	}
-	fmt.Fprintln(w, bullet("Required Format: helper users <subcommand> [options]"))
-	fmt.Fprintln(w, bullet("Valid Subcommands Are As Follows..."))
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "  %sUser Subcommands:%s\n", clrBold, clrReset)
-	fmt.Fprintln(w, helpcmd("PURGE", "Permanently remove soft-deleted users past retention"))
-	fmt.Fprintln(w, helpcmd("LIST", "List user accounts (optionally filtered to deleted)"))
-	fmt.Fprintln(w, helpcmd("ADDKEY <handle> <keyfile|->", "Register a WFC SSH public key for a user"))
-	fmt.Fprintln(w, helpcmd("LISTKEYS <handle>", "List a user's WFC public keys (fingerprints)"))
-	fmt.Fprintln(w, helpcmd("DELKEY <handle> <fingerprint|index>", "Remove a WFC public key from a user"))
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "  %sOptions:%s\n", clrBold, clrReset)
-	fmt.Fprintln(w, helpopt("--config DIR", "Config directory (default: configs)"))
-	fmt.Fprintln(w, helpopt("--data DIR", "Data directory (default: data/users)"))
-	fmt.Fprintln(w, helpopt("--days N", "Retention days override (purge)"))
-	fmt.Fprintln(w, helpopt("--dry-run", "Show what would happen without making changes"))
-	fmt.Fprintln(w, helpopt("--deleted", "Show only soft-deleted accounts (list)"))
-	fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, bullet("Required Format: helper users <subcommand> [options]"))
+	_, _ = fmt.Fprintln(w, bullet("Valid Subcommands Are As Follows..."))
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintf(w, "  %sUser Subcommands:%s\n", clrBold, clrReset)
+	_, _ = fmt.Fprintln(w, helpcmd("PURGE", "Permanently remove soft-deleted users past retention"))
+	_, _ = fmt.Fprintln(w, helpcmd("LIST", "List user accounts (optionally filtered to deleted)"))
+	_, _ = fmt.Fprintln(w, helpcmd("ADDKEY <handle> <keyfile|->", "Register a WFC SSH public key for a user"))
+	_, _ = fmt.Fprintln(w, helpcmd("LISTKEYS <handle>", "List a user's WFC public keys (fingerprints)"))
+	_, _ = fmt.Fprintln(w, helpcmd("DELKEY <handle> <fingerprint|index>", "Remove a WFC public key from a user"))
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintf(w, "  %sOptions:%s\n", clrBold, clrReset)
+	_, _ = fmt.Fprintln(w, helpopt("--config DIR", "Config directory (default: configs)"))
+	_, _ = fmt.Fprintln(w, helpopt("--data DIR", "Data directory (default: data/users)"))
+	_, _ = fmt.Fprintln(w, helpopt("--days N", "Retention days override (purge)"))
+	_, _ = fmt.Fprintln(w, helpopt("--dry-run", "Show what would happen without making changes"))
+	_, _ = fmt.Fprintln(w, helpopt("--deleted", "Show only soft-deleted accounts (list)"))
+	_, _ = fmt.Fprintln(w)
 }
 
 func cmdUsers(args []string) {
@@ -188,30 +188,30 @@ func cmdUsers(args []string) {
 func printFilesHelp(errMsg string) {
 	w := os.Stderr
 	printHeader()
-	fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w)
 	if errMsg != "" {
-		fmt.Fprintln(w, bullet(errMsg))
+		_, _ = fmt.Fprintln(w, bullet(errMsg))
 	}
-	fmt.Fprintln(w, bullet("Required Format: helper files <subcommand> [options]"))
-	fmt.Fprintln(w, bullet("Valid Subcommands Are As Follows..."))
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "  %sFile Subcommands:%s\n", clrBold, clrReset)
-	fmt.Fprintln(w, helpcmd("IMPORT", "Bulk import files from a directory into a file area"))
-	fmt.Fprintln(w, helpcmd("REEXTRACTDIZ", "Re-extract FILE_ID.DIZ and update descriptions"))
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "  %sImport Options:%s\n", clrBold, clrReset)
-	fmt.Fprintln(w, helpopt("--dir DIR", "Source directory containing files (required)"))
-	fmt.Fprintln(w, helpopt("--area TAG", "Target file area tag (required)"))
-	fmt.Fprintln(w, helpopt("--uploader NAME", "Uploader handle (default: Sysop)"))
-	fmt.Fprintln(w, helpopt("--move", "Move files instead of copying"))
-	fmt.Fprintln(w, helpopt("--preserve-dates", "Use file modification time as upload date"))
-	fmt.Fprintln(w, helpopt("--no-diz", "Skip FILE_ID.DIZ extraction from archives"))
-	fmt.Fprintln(w, helpopt("--dry-run", "Show what would happen without making changes"))
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "  %sGlobal Options:%s\n", clrBold, clrReset)
-	fmt.Fprintln(w, helpopt("--config DIR", "Config directory (default: configs)"))
-	fmt.Fprintln(w, helpopt("--data DIR", "Data directory (default: data)"))
-	fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, bullet("Required Format: helper files <subcommand> [options]"))
+	_, _ = fmt.Fprintln(w, bullet("Valid Subcommands Are As Follows..."))
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintf(w, "  %sFile Subcommands:%s\n", clrBold, clrReset)
+	_, _ = fmt.Fprintln(w, helpcmd("IMPORT", "Bulk import files from a directory into a file area"))
+	_, _ = fmt.Fprintln(w, helpcmd("REEXTRACTDIZ", "Re-extract FILE_ID.DIZ and update descriptions"))
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintf(w, "  %sImport Options:%s\n", clrBold, clrReset)
+	_, _ = fmt.Fprintln(w, helpopt("--dir DIR", "Source directory containing files (required)"))
+	_, _ = fmt.Fprintln(w, helpopt("--area TAG", "Target file area tag (required)"))
+	_, _ = fmt.Fprintln(w, helpopt("--uploader NAME", "Uploader handle (default: Sysop)"))
+	_, _ = fmt.Fprintln(w, helpopt("--move", "Move files instead of copying"))
+	_, _ = fmt.Fprintln(w, helpopt("--preserve-dates", "Use file modification time as upload date"))
+	_, _ = fmt.Fprintln(w, helpopt("--no-diz", "Skip FILE_ID.DIZ extraction from archives"))
+	_, _ = fmt.Fprintln(w, helpopt("--dry-run", "Show what would happen without making changes"))
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintf(w, "  %sGlobal Options:%s\n", clrBold, clrReset)
+	_, _ = fmt.Fprintln(w, helpopt("--config DIR", "Config directory (default: configs)"))
+	_, _ = fmt.Fprintln(w, helpopt("--data DIR", "Data directory (default: data)"))
+	_, _ = fmt.Fprintln(w)
 }
 
 func cmdFiles(args []string) {
@@ -242,22 +242,22 @@ func cmdUsersPurge(args []string) {
 	dryRun := fs.Bool("dry-run", false, "Show what would be purged without making changes")
 
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: helper users purge [options]\n\n")
-		fmt.Fprintf(os.Stderr, "Permanently remove soft-deleted user accounts past the retention period.\n\n")
-		fmt.Fprintf(os.Stderr, "Options:\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Usage: helper users purge [options]\n\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Permanently remove soft-deleted user accounts past the retention period.\n\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Options:\n")
 		fs.PrintDefaults()
-		fmt.Fprintf(os.Stderr, "\nExamples:\n")
-		fmt.Fprintf(os.Stderr, "  helper users purge\n")
-		fmt.Fprintf(os.Stderr, "  helper users purge --days 90 --dry-run\n")
+		_, _ = fmt.Fprintf(os.Stderr, "\nExamples:\n")
+		_, _ = fmt.Fprintf(os.Stderr, "  helper users purge\n")
+		_, _ = fmt.Fprintf(os.Stderr, "  helper users purge --days 90 --dry-run\n")
 	}
-	fs.Parse(args)
+	_ = fs.Parse(args) // ExitOnError: Parse exits the program on failure
 
 	// Load config to get retention days if not overridden
 	retentionDays := *days
 	if retentionDays < 0 {
 		cfg, err := config.LoadServerConfig(*configDir)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
+			_, _ = fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
 			os.Exit(1)
 		}
 		retentionDays = cfg.DeletedUserRetentionDays
@@ -271,7 +271,7 @@ func cmdUsersPurge(args []string) {
 	// Load user manager
 	um, err := user.NewUserManager(*dataDir)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error loading users: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error loading users: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -301,7 +301,7 @@ func cmdUsersPurge(args []string) {
 
 	purged, err := um.PurgeDeletedUsers(retentionDays)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error purging users: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error purging users: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -344,7 +344,7 @@ func cleanupInfoformResponses(responsesDir string, userID int) int {
 		if err := os.Remove(f); err == nil {
 			removed++
 		} else {
-			fmt.Fprintf(os.Stderr, "  Warning: failed to remove %s: %v\n", f, err)
+			_, _ = fmt.Fprintf(os.Stderr, "  Warning: failed to remove %s: %v\n", f, err)
 		}
 	}
 	return removed
@@ -357,16 +357,16 @@ func cmdUsersList(args []string) {
 	deletedOnly := fs.Bool("deleted", false, "Show only soft-deleted accounts")
 
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: helper users list [options]\n\n")
-		fmt.Fprintf(os.Stderr, "List user accounts.\n\n")
-		fmt.Fprintf(os.Stderr, "Options:\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Usage: helper users list [options]\n\n")
+		_, _ = fmt.Fprintf(os.Stderr, "List user accounts.\n\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Options:\n")
 		fs.PrintDefaults()
 	}
-	fs.Parse(args)
+	_ = fs.Parse(args) // ExitOnError: Parse exits the program on failure
 
 	um, err := user.NewUserManager(*dataDir)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error loading users: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error loading users: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -475,19 +475,19 @@ func cmdFTNSetup(args []string) {
 	quiet := fs.Bool("quiet", false, "Suppress detailed output")
 
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: helper ftnsetup [options]\n\n")
-		fmt.Fprintf(os.Stderr, "Import FTN echo areas from a FIDONET.NA file.\n")
-		fmt.Fprintf(os.Stderr, "Updates ftn.json, message_areas.json, and conferences.json.\n\n")
-		fmt.Fprintf(os.Stderr, "Options:\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Usage: helper ftnsetup [options]\n\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Import FTN echo areas from a FIDONET.NA file.\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Updates ftn.json, message_areas.json, and conferences.json.\n\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Options:\n")
 		fs.PrintDefaults()
-		fmt.Fprintf(os.Stderr, "\nExample:\n")
-		fmt.Fprintf(os.Stderr, "  helper ftnsetup --na fsxnet.na --address 21:3/110 --hub 21:1/100 --network FSxNet\n")
-		fmt.Fprintf(os.Stderr, "  helper ftnsetup --na fidonet.na --address 3:633/2744.11 --hub 3:633/2744 --tag-prefix fd_\n")
+		_, _ = fmt.Fprintf(os.Stderr, "\nExample:\n")
+		_, _ = fmt.Fprintf(os.Stderr, "  helper ftnsetup --na fsxnet.na --address 21:3/110 --hub 21:1/100 --network FSxNet\n")
+		_, _ = fmt.Fprintf(os.Stderr, "  helper ftnsetup --na fidonet.na --address 3:633/2744.11 --hub 3:633/2744 --tag-prefix fd_\n")
 	}
-	fs.Parse(args)
+	_ = fs.Parse(args) // ExitOnError: Parse exits the program on failure
 
 	if *naFile == "" || *address == "" || *hub == "" {
-		fmt.Fprintf(os.Stderr, "Error: --na, --address, and --hub are required\n\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Error: --na, --address, and --hub are required\n\n")
 		fs.Usage()
 		os.Exit(1)
 	}
@@ -508,7 +508,7 @@ func cmdFTNSetup(args []string) {
 	// 1. Parse the NA file
 	areas, err := parseNAFile(*naFile)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error parsing NA file: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error parsing NA file: %v\n", err)
 		os.Exit(1)
 	}
 	if !*quiet {
@@ -522,19 +522,19 @@ func cmdFTNSetup(args []string) {
 
 	ftn, err := loadFTNConfig(ftnPath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error loading %s: %v\n", ftnPath, err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error loading %s: %v\n", ftnPath, err)
 		os.Exit(1)
 	}
 
 	existingAreas, err := loadAreas(areasPath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error loading %s: %v\n", areasPath, err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error loading %s: %v\n", areasPath, err)
 		os.Exit(1)
 	}
 
 	conferences, err := loadConferences(confsPath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error loading %s: %v\n", confsPath, err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error loading %s: %v\n", confsPath, err)
 		os.Exit(1)
 	}
 
@@ -561,7 +561,7 @@ func cmdFTNSetup(args []string) {
 			}
 		}
 		if !found {
-			fmt.Fprintf(os.Stderr, "Error: conference ID %d not found in %s\n", *conferenceID, confsPath)
+			_, _ = fmt.Fprintf(os.Stderr, "Error: conference ID %d not found in %s\n", *conferenceID, confsPath)
 			os.Exit(1)
 		}
 		confID = *conferenceID
@@ -589,7 +589,7 @@ func cmdFTNSetup(args []string) {
 		effectiveTag := strings.ToUpper(*tagPrefix + a.Tag)
 		if !isValidEchoTag(effectiveTag) {
 			if !*quiet {
-				fmt.Fprintf(os.Stderr, "Warn: skipping %s — tag %q exceeds length or invalid chars\n", a.Tag, effectiveTag)
+				_, _ = fmt.Fprintf(os.Stderr, "Warn: skipping %s — tag %q exceeds length or invalid chars\n", a.Tag, effectiveTag)
 			}
 			continue
 		}
@@ -747,7 +747,7 @@ func cmdFTNSetup(args []string) {
 
 	// 9. Write files
 	if err := writeJSON(confsPath, conferences); err != nil {
-		fmt.Fprintf(os.Stderr, "Error writing %s: %v\n", confsPath, err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error writing %s: %v\n", confsPath, err)
 		os.Exit(1)
 	}
 	if !*quiet {
@@ -755,7 +755,7 @@ func cmdFTNSetup(args []string) {
 	}
 
 	if err := writeJSON(areasPath, existingAreas); err != nil {
-		fmt.Fprintf(os.Stderr, "Error writing %s: %v\n", areasPath, err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error writing %s: %v\n", areasPath, err)
 		os.Exit(1)
 	}
 	if !*quiet {
@@ -763,7 +763,7 @@ func cmdFTNSetup(args []string) {
 	}
 
 	if err := writeJSON(ftnPath, ftn); err != nil {
-		fmt.Fprintf(os.Stderr, "Error writing %s: %v\n", ftnPath, err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error writing %s: %v\n", ftnPath, err)
 		os.Exit(1)
 	}
 	if !*quiet {
@@ -785,26 +785,26 @@ func cmdAreafix(args []string) {
 	configDir := fs.String("config", "configs", "Config directory")
 
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: helper areafix [options]\n\n")
-		fmt.Fprintf(os.Stderr, "Send an AreaFix netmail message to a network hub.\n")
-		fmt.Fprintf(os.Stderr, "To: AreaFix, Subject: <areafix_password>, Body: <command>---\n\n")
-		fmt.Fprintf(os.Stderr, "Options:\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Usage: helper areafix [options]\n\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Send an AreaFix netmail message to a network hub.\n")
+		_, _ = fmt.Fprintf(os.Stderr, "To: AreaFix, Subject: <areafix_password>, Body: <command>---\n\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Options:\n")
 		fs.PrintDefaults()
-		fmt.Fprintf(os.Stderr, "\nAreaFix commands: %%HELP %%LIST %%QUERY %%UNLINKED +area -area =area,R=<n> %%RESCAN\n")
-		fmt.Fprintf(os.Stderr, "\nExamples:\n")
-		fmt.Fprintf(os.Stderr, "  helper areafix --network fidonet --command \"%%LIST\"\n")
-		fmt.Fprintf(os.Stderr, "  helper areafix --network fidonet --seed\n")
-		fmt.Fprintf(os.Stderr, "  helper areafix --network fidonet --seed --seed-messages 50\n")
+		_, _ = fmt.Fprintf(os.Stderr, "\nAreaFix commands: %%HELP %%LIST %%QUERY %%UNLINKED +area -area =area,R=<n> %%RESCAN\n")
+		_, _ = fmt.Fprintf(os.Stderr, "\nExamples:\n")
+		_, _ = fmt.Fprintf(os.Stderr, "  helper areafix --network fidonet --command \"%%LIST\"\n")
+		_, _ = fmt.Fprintf(os.Stderr, "  helper areafix --network fidonet --seed\n")
+		_, _ = fmt.Fprintf(os.Stderr, "  helper areafix --network fidonet --seed --seed-messages 50\n")
 	}
-	fs.Parse(args)
+	_ = fs.Parse(args) // ExitOnError: Parse exits the program on failure
 
 	if *network == "" {
-		fmt.Fprintf(os.Stderr, "Error: --network is required\n\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Error: --network is required\n\n")
 		fs.Usage()
 		os.Exit(1)
 	}
 	if !*seed && *command == "" {
-		fmt.Fprintf(os.Stderr, "Error: --command or --seed is required\n\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Error: --command or --seed is required\n\n")
 		fs.Usage()
 		os.Exit(1)
 	}
@@ -812,7 +812,7 @@ func cmdAreafix(args []string) {
 	ftnPath := filepath.Join(*configDir, "ftn.json")
 	ftnCfg, err := loadFTNConfig(ftnPath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error loading %s: %v\n", ftnPath, err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error loading %s: %v\n", ftnPath, err)
 		os.Exit(1)
 	}
 
@@ -825,13 +825,13 @@ func cmdAreafix(args []string) {
 		}
 	}
 	if netKey == "" {
-		fmt.Fprintf(os.Stderr, "Error: network %q not found in %s\n", *network, ftnPath)
+		_, _ = fmt.Fprintf(os.Stderr, "Error: network %q not found in %s\n", *network, ftnPath)
 		os.Exit(1)
 	}
 
 	netCfg := ftnCfg.Networks[netKey]
 	if len(netCfg.Links) == 0 {
-		fmt.Fprintf(os.Stderr, "Error: network %s has no links\n", netKey)
+		_, _ = fmt.Fprintf(os.Stderr, "Error: network %s has no links\n", netKey)
 		os.Exit(1)
 	}
 
@@ -844,7 +844,7 @@ func cmdAreafix(args []string) {
 			}
 		}
 		if link == nil {
-			fmt.Fprintf(os.Stderr, "Error: link %s not found in network %s\n", *linkAddr, netKey)
+			_, _ = fmt.Fprintf(os.Stderr, "Error: link %s not found in network %s\n", *linkAddr, netKey)
 			os.Exit(1)
 		}
 	} else {
@@ -852,7 +852,7 @@ func cmdAreafix(args []string) {
 	}
 
 	if link.AreafixPassword == "" {
-		fmt.Fprintf(os.Stderr, "Error: link %s has no areafix_password configured\n", link.Address)
+		_, _ = fmt.Fprintf(os.Stderr, "Error: link %s has no areafix_password configured\n", link.Address)
 		os.Exit(1)
 	}
 
@@ -864,13 +864,13 @@ func cmdAreafix(args []string) {
 
 	ownAddr, err := jam.ParseAddress(netCfg.OwnAddress)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: invalid own_address %q: %v\n", netCfg.OwnAddress, err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error: invalid own_address %q: %v\n", netCfg.OwnAddress, err)
 		os.Exit(1)
 	}
 
 	destAddr, err := jam.ParseAddress(link.Address)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: invalid link address %q: %v\n", link.Address, err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error: invalid link address %q: %v\n", link.Address, err)
 		os.Exit(1)
 	}
 
@@ -881,7 +881,7 @@ func cmdAreafix(args []string) {
 		areasPath := filepath.Join(*configDir, "message_areas.json")
 		areas, err := loadAreas(areasPath)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error loading %s: %v\n", areasPath, err)
+			_, _ = fmt.Fprintf(os.Stderr, "Error loading %s: %v\n", areasPath, err)
 			os.Exit(1)
 		}
 		var lines []string
@@ -899,7 +899,7 @@ func cmdAreafix(args []string) {
 			lines = append(lines, fmt.Sprintf("+%s,R=%d", tag, *seedMessages))
 		}
 		if len(lines) == 0 {
-			fmt.Fprintf(os.Stderr, "Error: no echomail areas found for network %s in message_areas.json\n", netKey)
+			_, _ = fmt.Fprintf(os.Stderr, "Error: no echomail areas found for network %s in message_areas.json\n", netKey)
 			os.Exit(1)
 		}
 		seedCount = len(lines)
@@ -965,25 +965,25 @@ func cmdAreafix(args []string) {
 		outboundPath = "data/ftn/temp_out"
 	}
 	if err := os.MkdirAll(outboundPath, 0755); err != nil {
-		fmt.Fprintf(os.Stderr, "Error creating outbound dir: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error creating outbound dir: %v\n", err)
 		os.Exit(1)
 	}
 
 	f, err := os.CreateTemp(outboundPath, "areafix_*.pkt")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error creating packet: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error creating packet: %v\n", err)
 		os.Exit(1)
 	}
 	pktPath := f.Name()
 	if err := ftn.WritePacket(f, hdr, []*ftn.PackedMessage{msg}); err != nil {
-		f.Close()
-		os.Remove(pktPath)
-		fmt.Fprintf(os.Stderr, "Error writing packet: %v\n", err)
+		_ = f.Close()          // cleanup on error path
+		_ = os.Remove(pktPath) // cleanup on error path
+		_, _ = fmt.Fprintf(os.Stderr, "Error writing packet: %v\n", err)
 		os.Exit(1)
 	}
 	if err := f.Close(); err != nil {
-		os.Remove(pktPath)
-		fmt.Fprintf(os.Stderr, "Error finalizing packet: %v\n", err)
+		_ = os.Remove(pktPath) // cleanup on error path
+		_, _ = fmt.Fprintf(os.Stderr, "Error finalizing packet: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -1003,7 +1003,7 @@ func parseNAFile(path string) ([]naArea, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }() // read-only
 
 	var areas []naArea
 	scanner := bufio.NewScanner(f)

--- a/cmd/v3mail/cmd_ftn.go
+++ b/cmd/v3mail/cmd_ftn.go
@@ -18,7 +18,7 @@ func cmdToss(args []string) {
 	dataDir := fs.String("data", "data", "Data directory")
 	networkName := fs.String("network", "", "Limit to a single network (default: all enabled)")
 	quiet := fs.Bool("q", false, "Quiet mode")
-	fs.Parse(args)
+	_ = fs.Parse(args) // ExitOnError: Parse exits the program on failure
 
 	ftnCfg, msgMgr, dupeDB, err := loadFTNDeps(*configDir, *dataDir)
 	if err != nil {
@@ -80,7 +80,7 @@ func cmdScan(args []string) {
 	dataDir := fs.String("data", "data", "Data directory")
 	networkName := fs.String("network", "", "Limit to a single network (default: all enabled)")
 	quiet := fs.Bool("q", false, "Quiet mode")
-	fs.Parse(args)
+	_ = fs.Parse(args) // ExitOnError: Parse exits the program on failure
 
 	ftnCfg, msgMgr, dupeDB, err := loadFTNDeps(*configDir, *dataDir)
 	if err != nil {
@@ -139,7 +139,7 @@ func cmdFtnPack(args []string) {
 	dataDir := fs.String("data", "data", "Data directory")
 	networkName := fs.String("network", "", "Limit to a single network (default: all enabled)")
 	quiet := fs.Bool("q", false, "Quiet mode")
-	fs.Parse(args)
+	_ = fs.Parse(args) // ExitOnError: Parse exits the program on failure
 
 	ftnCfg, msgMgr, dupeDB, err := loadFTNDeps(*configDir, *dataDir)
 	if err != nil {

--- a/cmd/v3mail/main.go
+++ b/cmd/v3mail/main.go
@@ -207,6 +207,7 @@ func cmdStats(args []string) {
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+	hadErrors := false
 
 	for _, meta := range paths {
 		b, err := jam.Open(meta.Path)
@@ -243,7 +244,12 @@ func cmdStats(args []string) {
 			}
 			fmt.Println()
 		}
-		closeBase(b, meta.Path)
+		if !closeBase(b, meta.Path) {
+			hadErrors = true
+		}
+	}
+	if hadErrors {
+		os.Exit(1)
 	}
 }
 
@@ -259,6 +265,7 @@ func cmdPack(args []string) {
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+	hadErrors := false
 
 	for _, meta := range paths {
 		b, err := jam.Open(meta.Path)
@@ -276,7 +283,9 @@ func cmdPack(args []string) {
 				fmt.Printf("%s: %d total, %d active, %d deleted (would remove %d)\n",
 					meta.Tag, total, active, deleted, deleted)
 			}
-			closeBase(b, meta.Path)
+			if !closeBase(b, meta.Path) {
+				hadErrors = true
+			}
 			continue
 		}
 
@@ -284,7 +293,9 @@ func cmdPack(args []string) {
 			if !*quiet {
 				fmt.Printf("%s: no deleted messages, skipping\n", meta.Tag)
 			}
-			closeBase(b, meta.Path)
+			if !closeBase(b, meta.Path) {
+				hadErrors = true
+			}
 			continue
 		}
 
@@ -295,7 +306,9 @@ func cmdPack(args []string) {
 		result, err := b.Pack()
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Error packing %s: %v\n", meta.Path, err)
-			closeBase(b, meta.Path)
+			if !closeBase(b, meta.Path) {
+				hadErrors = true
+			}
 			continue
 		}
 
@@ -305,7 +318,12 @@ func cmdPack(args []string) {
 			fmt.Printf("  After:  %d messages\n", result.MessagesAfter)
 			fmt.Printf("  Reclaimed: %s\n", formatBytes(result.BytesBefore-result.BytesAfter))
 		}
-		closeBase(b, meta.Path)
+		if !closeBase(b, meta.Path) {
+			hadErrors = true
+		}
+	}
+	if hadErrors {
+		os.Exit(1)
 	}
 }
 
@@ -326,6 +344,7 @@ func cmdPurge(args []string) {
 		_, _ = fmt.Fprintf(os.Stderr, "Error: --days or --keep is required\n")
 		os.Exit(1)
 	}
+	hadErrors := false
 
 	paths, err := resolveBasePaths(*allFlag, *configDir, *dataDir, fs.Args())
 	if err != nil {
@@ -413,7 +432,9 @@ func cmdPurge(args []string) {
 				fmt.Printf("%s: would delete %d messages (age>%dd, keep<=%d)\n",
 					meta.Tag, len(toDelete), effectiveDays, effectiveKeep)
 			}
-			closeBase(b, meta.Path)
+			if !closeBase(b, meta.Path) {
+				hadErrors = true
+			}
 			continue
 		}
 
@@ -426,7 +447,12 @@ func cmdPurge(args []string) {
 		if !*quiet {
 			fmt.Printf("%s: deleted %d messages (run 'pack' to reclaim space)\n", meta.Tag, deleted)
 		}
-		closeBase(b, meta.Path)
+		if !closeBase(b, meta.Path) {
+			hadErrors = true
+		}
+	}
+	if hadErrors {
+		os.Exit(1)
 	}
 }
 
@@ -556,7 +582,9 @@ func cmdFix(args []string) {
 				fmt.Printf("  Found %d issue(s)\n", issues)
 			}
 		}
-		closeBase(b, meta.Path)
+		if !closeBase(b, meta.Path) {
+			hadErrors = true
+		}
 	}
 
 	if hadErrors {
@@ -576,6 +604,7 @@ func cmdLastread(args []string) {
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+	hadErrors := false
 
 	for _, meta := range paths {
 		b, err := jam.Open(meta.Path)
@@ -590,14 +619,18 @@ func cmdLastread(args []string) {
 			} else if !*quiet {
 				fmt.Printf("%s: reset lastread for %q\n", meta.Tag, *resetUser)
 			}
-			closeBase(b, meta.Path)
+			if !closeBase(b, meta.Path) {
+				hadErrors = true
+			}
 			continue
 		}
 
 		records, err := b.GetAllLastReadRecords()
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Error reading lastread for %s: %v\n", meta.Tag, err)
-			closeBase(b, meta.Path)
+			if !closeBase(b, meta.Path) {
+				hadErrors = true
+			}
 			continue
 		}
 
@@ -605,7 +638,9 @@ func cmdLastread(args []string) {
 			if !*quiet {
 				fmt.Printf("%s: no lastread records\n", meta.Tag)
 			}
-			closeBase(b, meta.Path)
+			if !closeBase(b, meta.Path) {
+				hadErrors = true
+			}
 			continue
 		}
 
@@ -617,7 +652,12 @@ func cmdLastread(args []string) {
 			}
 			fmt.Println()
 		}
-		closeBase(b, meta.Path)
+		if !closeBase(b, meta.Path) {
+			hadErrors = true
+		}
+	}
+	if hadErrors {
+		os.Exit(1)
 	}
 }
 
@@ -643,6 +683,7 @@ func cmdLink(args []string) {
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+	hadErrors := false
 
 	totalUpdated := 0
 	for _, meta := range paths {
@@ -653,7 +694,9 @@ func cmdLink(args []string) {
 		}
 
 		updated, linkErr := linkBase(b, *quiet, meta.Tag)
-		closeBase(b, meta.Path)
+		if !closeBase(b, meta.Path) {
+			hadErrors = true
+		}
 		if linkErr != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Error linking %s: %v\n", meta.Path, linkErr)
 			continue
@@ -663,6 +706,9 @@ func cmdLink(args []string) {
 
 	if !*quiet && len(paths) > 1 {
 		fmt.Printf("\nTotal: %d links updated across %d areas\n", totalUpdated, len(paths))
+	}
+	if hadErrors {
+		os.Exit(1)
 	}
 }
 
@@ -864,10 +910,13 @@ func cleanReplyIDsPack(b *jam.Base) error {
 	return err
 }
 
-// closeBase closes a JAM base, reporting (but not aborting on) close errors
-// so flush failures after write operations are not silently ignored.
-func closeBase(b *jam.Base, path string) {
+// closeBase closes a JAM base, reporting close errors on stderr so
+// commands exit non-zero when a delayed flush/close failure occurs after
+// write operations. Returns true when the close succeeded.
+func closeBase(b *jam.Base, path string) bool {
 	if err := b.Close(); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Warning: closing %s: %v\n", path, err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error closing %s: %v\n", path, err)
+		return false
 	}
+	return true
 }

--- a/cmd/v3mail/main.go
+++ b/cmd/v3mail/main.go
@@ -33,9 +33,9 @@ func main() {
 	// absent, and a logging-init failure leaves the stdlib default (stderr).
 	cfg, _ := config.LoadServerConfig("configs")
 	if _, closeLog, err := logging.Init(cfg.Logging, "v3mail.log", true); err == nil {
-		defer closeLog()
+		defer func() { _ = closeLog() }() // best-effort log flush at exit
 	} else {
-		fmt.Fprintf(os.Stderr, "WARN: failed to initialize logging: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "WARN: failed to initialize logging: %v\n", err)
 	}
 
 	if len(os.Args) < 2 {
@@ -87,9 +87,9 @@ const (
 )
 
 func printHeader() {
-	fmt.Fprintf(os.Stderr, "%sViSiON/3 Mail Utility v%s  ·  MIT License%s\n",
+	_, _ = fmt.Fprintf(os.Stderr, "%sViSiON/3 Mail Utility v%s  ·  MIT License%s\n",
 		clrBold, version.Number, clrReset)
-	fmt.Fprintln(os.Stderr, separator)
+	_, _ = fmt.Fprintln(os.Stderr, separator)
 }
 
 func bullet(msg string) string {
@@ -109,34 +109,34 @@ func opt(flag, desc string) string {
 func printUsage(errMsg string) {
 	w := os.Stderr
 	printHeader()
-	fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w)
 	if errMsg != "" {
-		fmt.Fprintln(w, bullet(errMsg))
+		_, _ = fmt.Fprintln(w, bullet(errMsg))
 	}
-	fmt.Fprintln(w, bullet("v3mail needs a little more information!"))
-	fmt.Fprintln(w, bullet("Required Format: v3mail <command> [options] [base_path...]"))
-	fmt.Fprintln(w, bullet("Valid Commands Are As Follows..."))
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "  %sJAM Base Commands:%s\n", clrBold, clrReset)
-	fmt.Fprintln(w, cmd("STATS", "Display message base statistics"))
-	fmt.Fprintln(w, cmd("PACK", "Defragment base, removing deleted messages"))
-	fmt.Fprintln(w, cmd("PURGE", "Delete messages exceeding age or count limits"))
-	fmt.Fprintln(w, cmd("FIX", "Verify and repair JAM base integrity"))
-	fmt.Fprintln(w, cmd("LINK", "Build reply-threading chains (ReplyTo/Reply1st/ReplyNext)"))
-	fmt.Fprintln(w, cmd("LASTREAD", "Show or reset per-user lastread pointers"))
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "  %sFTN Echomail Commands:%s\n", clrBold, clrReset)
-	fmt.Fprintln(w, cmd("TOSS", "Unpack inbound FTN bundles and toss .PKT files into JAM bases"))
-	fmt.Fprintln(w, cmd("SCAN", "Scan JAM bases for unsent echomail; create outbound .PKT files"))
-	fmt.Fprintln(w, cmd("FTN-PACK", "Pack outbound .PKT files into ZIP bundles for binkd"))
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "  %sGlobal Options:%s\n", clrBold, clrReset)
-	fmt.Fprintln(w, opt("--all", "Operate on all areas in message_areas.json"))
-	fmt.Fprintln(w, opt("--config DIR", "Config directory (default: configs)"))
-	fmt.Fprintln(w, opt("--data DIR", "Data directory (default: data)"))
-	fmt.Fprintln(w, opt("-q", "Suppress output"))
-	fmt.Fprintln(w, opt("--network NAME", "FTN: limit to a single network"))
-	fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, bullet("v3mail needs a little more information!"))
+	_, _ = fmt.Fprintln(w, bullet("Required Format: v3mail <command> [options] [base_path...]"))
+	_, _ = fmt.Fprintln(w, bullet("Valid Commands Are As Follows..."))
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintf(w, "  %sJAM Base Commands:%s\n", clrBold, clrReset)
+	_, _ = fmt.Fprintln(w, cmd("STATS", "Display message base statistics"))
+	_, _ = fmt.Fprintln(w, cmd("PACK", "Defragment base, removing deleted messages"))
+	_, _ = fmt.Fprintln(w, cmd("PURGE", "Delete messages exceeding age or count limits"))
+	_, _ = fmt.Fprintln(w, cmd("FIX", "Verify and repair JAM base integrity"))
+	_, _ = fmt.Fprintln(w, cmd("LINK", "Build reply-threading chains (ReplyTo/Reply1st/ReplyNext)"))
+	_, _ = fmt.Fprintln(w, cmd("LASTREAD", "Show or reset per-user lastread pointers"))
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintf(w, "  %sFTN Echomail Commands:%s\n", clrBold, clrReset)
+	_, _ = fmt.Fprintln(w, cmd("TOSS", "Unpack inbound FTN bundles and toss .PKT files into JAM bases"))
+	_, _ = fmt.Fprintln(w, cmd("SCAN", "Scan JAM bases for unsent echomail; create outbound .PKT files"))
+	_, _ = fmt.Fprintln(w, cmd("FTN-PACK", "Pack outbound .PKT files into ZIP bundles for binkd"))
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintf(w, "  %sGlobal Options:%s\n", clrBold, clrReset)
+	_, _ = fmt.Fprintln(w, opt("--all", "Operate on all areas in message_areas.json"))
+	_, _ = fmt.Fprintln(w, opt("--config DIR", "Config directory (default: configs)"))
+	_, _ = fmt.Fprintln(w, opt("--data DIR", "Data directory (default: data)"))
+	_, _ = fmt.Fprintln(w, opt("-q", "Suppress output"))
+	_, _ = fmt.Fprintln(w, opt("--network NAME", "FTN: limit to a single network"))
+	_, _ = fmt.Fprintln(w)
 }
 
 // resolveBasePaths returns base paths from positional args or --all flag.
@@ -200,18 +200,18 @@ func addGlobalFlags(fs *flag.FlagSet) (*bool, *string, *string, *bool) {
 func cmdStats(args []string) {
 	fs := flag.NewFlagSet("stats", flag.ExitOnError)
 	allFlag, configDir, dataDir, quiet := addGlobalFlags(fs)
-	fs.Parse(args)
+	_ = fs.Parse(args) // ExitOnError: Parse exits the program on failure
 
 	paths, err := resolveBasePaths(*allFlag, *configDir, *dataDir, fs.Args())
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 
 	for _, meta := range paths {
 		b, err := jam.Open(meta.Path)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error opening %s: %v\n", meta.Path, err)
+			_, _ = fmt.Fprintf(os.Stderr, "Error opening %s: %v\n", meta.Path, err)
 			continue
 		}
 
@@ -243,7 +243,7 @@ func cmdStats(args []string) {
 			}
 			fmt.Println()
 		}
-		b.Close()
+		closeBase(b, meta.Path)
 	}
 }
 
@@ -252,18 +252,18 @@ func cmdPack(args []string) {
 	fs := flag.NewFlagSet("pack", flag.ExitOnError)
 	allFlag, configDir, dataDir, quiet := addGlobalFlags(fs)
 	dryRun := fs.Bool("dry-run", false, "Report what would happen without modifying")
-	fs.Parse(args)
+	_ = fs.Parse(args) // ExitOnError: Parse exits the program on failure
 
 	paths, err := resolveBasePaths(*allFlag, *configDir, *dataDir, fs.Args())
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 
 	for _, meta := range paths {
 		b, err := jam.Open(meta.Path)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error opening %s: %v\n", meta.Path, err)
+			_, _ = fmt.Fprintf(os.Stderr, "Error opening %s: %v\n", meta.Path, err)
 			continue
 		}
 
@@ -276,7 +276,7 @@ func cmdPack(args []string) {
 				fmt.Printf("%s: %d total, %d active, %d deleted (would remove %d)\n",
 					meta.Tag, total, active, deleted, deleted)
 			}
-			b.Close()
+			closeBase(b, meta.Path)
 			continue
 		}
 
@@ -284,7 +284,7 @@ func cmdPack(args []string) {
 			if !*quiet {
 				fmt.Printf("%s: no deleted messages, skipping\n", meta.Tag)
 			}
-			b.Close()
+			closeBase(b, meta.Path)
 			continue
 		}
 
@@ -294,8 +294,8 @@ func cmdPack(args []string) {
 
 		result, err := b.Pack()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error packing %s: %v\n", meta.Path, err)
-			b.Close()
+			_, _ = fmt.Fprintf(os.Stderr, "Error packing %s: %v\n", meta.Path, err)
+			closeBase(b, meta.Path)
 			continue
 		}
 
@@ -305,7 +305,7 @@ func cmdPack(args []string) {
 			fmt.Printf("  After:  %d messages\n", result.MessagesAfter)
 			fmt.Printf("  Reclaimed: %s\n", formatBytes(result.BytesBefore-result.BytesAfter))
 		}
-		b.Close()
+		closeBase(b, meta.Path)
 	}
 }
 
@@ -319,17 +319,17 @@ func cmdPurge(args []string) {
 	days := fs.Int("days", 0, "Delete messages older than N days (fallback when --all is used)")
 	keep := fs.Int("keep", 0, "Keep only the newest N messages (fallback when --all is used)")
 	dryRun := fs.Bool("dry-run", false, "Report what would happen without modifying")
-	fs.Parse(args)
+	_ = fs.Parse(args) // ExitOnError: Parse exits the program on failure
 
 	// --days or --keep are required for manual (non-all) invocations.
 	if !*allFlag && *days == 0 && *keep == 0 {
-		fmt.Fprintf(os.Stderr, "Error: --days or --keep is required\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Error: --days or --keep is required\n")
 		os.Exit(1)
 	}
 
 	paths, err := resolveBasePaths(*allFlag, *configDir, *dataDir, fs.Args())
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -353,7 +353,7 @@ func cmdPurge(args []string) {
 
 		b, err := jam.Open(meta.Path)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error opening %s: %v\n", meta.Path, err)
+			_, _ = fmt.Fprintf(os.Stderr, "Error opening %s: %v\n", meta.Path, err)
 			continue
 		}
 
@@ -413,7 +413,7 @@ func cmdPurge(args []string) {
 				fmt.Printf("%s: would delete %d messages (age>%dd, keep<=%d)\n",
 					meta.Tag, len(toDelete), effectiveDays, effectiveKeep)
 			}
-			b.Close()
+			closeBase(b, meta.Path)
 			continue
 		}
 
@@ -426,7 +426,7 @@ func cmdPurge(args []string) {
 		if !*quiet {
 			fmt.Printf("%s: deleted %d messages (run 'pack' to reclaim space)\n", meta.Tag, deleted)
 		}
-		b.Close()
+		closeBase(b, meta.Path)
 	}
 }
 
@@ -435,11 +435,11 @@ func cmdFix(args []string) {
 	fs := flag.NewFlagSet("fix", flag.ExitOnError)
 	allFlag, configDir, dataDir, quiet := addGlobalFlags(fs)
 	repair := fs.Bool("repair", false, "Attempt to repair issues")
-	fs.Parse(args)
+	_ = fs.Parse(args) // ExitOnError: Parse exits the program on failure
 
 	paths, err := resolveBasePaths(*allFlag, *configDir, *dataDir, fs.Args())
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -447,7 +447,7 @@ func cmdFix(args []string) {
 	for _, meta := range paths {
 		b, err := jam.Open(meta.Path)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error opening %s: %v\n", meta.Path, err)
+			_, _ = fmt.Fprintf(os.Stderr, "Error opening %s: %v\n", meta.Path, err)
 			hadErrors = true
 			continue
 		}
@@ -556,7 +556,7 @@ func cmdFix(args []string) {
 				fmt.Printf("  Found %d issue(s)\n", issues)
 			}
 		}
-		b.Close()
+		closeBase(b, meta.Path)
 	}
 
 	if hadErrors {
@@ -569,35 +569,35 @@ func cmdLastread(args []string) {
 	fs := flag.NewFlagSet("lastread", flag.ExitOnError)
 	allFlag, configDir, dataDir, quiet := addGlobalFlags(fs)
 	resetUser := fs.String("reset", "", "Reset lastread for this username")
-	fs.Parse(args)
+	_ = fs.Parse(args) // ExitOnError: Parse exits the program on failure
 
 	paths, err := resolveBasePaths(*allFlag, *configDir, *dataDir, fs.Args())
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 
 	for _, meta := range paths {
 		b, err := jam.Open(meta.Path)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error opening %s: %v\n", meta.Path, err)
+			_, _ = fmt.Fprintf(os.Stderr, "Error opening %s: %v\n", meta.Path, err)
 			continue
 		}
 
 		if *resetUser != "" {
 			if err := b.ResetLastRead(*resetUser); err != nil {
-				fmt.Fprintf(os.Stderr, "Error resetting lastread for %s in %s: %v\n", *resetUser, meta.Tag, err)
+				_, _ = fmt.Fprintf(os.Stderr, "Error resetting lastread for %s in %s: %v\n", *resetUser, meta.Tag, err)
 			} else if !*quiet {
 				fmt.Printf("%s: reset lastread for %q\n", meta.Tag, *resetUser)
 			}
-			b.Close()
+			closeBase(b, meta.Path)
 			continue
 		}
 
 		records, err := b.GetAllLastReadRecords()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error reading lastread for %s: %v\n", meta.Tag, err)
-			b.Close()
+			_, _ = fmt.Fprintf(os.Stderr, "Error reading lastread for %s: %v\n", meta.Tag, err)
+			closeBase(b, meta.Path)
 			continue
 		}
 
@@ -605,7 +605,7 @@ func cmdLastread(args []string) {
 			if !*quiet {
 				fmt.Printf("%s: no lastread records\n", meta.Tag)
 			}
-			b.Close()
+			closeBase(b, meta.Path)
 			continue
 		}
 
@@ -617,7 +617,7 @@ func cmdLastread(args []string) {
 			}
 			fmt.Println()
 		}
-		b.Close()
+		closeBase(b, meta.Path)
 	}
 }
 
@@ -636,11 +636,11 @@ func formatBytes(b int64) string {
 func cmdLink(args []string) {
 	fs := flag.NewFlagSet("link", flag.ExitOnError)
 	allFlag, configDir, dataDir, quiet := addGlobalFlags(fs)
-	fs.Parse(args)
+	_ = fs.Parse(args) // ExitOnError: Parse exits the program on failure
 
 	paths, err := resolveBasePaths(*allFlag, *configDir, *dataDir, fs.Args())
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -648,14 +648,14 @@ func cmdLink(args []string) {
 	for _, meta := range paths {
 		b, err := jam.Open(meta.Path)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error opening %s: %v\n", meta.Path, err)
+			_, _ = fmt.Fprintf(os.Stderr, "Error opening %s: %v\n", meta.Path, err)
 			continue
 		}
 
 		updated, linkErr := linkBase(b, *quiet, meta.Tag)
-		b.Close()
+		closeBase(b, meta.Path)
 		if linkErr != nil {
-			fmt.Fprintf(os.Stderr, "Error linking %s: %v\n", meta.Path, linkErr)
+			_, _ = fmt.Fprintf(os.Stderr, "Error linking %s: %v\n", meta.Path, linkErr)
 			continue
 		}
 		totalUpdated += updated
@@ -862,4 +862,12 @@ func cleanReplyIDsPack(b *jam.Base) error {
 	// Use the new PackWithReplyIDCleanup function
 	_, err := b.PackWithReplyIDCleanup()
 	return err
+}
+
+// closeBase closes a JAM base, reporting (but not aborting on) close errors
+// so flush failures after write operations are not silently ignored.
+func closeBase(b *jam.Base, path string) {
+	if err := b.Close(); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Warning: closing %s: %v\n", path, err)
+	}
 }

--- a/cmd/v3net-bootstrap/main.go
+++ b/cmd/v3net-bootstrap/main.go
@@ -112,7 +112,7 @@ func main() {
 	if err != nil {
 		logging.Fatal("POST NAL", "error", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // response fully consumed below
 
 	// Diagnostic output only: cap the read; truncation is acceptable.
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))

--- a/cmd/vision3/config_watcher.go
+++ b/cmd/vision3/config_watcher.go
@@ -48,7 +48,7 @@ func NewConfigWatcher(rootConfigPath, menuSetPath string, menuExecutor *menu.Men
 
 	// Watch the configs directory
 	if err := watcher.Add(rootConfigPath); err != nil {
-		watcher.Close()
+		_ = watcher.Close() // cleanup on error path
 		return nil, fmt.Errorf("failed to watch %s: %w", rootConfigPath, err)
 	}
 	slog.Info("watching for config changes", "path", rootConfigPath)
@@ -86,7 +86,7 @@ func (cw *ConfigWatcher) Stop() {
 	}
 	cw.watcherDone = nil
 
-	cw.watcher.Close()
+	_ = cw.watcher.Close() // best-effort watcher shutdown
 	cw.watcher = nil
 	slog.Info("configuration file watcher stopped")
 }

--- a/cmd/vision3/main.go
+++ b/cmd/vision3/main.go
@@ -452,12 +452,14 @@ func (ct *ConnectionTracker) AppendToBlocklist(ip string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open blocklist file: %w", err)
 	}
-	defer f.Close()
-
 	timestamp := time.Now().Format("2006-01-02 15:04:05")
 	line := fmt.Sprintf("%s # auto-blocked %s: too many failed logins\n", normalizedIP, timestamp)
 	if _, err := f.WriteString(line); err != nil {
+		_ = f.Close() // best-effort; the write error takes precedence
 		return fmt.Errorf("failed to write to blocklist file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("failed to close blocklist file: %w", err)
 	}
 
 	// Update in-memory list immediately — don't wait for fsnotify debounce
@@ -617,7 +619,7 @@ func (ct *ConnectionTracker) watchLoop() {
 func (ct *ConnectionTracker) StopWatching() {
 	if ct.watcher != nil {
 		close(ct.watcherDone)
-		ct.watcher.Close()
+		_ = ct.watcher.Close() // best-effort watcher shutdown
 	}
 }
 
@@ -689,7 +691,7 @@ func sessionHandler(s ssh.Session) {
 			slog.Debug("no authenticated user, skipping call record", "node", nodeID)
 		}
 		// ------------------------
-		s.Close() // Ensure the session is closed
+		_ = s.Close() // ensure the session is closed; best-effort
 	}(capturedStartTime) // Pass only the startTime value
 
 	// Create the session state object *early* - COMMENTED OUT (not used, type mismatch)
@@ -967,7 +969,7 @@ func sessionHandler(s ssh.Session) {
 			// Log the error and decide how to proceed
 			slog.Error("error executing menu", "node", nodeID, "menu", currentMenuName, "error", execErr)
 			// Optionally display an error message to the user
-			fmt.Fprintf(terminal, "\r\nSystem error during menu execution: %v\r\n", execErr)
+			_, _ = fmt.Fprintf(terminal, "\r\nSystem error during menu execution: %v\r\n", execErr) // best-effort display
 			// Maybe force logoff or retry?
 			currentMenuName = "LOGOFF" // Force logoff on error for now
 			continue
@@ -1062,7 +1064,7 @@ func sessionHandler(s ssh.Session) {
 		invLevel = cfg.CoSysOpLevel // backward compat: missing config uses coSysOpLevel
 	}
 	if authenticatedUser.AccessLevel >= invLevel {
-		terminal.Write([]byte("\x1b[2J\x1b[H"))
+		_, _ = terminal.Write([]byte("\x1b[2J\x1b[H")) // best-effort display
 		invisPrompt := loadedStrings.InvisibleLogonPrompt
 		if invisPrompt == "" {
 			invisPrompt = " |03Invisible Logon?|07"
@@ -1105,7 +1107,7 @@ func sessionHandler(s ssh.Session) {
 				"detected_h", detectedH,
 				"stored_w", authenticatedUser.ScreenWidth,
 				"stored_h", authenticatedUser.ScreenHeight)
-			terminal.Write([]byte("\r\n"))
+			_, _ = terminal.Write([]byte("\r\n")) // best-effort display
 
 			useNew, promptErr := menuExecutor.PromptYesNo(s, terminal,
 				fmt.Sprintf(loadedStrings.TermSizeNewDetectedPrompt,
@@ -1184,16 +1186,16 @@ func sessionHandler(s ssh.Session) {
 
 		// Encoding Selection Prompt (for ambiguous terminals like xterm)
 		if effectiveMode == ansi.OutputModeUTF8 && termType == "xterm" && authenticatedUser.PreferredEncoding == "" {
-			terminal.Write([]byte("\r\n"))
-			terminal.Write([]byte("\x1b[1;36m CHARACTER ENCODING SELECTION\x1b[0m\r\n"))
-			terminal.Write([]byte("\x1b[1;33m ----------------------------\x1b[0m\r\n"))
-			terminal.Write([]byte("\r\n"))
-			terminal.Write([]byte("Your terminal reported as '\x1b[1m" + termType + "\x1b[0m' which can support multiple encodings.\r\n"))
-			terminal.Write([]byte("\r\n"))
-			terminal.Write([]byte("\x1b[1;32m[U]\x1b[0m Continue with \x1b[1mUTF-8\x1b[0m (modern terminals, Unicode support)\r\n"))
-			terminal.Write([]byte("\x1b[1;32m[C]\x1b[0m Switch to \x1b[1mCP437\x1b[0m (retro BBS terminals: SyncTerm, NetRunner, etc.)\r\n"))
-			terminal.Write([]byte("\r\n"))
-			terminal.Write([]byte("Choice \x1b[1;33m[U/C]\x1b[0m: "))
+			_, _ = terminal.Write([]byte("\r\n"))                                                                                                    // best-effort display
+			_, _ = terminal.Write([]byte("\x1b[1;36m CHARACTER ENCODING SELECTION\x1b[0m\r\n"))                                                      // best-effort display
+			_, _ = terminal.Write([]byte("\x1b[1;33m ----------------------------\x1b[0m\r\n"))                                                      // best-effort display
+			_, _ = terminal.Write([]byte("\r\n"))                                                                                                    // best-effort display
+			_, _ = terminal.Write([]byte("Your terminal reported as '\x1b[1m" + termType + "\x1b[0m' which can support multiple encodings.\r\n"))    // best-effort display
+			_, _ = terminal.Write([]byte("\r\n"))                                                                                                    // best-effort display
+			_, _ = terminal.Write([]byte("\x1b[1;32m[U]\x1b[0m Continue with \x1b[1mUTF-8\x1b[0m (modern terminals, Unicode support)\r\n"))          // best-effort display
+			_, _ = terminal.Write([]byte("\x1b[1;32m[C]\x1b[0m Switch to \x1b[1mCP437\x1b[0m (retro BBS terminals: SyncTerm, NetRunner, etc.)\r\n")) // best-effort display
+			_, _ = terminal.Write([]byte("\r\n"))                                                                                                    // best-effort display
+			_, _ = terminal.Write([]byte("Choice \x1b[1;33m[U/C]\x1b[0m: "))                                                                         // best-effort display
 
 			choice, err := terminal.ReadLine()
 			if err == nil {
@@ -1203,12 +1205,12 @@ func sessionHandler(s ssh.Session) {
 					effectiveMode = ansi.OutputModeCP437
 					authenticatedUser.PreferredEncoding = "cp437"
 					setupChanged = true
-					terminal.Write([]byte("\r\n\x1b[1;32m[OK]\x1b[0m Switched to CP437 encoding for retro BBS experience.\r\n"))
+					_, _ = terminal.Write([]byte("\r\n\x1b[1;32m[OK]\x1b[0m Switched to CP437 encoding for retro BBS experience.\r\n")) // best-effort display
 				} else {
 					slog.Info("user selected UTF-8 encoding", "node", nodeID)
 					authenticatedUser.PreferredEncoding = "utf8"
 					setupChanged = true
-					terminal.Write([]byte("\r\n\x1b[1;32m[OK]\x1b[0m Continuing with UTF-8 encoding.\r\n"))
+					_, _ = terminal.Write([]byte("\r\n\x1b[1;32m[OK]\x1b[0m Continuing with UTF-8 encoding.\r\n")) // best-effort display
 				}
 			}
 		}
@@ -1216,12 +1218,12 @@ func sessionHandler(s ssh.Session) {
 		// Terminal Height Adjustment Prompt
 		detectedHeight := int(termHeight.Load())
 		if detectedHeight > 25 && (authenticatedUser.ScreenWidth == 0 || authenticatedUser.ScreenHeight == 0) {
-			terminal.Write([]byte("\r\n"))
-			terminal.Write([]byte("Your terminal reports \x1b[1m" + fmt.Sprintf("%d", detectedHeight) + " rows\x1b[0m.\r\n"))
-			terminal.Write([]byte("If you have a status bar enabled (NetRunner, SyncTerm, etc.),\r\n"))
-			terminal.Write([]byte("some rows may not be available for display.\r\n"))
-			terminal.Write([]byte("\r\n"))
-			terminal.Write([]byte("How many rows are available for BBS display? [\x1b[1m" + fmt.Sprintf("%d", detectedHeight) + "\x1b[0m]: "))
+			_, _ = terminal.Write([]byte("\r\n"))                                                                                                     // best-effort display
+			_, _ = terminal.Write([]byte("Your terminal reports \x1b[1m" + fmt.Sprintf("%d", detectedHeight) + " rows\x1b[0m.\r\n"))                  // best-effort display
+			_, _ = terminal.Write([]byte("If you have a status bar enabled (NetRunner, SyncTerm, etc.),\r\n"))                                        // best-effort display
+			_, _ = terminal.Write([]byte("some rows may not be available for display.\r\n"))                                                          // best-effort display
+			_, _ = terminal.Write([]byte("\r\n"))                                                                                                     // best-effort display
+			_, _ = terminal.Write([]byte("How many rows are available for BBS display? [\x1b[1m" + fmt.Sprintf("%d", detectedHeight) + "\x1b[0m]: ")) // best-effort display
 
 			heightChoice, heightErr := terminal.ReadLine()
 			if heightErr != nil {
@@ -1240,7 +1242,7 @@ func sessionHandler(s ssh.Session) {
 						authenticatedUser.ScreenHeight = adjustedHeight
 						setupChanged = true
 						_ = terminal.SetSize(int(termWidth.Load()), adjustedHeight)
-						terminal.Write([]byte("\r\n\x1b[1;32m[OK]\x1b[0m Display height set to " + fmt.Sprintf("%d", adjustedHeight) + " rows.\r\n"))
+						_, _ = terminal.Write([]byte("\r\n\x1b[1;32m[OK]\x1b[0m Display height set to " + fmt.Sprintf("%d", adjustedHeight) + " rows.\r\n")) // best-effort display
 					}
 				}
 			}
@@ -1248,29 +1250,29 @@ func sessionHandler(s ssh.Session) {
 
 		// Ask to save as default if anything changed
 		if setupChanged {
-			terminal.Write([]byte("\r\n"))
-			terminal.Write([]byte("Save these settings as your default preference? \x1b[1;33m[Y/n]\x1b[0m: "))
+			_, _ = terminal.Write([]byte("\r\n"))                                                                     // best-effort display
+			_, _ = terminal.Write([]byte("Save these settings as your default preference? \x1b[1;33m[Y/n]\x1b[0m: ")) // best-effort display
 			saveChoice, saveErr := terminal.ReadLine()
 			if saveErr == nil {
 				saveChoice = strings.TrimSpace(strings.ToUpper(saveChoice))
 				if saveChoice == "" || saveChoice == "Y" || saveChoice == "YES" {
 					if err := userMgr.UpdateUser(authenticatedUser); err != nil {
 						slog.Warn("failed to save user preferences", "node", nodeID, "error", err)
-						terminal.Write([]byte("\r\n\x1b[1;33m[WARN]\x1b[0m Failed to save preferences.\r\n"))
+						_, _ = terminal.Write([]byte("\r\n\x1b[1;33m[WARN]\x1b[0m Failed to save preferences.\r\n")) // best-effort display
 					} else {
 						slog.Info("saved user preferences",
 							"node", nodeID,
 							"encoding", authenticatedUser.PreferredEncoding,
 							"width", authenticatedUser.ScreenWidth,
 							"height", authenticatedUser.ScreenHeight)
-						terminal.Write([]byte("\r\n\x1b[1;32m[SAVED]\x1b[0m Your preferences have been saved.\r\n"))
+						_, _ = terminal.Write([]byte("\r\n\x1b[1;32m[SAVED]\x1b[0m Your preferences have been saved.\r\n")) // best-effort display
 					}
 				} else {
 					slog.Info("user declined to save preferences", "node", nodeID)
-					terminal.Write([]byte("\r\n\x1b[1;36m[INFO]\x1b[0m Settings will be used for this session only.\r\n"))
+					_, _ = terminal.Write([]byte("\r\n\x1b[1;36m[INFO]\x1b[0m Settings will be used for this session only.\r\n")) // best-effort display
 				}
 			}
-			terminal.Write([]byte("\r\n"))
+			_, _ = terminal.Write([]byte("\r\n")) // best-effort display
 		}
 	} else if authenticatedUser.PreferredEncoding != "" {
 		// User has saved encoding preference - apply it
@@ -1310,7 +1312,7 @@ func sessionHandler(s ssh.Session) {
 	for {
 		if currentMenuName == "" || currentMenuName == "LOGOFF" {
 			slog.Info("user selected logoff", "node", nodeID, "user", authenticatedUser.Handle)
-			fmt.Fprintln(terminal, "\r\nLogging off...")
+			_, _ = fmt.Fprintln(terminal, "\r\nLogging off...") // best-effort display
 			// Add any cleanup tasks before closing the session
 			break // Exit the loop
 		}
@@ -1331,7 +1333,7 @@ func sessionHandler(s ssh.Session) {
 		nextMenuName, _, execErr := menuExecutor.Run(s, terminal, userMgr, authenticatedUser, currentMenuName, int(nodeID), sessionStartTime, autoRunLog, effectiveMode, "", int(termWidth.Load()), int(termHeight.Load()))
 		if execErr != nil {
 			slog.Error("error executing menu", "node", nodeID, "menu", currentMenuName, "error", execErr)
-			fmt.Fprintf(terminal, "\r\nSystem error during menu execution: %v\r\n", execErr)
+			_, _ = fmt.Fprintf(terminal, "\r\nSystem error during menu execution: %v\r\n", execErr) // best-effort display
 			// Logoff on error?
 			currentMenuName = "LOGOFF"
 			continue
@@ -1350,9 +1352,9 @@ func telnetSessionHandler(adapter *telnetserver.TelnetSessionAdapter) {
 	canAccept, reason := connectionTracker.TryAccept(adapter.RemoteAddr())
 	if !canAccept {
 		slog.Info("rejecting telnet connection", "addr", adapter.RemoteAddr(), "reason", reason)
-		fmt.Fprintf(adapter, "\r\nConnection rejected: %s\r\n", reason)
-		fmt.Fprintf(adapter, "Please try again later.\r\n")
-		time.Sleep(2 * time.Second) // Brief delay before closing
+		_, _ = fmt.Fprintf(adapter, "\r\nConnection rejected: %s\r\n", reason) // best-effort display
+		_, _ = fmt.Fprintf(adapter, "Please try again later.\r\n")             // best-effort display
+		time.Sleep(2 * time.Second)                                            // Brief delay before closing
 		return
 	}
 
@@ -1413,7 +1415,7 @@ func main() {
 	if err != nil {
 		logging.Fatal("failed to initialize logging", "error", err)
 	}
-	defer closeLog()
+	defer func() { _ = closeLog() }() // best-effort log flush at exit
 	slog.Info("starting ViSiON/3 BBS server")
 
 	// Initialize connection tracker with configured limits and IP filter file paths
@@ -1494,7 +1496,11 @@ func main() {
 	if err != nil {
 		logging.Fatal("failed to initialize message manager", "error", err)
 	}
-	defer messageMgr.Close() // Ensure JAM bases are closed on shutdown
+	defer func() {
+		if cerr := messageMgr.Close(); cerr != nil {
+			slog.Error("closing JAM message bases on shutdown", "error", cerr)
+		}
+	}()
 
 	// Initialize FileManager (using dataPath)
 	fileMgr, err = file.NewFileManager(dataPath, rootConfigPath)
@@ -1687,7 +1693,9 @@ func main() {
 			defer func() {
 				slog.Info("shutting down V3Net service")
 				v3netCancel()
-				v3netService.Close()
+				if cerr := v3netService.Close(); cerr != nil {
+					slog.Error("closing V3Net service", "error", cerr)
+				}
 			}()
 
 			go v3netService.Start(v3netCtx)
@@ -1743,7 +1751,7 @@ func main() {
 		if telnetErr != nil {
 			logging.Fatal("failed to create telnet server", "error", telnetErr)
 		}
-		defer telnetSrv.Close()
+		defer func() { _ = telnetSrv.Close() }() // best-effort shutdown
 
 		go func() {
 			if listenErr := telnetSrv.ListenAndServe(); listenErr != nil {

--- a/cmd/vision3/ssh_server.go
+++ b/cmd/vision3/ssh_server.go
@@ -60,7 +60,7 @@ func startSSHServer(hostKeyPath, sshHost string, sshPort int, legacyAlgorithms b
 	}
 
 	cleanup := func() {
-		server.Close()
+		_ = server.Close() // best-effort shutdown
 		sshserver.Cleanup()
 	}
 
@@ -82,8 +82,8 @@ func sshSessionHandler(sess ssh.Session) {
 	canAccept, reason := connectionTracker.TryAccept(wrapped.RemoteAddr())
 	if !canAccept {
 		slog.Info("rejecting SSH connection", "addr", wrapped.RemoteAddr(), "reason", reason)
-		fmt.Fprintf(wrapped, "\r\nConnection rejected: %s\r\n", reason)
-		fmt.Fprintf(wrapped, "Please try again later.\r\n")
+		_, _ = fmt.Fprintf(wrapped, "\r\nConnection rejected: %s\r\n", reason) // best-effort notice to client
+		_, _ = fmt.Fprintf(wrapped, "Please try again later.\r\n") // best-effort notice to client
 		time.Sleep(2 * time.Second)
 		return
 	}

--- a/cmd/vision3/ssh_server.go
+++ b/cmd/vision3/ssh_server.go
@@ -83,7 +83,7 @@ func sshSessionHandler(sess ssh.Session) {
 	if !canAccept {
 		slog.Info("rejecting SSH connection", "addr", wrapped.RemoteAddr(), "reason", reason)
 		_, _ = fmt.Fprintf(wrapped, "\r\nConnection rejected: %s\r\n", reason) // best-effort notice to client
-		_, _ = fmt.Fprintf(wrapped, "Please try again later.\r\n") // best-effort notice to client
+		_, _ = fmt.Fprintf(wrapped, "Please try again later.\r\n")             // best-effort notice to client
 		time.Sleep(2 * time.Second)
 		return
 	}

--- a/cmd/vision3/wfc_admin.go
+++ b/cmd/vision3/wfc_admin.go
@@ -71,7 +71,7 @@ func wfcAdminSubsystem(sess ssh.Session) {
 	handle, _ := sess.Context().Value(wfcAdminHandleKey{}).(string)
 	if handle == "" || !authorizeAdmin(handle) {
 		slog.Warn("wfc-admin: subsystem access denied", "user", handle, "addr", sess.RemoteAddr())
-		fmt.Fprintf(sess, "access denied\n")
+		_, _ = fmt.Fprintf(sess, "access denied\n") // best-effort notice to client
 		return
 	}
 
@@ -83,7 +83,7 @@ func wfcAdminSubsystem(sess ssh.Session) {
 
 	if adminServer == nil {
 		slog.Warn("wfc-admin: subsystem requested before admin server initialized", "remote", sess.RemoteAddr())
-		fmt.Fprintf(sess, "server not ready\r\n")
+		_, _ = fmt.Fprintf(sess, "server not ready\r\n") // best-effort notice to client
 		return
 	}
 

--- a/cmd/wfc/main.go
+++ b/cmd/wfc/main.go
@@ -90,7 +90,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "wfc: connect: %v\n", err)
 		os.Exit(1)
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }() // best-effort teardown
 
 	model := wfcui.New(client, wfcui.Options{
 		ASCII:     f.ascii,

--- a/internal/admin/client_ssh.go
+++ b/internal/admin/client_ssh.go
@@ -76,13 +76,13 @@ func DialSSH(cfg SSHDialConfig) (*SSHChannelClient, error) {
 
 	sess, err := conn.NewSession()
 	if err != nil {
-		conn.Close()
+		_ = conn.Close() // cleanup on error path
 		return nil, fmt.Errorf("admin: ssh new session: %w", err)
 	}
 
 	if err := sess.RequestSubsystem("wfc-admin"); err != nil {
-		sess.Close()
-		conn.Close()
+		_ = sess.Close() // cleanup on error path
+		_ = conn.Close() // cleanup on error path
 		return nil, fmt.Errorf("admin: request wfc-admin subsystem: %w", err)
 	}
 

--- a/internal/admin/rpc.go
+++ b/internal/admin/rpc.go
@@ -48,7 +48,7 @@ func ServeRPC(ctx context.Context, rw io.ReadWriteCloser, srv *Server, audit fun
 	// write error — a second Close is safe on most transports, but Once avoids
 	// any log noise from double-close.
 	var closeOnce sync.Once
-	closeRW := func() { closeOnce.Do(func() { rw.Close() }) }
+	closeRW := func() { closeOnce.Do(func() { _ = rw.Close() }) }
 	go func() {
 		<-subCtx.Done()
 		closeRW()

--- a/internal/ansi/ansi.go
+++ b/internal/ansi/ansi.go
@@ -331,8 +331,7 @@ func ReplacePipeCodes(data []byte) []byte {
 		if data[i] == '|' && i+1 < dataLen {
 			// Try 4-char code first (e.g., |B10)
 			if i+3 < dataLen {
-				code := string(data[i : i+4])
-				if replacement, ok := pipeCodeReplacements[code]; ok {
+				if replacement, ok := pipeCodeReplacements[string(data[i:i+4])]; ok {
 					buf.WriteString(replacement)
 					i += 4
 					continue
@@ -340,16 +339,14 @@ func ReplacePipeCodes(data []byte) []byte {
 			}
 			// Try 3-char code (e.g., |PP, |CL, |01)
 			if i+2 < dataLen {
-				code := string(data[i : i+3])
-				if replacement, ok := pipeCodeReplacements[code]; ok {
+				if replacement, ok := pipeCodeReplacements[string(data[i:i+3])]; ok {
 					buf.WriteString(replacement)
 					i += 3
 					continue
 				}
 			}
 			// Try 2-char code (e.g., |P save cursor)
-			code := string(data[i : i+2])
-			if replacement, ok := pipeCodeReplacements[code]; ok {
+			if replacement, ok := pipeCodeReplacements[string(data[i:i+2])]; ok {
 				buf.WriteString(replacement)
 				i += 2
 				continue
@@ -768,8 +765,7 @@ func ProcessAnsiAndExtractCoords(rawContent []byte, outputMode OutputMode) (Proc
 
 				// Try 2-char code |X (e.g., |P save cursor)
 				if !pipeCodeFound {
-					codeStr := string(content[i : i+2])
-					if replacement, ok := pipeCodeReplacements[codeStr]; ok {
+					if replacement, ok := pipeCodeReplacements[string(content[i:i+2])]; ok {
 						displayBuf.WriteString(replacement)
 						consumed = 2
 						pipeCodeFound = true

--- a/internal/chat/local.go
+++ b/internal/chat/local.go
@@ -59,9 +59,12 @@ func NewLocalChatService(handle, dbPath string) (*LocalChatService, error) {
 		return nil, fmt.Errorf("local chat: open db: %w", err)
 	}
 	db.SetMaxOpenConns(1)
-	db.Exec("PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000")
+	if _, err := db.Exec("PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000"); err != nil {
+		_ = db.Close() // cleanup on error path
+		return nil, fmt.Errorf("local chat: configure pragmas: %w", err)
+	}
 	if _, err := db.Exec(localChatSchema); err != nil {
-		db.Close()
+		_ = db.Close() // cleanup on error path
 		return nil, fmt.Errorf("local chat: create tables: %w", err)
 	}
 	pruneLocalHistory(db, 7)
@@ -185,7 +188,7 @@ func (s *LocalChatService) History(room string, limit int) ([]ChatMessage, error
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }() // read-only
 	var msgs []ChatMessage
 	for rows.Next() {
 		var m ChatMessage
@@ -222,7 +225,7 @@ func (s *LocalChatService) Close() error {
 		defer s.mu.RUnlock()
 		return s.currentRoom
 	}(); room != "" {
-		s.Leave(room)
+		_ = s.Leave(room) // best-effort on shutdown
 	}
 	close(s.events)
 	return s.db.Close()
@@ -274,6 +277,7 @@ func broadcastLocalEvent(room, senderHandle string, ev ChatEvent) {
 
 func pruneLocalHistory(db *sql.DB, days int) {
 	cutoff := time.Now().UTC().AddDate(0, 0, -days)
-	db.Exec(`DELETE FROM chat_history WHERE created_at < ?`, cutoff)
-	db.Exec(`DELETE FROM chat_private_history WHERE created_at < ?`, cutoff)
+	// Best-effort maintenance; stale rows are retried on the next prune.
+	_, _ = db.Exec(`DELETE FROM chat_history WHERE created_at < ?`, cutoff)
+	_, _ = db.Exec(`DELETE FROM chat_private_history WHERE created_at < ?`, cutoff)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -760,9 +760,8 @@ func LoadThemeConfig(menuSetPath string) (ThemeConfig, error) {
 		return defaultTheme, fmt.Errorf("failed to read theme file %s: %w", filePath, err)
 	}
 
-	var theme ThemeConfig
 	// Initialize theme with defaults before unmarshalling
-	theme = defaultTheme
+	theme := defaultTheme
 	err = json.Unmarshal(data, &theme)
 	if err != nil {
 		slog.Error("failed to parse theme JSON, using default theme settings", "path", filePath, "error", err)
@@ -1119,9 +1118,8 @@ func LoadServerConfig(configPath string) (ServerConfig, error) {
 		return defaultConfig, fmt.Errorf("failed to read config file %s: %w", filePath, err)
 	}
 
-	var config ServerConfig
 	// Initialize with defaults before unmarshalling
-	config = defaultConfig
+	config := defaultConfig
 	err = json.Unmarshal(data, &config)
 	if err != nil {
 		slog.Error("failed to parse config JSON, using default settings", "path", filePath, "error", err)

--- a/internal/configeditor/update_records.go
+++ b/internal/configeditor/update_records.go
@@ -461,7 +461,7 @@ func (m *Model) toggleYesNo(f fieldDef) {
 		} else {
 			val = "Y"
 		}
-		f.Set(val)
+		_ = f.Set(val) // Y/N field setters never fail
 		m.dirty = true
 		m.message = ""
 		if f.AfterSet != nil {

--- a/internal/configeditor/update_syscfg.go
+++ b/internal/configeditor/update_syscfg.go
@@ -143,9 +143,9 @@ func (m Model) nextSysEditableField(dir int) int {
 func (m *Model) toggleSysYesNo(f fieldDef) {
 	if f.Get != nil && f.Set != nil {
 		if f.Get() == "Y" {
-			f.Set("N")
+			_ = f.Set("N") // Y/N field setters never fail
 		} else {
-			f.Set("Y")
+			_ = f.Set("Y") // Y/N field setters never fail
 		}
 		m.dirty = true
 		m.message = ""

--- a/internal/configeditor/update_v3net_wizard.go
+++ b/internal/configeditor/update_v3net_wizard.go
@@ -24,7 +24,7 @@ func fetchHubNetworks(hubURL string) tea.Cmd {
 		if err != nil {
 			return fetchNetworksMsg{err: err}
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }() // read-only
 		if resp.StatusCode != http.StatusOK {
 			return fetchNetworksMsg{err: fmt.Errorf("status %d", resp.StatusCode)}
 		}

--- a/internal/configeditor/update_wizard_form.go
+++ b/internal/configeditor/update_wizard_form.go
@@ -193,9 +193,9 @@ func (m Model) nextWizardEditableField(dir int) int {
 func (m *Model) toggleWizardYesNo(f fieldDef) {
 	if f.Get != nil && f.Set != nil {
 		if f.Get() == "Y" {
-			f.Set("N")
+			_ = f.Set("N") // Y/N field setters never fail
 		} else {
-			f.Set("Y")
+			_ = f.Set("Y") // Y/N field setters never fail
 		}
 		m.message = ""
 	}

--- a/internal/configeditor/v3net_area_browser_cmds.go
+++ b/internal/configeditor/v3net_area_browser_cmds.go
@@ -36,7 +36,7 @@ func fetchHubNAL(hubURL, network string) tea.Cmd {
 		if err != nil {
 			return fetchNALMsg{err: err}
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }() // read-only
 		if resp.StatusCode != http.StatusOK {
 			body, readErr := io.ReadAll(io.LimitReader(resp.Body, 512))
 			detail := strings.TrimSpace(string(body))
@@ -87,7 +87,7 @@ func subscribeToAreas(hubURL, network string, areaTags []string,
 		if err != nil {
 			return subscribeAreasMsg{err: err}
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }() // read-only
 
 		if resp.StatusCode != http.StatusOK {
 			return subscribeAreasMsg{err: fmt.Errorf("subscribe returned status %d", resp.StatusCode)}

--- a/internal/configeditor/v3net_identity_helpers.go
+++ b/internal/configeditor/v3net_identity_helpers.go
@@ -118,26 +118,26 @@ func (m Model) writeRecoveryFile(path string, ks *keystore.Keystore) error {
 	tmpName := tmp.Name()
 
 	if err := tmp.Chmod(0600); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
+		_ = tmp.Close()        // cleanup on error path
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("chmod temp file: %w", err)
 	}
 	if _, err := tmp.WriteString(b.String()); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
+		_ = tmp.Close()        // cleanup on error path
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("write temp file: %w", err)
 	}
 	if err := tmp.Sync(); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
+		_ = tmp.Close()        // cleanup on error path
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("sync temp file: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("close temp file: %w", err)
 	}
 	if err := os.Rename(tmpName, path); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("rename %s -> %s: %w", tmpName, path, err)
 	}
 	return nil

--- a/internal/editor/commands.go
+++ b/internal/editor/commands.go
@@ -175,7 +175,7 @@ func (ch *CommandHandler) HandleQuote(inputHandler *InputHandler, currentLine, c
 		ch.screen.GoXY(1, promptRow)
 		ch.screen.ClearEOL()
 		ch.screen.WriteDirectProcessed("|12You are not replying to anything! Press any key...")
-		inputHandler.ReadKey()
+		_, _ = inputHandler.ReadKey() // wait for any key
 		return currentLine, 1
 	}
 
@@ -421,7 +421,7 @@ func (ch *CommandHandler) HandleHelp(inputHandler *InputHandler) {
 	// Wait for key press
 	ch.screen.GoXY(1, ch.screen.termHeight)
 	ch.screen.WriteDirectProcessed("|15Press any key to continue...")
-	inputHandler.ReadKey()
+	_, _ = inputHandler.ReadKey() // wait for any key
 }
 
 // displayBuiltInHelp displays built-in help text
@@ -484,7 +484,7 @@ func (ch *CommandHandler) HandleView(inputHandler *InputHandler) {
 	// Wait for key press
 	ch.screen.GoXY(1, ch.screen.termHeight)
 	ch.screen.WriteDirectProcessed("|15Press any key to continue...")
-	inputHandler.ReadKey()
+	_, _ = inputHandler.ReadKey() // wait for any key
 }
 
 // ShowEscapeMenu displays a lightbar selection menu at PromptRow when Escape is pressed.

--- a/internal/editor/fseditor.go
+++ b/internal/editor/fseditor.go
@@ -265,7 +265,7 @@ func (e *FSEditor) handleCommand(cmdType CommandType) {
 			e.quit = true
 		} else {
 			// Error message already written; wait for key then restore footer
-			e.input.ReadKey()
+			_, _ = e.input.ReadKey() // wait for any key
 			e.screen.DisplayFooter()
 			e.screen.RefreshScreen(e.buffer, e.topLine, e.currentLine, e.currentCol, e.insertMode, true)
 		}

--- a/internal/editor/fseditor.go
+++ b/internal/editor/fseditor.go
@@ -137,11 +137,8 @@ func (e *FSEditor) Run() (string, bool, error) {
 	if e.ownsInput {
 		defer e.input.CloseAndWait()
 	}
-	// Load and display header
-	err := e.screen.LoadHeaderTemplate(e.menuSetPath, e.subject, e.recipient, e.fromName, e.isAnon)
-	if err != nil {
-		// Non-fatal - continue with minimal header
-	}
+	// Load and display header (non-fatal on error - continue with minimal header)
+	_ = e.screen.LoadHeaderTemplate(e.menuSetPath, e.subject, e.recipient, e.fromName, e.isAnon)
 
 	// Load footer template — adjusts statusLineY to reserve the bottom 2 rows.
 	// Must be called after LoadHeaderTemplate so editingStartY is already set from |#N.

--- a/internal/editor/wordwrap.go
+++ b/internal/editor/wordwrap.go
@@ -141,7 +141,6 @@ func (ww *WordWrapper) ReflowRange(startLine, cursorLine, cursorCol int) (int, i
 		// Truncate tracking to what was actually written
 		if actualNew < newCount {
 			newCount = actualNew
-			outputLines = outputLines[:newCount]
 			lineStarts = lineStarts[:newCount]
 		}
 	} else if newCount < originalCount {

--- a/internal/file/manager.go
+++ b/internal/file/manager.go
@@ -460,8 +460,8 @@ func (fm *FileManager) IncrementDownloadCount(fileID uuid.UUID) error {
 	fm.muFiles.Lock()
 	defer fm.muFiles.Unlock()
 
-	var foundAreaID int = -1
-	var foundIndex int = -1
+	foundAreaID := -1
+	foundIndex := -1
 
 	// Find the file across all areas
 searchLoop:
@@ -505,8 +505,8 @@ func (fm *FileManager) UpdateFileRecord(fileID uuid.UUID, updateFunc func(*FileR
 	fm.muFiles.Lock()
 	defer fm.muFiles.Unlock()
 
-	var foundAreaID int = -1
-	var foundIndex int = -1
+	foundAreaID := -1
+	foundIndex := -1
 
 searchLoop:
 	for areaID, records := range fm.fileRecords {
@@ -552,8 +552,8 @@ func (fm *FileManager) DeleteFileRecord(fileID uuid.UUID, deleteFromDisk bool) e
 	fm.muFiles.Lock()
 	defer fm.muFiles.Unlock()
 
-	var foundAreaID int = -1
-	var foundIndex int = -1
+	foundAreaID := -1
+	foundIndex := -1
 	var foundFilename string
 
 searchLoop:
@@ -622,8 +622,8 @@ func (fm *FileManager) MoveFileRecord(fileID uuid.UUID, targetAreaID int) error 
 	fm.muFiles.Lock()
 	defer fm.muFiles.Unlock()
 
-	var srcAreaID int = -1
-	var srcIndex int = -1
+	srcAreaID := -1
+	srcIndex := -1
 
 searchLoop:
 	for areaID, records := range fm.fileRecords {

--- a/internal/ftn/binkd.go
+++ b/internal/ftn/binkd.go
@@ -147,17 +147,17 @@ func writeFreshBinkdConf(out *strings.Builder, cfg BinkdConfig, outPath, logPath
 	// Domains.
 	out.WriteString("#\n# Domains:\n#\n")
 	for name, zone := range cfg.Domains {
-		out.WriteString(fmt.Sprintf("domain %s %s %d\n", name, outPath, zone))
+		fmt.Fprintf(out, "domain %s %s %d\n", name, outPath, zone)
 	}
 
 	// Addresses.
 	out.WriteString("\n#\n# Your Addresses:\n#\n")
 	for _, addr := range cfg.Addresses {
-		out.WriteString(fmt.Sprintf("address %s\n", addr))
+		fmt.Fprintf(out, "address %s\n", addr)
 	}
 
 	// General settings.
-	out.WriteString(fmt.Sprintf(`
+	fmt.Fprintf(out, `
 #
 # General variables for your BBS:
 #
@@ -183,10 +183,10 @@ kill-old-bsy 43200
 try 2
 hold 1800
 iport 24554
-`, boardName, location, sysop, logPath, secureIn, insecureIn))
+`, boardName, location, sysop, logPath, secureIn, insecureIn)
 
 	// Exec / prescan.
-	out.WriteString(fmt.Sprintf(`
+	fmt.Fprintf(out, `
 #
 # Execute v3mail toss after receiving files:
 #
@@ -197,7 +197,7 @@ exec "%s toss" *.[mwtfsMWTFS][oehrauOEHRAU][0-9a-zA-Z] *.pkt
 # BinkD additional options:
 #
 percents
-`, v3mailPath))
+`, v3mailPath)
 }
 
 // rewriteBinkdConf filters an existing binkd.conf, replacing placeholder
@@ -216,44 +216,44 @@ func rewriteBinkdConf(out *strings.Builder, content string, cfg BinkdConfig, out
 			// If this is a domain placeholder, inject real domains once.
 			if strings.HasPrefix(trimmed, "domain ") && !injectedDomains {
 				for name, zone := range cfg.Domains {
-					out.WriteString(fmt.Sprintf("domain %s %s %d\n", name, outPath, zone))
+					fmt.Fprintf(out, "domain %s %s %d\n", name, outPath, zone)
 				}
 				injectedDomains = true
 			}
 			// If this is an address placeholder, inject real addresses once.
 			if strings.HasPrefix(trimmed, "address ") && !injectedAddresses {
 				for _, addr := range cfg.Addresses {
-					out.WriteString(fmt.Sprintf("address %s\n", addr))
+					fmt.Fprintf(out, "address %s\n", addr)
 				}
 				injectedAddresses = true
 			}
 			// Replace sysname/sysop/log/inbound/exec placeholders.
 			if strings.HasPrefix(trimmed, "sysname ") {
-				out.WriteString(fmt.Sprintf("sysname \"%s\"\n", boardName))
+				fmt.Fprintf(out, "sysname \"%s\"\n", boardName)
 				continue
 			}
 			if strings.HasPrefix(trimmed, "location ") {
-				out.WriteString(fmt.Sprintf("location \"%s\"\n", location))
+				fmt.Fprintf(out, "location \"%s\"\n", location)
 				continue
 			}
 			if strings.HasPrefix(trimmed, "sysop ") {
-				out.WriteString(fmt.Sprintf("sysop \"%s\"\n", sysop))
+				fmt.Fprintf(out, "sysop \"%s\"\n", sysop)
 				continue
 			}
 			if strings.HasPrefix(trimmed, "log ") {
-				out.WriteString(fmt.Sprintf("log %s\n", logPath))
+				fmt.Fprintf(out, "log %s\n", logPath)
 				continue
 			}
 			if strings.HasPrefix(trimmed, "inbound-nonsecure ") {
-				out.WriteString(fmt.Sprintf("inbound-nonsecure %s\n", insecureIn))
+				fmt.Fprintf(out, "inbound-nonsecure %s\n", insecureIn)
 				continue
 			}
 			if strings.HasPrefix(trimmed, "inbound ") {
-				out.WriteString(fmt.Sprintf("inbound %s\n", secureIn))
+				fmt.Fprintf(out, "inbound %s\n", secureIn)
 				continue
 			}
 			if strings.HasPrefix(trimmed, "exec ") {
-				out.WriteString(fmt.Sprintf("exec \"%s toss\" *.[mwtfsMWTFS][oehrauOEHRAU][0-9a-zA-Z] *.pkt\n", v3mailPath))
+				fmt.Fprintf(out, "exec \"%s toss\" *.[mwtfsMWTFS][oehrauOEHRAU][0-9a-zA-Z] *.pkt\n", v3mailPath)
 				continue
 			}
 			// Skip other placeholder lines (node hub.example.com, etc).
@@ -269,13 +269,13 @@ func rewriteBinkdConf(out *strings.Builder, content string, cfg BinkdConfig, out
 	if !injectedDomains {
 		out.WriteString("\n#\n# Domains:\n#\n")
 		for name, zone := range cfg.Domains {
-			out.WriteString(fmt.Sprintf("domain %s %s %d\n", name, outPath, zone))
+			fmt.Fprintf(out, "domain %s %s %d\n", name, outPath, zone)
 		}
 	}
 	if !injectedAddresses {
 		out.WriteString("\n#\n# Your Addresses:\n#\n")
 		for _, addr := range cfg.Addresses {
-			out.WriteString(fmt.Sprintf("address %s\n", addr))
+			fmt.Fprintf(out, "address %s\n", addr)
 		}
 	}
 }
@@ -386,20 +386,20 @@ func writeFileAtomic(path, content string, perm os.FileMode) error {
 	}
 	tmpName := tmp.Name()
 	if _, err := tmp.WriteString(content); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
+		_ = tmp.Close()        // cleanup on error path
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("writing %s: %w", path, err)
 	}
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("closing %s: %w", path, err)
 	}
 	if err := os.Chmod(tmpName, perm); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("chmod %s: %w", path, err)
 	}
 	if err := os.Rename(tmpName, path); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("installing %s: %w", path, err)
 	}
 	return nil

--- a/internal/ftn/bundle.go
+++ b/internal/ftn/bundle.go
@@ -56,7 +56,7 @@ func IsZIPBundle(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }() // read-only
 
 	magic := make([]byte, 4)
 	n, err := f.Read(magic)
@@ -73,7 +73,7 @@ func ExtractBundle(srcPath, destDir string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open bundle %s: %w", filepath.Base(srcPath), err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }() // read-only zip reader
 
 	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return nil, fmt.Errorf("create dest dir %s: %w", destDir, err)
@@ -101,16 +101,17 @@ func extractZipFile(zf *zip.File, destPath string) error {
 	if err != nil {
 		return err
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }() // read-only
 
 	out, err := os.Create(destPath)
 	if err != nil {
 		return err
 	}
-	defer out.Close()
-
-	_, err = io.Copy(out, rc)
-	return err
+	if _, err := io.Copy(out, rc); err != nil {
+		_ = out.Close() // cleanup on error path
+		return err
+	}
+	return out.Close()
 }
 
 // CreateBundle creates a ZIP bundle archive at bundlePath containing the .PKT
@@ -136,25 +137,25 @@ func CreateBundle(bundlePath string, pktPaths []string) (int, error) {
 	count := 0
 	for _, pktPath := range pktPaths {
 		if err := addFileToZip(zw, pktPath); err != nil {
-			zw.Close()
-			f.Close()
-			os.Remove(tmpPath)
+			_ = zw.Close()         // cleanup on error path
+			_ = f.Close()          // cleanup on error path
+			_ = os.Remove(tmpPath) // cleanup on error path
 			return count, fmt.Errorf("add %s to bundle: %w", filepath.Base(pktPath), err)
 		}
 		count++
 	}
 
 	if err := zw.Close(); err != nil {
-		f.Close()
-		os.Remove(tmpPath)
+		_ = f.Close()          // cleanup on error path
+		_ = os.Remove(tmpPath) // cleanup on error path
 		return count, fmt.Errorf("close zip writer: %w", err)
 	}
 	if err := f.Close(); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath) // cleanup on error path
 		return count, fmt.Errorf("close bundle file: %w", err)
 	}
 	if err := os.Rename(tmpPath, bundlePath); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath) // cleanup on error path
 		return 0, fmt.Errorf("rename bundle: %w", err)
 	}
 	return count, nil
@@ -166,7 +167,7 @@ func addFileToZip(zw *zip.Writer, filePath string) error {
 	if err != nil {
 		return err
 	}
-	defer in.Close()
+	defer func() { _ = in.Close() }() // read-only
 
 	info, err := in.Stat()
 	if err != nil {

--- a/internal/ftn/echolist.go
+++ b/internal/ftn/echolist.go
@@ -97,7 +97,7 @@ func DownloadEcholist(ctx context.Context, url string) ([]EchoArea, error) {
 	if err != nil {
 		return nil, fmt.Errorf("fetching echolist: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // read-only
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("echolist download returned status %d", resp.StatusCode)

--- a/internal/ftn/packet.go
+++ b/internal/ftn/packet.go
@@ -147,7 +147,7 @@ func ReadPacketHeaderFromFile(path string) (*PacketHeader, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }() // read-only
 
 	data := make([]byte, PacketHeaderSize)
 	if _, err := io.ReadFull(f, data); err != nil {

--- a/internal/jam/base.go
+++ b/internal/jam/base.go
@@ -66,26 +66,26 @@ func Open(basePath string) (*Base, error) {
 	}
 	b.jdtFile, err = os.OpenFile(jdtPath, os.O_RDWR, 0644)
 	if err != nil {
-		b.jhrFile.Close()
+		_ = b.jhrFile.Close() // cleanup on error path
 		return nil, fmt.Errorf("jam: failed to open .jdt: %w", err)
 	}
 	b.jdxFile, err = os.OpenFile(jdxPath, os.O_RDWR, 0644)
 	if err != nil {
-		b.jhrFile.Close()
-		b.jdtFile.Close()
+		_ = b.jhrFile.Close() // cleanup on error path
+		_ = b.jdtFile.Close() // cleanup on error path
 		return nil, fmt.Errorf("jam: failed to open .jdx: %w", err)
 	}
 	b.jlrFile, err = os.OpenFile(jlrPath, os.O_RDWR, 0644)
 	if err != nil {
-		b.jhrFile.Close()
-		b.jdtFile.Close()
-		b.jdxFile.Close()
+		_ = b.jhrFile.Close() // cleanup on error path
+		_ = b.jdtFile.Close() // cleanup on error path
+		_ = b.jdxFile.Close() // cleanup on error path
 		return nil, fmt.Errorf("jam: failed to open .jlr: %w", err)
 	}
 
 	b.isOpen = true
 	if err := b.readFixedHeader(); err != nil {
-		b.Close()
+		_ = b.Close() // cleanup on error path
 		if strings.Contains(err.Error(), "EOF") || strings.Contains(err.Error(), "invalid") {
 			removeBaseFiles(jhrPath, jdtPath, jdxPath, jlrPath)
 			return b, b.create()
@@ -111,20 +111,20 @@ func (b *Base) create() error {
 	}
 	b.jdtFile, err = os.Create(jdtPath)
 	if err != nil {
-		b.jhrFile.Close()
+		_ = b.jhrFile.Close() // cleanup on error path
 		return fmt.Errorf("jam: failed to create .jdt: %w", err)
 	}
 	b.jdxFile, err = os.Create(jdxPath)
 	if err != nil {
-		b.jhrFile.Close()
-		b.jdtFile.Close()
+		_ = b.jhrFile.Close() // cleanup on error path
+		_ = b.jdtFile.Close() // cleanup on error path
 		return fmt.Errorf("jam: failed to create .jdx: %w", err)
 	}
 	b.jlrFile, err = os.Create(jlrPath)
 	if err != nil {
-		b.jhrFile.Close()
-		b.jdtFile.Close()
-		b.jdxFile.Close()
+		_ = b.jhrFile.Close() // cleanup on error path
+		_ = b.jdtFile.Close() // cleanup on error path
+		_ = b.jdxFile.Close() // cleanup on error path
 		return fmt.Errorf("jam: failed to create .jlr: %w", err)
 	}
 
@@ -136,7 +136,7 @@ func (b *Base) create() error {
 
 	b.isOpen = true
 	if err := b.writeFixedHeader(); err != nil {
-		b.Close()
+		_ = b.Close() // cleanup on error path
 		return fmt.Errorf("jam: failed to write initial header: %w", err)
 	}
 	return nil
@@ -215,7 +215,9 @@ func (b *Base) GetModCounter() (uint32, error) {
 
 // readFixedHeader reads the 1024-byte fixed header from the .jhr file.
 func (b *Base) readFixedHeader() error {
-	b.jhrFile.Seek(0, 0)
+	if _, err := b.jhrFile.Seek(0, 0); err != nil {
+		return fmt.Errorf("failed to seek fixed header: %w", err)
+	}
 	b.fixedHeader = &FixedHeaderInfo{}
 	if err := binary.Read(b.jhrFile, binary.LittleEndian, b.fixedHeader); err != nil {
 		return fmt.Errorf("failed to read fixed header: %w", err)
@@ -228,7 +230,9 @@ func (b *Base) readFixedHeader() error {
 
 // writeFixedHeader writes the fixed header to the .jhr file.
 func (b *Base) writeFixedHeader() error {
-	b.jhrFile.Seek(0, 0)
+	if _, err := b.jhrFile.Seek(0, 0); err != nil {
+		return fmt.Errorf("failed to seek fixed header: %w", err)
+	}
 	return binary.Write(b.jhrFile, binary.LittleEndian, b.fixedHeader)
 }
 
@@ -354,6 +358,6 @@ func (b *Base) getNextMsgSerialLocked() (uint32, error) {
 
 func removeBaseFiles(paths ...string) {
 	for _, p := range paths {
-		os.Remove(p)
+		_ = os.Remove(p) // best-effort removal of a corrupt base
 	}
 }

--- a/internal/jam/message.go
+++ b/internal/jam/message.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 )
@@ -157,7 +158,9 @@ func (b *Base) writeMessageHeader(hdr *MessageHeader) (uint32, error) {
 	}
 	if pos == 0 {
 		pos = HeaderSize
-		b.jhrFile.Seek(pos, 0)
+		if _, err := b.jhrFile.Seek(pos, 0); err != nil {
+			return 0, fmt.Errorf("jam: seek failed on .jhr: %w", err)
+		}
 	}
 
 	if err := writeBinaryLE(b.jhrFile, hdr.Signature, "header signature"); err != nil {
@@ -510,9 +513,11 @@ func (b *Base) WriteMessage(msg *Message) (int, error) {
 		}
 
 		// Sync all files to ensure consistency on crash
-		b.jdtFile.Sync()
-		b.jhrFile.Sync()
-		b.jdxFile.Sync()
+		for name, f := range map[string]*os.File{".jdt": b.jdtFile, ".jhr": b.jhrFile, ".jdx": b.jdxFile} {
+			if err := f.Sync(); err != nil {
+				return fmt.Errorf("jam: sync %s: %w", name, err)
+			}
+		}
 
 		return nil
 	})
@@ -543,27 +548,20 @@ func (b *Base) DeleteMessage(msgNum int) error {
 		}
 
 		// Rewrite header at original offset
-		b.jhrFile.Seek(int64(idx.HdrOffset), 0)
-		binary.Write(b.jhrFile, binary.LittleEndian, hdr.Signature)
-		binary.Write(b.jhrFile, binary.LittleEndian, hdr.Revision)
-		binary.Write(b.jhrFile, binary.LittleEndian, hdr.ReservedWord)
-		binary.Write(b.jhrFile, binary.LittleEndian, hdr.SubfieldLen)
-		binary.Write(b.jhrFile, binary.LittleEndian, hdr.TimesRead)
-		binary.Write(b.jhrFile, binary.LittleEndian, hdr.MSGIDcrc)
-		binary.Write(b.jhrFile, binary.LittleEndian, hdr.REPLYcrc)
-		binary.Write(b.jhrFile, binary.LittleEndian, hdr.ReplyTo)
-		binary.Write(b.jhrFile, binary.LittleEndian, hdr.Reply1st)
-		binary.Write(b.jhrFile, binary.LittleEndian, hdr.ReplyNext)
-		binary.Write(b.jhrFile, binary.LittleEndian, hdr.DateWritten)
-		binary.Write(b.jhrFile, binary.LittleEndian, hdr.DateReceived)
-		binary.Write(b.jhrFile, binary.LittleEndian, hdr.DateProcessed)
-		binary.Write(b.jhrFile, binary.LittleEndian, hdr.MessageNumber)
-		binary.Write(b.jhrFile, binary.LittleEndian, hdr.Attribute)
-		binary.Write(b.jhrFile, binary.LittleEndian, hdr.Attribute2)
-		binary.Write(b.jhrFile, binary.LittleEndian, hdr.Offset)
-		binary.Write(b.jhrFile, binary.LittleEndian, hdr.TxtLen)
-		binary.Write(b.jhrFile, binary.LittleEndian, hdr.PasswordCRC)
-		binary.Write(b.jhrFile, binary.LittleEndian, hdr.Cost)
+		if _, err := b.jhrFile.Seek(int64(idx.HdrOffset), 0); err != nil {
+			return fmt.Errorf("jam: seek header for delete: %w", err)
+		}
+		for _, field := range []interface{}{
+			hdr.Signature, hdr.Revision, hdr.ReservedWord, hdr.SubfieldLen,
+			hdr.TimesRead, hdr.MSGIDcrc, hdr.REPLYcrc, hdr.ReplyTo,
+			hdr.Reply1st, hdr.ReplyNext, hdr.DateWritten, hdr.DateReceived,
+			hdr.DateProcessed, hdr.MessageNumber, hdr.Attribute, hdr.Attribute2,
+			hdr.Offset, hdr.TxtLen, hdr.PasswordCRC, hdr.Cost,
+		} {
+			if err := writeBinaryLE(b.jhrFile, field, "deleted message header field"); err != nil {
+				return err
+			}
+		}
 
 		b.fixedHeader.ActiveMsgs--
 		b.fixedHeader.ModCounter++

--- a/internal/jam/message.go
+++ b/internal/jam/message.go
@@ -512,10 +512,19 @@ func (b *Base) WriteMessage(msg *Message) (int, error) {
 			return err
 		}
 
-		// Sync all files to ensure consistency on crash
-		for name, f := range map[string]*os.File{".jdt": b.jdtFile, ".jhr": b.jhrFile, ".jdx": b.jdxFile} {
-			if err := f.Sync(); err != nil {
-				return fmt.Errorf("jam: sync %s: %w", name, err)
+		// Sync all files to ensure consistency on crash. Order matters:
+		// message data (.jdt) must reach disk before the header (.jhr) and
+		// index (.jdx) records that reference it.
+		for _, sf := range []struct {
+			name string
+			file *os.File
+		}{
+			{".jdt", b.jdtFile},
+			{".jhr", b.jhrFile},
+			{".jdx", b.jdxFile},
+		} {
+			if err := sf.file.Sync(); err != nil {
+				return fmt.Errorf("jam: sync %s: %w", sf.name, err)
 			}
 		}
 

--- a/internal/jam/pack.go
+++ b/internal/jam/pack.go
@@ -133,26 +133,26 @@ func (b *Base) packWithReplyIDCleanup(cleanReplyIDs bool) (PackResult, error) {
 	}
 	jdtOut, err := os.Create(tmpJdt)
 	if err != nil {
-		jhrOut.Close()
-		os.Remove(tmpJhr)
+		_ = jhrOut.Close()    // cleanup on error path
+		_ = os.Remove(tmpJhr) // cleanup on error path
 		return result, fmt.Errorf("jam: failed to create temp .jdt: %w", err)
 	}
 	jdxOut, err := os.Create(tmpJdx)
 	if err != nil {
-		jhrOut.Close()
-		jdtOut.Close()
-		os.Remove(tmpJhr)
-		os.Remove(tmpJdt)
+		_ = jhrOut.Close()    // cleanup on error path
+		_ = jdtOut.Close()    // cleanup on error path
+		_ = os.Remove(tmpJhr) // cleanup on error path
+		_ = os.Remove(tmpJdt) // cleanup on error path
 		return result, fmt.Errorf("jam: failed to create temp .jdx: %w", err)
 	}
 
 	cleanup := func() {
-		jhrOut.Close()
-		jdtOut.Close()
-		jdxOut.Close()
-		os.Remove(tmpJhr)
-		os.Remove(tmpJdt)
-		os.Remove(tmpJdx)
+		_ = jhrOut.Close()    // cleanup on error path
+		_ = jdtOut.Close()    // cleanup on error path
+		_ = jdxOut.Close()    // cleanup on error path
+		_ = os.Remove(tmpJhr) // cleanup on error path
+		_ = os.Remove(tmpJdt) // cleanup on error path
+		_ = os.Remove(tmpJdx) // cleanup on error path
 	}
 
 	// Write placeholder fixed header (will update ActiveMsgs at end)
@@ -291,10 +291,10 @@ func (b *Base) packWithReplyIDCleanup(cleanReplyIDs bool) (PackResult, error) {
 		}
 	}
 
-	// Close original file handles
-	b.jhrFile.Close()
-	b.jdtFile.Close()
-	b.jdxFile.Close()
+	// Close original file handles (read-side; contents already copied)
+	_ = b.jhrFile.Close()
+	_ = b.jdtFile.Close()
+	_ = b.jdxFile.Close()
 
 	// Atomic rename
 	for _, pair := range [][2]string{
@@ -304,9 +304,9 @@ func (b *Base) packWithReplyIDCleanup(cleanReplyIDs bool) (PackResult, error) {
 	} {
 		if err := os.Rename(pair[0], pair[1]); err != nil {
 			// Try to clean up remaining temp files
-			os.Remove(tmpJhr)
-			os.Remove(tmpJdt)
-			os.Remove(tmpJdx)
+			_ = os.Remove(tmpJhr) // cleanup on error path
+			_ = os.Remove(tmpJdt) // cleanup on error path
+			_ = os.Remove(tmpJdx) // cleanup on error path
 			// Attempt to reopen original files; if any reopen fails the
 			// base is unusable and must not claim to be open with nil
 			// handles.

--- a/internal/jsutil/jsutil.go
+++ b/internal/jsutil/jsutil.go
@@ -1,0 +1,34 @@
+// Package jsutil provides small helpers for building goja JavaScript
+// runtimes. It centralizes error handling for property registration so
+// call sites stay readable while errors are still surfaced via slog.
+package jsutil
+
+import (
+	"log/slog"
+
+	"github.com/dop251/goja"
+)
+
+// Setter is satisfied by both *goja.Runtime and *goja.Object.
+type Setter interface {
+	Set(name string, value any) error
+}
+
+// Set assigns a property on a JS object or a runtime global. goja's Set
+// only fails on frozen/non-extensible targets, which never applies to the
+// runtime objects built by this codebase, so a failure indicates a
+// programming error and is logged rather than propagated.
+func Set(target Setter, name string, value any) {
+	if err := target.Set(name, value); err != nil {
+		slog.Error("jsutil: failed to set JS property", "name", name, "error", err)
+	}
+}
+
+// DefineAccessor defines a getter/setter property on a JS object. As with
+// Set, failure indicates a programming error (e.g. redefining a
+// non-configurable property) and is logged rather than propagated.
+func DefineAccessor(obj *goja.Object, name string, getter, setter goja.Value, configurable, enumerable goja.Flag) {
+	if err := obj.DefineAccessorProperty(name, getter, setter, configurable, enumerable); err != nil {
+		slog.Error("jsutil: failed to define JS accessor", "name", name, "error", err)
+	}
+}

--- a/internal/logging/writer.go
+++ b/internal/logging/writer.go
@@ -114,7 +114,7 @@ func (w *rollingWriter) openCurrent() error {
 	}
 	fi, err := f.Stat()
 	if err != nil {
-		f.Close()
+		_ = f.Close() // cleanup on error path
 		return err
 	}
 	w.f = f
@@ -219,7 +219,7 @@ func (w *rollingWriter) pruneDaily() {
 			continue // not a dated file (e.g. a size-style backup)
 		}
 		if d.Before(cutoff) {
-			os.Remove(m)
+			_ = os.Remove(m) // best-effort prune of old logs
 		}
 	}
 }

--- a/internal/menu/admin_browser_test.go
+++ b/internal/menu/admin_browser_test.go
@@ -12,13 +12,13 @@ import (
 
 // runAdminBrowser drives adminUserLightbarBrowser through the test harness with
 // the given scripted keystrokes, returning its result plus the captured output.
-func runAdminBrowser(t *testing.T, users []*user.User, input string, selectOnEnter bool) (*user.User, bool, error, string) {
+func runAdminBrowser(t *testing.T, users []*user.User, input string, selectOnEnter bool) (*user.User, bool, string, error) {
 	t.Helper()
 	ts := newTestSession(input)
 	terminal := newTestTerminal(ts)
 	u, ok, err := adminUserLightbarBrowser(ts, terminal, users, "Test Title", "pick one", ansi.OutputModeUTF8, selectOnEnter)
 	resetSessionIH(ts)
-	return u, ok, err, ts.output()
+	return u, ok, ts.output(), err
 }
 
 func browserTestUsers() []*user.User {
@@ -30,7 +30,7 @@ func browserTestUsers() []*user.User {
 }
 
 func TestAdminBrowser_QuitNoSelection(t *testing.T) {
-	u, ok, err, out := runAdminBrowser(t, browserTestUsers(), "Q", true)
+	u, ok, out, err := runAdminBrowser(t, browserTestUsers(), "Q", true)
 	if u != nil || ok || err != nil {
 		t.Fatalf("quit = (%v, %v, %v), want (nil, false, nil)", u, ok, err)
 	}
@@ -43,7 +43,7 @@ func TestAdminBrowser_QuitNoSelection(t *testing.T) {
 }
 
 func TestAdminBrowser_EnterSelectsCurrent(t *testing.T) {
-	u, ok, err, _ := runAdminBrowser(t, browserTestUsers(), "\r", true)
+	u, ok, _, err := runAdminBrowser(t, browserTestUsers(), "\r", true)
 	if err != nil || !ok || u == nil || u.Handle != "Alice" {
 		t.Fatalf("enter selected (%v, %v, %v), want Alice/true/nil", u, ok, err)
 	}
@@ -73,7 +73,7 @@ func TestAdminBrowser_NavigateUpClampsAtTop(t *testing.T) {
 }
 
 func TestAdminBrowser_EOFReturnsEOF(t *testing.T) {
-	u, ok, err, _ := runAdminBrowser(t, browserTestUsers(), "", true)
+	u, ok, _, err := runAdminBrowser(t, browserTestUsers(), "", true)
 	if !errors.Is(err, io.EOF) || u != nil || ok {
 		t.Fatalf("EOF case = (%v, %v, %v), want (nil, false, io.EOF)", u, ok, err)
 	}
@@ -81,7 +81,7 @@ func TestAdminBrowser_EOFReturnsEOF(t *testing.T) {
 
 func TestAdminBrowser_EnterIgnoredWhenSelectDisabled(t *testing.T) {
 	// With selectOnEnter=false, Enter does nothing; input then hits EOF.
-	u, ok, err, _ := runAdminBrowser(t, browserTestUsers(), "\r", false)
+	u, ok, _, err := runAdminBrowser(t, browserTestUsers(), "\r", false)
 	if !errors.Is(err, io.EOF) || u != nil || ok {
 		t.Fatalf("enter (selectOnEnter=false) = (%v, %v, %v), want (nil, false, io.EOF)", u, ok, err)
 	}

--- a/internal/menu/ansi_renderer.go
+++ b/internal/menu/ansi_renderer.go
@@ -344,7 +344,7 @@ func (r *ANSIRenderer) parseCSI(seq string) ([]int, byte) {
 			continue
 		}
 		var num int
-		fmt.Sscanf(part, "%d", &num)
+		_, _ = fmt.Sscanf(part, "%d", &num) // best-effort parse; num stays 0
 		params = append(params, num)
 	}
 

--- a/internal/menu/door_handler.go
+++ b/internal/menu/door_handler.go
@@ -154,7 +154,7 @@ func runListDoors(c *cmdCtx, args string) (*user.User, string, error) {
 	// For CP437 mode, write raw bytes directly to avoid UTF-8 false positives
 	processedTop := ansi.ReplacePipeCodes(topBytes)
 	if outputMode == ansi.OutputModeCP437 {
-		terminal.Write(processedTop)
+		_, _ = terminal.Write(processedTop) // best-effort display
 	} else {
 		terminalio.WriteProcessedBytes(terminal, processedTop, outputMode)
 	}
@@ -211,7 +211,7 @@ func runListDoors(c *cmdCtx, args string) (*user.User, string, error) {
 	// Display footer
 	processedBot := ansi.ReplacePipeCodes(botBytes)
 	if outputMode == ansi.OutputModeCP437 {
-		terminal.Write(processedBot)
+		_, _ = terminal.Write(processedBot) // best-effort display
 	} else {
 		terminalio.WriteProcessedBytes(terminal, processedBot, outputMode)
 	}
@@ -269,7 +269,7 @@ func runOpenDoor(c *cmdCtx, args string) (*user.User, string, error) {
 		}
 
 		if upperInput == "?" {
-			runListDoors(&cmdCtx{e: e, s: s, terminal: terminal, userManager: userManager, currentUser: currentUser, nodeNumber: nodeNumber, sessionStartTime: sessionStartTime, outputMode: outputMode, termWidth: termWidth, termHeight: termHeight}, "")
+			_, _, _ = runListDoors(&cmdCtx{e: e, s: s, terminal: terminal, userManager: userManager, currentUser: currentUser, nodeNumber: nodeNumber, sessionStartTime: sessionStartTime, outputMode: outputMode, termWidth: termWidth, termHeight: termHeight}, "")
 			terminalio.WriteProcessedBytes(terminal, renderedPrompt, outputMode)
 			continue
 		}
@@ -382,7 +382,7 @@ func runDoorInfo(c *cmdCtx, args string) (*user.User, string, error) {
 		}
 
 		if upperInput == "?" {
-			runListDoors(&cmdCtx{e: e, s: s, terminal: terminal, userManager: userManager, currentUser: currentUser, nodeNumber: nodeNumber, sessionStartTime: sessionStartTime, outputMode: outputMode, termWidth: termWidth, termHeight: termHeight}, "")
+			_, _, _ = runListDoors(&cmdCtx{e: e, s: s, terminal: terminal, userManager: userManager, currentUser: currentUser, nodeNumber: nodeNumber, sessionStartTime: sessionStartTime, outputMode: outputMode, termWidth: termWidth, termHeight: termHeight}, "")
 			terminalio.WriteProcessedBytes(terminal, renderedPrompt, outputMode)
 			continue
 		}

--- a/internal/menu/door_handler_dos.go
+++ b/internal/menu/door_handler_dos.go
@@ -245,7 +245,7 @@ func executeDOSDoor(ctx *DoorCtx) error {
 	// Set PTY master to raw mode for clean passthrough of CP437 bytes
 	fd := int(ptmx.Fd())
 	if oldState, err := term.MakeRaw(fd); err == nil {
-		defer term.Restore(fd, oldState)
+		defer func() { _ = term.Restore(fd, oldState) }() // best-effort terminal restore
 	}
 
 	// Set up a read interrupt so we can cleanly stop the input goroutine
@@ -304,18 +304,18 @@ func executeDOSDoor(ctx *DoorCtx) error {
 						accum = append(accum, buf[:n]...)
 						if idx := bytes.IndexByte(accum, 0x1b); idx >= 0 {
 							gated = false
-							ctx.Session.Write(accum[idx:])
+							_, _ = ctx.Session.Write(accum[idx:]) // best-effort door output relay
 							accum = nil
 							slog.Debug("FOSSIL boot text gate opened", "node", ctx.NodeNumber, "offset", idx)
 						}
 						if gated && len(accum) > 32768 {
 							slog.Warn("FOSSIL gate: no ESC after 32KB, flushing", "node", ctx.NodeNumber)
 							gated = false
-							ctx.Session.Write(accum)
+							_, _ = ctx.Session.Write(accum) // best-effort door output relay
 							accum = nil
 						}
 					} else {
-						ctx.Session.Write(buf[:n])
+						_, _ = ctx.Session.Write(buf[:n]) // best-effort door output relay
 					}
 				}
 				if err != nil {
@@ -343,7 +343,7 @@ func executeDOSDoor(ctx *DoorCtx) error {
 					if idx := bytes.Index(accum, clearScreen); idx >= 0 {
 						// Found clear screen — forward it and everything after
 						gated = false
-						ctx.Session.Write(accum[idx:])
+						_, _ = ctx.Session.Write(accum[idx:]) // best-effort door output relay
 						accum = nil
 						slog.Debug("DOS boot text gate opened (clear screen detected)", "node", ctx.NodeNumber)
 					}
@@ -351,11 +351,11 @@ func executeDOSDoor(ctx *DoorCtx) error {
 					if gated && len(accum) > 32768 {
 						slog.Warn("clear screen not found after 32KB, flushing", "node", ctx.NodeNumber)
 						gated = false
-						ctx.Session.Write(accum)
+						_, _ = ctx.Session.Write(accum) // best-effort door output relay
 						accum = nil
 					}
 				} else {
-					ctx.Session.Write(buf[:n])
+					_, _ = ctx.Session.Write(buf[:n]) // best-effort door output relay
 				}
 			}
 			if err != nil {
@@ -380,7 +380,7 @@ func executeDOSDoor(ctx *DoorCtx) error {
 	if hasInterrupt {
 		<-inputDone
 	}
-	ptmx.Close()
+	_ = ptmx.Close() // best-effort PTY teardown
 	<-outputDone
 
 	if cmdErr != nil {

--- a/internal/menu/door_handler_native.go
+++ b/internal/menu/door_handler_native.go
@@ -296,7 +296,7 @@ func executeNativeDoor(ctx *DoorCtx) error {
 				}
 			}
 
-			ptmx.Close()
+			_ = ptmx.Close() // best-effort PTY teardown
 			<-outputDone
 		}
 	} else if strings.ToUpper(doorConfig.IOMode) == "SOCKET" {
@@ -316,12 +316,12 @@ func executeNativeDoor(ctx *DoorCtx) error {
 			cmd.Env = append(cmd.Env, "DOOR_SOCKET_FD=3")
 
 			if startErr := cmd.Start(); startErr != nil {
-				bbsSock.Close()
-				doorSock.Close()
+				_ = bbsSock.Close()  // best-effort socket teardown
+				_ = doorSock.Close() // best-effort socket teardown
 				cmdErr = fmt.Errorf("failed to start door '%s' with socket I/O: %w", ctx.DoorName, startErr)
 			} else {
 				// Parent closes the door's end
-				doorSock.Close()
+				_ = doorSock.Close() // best-effort socket teardown
 
 				// Set up read interrupt for clean shutdown
 				readInterrupt := make(chan struct{})
@@ -359,7 +359,7 @@ func executeNativeDoor(ctx *DoorCtx) error {
 				if hasInterrupt {
 					<-inputDone
 				}
-				bbsSock.Close()
+				_ = bbsSock.Close() // best-effort socket teardown
 				<-outputDone
 			}
 		}

--- a/internal/menu/door_lock.go
+++ b/internal/menu/door_lock.go
@@ -54,15 +54,16 @@ func acquireDoorLock(doorName string, nodeNumber int) error {
 	}
 
 	if !tryFileLock(f) {
-		f.Close()
+		_ = f.Close() // cleanup: lock not acquired
 		return ErrDoorBusy
 	}
 
 	// Write node/pid info for debugging stale locks
-	f.Truncate(0)
-	f.Seek(0, 0)
-	fmt.Fprintf(f, "node=%d\npid=%d\n", nodeNumber, os.Getpid())
-	f.Sync()
+	// Best-effort: this metadata is only for debugging stale locks.
+	_ = f.Truncate(0)
+	_, _ = f.Seek(0, 0)
+	_, _ = fmt.Fprintf(f, "node=%d\npid=%d\n", nodeNumber, os.Getpid())
+	_ = f.Sync()
 
 	doorLockFiles[key] = f
 	doorLockNodes[key] = nodeNumber
@@ -80,7 +81,7 @@ func releaseDoorLock(doorName string, nodeNumber int) {
 	if holder, exists := doorLockNodes[key]; exists && holder == nodeNumber {
 		if f, ok := doorLockFiles[key]; ok {
 			releaseFileLock(f)
-			f.Close()
+			_ = f.Close() // lock already released
 			// Lock file is intentionally NOT deleted: removing it after unlock
 			// creates a race where another process can lock the same path between
 			// our unlock and remove, then our remove unlinks their lock file.

--- a/internal/menu/door_lock_unix.go
+++ b/internal/menu/door_lock_unix.go
@@ -15,5 +15,5 @@ func tryFileLock(f *os.File) bool {
 
 // releaseFileLock releases the flock on the file.
 func releaseFileLock(f *os.File) {
-	syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN) // kernel drops the lock on close regardless
 }

--- a/internal/menu/executor.go
+++ b/internal/menu/executor.go
@@ -210,7 +210,7 @@ func (e *MenuExecutor) handleIdleTimeout(terminal *term.Terminal, outputMode ans
 	if rawContent, err := ansi.GetAnsiFileContent(ansPath); err == nil {
 		terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 		if outputMode == ansi.OutputModeCP437 {
-			terminal.Write(rawContent)
+			_, _ = terminal.Write(rawContent) // best-effort display
 		} else {
 			terminalio.WriteProcessedBytes(terminal, rawContent, outputMode)
 		}

--- a/internal/menu/executor_admin_users.go
+++ b/internal/menu/executor_admin_users.go
@@ -46,9 +46,7 @@ func runListUsers(c *cmdCtx, args string) (*user.User, string, error) {
 	if errTop != nil || errMid != nil || errBot != nil {
 		slog.Error("failed to load USERLIST template files", "node", nodeNumber, "top", errTop, "mid", errMid, "bot", errBot)
 		msg := e.LoadedStrings.ExecUserlistTemplateErr
-		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
-		if wErr != nil { /* Log? */
-		}
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
 		return nil, "", fmt.Errorf("failed loading USERLIST templates")
 	}

--- a/internal/menu/executor_files.go
+++ b/internal/menu/executor_files.go
@@ -335,7 +335,7 @@ func (e *MenuExecutor) runUploadFiles(
 		slog.Error("failed to create incoming directory", "node", nodeNumber, "error", err)
 		return fmt.Errorf("failed to create incoming directory: %w", err)
 	}
-	defer os.RemoveAll(incomingDir)
+	defer func() { _ = os.RemoveAll(incomingDir) }() // best-effort temp cleanup
 
 	// 8. Execute protocol receive into temp directory
 	msg = fmt.Sprintf("\r\n|15Starting %s receive...|07\r\n", proto.Name)
@@ -411,7 +411,7 @@ func (e *MenuExecutor) runUploadFiles(
 		safeName := filepath.Base(nf.name)
 		if safeName != nf.name || safeName == "." || safeName == ".." || strings.Contains(nf.name, "..") || filepath.IsAbs(nf.name) {
 			slog.Error("rejected unsafe filename", "node", nodeNumber, "name", nf.name)
-			os.Remove(incomingPath)
+			_ = os.Remove(incomingPath) // best-effort cleanup of rejected upload
 			errMsg := fmt.Sprintf("\r\n|01'%s' rejected: invalid filename.|07\r\n", nf.name)
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(errMsg)), outputMode)
 			continue
@@ -421,7 +421,7 @@ func (e *MenuExecutor) runUploadFiles(
 		if existingNames[strings.ToLower(nf.name)] {
 			slog.Warn("duplicate file rejected", "node", nodeNumber, "name", nf.name)
 			duplicateCount++
-			os.Remove(incomingPath)
+			_ = os.Remove(incomingPath) // best-effort cleanup of rejected upload
 
 			dupMsg := fmt.Sprintf("\r\n|09'%s' already exists in this area. Rejected.|07\r\n", nf.name)
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(dupMsg)), outputMode)
@@ -517,7 +517,7 @@ func (e *MenuExecutor) runUploadFiles(
 		if _, statErr := os.Stat(finalPath); statErr == nil {
 			slog.Warn("upload rejected, file already exists on disk", "node", nodeNumber, "name", nf.name)
 			duplicateCount++
-			os.Remove(incomingPath)
+			_ = os.Remove(incomingPath) // best-effort cleanup of rejected upload
 			dupMsg := fmt.Sprintf("\r\n|09'%s' already exists in this area. Rejected.|07\r\n", nf.name)
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(dupMsg)), outputMode)
 			continue

--- a/internal/menu/executor_files.go
+++ b/internal/menu/executor_files.go
@@ -635,9 +635,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 	if currentUser == nil {
 		slog.Warn("LISTFILES called without logged in user", "node", nodeNumber)
 		msg := "\r\n|01Error: You must be logged in to list files.|07\r\n"
-		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
-		if wErr != nil { /* Log? */
-		}
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
 		return nil, "", nil // Return to menu
 	}
@@ -649,9 +647,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 	if currentAreaID <= 0 {
 		slog.Warn("user has no current file area selected", "node", nodeNumber, "handle", currentUser.Handle)
 		msg := "\r\n|01Error: No file area selected.|07\r\n"
-		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
-		if wErr != nil { /* Log? */
-		}
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
 		return nil, "", nil // Return to menu
 	}
@@ -684,9 +680,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 		} else {
 			slog.Error("failed to load FILELIST.BOT template", "node", nodeNumber, "error", errBot)
 			msg := "\r\n|01Error loading File List screen templates.|07\r\n"
-			wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
-			if wErr != nil { /* Log? */
-			}
+			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 			time.Sleep(1 * time.Second)
 			return nil, "", fmt.Errorf("failed loading FILELIST templates")
 		}
@@ -695,9 +689,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 	if errTop != nil || errMid != nil {
 		slog.Error("failed to load FILELIST template files", "node", nodeNumber, "topError", errTop, "midError", errMid)
 		msg := "\r\n|01Error loading File List screen templates.|07\r\n"
-		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
-		if wErr != nil { /* Log? */
-		}
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
 		return nil, "", fmt.Errorf("failed loading FILELIST templates")
 	}
@@ -749,9 +741,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 	if err != nil {
 		slog.Error("failed to get file count for area", "node", nodeNumber, "area", currentAreaID, "error", err)
 		msg := fmt.Sprintf("\r\n|01Error retrieving file list for area '%s'.|07\r\n", currentAreaTag)
-		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
-		if wErr != nil { /* Log? */
-		}
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
 		return nil, "", fmt.Errorf("failed getting file count: %w", err)
 	}
@@ -774,9 +764,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 		if err != nil {
 			slog.Error("failed to get files for area page", "node", nodeNumber, "area", currentAreaID, "page", currentPage, "error", err)
 			msg := fmt.Sprintf("\r\n|01Error retrieving file list page for area '%s'.|07\r\n", currentAreaTag)
-			wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
-			if wErr != nil { /* Log? */
-			}
+			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 			time.Sleep(1 * time.Second)
 			return nil, "", fmt.Errorf("failed getting file page: %w", err)
 		}
@@ -832,9 +820,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 			// Display "No files in this area" message
 			// TODO: Use a configurable string?
 			noFilesMsg := "\r\n|07   No files in this area.   \r\n"
-			wErr = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(noFilesMsg)), outputMode)
-			if wErr != nil { /* Log? */
-			}
+			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(noFilesMsg)), outputMode)
 		} else {
 			for i, fileRec := range filesOnPage {
 				line := processedMidTemplate
@@ -935,10 +921,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 		// 4.5 Display Prompt (Use a standard file list prompt or configure one)
 		// TODO: Use configurable prompt string
 		prompt := "\r\n|07File Cmd (|15N|07=Next, |15P|07=Prev, |15#|07=Mark, |15V|07=View, |15D|07=Download, |15U|07=Upload, |15Q|07=Quit): |15"
-		wErr = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(prompt)), outputMode)
-		if wErr != nil {
-			// Handle error
-		}
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(prompt)), outputMode)
 
 		// 4.6 Read User Input
 		input, err := readLineFromSessionIH(s, terminal)
@@ -999,9 +982,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 			// 1. Check if any files are marked
 			if len(currentUser.TaggedFileIDs) == 0 {
 				msg := "\r\n|07No files marked for download. Use |15#|07 to mark files.|07\r\n"
-				wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
-				if wErr != nil { /* Log? */
-				}
+				terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 				time.Sleep(1 * time.Second)
 				continue // Go back to file list display
 			}
@@ -1182,9 +1163,7 @@ func runListFiles(c *cmdCtx, args string) (*user.User, string, error) {
 		case "A": // Area Change (Placeholder/Not implemented here, handled by menu?)
 			slog.Debug("area change command entered (handled by menu)", "node", nodeNumber)
 			msg := "\r\n|01Use menu options to change area.|07\r\n"
-			wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
-			if wErr != nil { /* Log? */
-			}
+			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 			time.Sleep(1 * time.Second)
 		default: // Includes 'T' (Tagging) and potential numeric input
 			// Try to parse as a number for tagging
@@ -1255,9 +1234,7 @@ func displayFileAreaList(e *MenuExecutor, s ssh.Session, terminal *term.Terminal
 		slog.Error("failed to load FILEAREA template files", "node", nodeNumber, "top_error", errTop, "mid_error", errMid, "bot_error", errBot)
 		// Display error message to terminal
 		msg := "\r\n|01Error loading File Area screen templates.|07\r\n"
-		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
-		if wErr != nil { /* Log? */
-		}
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
 		return fmt.Errorf("failed loading FILEAREA templates")
 	}
@@ -1398,9 +1375,7 @@ func runListFileAreas(c *cmdCtx, args string) (*user.User, string, error) {
 	if currentUser == nil {
 		slog.Warn("LISTFILEAR called without logged in user", "node", nodeNumber)
 		msg := "\r\n|01Error: You must be logged in to list file areas.|07\r\n"
-		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
-		if wErr != nil { /* Log? */
-		}
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
 		return nil, "", nil
 	}
@@ -1478,9 +1453,7 @@ func runSelectFileArea(c *cmdCtx, args string) (*user.User, string, error) {
 	if currentUser == nil {
 		slog.Warn("SELECTFILEAREA called without logged in user", "node", nodeNumber)
 		msg := "\r\n|01Error: You must be logged in to select a file area.|07\r\n"
-		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
-		if wErr != nil { /* Log? */
-		}
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
 		return nil, "", nil
 	}

--- a/internal/menu/executor_lastcallers.go
+++ b/internal/menu/executor_lastcallers.go
@@ -56,9 +56,7 @@ func runLastCallers(c *cmdCtx, args string) (*user.User, string, error) {
 	if errTop != nil || errMid != nil || errBot != nil {
 		slog.Error("failed to load LASTCALL template files", "node", nodeNumber, "top", errTop, "mid", errMid, "bot", errBot)
 		msg := e.LoadedStrings.ExecLastcallTemplateErr
-		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
-		if wErr != nil { /* Log? */
-		}
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
 		return nil, "", fmt.Errorf("failed loading LASTCALL templates")
 	}

--- a/internal/menu/executor_lightbar.go
+++ b/internal/menu/executor_lightbar.go
@@ -181,7 +181,7 @@ func loadLightbarOptions(menuName string, e *MenuExecutor) ([]LightbarOption, er
 	if err != nil {
 		return nil, fmt.Errorf("failed to open BAR file %s: %w", barPath, err)
 	}
-	defer barFile.Close()
+	defer func() { _ = barFile.Close() }() // read-only
 
 	var options []LightbarOption
 	scanner := bufio.NewScanner(barFile)
@@ -251,7 +251,7 @@ func loadBarFile(barName string, e *MenuExecutor) ([]LightbarOption, error) {
 		}
 		return nil, fmt.Errorf("failed to open BAR file %s: %w", barPath, err)
 	}
-	defer barFile.Close()
+	defer func() { _ = barFile.Close() }() // read-only
 
 	var options []LightbarOption
 	scanner := bufio.NewScanner(barFile)

--- a/internal/menu/executor_login.go
+++ b/internal/menu/executor_login.go
@@ -461,7 +461,11 @@ func runNewMailScan(c *cmdCtx, args string) (*user.User, string, error) {
 		slog.Warn("JAM base not open for PRIVMAIL area", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
-	defer base.Close()
+	defer func() {
+		if cerr := base.Close(); cerr != nil {
+			slog.Warn("closing JAM base", "error", cerr)
+		}
+	}()
 
 	// Get total message count
 	totalMessages, err := e.MessageMgr.GetMessageCountForArea(privmailArea.ID)

--- a/internal/menu/executor_messages.go
+++ b/internal/menu/executor_messages.go
@@ -101,18 +101,14 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 		if currentUser == nil {
 			slog.Warn("COMPOSEMSG called without user and without args", "node", nodeNumber)
 			msg := "\r\n|01Error: Not logged in and no area specified.|07\r\n"
-			wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
-			if wErr != nil { /* Log? */
-			}
+			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 			time.Sleep(1 * time.Second)
 			return nil, "", nil // Return to menu
 		}
 		if currentUser.CurrentMessageAreaTag == "" || currentUser.CurrentMessageAreaID <= 0 {
 			slog.Warn("COMPOSEMSG called but no current message area is set", "node", nodeNumber, "handle", currentUser.Handle)
 			msg := "\r\n|01Error: No current message area selected.|07\r\n"
-			wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
-			if wErr != nil { /* Log? */
-			}
+			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 			time.Sleep(1 * time.Second)
 			return nil, "", nil // Return to menu
 		}
@@ -130,9 +126,7 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 	if !exists {
 		slog.Error("COMPOSEMSG called with invalid area tag", "node", nodeNumber, "tag", areaTag)
 		msg := fmt.Sprintf("\r\n|01Invalid message area: %s|07\r\n", areaTag)
-		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
-		if wErr != nil { /* Log? */
-		}
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
 		return nil, "", nil // Return to menu, not an error
 	}
@@ -141,9 +135,7 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 	if currentUser == nil {
 		slog.Warn("COMPOSEMSG reached ACS check without logged in user", "node", nodeNumber, "tag", areaTag)
 		msg := "\r\n|01Error: You must be logged in to post messages.|07\r\n"
-		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
-		if wErr != nil { /* Log? */
-		}
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
 		return nil, "", nil // Return to menu
 	}

--- a/internal/menu/executor_messages.go
+++ b/internal/menu/executor_messages.go
@@ -569,7 +569,7 @@ func runReadMsgs(c *cmdCtx, args string) (*user.User, string, error) {
 		if _, statErr := os.Stat(selPath); statErr == nil {
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|07Please select a message header style.|07\r\n")), outputMode)
 			time.Sleep(500 * time.Millisecond)
-			runGetHeaderType(&cmdCtx{e: e, s: s, terminal: terminal, userManager: userManager, currentUser: currentUser, nodeNumber: nodeNumber, sessionStartTime: sessionStartTime, outputMode: outputMode, termWidth: termWidth, termHeight: termHeight}, "")
+			_, _, _ = runGetHeaderType(&cmdCtx{e: e, s: s, terminal: terminal, userManager: userManager, currentUser: currentUser, nodeNumber: nodeNumber, sessionStartTime: sessionStartTime, outputMode: outputMode, termWidth: termWidth, termHeight: termHeight}, "")
 		}
 	}
 
@@ -1128,7 +1128,11 @@ func runReadPrivateMail(c *cmdCtx, args string) (*user.User, string, error) {
 		time.Sleep(1 * time.Second)
 		return nil, "", nil
 	}
-	defer base.Close()
+	defer func() {
+		if cerr := base.Close(); cerr != nil {
+			slog.Warn("closing JAM base", "error", cerr)
+		}
+	}()
 
 	// Get total message count
 	totalMessages, err := e.MessageMgr.GetMessageCountForArea(privmailArea.ID)

--- a/internal/menu/executor_oneliners.go
+++ b/internal/menu/executor_oneliners.go
@@ -343,9 +343,7 @@ func runOneliners(c *cmdCtx, args string) (*user.User, string, error) {
 	if errTop != nil || errMid != nil || errBot != nil {
 		slog.Error("failed to load one or more ONELINER template files", "node", nodeNumber, "topError", errTop, "midError", errMid, "botError", errBot)
 		msg := e.LoadedStrings.ExecOnelinerTemplateErr
-		wErr := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
-		if wErr != nil {
-		}
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 		time.Sleep(1 * time.Second)
 		return nil, "", fmt.Errorf("failed loading ONELINER templates")
 	}
@@ -497,14 +495,10 @@ func runOneliners(c *cmdCtx, args string) (*user.User, string, error) {
 		}
 
 		// Use WriteProcessedBytes for SaveCursor, positioning, and clear line
-		wErr = terminalio.WriteProcessedBytes(terminal, []byte(ansi.SaveCursor()), outputMode)
-		if wErr != nil { /* Log? */
-		}
+		terminalio.WriteProcessedBytes(terminal, []byte(ansi.SaveCursor()), outputMode)
 		// Clear legend row, detected input row, and prompt row fallback.
 		posClearCmd := fmt.Sprintf("\x1b[%d;1H\x1b[2K\x1b[%d;1H\x1b[2K\x1b[%d;1H\x1b[2K\x1b[%d;1H", legendRow, inputRow, promptRow, inputRow)
-		wErr = terminalio.WriteProcessedBytes(terminal, []byte(posClearCmd), outputMode)
-		if wErr != nil { /* Log? */
-		}
+		terminalio.WriteProcessedBytes(terminal, []byte(posClearCmd), outputMode)
 
 		if legendText != "" {
 			legendText = truncatePipeCodedText(legendText, promptColWidth)

--- a/internal/menu/file_info.go
+++ b/internal/menu/file_info.go
@@ -98,7 +98,7 @@ func runShowFileInfo(c *cmdCtx, args string) (*user.User, string, error) {
 	terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(info)), outputMode)
 
 	// Pause before returning.
-	writeCenteredPausePrompt(s, terminal, e.LoadedStrings.PauseString, outputMode, termWidth, termHeight)
+	_ = writeCenteredPausePrompt(s, terminal, e.LoadedStrings.PauseString, outputMode, termWidth, termHeight) // best-effort pause prompt
 
 	return currentUser, "", nil
 }

--- a/internal/menu/file_lightbar_test.go
+++ b/internal/menu/file_lightbar_test.go
@@ -25,7 +25,7 @@ var fixedUploadTime = time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 // in-memory area of numFiles files (file00.txt, file01.txt, …) and a real user
 // manager (the tag path persists via UpdateUser). The mid template renders each
 // file's mark/number/name/size so output reflects selection and tagging.
-func runFileLightbarN(t *testing.T, input string, numFiles int) (*user.User, string, error, string) {
+func runFileLightbarN(t *testing.T, input string, numFiles int) (*user.User, string, string, error) {
 	t.Helper()
 	dataDir, cfgDir := t.TempDir(), t.TempDir()
 	areasJSON := `[{"id":1,"tag":"UTILS","name":"Utilities","path":"utils","acs_list":""}]`
@@ -71,16 +71,16 @@ func runFileLightbarN(t *testing.T, input string, numFiles int) (*user.User, str
 		nil, nil, // cmd/hi bar options -> defaults
 		ansi.OutputModeUTF8)
 	resetSessionIH(ts)
-	return res, action, runErr, ts.output()
+	return res, action, ts.output(), runErr
 }
 
-func runFileLightbar(t *testing.T, input string) (*user.User, string, error, string) {
+func runFileLightbar(t *testing.T, input string) (*user.User, string, string, error) {
 	t.Helper()
 	return runFileLightbarN(t, input, 2)
 }
 
 func TestFileLightbar_QuitClean(t *testing.T) {
-	res, action, err, out := runFileLightbar(t, "q")
+	res, action, out, err := runFileLightbar(t, "q")
 	if res != nil || action != "" || err != nil {
 		t.Fatalf("quit = (%v, %q, %v), want (nil, \"\", nil)", res, action, err)
 	}
@@ -90,30 +90,30 @@ func TestFileLightbar_QuitClean(t *testing.T) {
 }
 
 func TestFileLightbar_EOFLogsOff(t *testing.T) {
-	res, action, err, _ := runFileLightbar(t, "")
+	res, action, _, err := runFileLightbar(t, "")
 	if res != nil || action != "LOGOFF" || !errors.Is(err, io.EOF) {
 		t.Fatalf("EOF = (%v, %q, %v), want (nil, \"LOGOFF\", io.EOF)", res, action, err)
 	}
 }
 
 func TestFileLightbar_EscQuits(t *testing.T) {
-	res, action, err, _ := runFileLightbar(t, "\x1b")
+	res, action, _, err := runFileLightbar(t, "\x1b")
 	if res != nil || action != "" || err != nil {
 		t.Fatalf("esc = (%v, %q, %v), want (nil, \"\", nil)", res, action, err)
 	}
 }
 
 func TestFileLightbar_ArrowDownMovesSelection(t *testing.T) {
-	_, _, _, noNav := runFileLightbar(t, "q")
-	_, _, _, down := runFileLightbar(t, "\x1b[Bq")
+	_, _, noNav, _ := runFileLightbar(t, "q")
+	_, _, down, _ := runFileLightbar(t, "\x1b[Bq")
 	if down == noNav {
 		t.Error("arrow-down produced identical output — selection did not move")
 	}
 }
 
 func TestFileLightbar_ArrowUpAtTopClamps(t *testing.T) {
-	_, _, _, noNav := runFileLightbar(t, "q")
-	_, _, _, up := runFileLightbar(t, "\x1b[Aq")
+	_, _, noNav, _ := runFileLightbar(t, "q")
+	_, _, up, _ := runFileLightbar(t, "\x1b[Aq")
 	if up != noNav {
 		t.Error("arrow-up at the top changed the render — should clamp at the first file")
 	}
@@ -122,8 +122,8 @@ func TestFileLightbar_ArrowUpAtTopClamps(t *testing.T) {
 // TestFileLightbar_SpaceTogglesTag pins the tag path: Space marks the selected
 // file (persisting via UpdateUser), which renders as a '*' in the ^MARK column.
 func TestFileLightbar_SpaceTogglesTag(t *testing.T) {
-	_, _, _, untagged := runFileLightbar(t, "q")
-	_, _, _, tagged := runFileLightbar(t, " q")
+	_, _, untagged, _ := runFileLightbar(t, "q")
+	_, _, tagged, _ := runFileLightbar(t, " q")
 	if strings.Contains(untagged, "*") {
 		t.Error("no file should be marked before tagging")
 	}
@@ -135,8 +135,8 @@ func TestFileLightbar_SpaceTogglesTag(t *testing.T) {
 // TestFileLightbar_CmdBarNavChangesRender pins that arrow-right moves the command
 // bar selection (re-rendering the bar differently).
 func TestFileLightbar_CmdBarNavChangesRender(t *testing.T) {
-	_, _, _, noNav := runFileLightbar(t, "q")
-	_, _, _, right := runFileLightbar(t, "\x1b[Cq")
+	_, _, noNav, _ := runFileLightbar(t, "q")
+	_, _, right, _ := runFileLightbar(t, "\x1b[Cq")
 	if right == noNav {
 		t.Error("arrow-right produced identical output — command-bar selection did not move")
 	}
@@ -145,8 +145,8 @@ func TestFileLightbar_CmdBarNavChangesRender(t *testing.T) {
 // TestFileLightbar_PageDownChangesView pins paging: with more files than fit on
 // one screen, PageDown shows a different slice of the list.
 func TestFileLightbar_PageDownChangesView(t *testing.T) {
-	_, _, _, page1 := runFileLightbarN(t, "q", 30)
-	_, _, _, paged := runFileLightbarN(t, "\x1b[6~q", 30)
+	_, _, page1, _ := runFileLightbarN(t, "q", 30)
+	_, _, paged, _ := runFileLightbarN(t, "\x1b[6~q", 30)
 	if paged == page1 {
 		t.Error("PageDown produced identical output with 30 files — paging did not advance")
 	}
@@ -155,8 +155,8 @@ func TestFileLightbar_PageDownChangesView(t *testing.T) {
 // TestFileLightbar_EndJumpsToLastFile pins End: with more files than fit on a
 // screen, End scrolls to the last page (a different rendered slice than the top).
 func TestFileLightbar_EndJumpsToLastFile(t *testing.T) {
-	_, _, _, top := runFileLightbarN(t, "q", 30)
-	_, _, _, end := runFileLightbarN(t, "\x1b[Fq", 30)
+	_, _, top, _ := runFileLightbarN(t, "q", 30)
+	_, _, end, _ := runFileLightbarN(t, "\x1b[Fq", 30)
 	if end == top {
 		t.Error("End produced identical output with 30 files — did not jump to the last page")
 	}

--- a/internal/menu/file_newscan.go
+++ b/internal/menu/file_newscan.go
@@ -418,7 +418,7 @@ func runFileNewscanConfig(c *cmdCtx, args string) (*user.User, string, error) {
 	headerContent, ansErr := ansi.GetAnsiFileContent(ansPath)
 	if ansErr == nil {
 		if outputMode == ansi.OutputModeCP437 {
-			terminal.Write(headerContent)
+			_, _ = terminal.Write(headerContent) // best-effort display
 		} else {
 			terminalio.WriteProcessedBytes(terminal, headerContent, outputMode)
 		}

--- a/internal/menu/file_search.go
+++ b/internal/menu/file_search.go
@@ -120,6 +120,6 @@ func runSearchFiles(c *cmdCtx, args string) (*user.User, string, error) {
 		fmt.Sprintf(e.LoadedStrings.SearchResultsSummary, len(filtered)),
 	)), outputMode)
 
-	writeCenteredPausePrompt(s, terminal, e.LoadedStrings.PauseString, outputMode, termWidth, termHeight)
+	_ = writeCenteredPausePrompt(s, terminal, e.LoadedStrings.PauseString, outputMode, termWidth, termHeight) // best-effort pause prompt
 	return currentUser, "", nil
 }

--- a/internal/menu/file_viewer.go
+++ b/internal/menu/file_viewer.go
@@ -244,7 +244,7 @@ func displayTextWithPaging(s ssh.Session, terminal *term.Terminal, filePath stri
 		// (UTF-8 after ConvertCP437ToUTF8, or raw CP437 for CP437 terminals).
 		// Going through WriteProcessedBytes would re-interpret the bytes and
 		// produce '?' for byte pairs that form false UTF-8 sequences.
-		terminal.Write(append(line, '\r', '\n'))
+		_, _ = terminal.Write(append(line, '\r', '\n')) // best-effort display
 		lineCount++
 
 		if lineCount >= linesPerPage {
@@ -315,24 +315,24 @@ func displayTextWithPaging_toWriter(w io.Writer, filePath string, filename strin
 	f, err := os.Open(filePath)
 	if err != nil {
 		slog.Error("failed to open file", "file", filePath, "error", err)
-		fmt.Fprintf(w, "\r\nError opening file.\r\n")
+		_, _ = fmt.Fprintf(w, "\r\nError opening file.\r\n") // best-effort display
 		return
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }() // read-only
 
-	fmt.Fprintf(w, "\r\n--- Viewing: %s ---\r\n\r\n", sanitizeControlChars(filename))
+	_, _ = fmt.Fprintf(w, "\r\n--- Viewing: %s ---\r\n\r\n", sanitizeControlChars(filename)) // best-effort display
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 4096), 4096)
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		fmt.Fprintf(w, "%s\r\n", line)
+		_, _ = fmt.Fprintf(w, "%s\r\n", line) // best-effort display
 	}
 
 	if err := scanner.Err(); err != nil {
 		slog.Warn("error reading file", "file", filePath, "error", err)
 	}
 
-	fmt.Fprintf(w, "\r\n--- End of File ---\r\n")
+	_, _ = fmt.Fprintf(w, "\r\n--- End of File ---\r\n") // best-effort display
 }

--- a/internal/menu/file_wantlist.go
+++ b/internal/menu/file_wantlist.go
@@ -86,7 +86,7 @@ func runWantListSysop(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, u
 	if len(entries) == 0 {
 		msg := e.LoadedStrings.WantListEmpty
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n"+msg+"\r\n")), outputMode)
-		writeCenteredPausePrompt(s, terminal, e.LoadedStrings.PauseString, outputMode, termWidth, termHeight)
+		_ = writeCenteredPausePrompt(s, terminal, e.LoadedStrings.PauseString, outputMode, termWidth, termHeight) // best-effort pause prompt
 		return currentUser, "", nil
 	}
 

--- a/internal/menu/infoforms.go
+++ b/internal/menu/infoforms.go
@@ -121,21 +121,21 @@ func saveInfoFormResponse(rootConfigPath string, resp *InfoFormResponse) error {
 	}
 	tmpName := tmp.Name()
 	if err := tmp.Chmod(0600); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
+		_ = tmp.Close()        // cleanup on error path
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("chmod temp file: %w", err)
 	}
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
+		_ = tmp.Close()        // cleanup on error path
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("write temp file: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("close temp file: %w", err)
 	}
 	if err := os.Rename(tmpName, fp); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("rename temp file: %w", err)
 	}
 	return nil

--- a/internal/menu/matrix.go
+++ b/internal/menu/matrix.go
@@ -126,7 +126,7 @@ func (e *MenuExecutor) RunMatrixScreen(
 
 		case ' ':
 			// Spacebar redraws screen (matches Pascal behavior)
-			drawMatrixScreen(terminal, ansBackground, options, selectedIndex, outputMode)
+			_ = drawMatrixScreen(terminal, ansBackground, options, selectedIndex, outputMode) // best-effort redraw
 
 		default:
 			if key < 32 || key > 126 {
@@ -139,7 +139,7 @@ func (e *MenuExecutor) RunMatrixScreen(
 				numIndex := int(r - '1')
 				if numIndex < len(options) {
 					selectedIndex = numIndex
-					drawMatrixOptions(terminal, options, selectedIndex, outputMode)
+					_ = drawMatrixOptions(terminal, options, selectedIndex, outputMode) // best-effort redraw
 					selectionMade = true
 				}
 				break
@@ -151,7 +151,7 @@ func (e *MenuExecutor) RunMatrixScreen(
 			for i, opt := range options {
 				if keyStr == opt.HotKey {
 					selectedIndex = i
-					drawMatrixOptions(terminal, options, selectedIndex, outputMode)
+					_ = drawMatrixOptions(terminal, options, selectedIndex, outputMode) // best-effort redraw
 					selectionMade = true
 					matchedHotkey = true
 					break
@@ -159,13 +159,13 @@ func (e *MenuExecutor) RunMatrixScreen(
 			}
 			if !matchedHotkey {
 				e.showUndefinedMenuInput(terminal, outputMode, nodeNumber)
-				drawMatrixScreen(terminal, ansBackground, options, selectedIndex, outputMode)
+				_ = drawMatrixScreen(terminal, ansBackground, options, selectedIndex, outputMode) // best-effort redraw
 			}
 		}
 
 		if newIndex != selectedIndex {
 			selectedIndex = newIndex
-			drawMatrixOptions(terminal, options, selectedIndex, outputMode)
+			_ = drawMatrixOptions(terminal, options, selectedIndex, outputMode) // best-effort redraw
 		}
 
 		if selectionMade {
@@ -190,7 +190,7 @@ func (e *MenuExecutor) RunMatrixScreen(
 			// redraw the screen and continue
 			tries++
 			selectedIndex = 0
-			drawMatrixScreen(terminal, ansBackground, options, selectedIndex, outputMode)
+			_ = drawMatrixScreen(terminal, ansBackground, options, selectedIndex, outputMode) // best-effort redraw
 		}
 	}
 
@@ -358,7 +358,7 @@ func (e *MenuExecutor) showPrelogon(s ssh.Session, terminal *term.Terminal, node
 	terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 	// For CP437 mode, write raw bytes directly to avoid UTF-8 false positives
 	if outputMode == ansi.OutputModeCP437 {
-		terminal.Write(rawContent)
+		_, _ = terminal.Write(rawContent) // best-effort display
 	} else {
 		terminalio.WriteProcessedBytes(terminal, rawContent, outputMode)
 	}
@@ -380,7 +380,7 @@ func drawMatrixScreen(
 	terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 	// For CP437 mode, write raw bytes directly to avoid UTF-8 false positives
 	if outputMode == ansi.OutputModeCP437 {
-		terminal.Write(ansBackground)
+		_, _ = terminal.Write(ansBackground) // best-effort display
 	} else {
 		terminalio.WriteProcessedBytes(terminal, ansBackground, outputMode)
 	}

--- a/internal/menu/message_lightbar.go
+++ b/internal/menu/message_lightbar.go
@@ -48,7 +48,7 @@ func readKeyWithEscapeHandling(reader *bufio.Reader) (rune, error) {
 		}
 
 		// Read the '[' and direction byte
-		reader.ReadByte() // consume '['
+		_, _ = reader.ReadByte() // consume '['; next read reports errors
 		dirByte, dirErr := reader.ReadByte()
 		if dirErr != nil {
 			return 27, nil

--- a/internal/menu/message_list.go
+++ b/internal/menu/message_list.go
@@ -709,7 +709,7 @@ func runListMsgsFiltered(c *cmdCtx, args string, msgFilter msgOwnershipFilter) (
 				actualIndex := start + previousIndex
 				if actualIndex < len(state.Entries) {
 					row := 6 + previousIndex
-					drawMessageLineAtRow(terminal, state.Entries[actualIndex], row, false, outputMode)
+					_ = drawMessageLineAtRow(terminal, state.Entries[actualIndex], row, false, outputMode) // best-effort redraw
 				}
 			}
 
@@ -718,7 +718,7 @@ func runListMsgsFiltered(c *cmdCtx, args string, msgFilter msgOwnershipFilter) (
 				actualIndex := start + state.SelectedIndex
 				if actualIndex < len(state.Entries) {
 					row := 6 + state.SelectedIndex
-					drawMessageLineAtRow(terminal, state.Entries[actualIndex], row, true, outputMode)
+					_ = drawMessageLineAtRow(terminal, state.Entries[actualIndex], row, true, outputMode) // best-effort redraw
 				}
 			}
 

--- a/internal/menu/message_reader.go
+++ b/internal/menu/message_reader.go
@@ -307,7 +307,7 @@ readerLoop:
 				// MSGHDR template are converted to Unicode before reaching the terminal.
 				terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 				if outputMode == ansi.OutputModeCP437 {
-					terminal.Write(processedHeader)
+					_, _ = terminal.Write(processedHeader) // best-effort display
 				} else {
 					terminalio.WriteProcessedBytes(terminal, processedHeader, outputMode)
 				}

--- a/internal/menu/message_reader_headers.go
+++ b/internal/menu/message_reader_headers.go
@@ -229,7 +229,7 @@ func runGetHeaderType(c *cmdCtx, args string) (*user.User, string, error) {
 		// For CP437 mode, write raw bytes directly to avoid UTF-8 false positives
 		processedSelBytes := ansi.ReplacePipeCodes(selectionBytes)
 		if outputMode == ansi.OutputModeCP437 {
-			terminal.Write(processedSelBytes)
+			_, _ = terminal.Write(processedSelBytes) // best-effort display
 		} else {
 			terminalio.WriteProcessedBytes(terminal, processedSelBytes, outputMode)
 		}
@@ -331,7 +331,7 @@ func runGetHeaderType(c *cmdCtx, args string) (*user.User, string, error) {
 			terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 			// For CP437 mode, write raw bytes directly to avoid UTF-8 false positives
 			if outputMode == ansi.OutputModeCP437 {
-				terminal.Write(processedPreview)
+				_, _ = terminal.Write(processedPreview) // best-effort display
 			} else {
 				terminalio.WriteProcessedBytes(terminal, processedPreview, outputMode)
 			}

--- a/internal/menu/message_scan.go
+++ b/internal/menu/message_scan.go
@@ -60,7 +60,7 @@ func runGetScanType(reader *bufio.Reader, e *MenuExecutor, terminal *term.Termin
 		if ansErr == nil {
 			// For CP437 mode, write raw bytes directly to avoid UTF-8 false positives
 			if outputMode == ansi.OutputModeCP437 {
-				terminal.Write(headerContent)
+				_, _ = terminal.Write(headerContent) // best-effort display
 			} else {
 				terminalio.WriteProcessedBytes(terminal, headerContent, outputMode)
 			}

--- a/internal/menu/message_scan_config.go
+++ b/internal/menu/message_scan_config.go
@@ -334,7 +334,7 @@ func runNewscanConfig(c *cmdCtx, args string) (*user.User, string, error) {
 	if ansErr == nil {
 		// For CP437 mode, write raw bytes directly to avoid UTF-8 false positives
 		if outputMode == ansi.OutputModeCP437 {
-			terminal.Write(headerContent)
+			_, _ = terminal.Write(headerContent) // best-effort display
 		} else {
 			terminalio.WriteProcessedBytes(terminal, headerContent, outputMode)
 		}

--- a/internal/menu/newuser.go
+++ b/internal/menu/newuser.go
@@ -263,7 +263,7 @@ func (e *MenuExecutor) displayNewUserScreen(terminal *term.Terminal, outputMode 
 	// For CP437 mode, write raw bytes directly to avoid UTF-8 false positives
 	// (some CP437 byte pairs accidentally form valid UTF-8)
 	if outputMode == ansi.OutputModeCP437 {
-		terminal.Write(rawContent)
+		_, _ = terminal.Write(rawContent) // best-effort display
 	} else {
 		terminalio.WriteProcessedBytes(terminal, rawContent, outputMode)
 	}

--- a/internal/menu/newuser.go
+++ b/internal/menu/newuser.go
@@ -627,11 +627,7 @@ func validateHandle(handle string) bool {
 			break
 		}
 	}
-	if allDigits {
-		return false
-	}
-
-	return true
+	return !allDigits
 }
 
 // validateRealName checks that a real name is >3 chars and contains a space.

--- a/internal/menu/qwk_handler.go
+++ b/internal/menu/qwk_handler.go
@@ -105,14 +105,17 @@ func runQWKDownload(c *cmdCtx, args string) (*user.User, string, error) {
 		return currentUser, "", nil
 	}
 	tmpPath := tmpFile.Name()
-	defer os.Remove(tmpPath)
+	defer func() { _ = os.Remove(tmpPath) }() // best-effort temp cleanup
 
 	if _, err := tmpFile.Write(res.Packet); err != nil {
-		tmpFile.Close()
+		_ = tmpFile.Close() // cleanup on error path
 		slog.Error("failed to write packet", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
-	tmpFile.Close()
+	if err := tmpFile.Close(); err != nil {
+		slog.Error("failed to finalize packet file", "node", nodeNumber, "error", err)
+		return currentUser, "", nil
+	}
 
 	// Rename to BBSID.QWK for the transfer
 	qwkPath := filepath.Join(filepath.Dir(tmpPath), bbsID+".QWK")
@@ -120,7 +123,7 @@ func runQWKDownload(c *cmdCtx, args string) (*user.User, string, error) {
 		slog.Error("rename failed", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
-	defer os.Remove(qwkPath)
+	defer func() { _ = os.Remove(qwkPath) }() // best-effort temp cleanup
 
 	// Protocol selection and send
 	proto, ok, protoErr := e.selectTransferProtocol(s, terminal, outputMode)
@@ -202,7 +205,7 @@ func runQWKUpload(c *cmdCtx, args string) (*user.User, string, error) {
 		slog.Error("failed to create temp dir", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
-	defer os.RemoveAll(incomingDir)
+	defer func() { _ = os.RemoveAll(incomingDir) }() // best-effort temp cleanup
 
 	resetSessionIH(s)
 	ctx, cancel := e.transferContext(s.Context())

--- a/internal/menu/syncjs_door.go
+++ b/internal/menu/syncjs_door.go
@@ -32,7 +32,7 @@ func executeSyncJSDoor(ctx *DoorCtx) error {
 	if err := os.MkdirAll(nodeDir, 0o755); err != nil {
 		return fmt.Errorf("creating node directory: %w", err)
 	}
-	defer os.RemoveAll(nodeDir)
+	defer func() { _ = os.RemoveAll(nodeDir) }() // best-effort temp cleanup
 
 	// Set up a read interrupt so the engine's copier goroutine can be
 	// cleanly stopped when the door exits, preventing it from consuming

--- a/internal/menueditor/update_command.go
+++ b/internal/menueditor/update_command.go
@@ -158,9 +158,9 @@ func (m Model) startCmdFieldEdit() (Model, tea.Cmd) {
 	if f.Type == ftYesNo {
 		// Toggle directly
 		if val == "Y" {
-			f.SetC(d, "N")
+			_ = f.SetC(d, "N") // Y/N field setters never fail
 		} else {
-			f.SetC(d, "Y")
+			_ = f.SetC(d, "Y") // Y/N field setters never fail
 		}
 		m.dirtyCmds = true
 		return m, nil

--- a/internal/menueditor/update_menu.go
+++ b/internal/menueditor/update_menu.go
@@ -161,9 +161,9 @@ func (m Model) startMenuFieldEdit() (Model, tea.Cmd) {
 	if f.Type == ftYesNo {
 		// Toggle directly without opening text input
 		if val == "Y" {
-			f.SetM(d, "N")
+			_ = f.SetM(d, "N") // Y/N field setters never fail
 		} else {
-			f.SetM(d, "Y")
+			_ = f.SetM(d, "Y") // Y/N field setters never fail
 		}
 		m.dirtyMenus[m.menus[m.menuEditIdx].Name] = true
 		return m, nil

--- a/internal/message/manager.go
+++ b/internal/message/manager.go
@@ -689,7 +689,11 @@ func (mm *MessageManager) GetMessage(areaID, msgNum int) (*DisplayMessage, error
 	if err != nil {
 		return nil, err
 	}
-	defer b.Close()
+	defer func() {
+		if cerr := b.Close(); cerr != nil {
+			slog.Warn("closing JAM base", "error", cerr)
+		}
+	}()
 
 	msg, err := b.ReadMessage(msgNum)
 	if err != nil {
@@ -729,7 +733,11 @@ func (mm *MessageManager) GetMessageCountForArea(areaID int) (int, error) {
 		}
 		return 0, err // Propagate I/O and other errors
 	}
-	defer b.Close()
+	defer func() {
+		if cerr := b.Close(); cerr != nil {
+			slog.Warn("closing JAM base", "error", cerr)
+		}
+	}()
 
 	return b.GetMessageCount()
 }
@@ -759,7 +767,11 @@ func (mm *MessageManager) GetThreadReplyCount(areaID int, msgNum int, subject st
 		}
 		return 0, err // Propagate I/O and other errors
 	}
-	defer b.Close()
+	defer func() {
+		if cerr := b.Close(); cerr != nil {
+			slog.Warn("closing JAM base", "error", cerr)
+		}
+	}()
 
 	mm.mu.RLock()
 	idx := mm.threadIndex[areaID]
@@ -850,7 +862,11 @@ func (mm *MessageManager) FindMessageByMSGID(areaID int, msgID string) int {
 	if err != nil {
 		return 0
 	}
-	defer b.Close()
+	defer func() {
+		if cerr := b.Close(); cerr != nil {
+			slog.Warn("closing JAM base", "error", cerr)
+		}
+	}()
 
 	total, err := b.GetMessageCount()
 	if err != nil || total == 0 {
@@ -929,7 +945,11 @@ func (mm *MessageManager) GetNewMessageCount(areaID int, username string) (int, 
 		}
 		return 0, err // Propagate I/O and other errors
 	}
-	defer b.Close()
+	defer func() {
+		if cerr := b.Close(); cerr != nil {
+			slog.Warn("closing JAM base", "error", cerr)
+		}
+	}()
 
 	return b.GetUnreadCount(username)
 }
@@ -944,7 +964,11 @@ func (mm *MessageManager) GetLastRead(areaID int, username string) (int, error) 
 		}
 		return 0, err // Propagate I/O and other errors
 	}
-	defer b.Close()
+	defer func() {
+		if cerr := b.Close(); cerr != nil {
+			slog.Warn("closing JAM base", "error", cerr)
+		}
+	}()
 
 	lr, err := b.GetLastRead(username)
 	if err != nil {
@@ -962,7 +986,11 @@ func (mm *MessageManager) SetLastRead(areaID int, username string, msgNum int) e
 	if err != nil {
 		return err
 	}
-	defer b.Close()
+	defer func() {
+		if cerr := b.Close(); cerr != nil {
+			slog.Warn("closing JAM base", "error", cerr)
+		}
+	}()
 
 	return b.MarkMessageRead(username, msgNum)
 }
@@ -974,7 +1002,11 @@ func (mm *MessageManager) MarkMessageSent(areaID, msgNum int) error {
 	if err != nil {
 		return err
 	}
-	defer b.Close()
+	defer func() {
+		if cerr := b.Close(); cerr != nil {
+			slog.Warn("closing JAM base", "error", cerr)
+		}
+	}()
 
 	hdr, err := b.ReadMessageHeader(msgNum)
 	if err != nil {
@@ -995,7 +1027,11 @@ func (mm *MessageManager) GetNextUnreadMessage(areaID int, username string) (int
 		}
 		return 0, err // Propagate I/O and other errors
 	}
-	defer b.Close()
+	defer func() {
+		if cerr := b.Close(); cerr != nil {
+			slog.Warn("closing JAM base", "error", cerr)
+		}
+	}()
 
 	next, err := b.GetNextUnreadMessage(username)
 	if err != nil {
@@ -1015,7 +1051,11 @@ func (mm *MessageManager) DeleteMessage(areaID, msgNum int) error {
 	if err != nil {
 		return fmt.Errorf("open base for area %d: %w", areaID, err)
 	}
-	defer b.Close()
+	defer func() {
+		if cerr := b.Close(); cerr != nil {
+			slog.Warn("closing JAM base", "error", cerr)
+		}
+	}()
 	if err := b.DeleteMessage(msgNum); err != nil {
 		return fmt.Errorf("delete message %d in area %d: %w", msgNum, areaID, err)
 	}
@@ -1032,7 +1072,11 @@ func (mm *MessageManager) PackAndLinkArea(areaID int) error {
 	if err != nil {
 		return fmt.Errorf("open base for area %d: %w", areaID, err)
 	}
-	defer b.Close()
+	defer func() {
+		if cerr := b.Close(); cerr != nil {
+			slog.Warn("closing JAM base", "error", cerr)
+		}
+	}()
 	if _, err := b.Pack(); err != nil {
 		return fmt.Errorf("pack area %d: %w", areaID, err)
 	}

--- a/internal/message/manager.go
+++ b/internal/message/manager.go
@@ -634,14 +634,19 @@ func (mm *MessageManager) addMessage(areaID int, from, to, subject, body, replyT
 	// Close the base before firing the callback. The V3Net hook calls
 	// MarkMessageSent which re-opens the same JAM base, so having it
 	// still open here can cause nested-open/file-sharing issues.
-	if cerr := b.Close(); cerr != nil && err == nil {
-		err = fmt.Errorf("closing message base: %w", cerr)
-	}
+	cerr := b.Close()
 
+	// The write already succeeded at this point, so run the post-write hooks
+	// even if the close failed — the message is on disk and downstream
+	// consumers (thread index, V3Net delivery) must still see it. The close
+	// error is folded into the returned error afterwards.
 	if err == nil {
 		mm.invalidateThreadIndex(areaID)
 		if !private && mm.OnMessagePosted != nil {
 			mm.OnMessagePosted(area, msgNum, from, to, subject, body)
+		}
+		if cerr != nil {
+			err = fmt.Errorf("closing message base: %w", cerr)
 		}
 	}
 	return msgNum, err

--- a/internal/message/manager.go
+++ b/internal/message/manager.go
@@ -634,7 +634,9 @@ func (mm *MessageManager) addMessage(areaID int, from, to, subject, body, replyT
 	// Close the base before firing the callback. The V3Net hook calls
 	// MarkMessageSent which re-opens the same JAM base, so having it
 	// still open here can cause nested-open/file-sharing issues.
-	b.Close()
+	if cerr := b.Close(); cerr != nil && err == nil {
+		err = fmt.Errorf("closing message base: %w", cerr)
+	}
 
 	if err == nil {
 		mm.invalidateThreadIndex(areaID)

--- a/internal/qwk/reader.go
+++ b/internal/qwk/reader.go
@@ -63,7 +63,7 @@ func ReadREPPacket(r io.ReaderAt, size int64, bbsID string) (*REPPacket, error) 
 	if err != nil {
 		return nil, fmt.Errorf("failed to open %s: %w", msgFile.Name, err)
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }() // read-only zip entry
 
 	data, err := io.ReadAll(rc)
 	if err != nil {
@@ -76,7 +76,7 @@ func ReadREPPacket(r io.ReaderAt, size int64, bbsID string) (*REPPacket, error) 
 			hrc, err := f.Open()
 			if err == nil {
 				hdata, rerr := io.ReadAll(hrc)
-				hrc.Close()
+				_ = hrc.Close() // read-only zip entry
 				if rerr == nil {
 					headers = parseHeadersDAT(hdata)
 				}

--- a/internal/qwk/rep_writer.go
+++ b/internal/qwk/rep_writer.go
@@ -52,13 +52,13 @@ func WriteREP(w io.Writer, bbsID string, msgs []PacketMessage) error {
 
 	name := bbsID + ".MSG"
 	if err := writeZipEntry(zw, name, msgBuf.Bytes()); err != nil {
-		zw.Close()
+		_ = zw.Close() // cleanup on error path
 		return fmt.Errorf("%s: %w", name, err)
 	}
 
 	if hdrs := encodeHeadersDAT(extHeadersFor(msgs, offsets, bbsID)); len(hdrs) > 0 {
 		if err := writeZipEntry(zw, "HEADERS.DAT", hdrs); err != nil {
-			zw.Close()
+			_ = zw.Close() // cleanup on error path
 			return fmt.Errorf("HEADERS.DAT: %w", err)
 		}
 	}

--- a/internal/qwk/writer.go
+++ b/internal/qwk/writer.go
@@ -60,7 +60,9 @@ func (pw *PacketWriter) MessageCount() int {
 // WritePacket writes the complete QWK ZIP packet to w.
 func (pw *PacketWriter) WritePacket(w io.Writer) error {
 	zw := zip.NewWriter(w)
-	defer zw.Close()
+	// Cleanup for early-error returns; the success path closes explicitly
+	// below, making this second Close a harmless no-op error.
+	defer func() { _ = zw.Close() }()
 
 	if err := pw.writeControlDAT(zw); err != nil {
 		return fmt.Errorf("CONTROL.DAT: %w", err)
@@ -93,6 +95,11 @@ func (pw *PacketWriter) WritePacket(w io.Writer) error {
 		}
 	}
 
+	// Close explicitly so a central-directory flush failure is reported
+	// rather than silently producing a truncated packet.
+	if err := zw.Close(); err != nil {
+		return fmt.Errorf("finalize QWK archive: %w", err)
+	}
 	return nil
 }
 

--- a/internal/qwk/writer_test.go
+++ b/internal/qwk/writer_test.go
@@ -3,6 +3,7 @@ package qwk
 import (
 	"archive/zip"
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -279,5 +280,47 @@ func TestFormatMessage_ReplyToNumber(t *testing.T) {
 	ref := strings.TrimSpace(string(data[108:116]))
 	if ref != "7" {
 		t.Errorf("reference field (108-115): want 7, got %q", ref)
+	}
+}
+
+// failAfterWriter fails all writes once limit bytes have been written,
+// simulating a full disk during zip finalization.
+type failAfterWriter struct {
+	n     int
+	limit int
+}
+
+func (w *failAfterWriter) Write(p []byte) (int, error) {
+	if w.n+len(p) > w.limit {
+		return 0, errDiskFull
+	}
+	w.n += len(p)
+	return len(p), nil
+}
+
+var errDiskFull = errors.New("disk full")
+
+func TestPacketWriter_WritePacketReportsFinalizeError(t *testing.T) {
+	pw := NewPacketWriter("VISION3", "ViSiON/3 BBS", "SysOp")
+	pw.AddConference(1, "General")
+	pw.AddMessage(PacketMessage{
+		Conference: 1,
+		Number:     1,
+		From:       "SysOp",
+		To:         "TestUser",
+		Subject:    "Hi",
+		DateTime:   time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC),
+		Body:       "Body",
+	})
+
+	// Measure the full packet size, then cut the writer off just before the
+	// end so only the trailing central-directory flush in Close() fails.
+	var buf bytes.Buffer
+	if err := pw.WritePacket(&buf); err != nil {
+		t.Fatalf("WritePacket failed: %v", err)
+	}
+	w := &failAfterWriter{limit: buf.Len() - 4}
+	if err := pw.WritePacket(w); !errors.Is(err, errDiskFull) {
+		t.Fatalf("WritePacket = %v, want errDiskFull from zip finalization", err)
 	}
 }

--- a/internal/qwkapi/ratelimit_test.go
+++ b/internal/qwkapi/ratelimit_test.go
@@ -7,8 +7,11 @@ import (
 
 func TestLimiter_AllowsThenBlocks(t *testing.T) {
 	l := newLimiter(2, time.Minute)
-	if !l.allow("a") || !l.allow("a") {
-		t.Fatal("first two should be allowed")
+	if !l.allow("a") {
+		t.Fatal("first should be allowed")
+	}
+	if !l.allow("a") {
+		t.Fatal("second should be allowed")
 	}
 	if l.allow("a") {
 		t.Error("third should be blocked")

--- a/internal/qwkservice/conference_map.go
+++ b/internal/qwkservice/conference_map.go
@@ -121,21 +121,21 @@ func (m *ConferenceMap) Save(path string) error {
 	}
 	tmpName := tmp.Name()
 	if _, err = tmp.Write(data); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
+		_ = tmp.Close()        // cleanup on error path
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("write temp conference map: %w", err)
 	}
 	if err = tmp.Sync(); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
+		_ = tmp.Close()        // cleanup on error path
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("sync temp conference map: %w", err)
 	}
 	if err = tmp.Close(); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("close temp conference map: %w", err)
 	}
 	if err = os.Rename(tmpName, path); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("rename conference map: %w", err)
 	}
 	return nil

--- a/internal/qwkservice/dedup.go
+++ b/internal/qwkservice/dedup.go
@@ -30,15 +30,15 @@ func openREPDedup(path string) (*repDedup, error) {
 	}
 	db.SetMaxOpenConns(1)
 	if _, err := db.Exec("PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000"); err != nil {
-		db.Close()
+		_ = db.Close() // cleanup on error path
 		return nil, fmt.Errorf("qwk dedup: configure pragmas: %w", err)
 	}
 	if _, err := db.Exec(repDedupSchema); err != nil {
-		db.Close()
+		_ = db.Close() // cleanup on error path
 		return nil, fmt.Errorf("qwk dedup: create schema: %w", err)
 	}
 	if _, err := db.Exec("DELETE FROM rep_uploads WHERE seen_at < datetime('now','-90 days')"); err != nil {
-		db.Close()
+		_ = db.Close() // cleanup on error path
 		return nil, fmt.Errorf("qwk dedup: prune: %w", err)
 	}
 	return &repDedup{db: db}, nil

--- a/internal/qwkservice/service_import.go
+++ b/internal/qwkservice/service_import.go
@@ -59,7 +59,11 @@ func (s *Service) ImportREP(data []byte, opts ImportOptions) (*ImportResult, err
 	if err != nil {
 		return nil, err
 	}
-	defer dedup.Close()
+	defer func() {
+		if cerr := dedup.Close(); cerr != nil {
+			slog.Warn("closing REP dedup database", "error", cerr)
+		}
+	}()
 	isNew, err := dedup.RecordIfNew(opts.Handle, fingerprint(packet.Payload))
 	if err != nil {
 		return nil, err

--- a/internal/scheduler/history.go
+++ b/internal/scheduler/history.go
@@ -66,21 +66,21 @@ func SaveHistory(path string, history map[string]*EventHistory) error {
 	tmpPath := tmp.Name()
 
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
+		_ = tmp.Close()        // cleanup on error path
+		_ = os.Remove(tmpPath) // cleanup on error path
 		return err
 	}
 	if err := tmp.Sync(); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
+		_ = tmp.Close()        // cleanup on error path
+		_ = os.Remove(tmpPath) // cleanup on error path
 		return err
 	}
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath) // cleanup on error path
 		return err
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath) // cleanup on error path
 		return err
 	}
 

--- a/internal/scripting/ansi_display.go
+++ b/internal/scripting/ansi_display.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/dop251/goja"
 )
 
@@ -17,7 +18,7 @@ func registerAnsi(v3 *goja.Object, eng *Engine) {
 	// display(filename) — read and display an .ANS file with pipe-code processing.
 	// File path is resolved relative to the script's working directory,
 	// then falls back to menus/v3/ansi/ and menus/v3/templates/.
-	obj.Set("display", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "display", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return goja.Undefined()
 		}
@@ -41,7 +42,7 @@ func registerAnsi(v3 *goja.Object, eng *Engine) {
 
 	// displayRaw(filename) — display an .ANS file without pipe-code processing.
 	// Sends raw CP437 bytes directly to the terminal.
-	obj.Set("displayRaw", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "displayRaw", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return goja.Undefined()
 		}
@@ -60,7 +61,7 @@ func registerAnsi(v3 *goja.Object, eng *Engine) {
 		return goja.Undefined()
 	})
 
-	v3.Set("ansi", obj)
+	jsutil.Set(v3, "ansi", obj)
 }
 
 // resolveAnsiPath finds an ANSI file by checking multiple locations:

--- a/internal/scripting/console.go
+++ b/internal/scripting/console.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/dop251/goja"
 )
 
@@ -16,25 +17,25 @@ func registerConsole(v3 *goja.Object, eng *Engine) {
 
 	// --- Properties ---
 
-	obj.Set("width", eng.session.ScreenWidth)
-	obj.Set("height", eng.session.ScreenHeight)
+	jsutil.Set(obj, "width", eng.session.ScreenWidth)
+	jsutil.Set(obj, "height", eng.session.ScreenHeight)
 
 	// --- Output ---
 
 	// write(text) — raw output, no pipe-code processing
-	obj.Set("write", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "write", func(call goja.FunctionCall) goja.Value {
 		eng.writeRaw(argsToString(call))
 		return goja.Undefined()
 	})
 
 	// writeln(text) — raw output + CRLF
-	obj.Set("writeln", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "writeln", func(call goja.FunctionCall) goja.Value {
 		eng.writeRaw(argsToString(call) + "\r\n")
 		return goja.Undefined()
 	})
 
 	// print(text) — output with pipe-code processing (|07, |09, etc.)
-	obj.Set("print", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "print", func(call goja.FunctionCall) goja.Value {
 		text := argsToString(call)
 		processed := ansi.ReplacePipeCodes([]byte(text))
 		eng.writeRaw(string(processed))
@@ -42,7 +43,7 @@ func registerConsole(v3 *goja.Object, eng *Engine) {
 	})
 
 	// println(text) — print with pipe-codes + CRLF
-	obj.Set("println", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "println", func(call goja.FunctionCall) goja.Value {
 		text := argsToString(call)
 		processed := ansi.ReplacePipeCodes([]byte(text))
 		eng.writeRaw(string(processed) + "\r\n")
@@ -54,11 +55,11 @@ func registerConsole(v3 *goja.Object, eng *Engine) {
 		eng.writeRaw("\x1b[2J\x1b[H")
 		return goja.Undefined()
 	}
-	obj.Set("clear", clearFn)
-	obj.Set("cls", clearFn)
+	jsutil.Set(obj, "clear", clearFn)
+	jsutil.Set(obj, "cls", clearFn)
 
 	// gotoxy(x, y) — cursor positioning (1-based)
-	obj.Set("gotoxy", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "gotoxy", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) < 2 {
 			return goja.Undefined()
 		}
@@ -69,7 +70,7 @@ func registerConsole(v3 *goja.Object, eng *Engine) {
 	})
 
 	// color(fg) or color(fg, bg) — set color by number
-	obj.Set("color", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "color", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return goja.Undefined()
 		}
@@ -85,13 +86,13 @@ func registerConsole(v3 *goja.Object, eng *Engine) {
 	})
 
 	// reset() — reset terminal attributes
-	obj.Set("reset", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "reset", func(call goja.FunctionCall) goja.Value {
 		eng.writeRaw("\x1b[0m")
 		return goja.Undefined()
 	})
 
 	// center(text) — center text on screen using pipe-code-aware width
-	obj.Set("center", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "center", func(call goja.FunctionCall) goja.Value {
 		text := argsToString(call)
 		processed := ansi.ReplacePipeCodes([]byte(text))
 		displayLen := displayLength(string(processed))
@@ -107,7 +108,7 @@ func registerConsole(v3 *goja.Object, eng *Engine) {
 	// --- Input ---
 
 	// getkey() or getkey(timeout_ms) — single key read
-	obj.Set("getkey", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "getkey", func(call goja.FunctionCall) goja.Value {
 		timeout := time.Duration(0)
 		if len(call.Arguments) > 0 {
 			ms := call.Arguments[0].ToInteger()
@@ -124,7 +125,7 @@ func registerConsole(v3 *goja.Object, eng *Engine) {
 
 	// getstr(maxlen) or getstr(maxlen, opts) — line input with editing
 	// opts: {echo: false, upper: true, number: true}
-	obj.Set("getstr", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "getstr", func(call goja.FunctionCall) goja.Value {
 		maxLen := 128
 		var opts lineOpts
 		if len(call.Arguments) > 0 {
@@ -150,7 +151,7 @@ func registerConsole(v3 *goja.Object, eng *Engine) {
 	})
 
 	// yesno(prompt) — Y/n prompt, returns true for Yes (default)
-	obj.Set("yesno", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "yesno", func(call goja.FunctionCall) goja.Value {
 		prompt := argsToString(call)
 		processed := ansi.ReplacePipeCodes([]byte(prompt + " (Y/n)? "))
 		eng.writeRaw(string(processed))
@@ -160,7 +161,7 @@ func registerConsole(v3 *goja.Object, eng *Engine) {
 	})
 
 	// noyes(prompt) — N/y prompt, returns true for No (default)
-	obj.Set("noyes", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "noyes", func(call goja.FunctionCall) goja.Value {
 		prompt := argsToString(call)
 		processed := ansi.ReplacePipeCodes([]byte(prompt + " (N/y)? "))
 		eng.writeRaw(string(processed))
@@ -170,7 +171,7 @@ func registerConsole(v3 *goja.Object, eng *Engine) {
 	})
 
 	// pause() — "press any key" prompt
-	obj.Set("pause", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "pause", func(call goja.FunctionCall) goja.Value {
 		eng.writeRaw("\r\n[Press any key] ")
 		eng.readKey(0) //nolint:errcheck
 		eng.writeRaw("\r\n")
@@ -178,7 +179,7 @@ func registerConsole(v3 *goja.Object, eng *Engine) {
 	})
 
 	// getnum(max) — read a number up to max
-	obj.Set("getnum", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "getnum", func(call goja.FunctionCall) goja.Value {
 		maxVal := 0
 		if len(call.Arguments) > 0 {
 			maxVal = int(call.Arguments[0].ToInteger())
@@ -193,14 +194,14 @@ func registerConsole(v3 *goja.Object, eng *Engine) {
 			return vm.ToValue(0)
 		}
 		n := 0
-		fmt.Sscanf(result, "%d", &n)
+		_, _ = fmt.Sscanf(result, "%d", &n) // best-effort parse; n stays 0 on failure
 		if maxVal > 0 && n > maxVal {
 			n = maxVal
 		}
 		return vm.ToValue(n)
 	})
 
-	v3.Set("console", obj)
+	jsutil.Set(v3, "console", obj)
 }
 
 // argsToString concatenates all JS function arguments into a single string.

--- a/internal/scripting/data.go
+++ b/internal/scripting/data.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/dop251/goja"
 )
 
@@ -36,7 +37,7 @@ func registerData(v3 *goja.Object, eng *Engine) {
 	}
 
 	// get(key) — read a value from the store, returns value or undefined.
-	obj.Set("get", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "get", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return goja.Undefined()
 		}
@@ -53,7 +54,7 @@ func registerData(v3 *goja.Object, eng *Engine) {
 	})
 
 	// set(key, value) — write a JSON-serializable value.
-	obj.Set("set", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "set", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) < 2 {
 			return goja.Undefined()
 		}
@@ -71,7 +72,7 @@ func registerData(v3 *goja.Object, eng *Engine) {
 	})
 
 	// delete(key) — remove a key.
-	obj.Set("delete", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "delete", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return goja.Undefined()
 		}
@@ -88,7 +89,7 @@ func registerData(v3 *goja.Object, eng *Engine) {
 	})
 
 	// keys() — return array of all keys.
-	obj.Set("keys", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "keys", func(call goja.FunctionCall) goja.Value {
 		mu := dataFileLock(store.path)
 		mu.Lock()
 		data := store.loadFile()
@@ -96,14 +97,14 @@ func registerData(v3 *goja.Object, eng *Engine) {
 		arr := vm.NewArray()
 		i := 0
 		for k := range data {
-			arr.Set(intToDataStr(i), k)
+			jsutil.Set(arr, intToDataStr(i), k)
 			i++
 		}
 		return arr
 	})
 
 	// getAll() — return entire store as an object.
-	obj.Set("getAll", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "getAll", func(call goja.FunctionCall) goja.Value {
 		mu := dataFileLock(store.path)
 		mu.Lock()
 		data := store.loadFile()
@@ -111,7 +112,7 @@ func registerData(v3 *goja.Object, eng *Engine) {
 		return vm.ToValue(data)
 	})
 
-	v3.Set("data", obj)
+	jsutil.Set(v3, "data", obj)
 }
 
 // dataFilePath computes the JSON storage path for a script.

--- a/internal/scripting/engine.go
+++ b/internal/scripting/engine.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/dop251/goja"
 	"golang.org/x/text/encoding/charmap"
 )
@@ -87,7 +88,7 @@ func NewEngine(ctx context.Context, session *SessionContext, cfg ScriptConfig, p
 	if providers.SessionRegistry != nil {
 		registerNodes(v3, eng)
 	}
-	eng.vm.Set("v3", v3)
+	jsutil.Set(eng.vm, "v3", v3)
 
 	// Register top-level helpers.
 	eng.registerGlobals()
@@ -127,7 +128,7 @@ func (eng *Engine) Run(scriptPath string) error {
 // Close cleans up the engine, stopping I/O goroutines.
 func (eng *Engine) Close() {
 	if eng.pipeWriter != nil {
-		eng.pipeWriter.Close()
+		_ = eng.pipeWriter.Close() // best-effort shutdown of the input pipe
 	}
 	// Wait for the copier goroutine to exit so it stops reading from
 	// the session. This relies on the caller closing the read interrupt
@@ -140,7 +141,7 @@ func (eng *Engine) Close() {
 		}
 	}
 	if eng.pipeReader != nil {
-		eng.pipeReader.Close()
+		_ = eng.pipeReader.Close() // best-effort shutdown of the input pipe
 	}
 	// Drain buffered results so goroutines don't block.
 	if eng.rawInputCh != nil {
@@ -164,7 +165,7 @@ func (eng *Engine) watchContext() {
 
 // registerGlobals adds top-level convenience functions (exit, sleep, etc.).
 func (eng *Engine) registerGlobals() {
-	eng.vm.Set("exit", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(eng.vm, "exit", func(call goja.FunctionCall) goja.Value {
 		code := 0
 		if len(call.Arguments) > 0 {
 			code = int(call.Arguments[0].ToInteger())

--- a/internal/scripting/file.go
+++ b/internal/scripting/file.go
@@ -2,6 +2,7 @@ package scripting
 
 import (
 	"github.com/ViSiON-3/vision-3-bbs/internal/file"
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/dop251/goja"
 )
 
@@ -12,17 +13,17 @@ func registerFile(v3 *goja.Object, eng *Engine) {
 	mgr := eng.providers.FileMgr
 
 	// areas() — list all file areas [{id, tag, name, description}].
-	obj.Set("areas", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "areas", func(call goja.FunctionCall) goja.Value {
 		areas := mgr.ListAreas()
 		arr := vm.NewArray()
 		for i, a := range areas {
-			arr.Set(itoa(i), fileAreaToJS(vm, &a))
+			jsutil.Set(arr, itoa(i), fileAreaToJS(vm, &a))
 		}
 		return arr
 	})
 
 	// area(tag) — get a single area by tag, returns object or null.
-	obj.Set("area", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "area", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return goja.Null()
 		}
@@ -35,7 +36,7 @@ func registerFile(v3 *goja.Object, eng *Engine) {
 	})
 
 	// list(areaID) — files in an area.
-	obj.Set("list", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "list", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.NewArray()
 		}
@@ -43,13 +44,13 @@ func registerFile(v3 *goja.Object, eng *Engine) {
 		files := mgr.GetFilesForArea(areaID)
 		arr := vm.NewArray()
 		for i, f := range files {
-			arr.Set(itoa(i), fileRecordToJS(vm, &f))
+			jsutil.Set(arr, itoa(i), fileRecordToJS(vm, &f))
 		}
 		return arr
 	})
 
 	// count(areaID) — file count in an area.
-	obj.Set("count", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "count", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue(0)
 		}
@@ -62,7 +63,7 @@ func registerFile(v3 *goja.Object, eng *Engine) {
 	})
 
 	// search(query) — keyword search across all areas.
-	obj.Set("search", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "search", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.NewArray()
 		}
@@ -70,38 +71,38 @@ func registerFile(v3 *goja.Object, eng *Engine) {
 		files := mgr.SearchFiles(query)
 		arr := vm.NewArray()
 		for i, f := range files {
-			arr.Set(itoa(i), fileRecordToJS(vm, &f))
+			jsutil.Set(arr, itoa(i), fileRecordToJS(vm, &f))
 		}
 		return arr
 	})
 
 	// totalCount() — total files across all areas.
-	obj.Set("totalCount", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "totalCount", func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(mgr.GetTotalFileCount())
 	})
 
-	v3.Set("file", obj)
+	jsutil.Set(v3, "file", obj)
 }
 
 func fileAreaToJS(vm *goja.Runtime, a *file.FileArea) goja.Value {
 	obj := vm.NewObject()
-	obj.Set("id", a.ID)
-	obj.Set("tag", a.Tag)
-	obj.Set("name", a.Name)
-	obj.Set("description", a.Description)
-	obj.Set("conferenceID", a.ConferenceID)
+	jsutil.Set(obj, "id", a.ID)
+	jsutil.Set(obj, "tag", a.Tag)
+	jsutil.Set(obj, "name", a.Name)
+	jsutil.Set(obj, "description", a.Description)
+	jsutil.Set(obj, "conferenceID", a.ConferenceID)
 	return obj
 }
 
 func fileRecordToJS(vm *goja.Runtime, f *file.FileRecord) goja.Value {
 	obj := vm.NewObject()
-	obj.Set("id", f.ID.String())
-	obj.Set("areaID", f.AreaID)
-	obj.Set("filename", f.Filename)
-	obj.Set("description", f.Description)
-	obj.Set("size", f.Size)
-	obj.Set("uploadedAt", f.UploadedAt.Unix())
-	obj.Set("uploadedBy", f.UploadedBy)
-	obj.Set("downloadCount", f.DownloadCount)
+	jsutil.Set(obj, "id", f.ID.String())
+	jsutil.Set(obj, "areaID", f.AreaID)
+	jsutil.Set(obj, "filename", f.Filename)
+	jsutil.Set(obj, "description", f.Description)
+	jsutil.Set(obj, "size", f.Size)
+	jsutil.Set(obj, "uploadedAt", f.UploadedAt.Unix())
+	jsutil.Set(obj, "uploadedBy", f.UploadedBy)
+	jsutil.Set(obj, "downloadCount", f.DownloadCount)
 	return obj
 }

--- a/internal/scripting/filesystem.go
+++ b/internal/scripting/filesystem.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/dop251/goja"
 )
 
@@ -18,7 +19,7 @@ func registerFS(v3 *goja.Object, eng *Engine) {
 	sandbox := sandboxRoot(eng.cfg)
 
 	// read(path) — read a text file, returns string or throws on error.
-	obj.Set("read", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "read", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			panic(vm.NewGoError(errMissingArgs("read", "path")))
 		}
@@ -34,7 +35,7 @@ func registerFS(v3 *goja.Object, eng *Engine) {
 	})
 
 	// write(path, content) — write a text file (overwrites if exists).
-	obj.Set("write", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "write", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) < 2 {
 			panic(vm.NewGoError(errMissingArgs("write", "path, content")))
 		}
@@ -50,7 +51,7 @@ func registerFS(v3 *goja.Object, eng *Engine) {
 	})
 
 	// append(path, content) — append content to a file (creates if not exists).
-	obj.Set("append", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "append", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) < 2 {
 			panic(vm.NewGoError(errMissingArgs("append", "path, content")))
 		}
@@ -63,15 +64,18 @@ func registerFS(v3 *goja.Object, eng *Engine) {
 		if err != nil {
 			panic(vm.NewGoError(err))
 		}
-		defer f.Close()
 		if _, err := f.WriteString(call.Arguments[1].String()); err != nil {
+			_ = f.Close() // best-effort; the write error takes precedence
+			panic(vm.NewGoError(err))
+		}
+		if err := f.Close(); err != nil {
 			panic(vm.NewGoError(err))
 		}
 		return goja.Undefined()
 	})
 
 	// exists(path) — returns true if the file or directory exists.
-	obj.Set("exists", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "exists", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue(false)
 		}
@@ -84,7 +88,7 @@ func registerFS(v3 *goja.Object, eng *Engine) {
 	})
 
 	// delete(path) — delete a file. Returns true if deleted.
-	obj.Set("delete", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "delete", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue(false)
 		}
@@ -97,7 +101,7 @@ func registerFS(v3 *goja.Object, eng *Engine) {
 	})
 
 	// list(dir) — list directory contents, returns array of {name, isDir, size}.
-	obj.Set("list", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "list", func(call goja.FunctionCall) goja.Value {
 		dir := ""
 		if len(call.Arguments) > 0 {
 			dir = call.Arguments[0].String()
@@ -114,20 +118,20 @@ func registerFS(v3 *goja.Object, eng *Engine) {
 		for i, entry := range entries {
 			info, _ := entry.Info()
 			obj := vm.NewObject()
-			obj.Set("name", entry.Name())
-			obj.Set("isDir", entry.IsDir())
+			jsutil.Set(obj, "name", entry.Name())
+			jsutil.Set(obj, "isDir", entry.IsDir())
 			if info != nil {
-				obj.Set("size", info.Size())
+				jsutil.Set(obj, "size", info.Size())
 			} else {
-				obj.Set("size", 0)
+				jsutil.Set(obj, "size", 0)
 			}
-			arr.Set(itoa(i), obj)
+			jsutil.Set(arr, itoa(i), obj)
 		}
 		return arr
 	})
 
 	// mkdir(path) — create a directory (and parents).
-	obj.Set("mkdir", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "mkdir", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			panic(vm.NewGoError(errMissingArgs("mkdir", "path")))
 		}
@@ -141,7 +145,7 @@ func registerFS(v3 *goja.Object, eng *Engine) {
 		return goja.Undefined()
 	})
 
-	v3.Set("fs", obj)
+	jsutil.Set(v3, "fs", obj)
 }
 
 // sandboxRoot returns the scripts/data/ directory for the current script config.

--- a/internal/scripting/message.go
+++ b/internal/scripting/message.go
@@ -3,6 +3,7 @@ package scripting
 import (
 	"fmt"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/ViSiON-3/vision-3-bbs/internal/message"
 	"github.com/dop251/goja"
 )
@@ -14,17 +15,17 @@ func registerMessage(v3 *goja.Object, eng *Engine) {
 	mgr := eng.providers.MessageMgr
 
 	// areas() — list all message areas [{id, tag, name, description, type}].
-	obj.Set("areas", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "areas", func(call goja.FunctionCall) goja.Value {
 		areas := mgr.ListAreas()
 		arr := vm.NewArray()
 		for i, a := range areas {
-			arr.Set(itoa(i), messageAreaToJS(vm, a))
+			jsutil.Set(arr, itoa(i), messageAreaToJS(vm, a))
 		}
 		return arr
 	})
 
 	// area(tag) — get a single area by tag, returns object or null.
-	obj.Set("area", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "area", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return goja.Null()
 		}
@@ -37,7 +38,7 @@ func registerMessage(v3 *goja.Object, eng *Engine) {
 	})
 
 	// count(areaID) — message count in an area.
-	obj.Set("count", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "count", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue(0)
 		}
@@ -50,7 +51,7 @@ func registerMessage(v3 *goja.Object, eng *Engine) {
 	})
 
 	// get(areaID, msgNum) — get a message, returns object or null.
-	obj.Set("get", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "get", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) < 2 {
 			return goja.Null()
 		}
@@ -64,7 +65,7 @@ func registerMessage(v3 *goja.Object, eng *Engine) {
 	})
 
 	// newCount(areaID) — count of unread messages for current user.
-	obj.Set("newCount", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "newCount", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue(0)
 		}
@@ -77,7 +78,7 @@ func registerMessage(v3 *goja.Object, eng *Engine) {
 	})
 
 	// post(areaID, {to, subject, body}) — post a message to an area.
-	obj.Set("post", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "post", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) < 2 {
 			panic(vm.NewGoError(errMissingArgs("post", "areaID, {to, subject, body}")))
 		}
@@ -96,7 +97,7 @@ func registerMessage(v3 *goja.Object, eng *Engine) {
 	})
 
 	// postPrivate(areaID, {to, subject, body}) — post a private message.
-	obj.Set("postPrivate", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "postPrivate", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) < 2 {
 			panic(vm.NewGoError(errMissingArgs("postPrivate", "areaID, {to, subject, body}")))
 		}
@@ -118,37 +119,37 @@ func registerMessage(v3 *goja.Object, eng *Engine) {
 	})
 
 	// totalCount() — total messages across all areas.
-	obj.Set("totalCount", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "totalCount", func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(mgr.GetTotalMessageCount())
 	})
 
-	v3.Set("message", obj)
+	jsutil.Set(v3, "message", obj)
 }
 
 func messageAreaToJS(vm *goja.Runtime, a *message.MessageArea) goja.Value {
 	obj := vm.NewObject()
-	obj.Set("id", a.ID)
-	obj.Set("tag", a.Tag)
-	obj.Set("name", a.Name)
-	obj.Set("description", a.Description)
-	obj.Set("type", a.AreaType)
-	obj.Set("echoTag", a.EchoTag)
-	obj.Set("conferenceID", a.ConferenceID)
+	jsutil.Set(obj, "id", a.ID)
+	jsutil.Set(obj, "tag", a.Tag)
+	jsutil.Set(obj, "name", a.Name)
+	jsutil.Set(obj, "description", a.Description)
+	jsutil.Set(obj, "type", a.AreaType)
+	jsutil.Set(obj, "echoTag", a.EchoTag)
+	jsutil.Set(obj, "conferenceID", a.ConferenceID)
 	return obj
 }
 
 func displayMessageToJS(vm *goja.Runtime, msg *message.DisplayMessage) goja.Value {
 	obj := vm.NewObject()
-	obj.Set("msgNum", msg.MsgNum)
-	obj.Set("from", msg.From)
-	obj.Set("to", msg.To)
-	obj.Set("subject", msg.Subject)
-	obj.Set("body", msg.Body)
-	obj.Set("date", msg.DateTime.Unix())
-	obj.Set("msgID", msg.MsgID)
-	obj.Set("replyID", msg.ReplyID)
-	obj.Set("replyToNum", msg.ReplyToNum)
-	obj.Set("isPrivate", msg.IsPrivate)
-	obj.Set("areaID", msg.AreaID)
+	jsutil.Set(obj, "msgNum", msg.MsgNum)
+	jsutil.Set(obj, "from", msg.From)
+	jsutil.Set(obj, "to", msg.To)
+	jsutil.Set(obj, "subject", msg.Subject)
+	jsutil.Set(obj, "body", msg.Body)
+	jsutil.Set(obj, "date", msg.DateTime.Unix())
+	jsutil.Set(obj, "msgID", msg.MsgID)
+	jsutil.Set(obj, "replyID", msg.ReplyID)
+	jsutil.Set(obj, "replyToNum", msg.ReplyToNum)
+	jsutil.Set(obj, "isPrivate", msg.IsPrivate)
+	jsutil.Set(obj, "areaID", msg.AreaID)
 	return obj
 }

--- a/internal/scripting/nodes.go
+++ b/internal/scripting/nodes.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/dop251/goja"
 )
 
@@ -15,7 +16,7 @@ func registerNodes(v3 *goja.Object, eng *Engine) {
 
 	// list() — returns array of active nodes [{node, handle, activity, idle, invisible}].
 	// Invisible sessions are excluded unless the current user is sysop (accessLevel >= 200).
-	obj.Set("list", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "list", func(call goja.FunctionCall) goja.Value {
 		sessions := registry.ListActive()
 		arr := vm.NewArray()
 		isSysop := eng.session.AccessLevel >= 200
@@ -37,19 +38,19 @@ func registerNodes(v3 *goja.Object, eng *Engine) {
 			}
 
 			entry := vm.NewObject()
-			entry.Set("node", nodeID)
-			entry.Set("handle", handle)
-			entry.Set("activity", activity)
-			entry.Set("idle", int(idle))
-			entry.Set("invisible", invisible)
-			arr.Set(itoa(i), entry)
+			jsutil.Set(entry, "node", nodeID)
+			jsutil.Set(entry, "handle", handle)
+			jsutil.Set(entry, "activity", activity)
+			jsutil.Set(entry, "idle", int(idle))
+			jsutil.Set(entry, "invisible", invisible)
+			jsutil.Set(arr, itoa(i), entry)
 			i++
 		}
 		return arr
 	})
 
 	// count() — returns the number of active nodes (respects invisible flag).
-	obj.Set("count", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "count", func(call goja.FunctionCall) goja.Value {
 		sessions := registry.ListActive()
 		isSysop := eng.session.AccessLevel >= 200
 		count := 0
@@ -66,7 +67,7 @@ func registerNodes(v3 *goja.Object, eng *Engine) {
 
 	// send(nodeNum, message) — send a page message to a specific node.
 	// Returns true if the node exists and the message was queued.
-	obj.Set("send", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "send", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) < 2 {
 			panic(vm.NewGoError(errMissingArgs("send", "nodeNum, message")))
 		}
@@ -84,7 +85,7 @@ func registerNodes(v3 *goja.Object, eng *Engine) {
 	})
 
 	// broadcast(message) — send a page message to all active nodes (except self).
-	obj.Set("broadcast", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "broadcast", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return goja.Undefined()
 		}
@@ -101,5 +102,5 @@ func registerNodes(v3 *goja.Object, eng *Engine) {
 		return goja.Undefined()
 	})
 
-	v3.Set("nodes", obj)
+	jsutil.Set(v3, "nodes", obj)
 }

--- a/internal/scripting/session.go
+++ b/internal/scripting/session.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/dop251/goja"
 )
 
@@ -12,11 +13,11 @@ func registerSession(v3 *goja.Object, eng *Engine) {
 	vm := eng.vm
 	obj := vm.NewObject()
 
-	obj.Set("node", eng.session.NodeNumber)
-	obj.Set("startTime", eng.session.SessionStartTime.Unix())
+	jsutil.Set(obj, "node", eng.session.NodeNumber)
+	jsutil.Set(obj, "startTime", eng.session.SessionStartTime.Unix())
 
 	// timeLeft — seconds remaining in session (dynamic)
-	obj.DefineAccessorProperty("timeLeft", vm.ToValue(func(call goja.FunctionCall) goja.Value {
+	jsutil.DefineAccessor(obj, "timeLeft", vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		elapsed := time.Since(eng.session.SessionStartTime)
 		limit := time.Duration(eng.session.TimeLimit) * time.Minute
 		if limit <= 0 {
@@ -30,7 +31,7 @@ func registerSession(v3 *goja.Object, eng *Engine) {
 	}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
 	// online — true if user is still connected (dynamic)
-	obj.DefineAccessorProperty("online", vm.ToValue(func(call goja.FunctionCall) goja.Value {
+	jsutil.DefineAccessor(obj, "online", vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		select {
 		case <-eng.ctx.Done():
 			return vm.ToValue(false)
@@ -41,29 +42,29 @@ func registerSession(v3 *goja.Object, eng *Engine) {
 
 	// v3.session.bbs — BBS info sub-object
 	bbs := vm.NewObject()
-	bbs.Set("name", eng.session.BoardName)
-	bbs.Set("sysop", eng.session.SysOpName)
-	bbs.Set("version", eng.session.BBSVersion)
-	obj.Set("bbs", bbs)
+	jsutil.Set(bbs, "name", eng.session.BoardName)
+	jsutil.Set(bbs, "sysop", eng.session.SysOpName)
+	jsutil.Set(bbs, "version", eng.session.BBSVersion)
+	jsutil.Set(obj, "bbs", bbs)
 
 	// v3.session.user — current user info (read-only snapshot)
 	usr := vm.NewObject()
-	usr.Set("id", eng.session.UserID)
-	usr.Set("handle", eng.session.UserHandle)
-	usr.Set("realName", eng.session.UserRealName)
-	usr.Set("accessLevel", eng.session.AccessLevel)
-	usr.Set("timesCalled", eng.session.TimesCalled)
-	usr.Set("location", eng.session.Location)
-	usr.Set("screenWidth", eng.session.ScreenWidth)
-	usr.Set("screenHeight", eng.session.ScreenHeight)
-	obj.Set("user", usr)
+	jsutil.Set(usr, "id", eng.session.UserID)
+	jsutil.Set(usr, "handle", eng.session.UserHandle)
+	jsutil.Set(usr, "realName", eng.session.UserRealName)
+	jsutil.Set(usr, "accessLevel", eng.session.AccessLevel)
+	jsutil.Set(usr, "timesCalled", eng.session.TimesCalled)
+	jsutil.Set(usr, "location", eng.session.Location)
+	jsutil.Set(usr, "screenWidth", eng.session.ScreenWidth)
+	jsutil.Set(usr, "screenHeight", eng.session.ScreenHeight)
+	jsutil.Set(obj, "user", usr)
 
 	// v3.args — script arguments
 	args := vm.NewArray()
 	for i, arg := range eng.cfg.Args {
-		args.Set(fmt.Sprintf("%d", i), arg)
+		jsutil.Set(args, fmt.Sprintf("%d", i), arg)
 	}
-	v3.Set("args", args)
+	jsutil.Set(v3, "args", args)
 
-	v3.Set("session", obj)
+	jsutil.Set(v3, "session", obj)
 }

--- a/internal/scripting/user.go
+++ b/internal/scripting/user.go
@@ -1,6 +1,7 @@
 package scripting
 
 import (
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/dop251/goja"
 )
 
@@ -13,53 +14,53 @@ func registerUser(v3 *goja.Object, eng *Engine) {
 	u := eng.providers.CurrentUser
 
 	// Read-only properties — reflect live user state.
-	obj.DefineAccessorProperty("id", vm.ToValue(func(call goja.FunctionCall) goja.Value {
+	jsutil.DefineAccessor(obj, "id", vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(eng.providers.CurrentUser.ID)
 	}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
-	obj.DefineAccessorProperty("handle", vm.ToValue(func(call goja.FunctionCall) goja.Value {
+	jsutil.DefineAccessor(obj, "handle", vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(eng.providers.CurrentUser.Handle)
 	}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
-	obj.DefineAccessorProperty("realName", vm.ToValue(func(call goja.FunctionCall) goja.Value {
+	jsutil.DefineAccessor(obj, "realName", vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(eng.providers.CurrentUser.RealName)
 	}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
-	obj.DefineAccessorProperty("accessLevel", vm.ToValue(func(call goja.FunctionCall) goja.Value {
+	jsutil.DefineAccessor(obj, "accessLevel", vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(eng.providers.CurrentUser.AccessLevel)
 	}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
-	obj.DefineAccessorProperty("timesCalled", vm.ToValue(func(call goja.FunctionCall) goja.Value {
+	jsutil.DefineAccessor(obj, "timesCalled", vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(eng.providers.CurrentUser.TimesCalled)
 	}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
-	obj.DefineAccessorProperty("location", vm.ToValue(func(call goja.FunctionCall) goja.Value {
+	jsutil.DefineAccessor(obj, "location", vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(eng.providers.CurrentUser.GroupLocation)
 	}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
-	obj.DefineAccessorProperty("messagesPosted", vm.ToValue(func(call goja.FunctionCall) goja.Value {
+	jsutil.DefineAccessor(obj, "messagesPosted", vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(eng.providers.CurrentUser.MessagesPosted)
 	}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
-	obj.DefineAccessorProperty("uploads", vm.ToValue(func(call goja.FunctionCall) goja.Value {
+	jsutil.DefineAccessor(obj, "uploads", vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(eng.providers.CurrentUser.NumUploads)
 	}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
-	obj.DefineAccessorProperty("downloads", vm.ToValue(func(call goja.FunctionCall) goja.Value {
+	jsutil.DefineAccessor(obj, "downloads", vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(eng.providers.CurrentUser.NumDownloads)
 	}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
-	obj.DefineAccessorProperty("filePoints", vm.ToValue(func(call goja.FunctionCall) goja.Value {
+	jsutil.DefineAccessor(obj, "filePoints", vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(eng.providers.CurrentUser.FilePoints)
 	}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
-	obj.DefineAccessorProperty("validated", vm.ToValue(func(call goja.FunctionCall) goja.Value {
+	jsutil.DefineAccessor(obj, "validated", vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(eng.providers.CurrentUser.Validated)
 	}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
 	// set(field, value) — update a writable field on the current user.
 	// Changes are held in memory until save() is called.
-	obj.Set("set", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "set", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) < 2 {
 			return goja.Undefined()
 		}
@@ -78,12 +79,12 @@ func registerUser(v3 *goja.Object, eng *Engine) {
 	})
 
 	// save() — persist current user changes to disk via UserMgr.
-	obj.Set("save", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "save", func(call goja.FunctionCall) goja.Value {
 		if err := eng.providers.UserMgr.UpdateUserByID(u); err != nil {
 			panic(vm.NewGoError(err))
 		}
 		return goja.Undefined()
 	})
 
-	v3.Set("user", obj)
+	jsutil.Set(v3, "user", obj)
 }

--- a/internal/scripting/users.go
+++ b/internal/scripting/users.go
@@ -1,6 +1,7 @@
 package scripting
 
 import (
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 	"github.com/dop251/goja"
 )
@@ -11,7 +12,7 @@ func registerUsers(v3 *goja.Object, eng *Engine) {
 	obj := vm.NewObject()
 
 	// get(handle) — look up a user by handle, returns object or null.
-	obj.Set("get", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "get", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return goja.Null()
 		}
@@ -24,7 +25,7 @@ func registerUsers(v3 *goja.Object, eng *Engine) {
 	})
 
 	// getByID(id) — look up a user by ID, returns object or null.
-	obj.Set("getByID", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "getByID", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return goja.Null()
 		}
@@ -37,40 +38,40 @@ func registerUsers(v3 *goja.Object, eng *Engine) {
 	})
 
 	// count() — total registered user count.
-	obj.Set("count", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "count", func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(eng.providers.UserMgr.GetUserCount())
 	})
 
 	// list() — returns array of all users (safe fields only).
-	obj.Set("list", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "list", func(call goja.FunctionCall) goja.Value {
 		all := eng.providers.UserMgr.GetAllUsers()
 		arr := vm.NewArray()
 		for i, u := range all {
-			arr.Set(intToStr(i), userToJS(vm, u))
+			jsutil.Set(arr, intToStr(i), userToJS(vm, u))
 		}
 		return arr
 	})
 
-	v3.Set("users", obj)
+	jsutil.Set(v3, "users", obj)
 }
 
 // userToJS converts a *user.User to a JS object with safe fields only.
 // Sensitive fields (password hash, private notes, flags) are excluded.
 func userToJS(vm *goja.Runtime, u *user.User) goja.Value {
 	obj := vm.NewObject()
-	obj.Set("id", u.ID)
-	obj.Set("handle", u.Handle)
-	obj.Set("realName", u.RealName)
-	obj.Set("accessLevel", u.AccessLevel)
-	obj.Set("timesCalled", u.TimesCalled)
-	obj.Set("location", u.GroupLocation)
-	obj.Set("messagesPosted", u.MessagesPosted)
-	obj.Set("uploads", u.NumUploads)
-	obj.Set("downloads", u.NumDownloads)
-	obj.Set("filePoints", u.FilePoints)
-	obj.Set("validated", u.Validated)
-	obj.Set("lastLogin", u.LastLogin.Unix())
-	obj.Set("createdAt", u.CreatedAt.Unix())
+	jsutil.Set(obj, "id", u.ID)
+	jsutil.Set(obj, "handle", u.Handle)
+	jsutil.Set(obj, "realName", u.RealName)
+	jsutil.Set(obj, "accessLevel", u.AccessLevel)
+	jsutil.Set(obj, "timesCalled", u.TimesCalled)
+	jsutil.Set(obj, "location", u.GroupLocation)
+	jsutil.Set(obj, "messagesPosted", u.MessagesPosted)
+	jsutil.Set(obj, "uploads", u.NumUploads)
+	jsutil.Set(obj, "downloads", u.NumDownloads)
+	jsutil.Set(obj, "filePoints", u.FilePoints)
+	jsutil.Set(obj, "validated", u.Validated)
+	jsutil.Set(obj, "lastLogin", u.LastLogin.Unix())
+	jsutil.Set(obj, "createdAt", u.CreatedAt.Unix())
 	return obj
 }
 

--- a/internal/scripting/util.go
+++ b/internal/scripting/util.go
@@ -7,6 +7,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/dop251/goja"
 )
 
@@ -17,7 +18,7 @@ func registerUtil(v3 *goja.Object, eng *Engine) {
 
 	// sleep(ms) — pause execution for the specified milliseconds.
 	// Respects context cancellation (returns early if user disconnects).
-	obj.Set("sleep", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "sleep", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return goja.Undefined()
 		}
@@ -35,7 +36,7 @@ func registerUtil(v3 *goja.Object, eng *Engine) {
 
 	// random(max) — returns a random integer from 0 to max-1.
 	// Note: math/rand is automatically seeded since Go 1.20 (we require 1.24+).
-	obj.Set("random", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "random", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue(0)
 		}
@@ -47,14 +48,14 @@ func registerUtil(v3 *goja.Object, eng *Engine) {
 	})
 
 	// time() — returns the current Unix timestamp in seconds.
-	obj.Set("time", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "time", func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(time.Now().Unix())
 	})
 
 	// date(format) — returns a formatted date string.
 	// Format uses Go's reference time (2006-01-02 15:04:05).
 	// With no arguments, returns "2006-01-02 15:04:05" format.
-	obj.Set("date", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "date", func(call goja.FunctionCall) goja.Value {
 		layout := "2006-01-02 15:04:05"
 		if len(call.Arguments) > 0 {
 			layout = call.Arguments[0].String()
@@ -64,7 +65,7 @@ func registerUtil(v3 *goja.Object, eng *Engine) {
 
 	// padRight(str, width) — pad string on the right to reach width.
 	// padRight(str, width, char) — pad with specified character.
-	obj.Set("padRight", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "padRight", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) < 2 {
 			return vm.ToValue("")
 		}
@@ -82,7 +83,7 @@ func registerUtil(v3 *goja.Object, eng *Engine) {
 
 	// padLeft(str, width) — pad string on the left to reach width.
 	// padLeft(str, width, char) — pad with specified character.
-	obj.Set("padLeft", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "padLeft", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) < 2 {
 			return vm.ToValue("")
 		}
@@ -104,7 +105,7 @@ func registerUtil(v3 *goja.Object, eng *Engine) {
 	})
 
 	// center(str, width) — center string within the given width.
-	obj.Set("center", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "center", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) < 2 {
 			return vm.ToValue("")
 		}
@@ -114,7 +115,7 @@ func registerUtil(v3 *goja.Object, eng *Engine) {
 	})
 
 	// stripAnsi(str) — remove ANSI escape sequences from a string.
-	obj.Set("stripAnsi", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "stripAnsi", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue("")
 		}
@@ -122,7 +123,7 @@ func registerUtil(v3 *goja.Object, eng *Engine) {
 	})
 
 	// stripPipe(str) — remove Vision/3 pipe codes from a string.
-	obj.Set("stripPipe", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "stripPipe", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue("")
 		}
@@ -134,7 +135,7 @@ func registerUtil(v3 *goja.Object, eng *Engine) {
 
 	// displayLen(str) — returns visible display length of a string,
 	// ignoring both ANSI escape sequences and pipe codes.
-	obj.Set("displayLen", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "displayLen", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue(0)
 		}
@@ -144,5 +145,5 @@ func registerUtil(v3 *goja.Object, eng *Engine) {
 		return vm.ToValue(ansi.VisibleLength(string(processed)))
 	})
 
-	v3.Set("util", obj)
+	jsutil.Set(v3, "util", obj)
 }

--- a/internal/sshserver/server.go
+++ b/internal/sshserver/server.go
@@ -90,7 +90,7 @@ func NewServer(cfg Config) (*Server, error) {
 		sc := &gossh.ServerConfig{}
 		if legacy {
 			slog.Debug("SSH legacy algorithms enabled for retro BBS client compatibility")
-			sc.Config.KeyExchanges = []string{
+			sc.KeyExchanges = []string{
 				"curve25519-sha256",
 				"curve25519-sha256@libssh.org",
 				"ecdh-sha2-nistp256",
@@ -101,7 +101,7 @@ func NewServer(cfg Config) (*Server, error) {
 				"diffie-hellman-group14-sha1",
 				"diffie-hellman-group1-sha1",
 			}
-			sc.Config.Ciphers = []string{
+			sc.Ciphers = []string{
 				"chacha20-poly1305@openssh.com",
 				"aes128-gcm@openssh.com",
 				"aes256-gcm@openssh.com",
@@ -112,7 +112,7 @@ func NewServer(cfg Config) (*Server, error) {
 				"aes256-cbc",
 				"3des-cbc",
 			}
-			sc.Config.MACs = []string{
+			sc.MACs = []string{
 				"hmac-sha2-256-etm@openssh.com",
 				"hmac-sha2-512-etm@openssh.com",
 				"hmac-sha2-256",
@@ -232,7 +232,7 @@ func (s *BBSSession) RawWrite(p []byte) (int, error) {
 	if s.rawCh != nil {
 		return s.rawCh.Write(p)
 	}
-	return s.Session.Write(p)
+	return s.Session.Write(p) //nolint:staticcheck // explicit: bypasses BBSSession wrappers
 }
 
 // SetTransferActive marks/unmarks the session as being in a binary transfer.

--- a/internal/sshserver/server_test.go
+++ b/internal/sshserver/server_test.go
@@ -79,7 +79,7 @@ func TestNewServer_LegacyAlgorithms(t *testing.T) {
 		t.Fatal(err)
 	}
 	sc := srv.inner.ServerConfigCallback(nil)
-	if containsStr(sc.Config.Ciphers, "3des-cbc") {
+	if containsStr(sc.Ciphers, "3des-cbc") {
 		t.Error("non-legacy config should not enable 3des-cbc")
 	}
 
@@ -89,10 +89,10 @@ func TestNewServer_LegacyAlgorithms(t *testing.T) {
 		t.Fatal(err)
 	}
 	scLegacy := srvLegacy.inner.ServerConfigCallback(nil)
-	if !containsStr(scLegacy.Config.Ciphers, "3des-cbc") {
+	if !containsStr(scLegacy.Ciphers, "3des-cbc") {
 		t.Error("legacy config should enable 3des-cbc")
 	}
-	if !containsStr(scLegacy.Config.KeyExchanges, "diffie-hellman-group1-sha1") {
+	if !containsStr(scLegacy.KeyExchanges, "diffie-hellman-group1-sha1") {
 		t.Error("legacy config should enable diffie-hellman-group1-sha1")
 	}
 }

--- a/internal/syncjs/bbs_object.go
+++ b/internal/syncjs/bbs_object.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/dop251/goja"
 )
 
@@ -11,11 +12,11 @@ import (
 func registerBBS(vm *goja.Runtime, eng *Engine) {
 	obj := vm.NewObject()
 
-	obj.Set("node_num", eng.session.NodeNumber)
+	jsutil.Set(obj, "node_num", eng.session.NodeNumber)
 
 	// bbs.sys_status — system status flags (read/write)
 	var sysStatus int64
-	obj.DefineAccessorProperty("sys_status", vm.ToValue(func(call goja.FunctionCall) goja.Value {
+	jsutil.DefineAccessor(obj, "sys_status", vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(sysStatus)
 	}), vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) > 0 {
@@ -25,7 +26,7 @@ func registerBBS(vm *goja.Runtime, eng *Engine) {
 	}), goja.FLAG_FALSE, goja.FLAG_TRUE)
 
 	// bbs.online — true if user is still connected
-	obj.DefineAccessorProperty("online", vm.ToValue(func(call goja.FunctionCall) goja.Value {
+	jsutil.DefineAccessor(obj, "online", vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		select {
 		case <-eng.ctx.Done():
 			return vm.ToValue(false)
@@ -35,7 +36,7 @@ func registerBBS(vm *goja.Runtime, eng *Engine) {
 	}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
 	// bbs.get_time_left() — seconds remaining in session
-	obj.Set("get_time_left", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "get_time_left", func(call goja.FunctionCall) goja.Value {
 		elapsed := time.Since(eng.session.SessionStartTime)
 		limit := time.Duration(eng.session.TimeLimit) * time.Minute
 		if limit <= 0 {
@@ -49,19 +50,19 @@ func registerBBS(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// bbs.atcode(code) — convert @-code to value string
-	obj.Set("atcode", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "atcode", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue("")
 		}
 		return vm.ToValue(resolveAtCode(call.Arguments[0].String(), eng))
 	})
 
-	obj.Set("logon_time", eng.session.SessionStartTime.Unix())
+	jsutil.Set(obj, "logon_time", eng.session.SessionStartTime.Unix())
 
 	// bbs.mods — shared object for inter-module communication
-	obj.Set("mods", vm.NewObject())
+	jsutil.Set(obj, "mods", vm.NewObject())
 
-	vm.Set("bbs", obj)
+	jsutil.Set(vm, "bbs", obj)
 }
 
 // resolveAtCode converts Synchronet @-codes to their values.

--- a/internal/syncjs/console.go
+++ b/internal/syncjs/console.go
@@ -6,6 +6,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/dop251/goja"
 )
 
@@ -16,14 +17,14 @@ func registerConsole(vm *goja.Runtime, eng *Engine) {
 	// --- Properties ---
 
 	// console.screen_columns / console.screen_rows
-	obj.Set("screen_columns", eng.session.ScreenWidth)
-	obj.Set("screen_rows", eng.session.ScreenHeight)
+	jsutil.Set(obj, "screen_columns", eng.session.ScreenWidth)
+	jsutil.Set(obj, "screen_rows", eng.session.ScreenHeight)
 
 	// console.line_counter (read/write)
-	obj.Set("line_counter", 0)
+	jsutil.Set(obj, "line_counter", 0)
 
 	// console.attributes (get/set) — Synchronet attribute byte
-	obj.DefineAccessorProperty("attributes", vm.ToValue(func(call goja.FunctionCall) goja.Value {
+	jsutil.DefineAccessor(obj, "attributes", vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(eng.currentAttr)
 	}), vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) > 0 {
@@ -36,38 +37,38 @@ func registerConsole(vm *goja.Runtime, eng *Engine) {
 
 	// --- Output Methods ---
 
-	obj.Set("write", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "write", func(call goja.FunctionCall) goja.Value {
 		eng.writeRaw(argsToString(call))
 		return goja.Undefined()
 	})
 
-	obj.Set("writeln", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "writeln", func(call goja.FunctionCall) goja.Value {
 		eng.writeRaw(argsToString(call) + "\r\n")
 		return goja.Undefined()
 	})
 
-	obj.Set("print", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "print", func(call goja.FunctionCall) goja.Value {
 		text := argsToString(call)
 		eng.writeRaw(ParseCtrlA(text))
 		return goja.Undefined()
 	})
 
-	obj.Set("clear", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "clear", func(call goja.FunctionCall) goja.Value {
 		eng.writeRaw("\x1b[2J\x1b[H")
 		return goja.Undefined()
 	})
 
-	obj.Set("home", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "home", func(call goja.FunctionCall) goja.Value {
 		eng.writeRaw("\x1b[H")
 		return goja.Undefined()
 	})
 
-	obj.Set("cleartoeol", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "cleartoeol", func(call goja.FunctionCall) goja.Value {
 		eng.writeRaw("\x1b[K")
 		return goja.Undefined()
 	})
 
-	obj.Set("gotoxy", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "gotoxy", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) < 2 {
 			return goja.Undefined()
 		}
@@ -77,7 +78,7 @@ func registerConsole(vm *goja.Runtime, eng *Engine) {
 		return goja.Undefined()
 	})
 
-	obj.Set("center", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "center", func(call goja.FunctionCall) goja.Value {
 		text := argsToString(call)
 		displayLen := displayLength(text)
 		cols := eng.session.ScreenWidth
@@ -89,14 +90,14 @@ func registerConsole(vm *goja.Runtime, eng *Engine) {
 		return goja.Undefined()
 	})
 
-	obj.Set("strlen", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "strlen", func(call goja.FunctionCall) goja.Value {
 		text := argsToString(call)
 		return vm.ToValue(displayLength(text))
 	})
 
 	// --- Input Methods ---
 
-	obj.Set("getkey", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "getkey", func(call goja.FunctionCall) goja.Value {
 		key, err := eng.readKey(0)
 		if err != nil {
 			return vm.ToValue("")
@@ -104,7 +105,7 @@ func registerConsole(vm *goja.Runtime, eng *Engine) {
 		return vm.ToValue(key)
 	})
 
-	obj.Set("inkey", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "inkey", func(call goja.FunctionCall) goja.Value {
 		timeout := int64(0)
 		if len(call.Arguments) > 0 {
 			timeout = call.Arguments[0].ToInteger()
@@ -116,7 +117,7 @@ func registerConsole(vm *goja.Runtime, eng *Engine) {
 		return vm.ToValue(key)
 	})
 
-	obj.Set("getstr", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "getstr", func(call goja.FunctionCall) goja.Value {
 		maxLen := 128
 		mode := int64(0)
 		if len(call.Arguments) > 0 {
@@ -132,7 +133,7 @@ func registerConsole(vm *goja.Runtime, eng *Engine) {
 		return vm.ToValue(result)
 	})
 
-	obj.Set("getkeys", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "getkeys", func(call goja.FunctionCall) goja.Value {
 		validKeys := ""
 		if len(call.Arguments) > 0 {
 			validKeys = strings.ToUpper(call.Arguments[0].String())
@@ -149,7 +150,7 @@ func registerConsole(vm *goja.Runtime, eng *Engine) {
 		}
 	})
 
-	obj.Set("pause", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "pause", func(call goja.FunctionCall) goja.Value {
 		eng.writeRaw("\r\n[Hit a key] ")
 		eng.readKey(0) //nolint:errcheck
 		eng.writeRaw("\r\n")
@@ -157,7 +158,7 @@ func registerConsole(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// console.noyes(prompt) — returns true for No (default), false for Yes
-	obj.Set("noyes", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "noyes", func(call goja.FunctionCall) goja.Value {
 		prompt := argsToString(call)
 		eng.writeRaw(prompt + " (N/y)? ")
 		key, _ := eng.readKey(0)
@@ -166,7 +167,7 @@ func registerConsole(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// console.yesno(prompt) — returns true for Yes (default), false for No
-	obj.Set("yesno", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "yesno", func(call goja.FunctionCall) goja.Value {
 		prompt := argsToString(call)
 		eng.writeRaw(prompt + " (Y/n)? ")
 		key, _ := eng.readKey(0)
@@ -175,7 +176,7 @@ func registerConsole(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// console.getnum(max) — reads a number up to max
-	obj.Set("getnum", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "getnum", func(call goja.FunctionCall) goja.Value {
 		maxVal := 0
 		if len(call.Arguments) > 0 {
 			maxVal = int(call.Arguments[0].ToInteger())
@@ -185,7 +186,7 @@ func registerConsole(vm *goja.Runtime, eng *Engine) {
 			return vm.ToValue(0)
 		}
 		n := 0
-		fmt.Sscanf(result, "%d", &n)
+		_, _ = fmt.Sscanf(result, "%d", &n) // best-effort parse; n stays 0 on failure
 		if maxVal > 0 && n > maxVal {
 			n = maxVal
 		}
@@ -193,13 +194,13 @@ func registerConsole(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// console.ctrlkey_passthru — read/write, controls which ctrl keys are passed through
-	obj.Set("ctrlkey_passthru", 0)
+	jsutil.Set(obj, "ctrlkey_passthru", 0)
 
 	// console.autoterm — terminal auto-detection flags (USER_ANSI=1, USER_UTF8=4)
-	obj.Set("autoterm", 1) // ANSI enabled
+	jsutil.Set(obj, "autoterm", 1) // ANSI enabled
 
 	// Cursor movement methods used by sbbs_console.js
-	obj.Set("right", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "right", func(call goja.FunctionCall) goja.Value {
 		n := int64(1)
 		if len(call.Arguments) > 0 {
 			n = call.Arguments[0].ToInteger()
@@ -210,7 +211,7 @@ func registerConsole(vm *goja.Runtime, eng *Engine) {
 		return goja.Undefined()
 	})
 
-	obj.Set("left", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "left", func(call goja.FunctionCall) goja.Value {
 		n := int64(1)
 		if len(call.Arguments) > 0 {
 			n = call.Arguments[0].ToInteger()
@@ -221,7 +222,7 @@ func registerConsole(vm *goja.Runtime, eng *Engine) {
 		return goja.Undefined()
 	})
 
-	obj.Set("up", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "up", func(call goja.FunctionCall) goja.Value {
 		n := int64(1)
 		if len(call.Arguments) > 0 {
 			n = call.Arguments[0].ToInteger()
@@ -232,7 +233,7 @@ func registerConsole(vm *goja.Runtime, eng *Engine) {
 		return goja.Undefined()
 	})
 
-	obj.Set("down", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "down", func(call goja.FunctionCall) goja.Value {
 		n := int64(1)
 		if len(call.Arguments) > 0 {
 			n = call.Arguments[0].ToInteger()
@@ -243,7 +244,7 @@ func registerConsole(vm *goja.Runtime, eng *Engine) {
 		return goja.Undefined()
 	})
 
-	vm.Set("console", obj)
+	jsutil.Set(vm, "console", obj)
 }
 
 // Input mode flags matching Synchronet's sbbsdefs.js K_* constants.

--- a/internal/syncjs/engine.go
+++ b/internal/syncjs/engine.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/dop251/goja"
 )
 
@@ -118,7 +119,9 @@ func (eng *Engine) Close() {
 					slog.Warn("exit handler panic", "panic", r)
 				}
 			}()
-			eng.exitHandlers[i](goja.Undefined())
+			if _, err := eng.exitHandlers[i](goja.Undefined()); err != nil {
+				slog.Warn("exit handler error", "error", err)
+			}
 		}()
 	}
 	// Eval string exit codes in reverse order (Synchronet behavior)
@@ -129,14 +132,16 @@ func (eng *Engine) Close() {
 					slog.Warn("exit code eval panic", "panic", r)
 				}
 			}()
-			eng.vm.RunString(eng.exitCodes[i])
+			if _, err := eng.vm.RunString(eng.exitCodes[i]); err != nil {
+				slog.Warn("exit code eval error", "error", err)
+			}
 		}()
 	}
 	// Stop the reader goroutines by closing the pipe. The caller should
 	// close a SetReadInterrupt channel before calling Close() so the
 	// copier goroutine's blocked session.Read() returns immediately.
 	if eng.pipeWriter != nil {
-		eng.pipeWriter.Close()
+		_ = eng.pipeWriter.Close() // best-effort shutdown of the input pipe
 	}
 	// Wait for the copier goroutine to exit so it stops reading from
 	// the session. This relies on the caller closing the read interrupt
@@ -149,7 +154,7 @@ func (eng *Engine) Close() {
 		}
 	}
 	if eng.pipeReader != nil {
-		eng.pipeReader.Close()
+		_ = eng.pipeReader.Close() // best-effort shutdown of the input pipe
 	}
 	// Drain any buffered results so goroutines don't block on channel send
 	if eng.rawInputCh != nil {
@@ -164,7 +169,7 @@ func (eng *Engine) Close() {
 	}
 	// Clean up lock files created by file_mutex()
 	for _, lf := range eng.lockFiles {
-		os.Remove(lf)
+		_ = os.Remove(lf) // best-effort lock-file cleanup
 	}
 	eng.cancel()
 }
@@ -688,7 +693,7 @@ func (eng *Engine) createInputQueue() goja.Value {
 	obj := eng.vm.NewObject()
 
 	// poll(timeout_ms) — check if input is available within timeout
-	obj.Set("poll", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "poll", func(call goja.FunctionCall) goja.Value {
 		timeout := int64(0)
 		if len(call.Arguments) > 0 {
 			timeout = call.Arguments[0].ToInteger()
@@ -709,7 +714,7 @@ func (eng *Engine) createInputQueue() goja.Value {
 	})
 
 	// read() — read a single key/character
-	obj.Set("read", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "read", func(call goja.FunctionCall) goja.Value {
 		if len(eng.inputBuf) > 0 {
 			ch := eng.inputBuf[0]
 			eng.inputBuf = eng.inputBuf[1:]
@@ -723,7 +728,7 @@ func (eng *Engine) createInputQueue() goja.Value {
 	})
 
 	// write() — no-op for input queue (used for signaling exit)
-	obj.Set("write", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "write", func(call goja.FunctionCall) goja.Value {
 		return eng.vm.ToValue(true)
 	})
 

--- a/internal/syncjs/file_class.go
+++ b/internal/syncjs/file_class.go
@@ -4,11 +4,14 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/dop251/goja"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
+	"github.com/dop251/goja"
 )
 
 // bytesToLatin1 converts raw bytes to a Go string using Latin-1 mapping,
@@ -35,7 +38,7 @@ type jsFile struct {
 
 // registerFileClass registers the File constructor and file_exists global on the JS runtime.
 func registerFileClass(vm *goja.Runtime, eng *Engine) {
-	vm.Set("File", func(call goja.ConstructorCall) *goja.Object {
+	jsutil.Set(vm, "File", func(call goja.ConstructorCall) *goja.Object {
 		path := ""
 		if len(call.Arguments) > 0 {
 			path = call.Arguments[0].String()
@@ -46,17 +49,17 @@ func registerFileClass(vm *goja.Runtime, eng *Engine) {
 		obj := call.This
 
 		// --- Properties ---
-		obj.Set("name", path)
-		obj.DefineAccessorProperty("is_open", vm.ToValue(func(goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "name", path)
+		jsutil.DefineAccessor(obj, "is_open", vm.ToValue(func(goja.FunctionCall) goja.Value {
 			return vm.ToValue(jf.isOpen)
 		}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
-		obj.DefineAccessorProperty("exists", vm.ToValue(func(goja.FunctionCall) goja.Value {
+		jsutil.DefineAccessor(obj, "exists", vm.ToValue(func(goja.FunctionCall) goja.Value {
 			_, err := os.Stat(jf.path)
 			return vm.ToValue(err == nil)
 		}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
-		obj.DefineAccessorProperty("position", vm.ToValue(func(goja.FunctionCall) goja.Value {
+		jsutil.DefineAccessor(obj, "position", vm.ToValue(func(goja.FunctionCall) goja.Value {
 			if jf.f == nil {
 				return vm.ToValue(0)
 			}
@@ -71,12 +74,12 @@ func registerFileClass(vm *goja.Runtime, eng *Engine) {
 				return goja.Undefined()
 			}
 			pos := call.Arguments[0].ToInteger()
-			jf.f.Seek(pos, io.SeekStart)
-			jf.reader = nil // invalidate buffered reader
+			_, _ = jf.f.Seek(pos, io.SeekStart) // JS position setter has no error path; next read/write surfaces failures
+			jf.reader = nil                     // invalidate buffered reader
 			return goja.Undefined()
 		}), goja.FLAG_FALSE, goja.FLAG_TRUE)
 
-		obj.DefineAccessorProperty("length", vm.ToValue(func(goja.FunctionCall) goja.Value {
+		jsutil.DefineAccessor(obj, "length", vm.ToValue(func(goja.FunctionCall) goja.Value {
 			if jf.f == nil {
 				info, err := os.Stat(jf.path)
 				if err != nil {
@@ -91,11 +94,11 @@ func registerFileClass(vm *goja.Runtime, eng *Engine) {
 			return vm.ToValue(info.Size())
 		}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
-		obj.DefineAccessorProperty("error", vm.ToValue(func(goja.FunctionCall) goja.Value {
+		jsutil.DefineAccessor(obj, "error", vm.ToValue(func(goja.FunctionCall) goja.Value {
 			return vm.ToValue(jf.lastErr)
 		}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
-		obj.DefineAccessorProperty("eof", vm.ToValue(func(goja.FunctionCall) goja.Value {
+		jsutil.DefineAccessor(obj, "eof", vm.ToValue(func(goja.FunctionCall) goja.Value {
 			if jf.f == nil {
 				return vm.ToValue(true)
 			}
@@ -112,44 +115,46 @@ func registerFileClass(vm *goja.Runtime, eng *Engine) {
 		}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
 		// --- Methods ---
-		obj.Set("open", func(call goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "open", func(call goja.FunctionCall) goja.Value {
 			return vm.ToValue(jf.open(call))
 		})
-		obj.Set("close", func(call goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "close", func(call goja.FunctionCall) goja.Value {
 			jf.close()
 			return goja.Undefined()
 		})
-		obj.Set("flush", func(call goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "flush", func(call goja.FunctionCall) goja.Value {
 			if jf.f != nil {
-				jf.f.Sync()
+				if err := jf.f.Sync(); err != nil {
+					slog.Warn("syncjs: File.flush sync failed", "path", jf.path, "error", err)
+				}
 			}
 			return vm.ToValue(true)
 		})
-		obj.Set("read", func(call goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "read", func(call goja.FunctionCall) goja.Value {
 			return jf.read(vm, call)
 		})
-		obj.Set("readln", func(call goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "readln", func(call goja.FunctionCall) goja.Value {
 			return jf.readln(vm)
 		})
-		obj.Set("readAll", func(call goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "readAll", func(call goja.FunctionCall) goja.Value {
 			return jf.readAll(vm)
 		})
-		obj.Set("write", func(call goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "write", func(call goja.FunctionCall) goja.Value {
 			return jf.write(vm, call)
 		})
-		obj.Set("writeln", func(call goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "writeln", func(call goja.FunctionCall) goja.Value {
 			return jf.writeln(vm, call)
 		})
-		obj.Set("writeAll", func(call goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "writeAll", func(call goja.FunctionCall) goja.Value {
 			return jf.writeAll(vm, call)
 		})
-		obj.Set("readBin", func(call goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "readBin", func(call goja.FunctionCall) goja.Value {
 			return jf.readBin(vm, call)
 		})
-		obj.Set("writeBin", func(call goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "writeBin", func(call goja.FunctionCall) goja.Value {
 			return jf.writeBin(vm, call)
 		})
-		obj.Set("truncate", func(call goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "truncate", func(call goja.FunctionCall) goja.Value {
 			if jf.f == nil {
 				return vm.ToValue(false)
 			}
@@ -160,15 +165,15 @@ func registerFileClass(vm *goja.Runtime, eng *Engine) {
 			err := jf.f.Truncate(length)
 			return vm.ToValue(err == nil)
 		})
-		obj.Set("lock", func(call goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "lock", func(call goja.FunctionCall) goja.Value {
 			return vm.ToValue(jf.fileLock(call, true))
 		})
-		obj.Set("unlock", func(call goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "unlock", func(call goja.FunctionCall) goja.Value {
 			return vm.ToValue(jf.fileLock(call, false))
 		})
 
 		// INI file methods — Synchronet File objects can read/write INI format
-		obj.Set("iniGetValue", func(call goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "iniGetValue", func(call goja.FunctionCall) goja.Value {
 			section := ""
 			key := ""
 			var defVal goja.Value
@@ -197,12 +202,12 @@ func registerFileClass(vm *goja.Runtime, eng *Engine) {
 			return vm.ToValue(val)
 		})
 
-		obj.Set("iniGetSections", func(call goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "iniGetSections", func(call goja.FunctionCall) goja.Value {
 			sections := jf.iniGetSections()
 			return vm.ToValue(sections)
 		})
 
-		obj.Set("iniGetKeys", func(call goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "iniGetKeys", func(call goja.FunctionCall) goja.Value {
 			section := ""
 			if len(call.Arguments) > 0 && !goja.IsNull(call.Arguments[0]) {
 				section = call.Arguments[0].String()
@@ -215,7 +220,7 @@ func registerFileClass(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// Global file_exists() function
-	vm.Set("file_exists", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "file_exists", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue(false)
 		}
@@ -225,7 +230,7 @@ func registerFileClass(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// Global file_remove() function
-	vm.Set("file_remove", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "file_remove", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue(false)
 		}
@@ -235,7 +240,7 @@ func registerFileClass(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// Global directory() function — list files in directory
-	vm.Set("directory", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "directory", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue(vm.NewArray())
 		}
@@ -252,7 +257,7 @@ func registerFileClass(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// Global mkdir() function
-	vm.Set("mkdir", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "mkdir", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue(false)
 		}
@@ -262,7 +267,7 @@ func registerFileClass(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// Global file_isdir() function
-	vm.Set("file_isdir", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "file_isdir", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue(false)
 		}
@@ -296,7 +301,9 @@ func (jf *jsFile) open(call goja.FunctionCall) bool {
 
 func (jf *jsFile) close() {
 	if jf.f != nil {
-		jf.f.Close()
+		if err := jf.f.Close(); err != nil {
+			slog.Warn("syncjs: File.close failed", "path", jf.path, "error", err)
+		}
 		jf.f = nil
 	}
 	jf.isOpen = false
@@ -483,7 +490,9 @@ func (jf *jsFile) iniParse() map[string]map[string]string {
 		return nil
 	}
 	// Seek to beginning
-	jf.f.Seek(0, io.SeekStart)
+	if _, err := jf.f.Seek(0, io.SeekStart); err != nil {
+		return nil
+	}
 	jf.reader = nil
 
 	sections := make(map[string]map[string]string)

--- a/internal/syncjs/module_loader.go
+++ b/internal/syncjs/module_loader.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/dop251/goja"
 )
 
@@ -19,13 +20,22 @@ func registerModuleSystem(vm *goja.Runtime, eng *Engine) {
 	registerPolyfills(vm)
 }
 
+// runInternalJS executes fixed, internally-defined JS source. A failure
+// indicates a programming error in the embedded source, so it is logged
+// rather than propagated.
+func runInternalJS(vm *goja.Runtime, src string) {
+	if _, err := vm.RunString(src); err != nil {
+		slog.Error("syncjs: internal JS snippet failed", "error", err)
+	}
+}
+
 // registerPolyfills adds Mozilla/SpiderMonkey extensions that Synchronet scripts expect.
 func registerPolyfills(vm *goja.Runtime) {
 	// toSource() — Mozilla extension used by recordfile.js for deep cloning.
 	// Converts a value to a source code string that eval() can recreate.
 	// toSource() and getYear() polyfills must be non-enumerable so they
 	// don't appear in for-in loops over arrays/objects.
-	vm.RunString(`
+	runInternalJS(vm, `
 		(function() {
 			function defHidden(obj, name, fn) {
 				if (!obj[name]) {
@@ -45,7 +55,7 @@ func registerPolyfills(vm *goja.Runtime) {
 	// as a function expression, but ES5 strict parsing treats bare "function" at the
 	// statement level as a FunctionDeclaration requiring a name. Wrapping in parens
 	// forces expression parsing. Used by Synchronet's l2lib.js (LORD II) extensively.
-	vm.RunString(`
+	runInternalJS(vm, `
 		(function() {
 			var _nativeEval = eval;
 			this.eval = function(code) {
@@ -66,7 +76,7 @@ func registerJSObject(vm *goja.Runtime, eng *Engine) {
 	obj := vm.NewObject()
 
 	// js.exec_dir — directory of the currently executing script (dynamic)
-	obj.DefineAccessorProperty("exec_dir", vm.ToValue(func(call goja.FunctionCall) goja.Value {
+	jsutil.DefineAccessor(obj, "exec_dir", vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(eng.currentExecDir())
 	}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
@@ -77,10 +87,10 @@ func registerJSObject(vm *goja.Runtime, eng *Engine) {
 	for i, p := range eng.cfg.LibraryPaths {
 		initPaths[i] = p
 	}
-	obj.Set("load_path_list", initPaths)
+	jsutil.Set(obj, "load_path_list", initPaths)
 
 	// js.terminated — true when context is cancelled
-	obj.DefineAccessorProperty("terminated", vm.ToValue(func(call goja.FunctionCall) goja.Value {
+	jsutil.DefineAccessor(obj, "terminated", vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		select {
 		case <-eng.ctx.Done():
 			return vm.ToValue(true)
@@ -90,7 +100,7 @@ func registerJSObject(vm *goja.Runtime, eng *Engine) {
 	}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
 	// js.on_exit(callback) — register cleanup function
-	obj.Set("on_exit", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "on_exit", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) > 0 {
 			if fn, ok := goja.AssertFunction(call.Arguments[0]); ok {
 				eng.addExitHandler(fn)
@@ -104,14 +114,14 @@ func registerJSObject(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// js.global — reference to global scope
-	obj.Set("global", vm.GlobalObject())
+	jsutil.Set(obj, "global", vm.GlobalObject())
 
 	// js.gc() — no-op, Go handles GC
-	obj.Set("gc", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(obj, "gc", func(call goja.FunctionCall) goja.Value {
 		return goja.Undefined()
 	})
 
-	vm.Set("js", obj)
+	jsutil.Set(vm, "js", obj)
 }
 
 // registerGlobalFunctions adds load(), require(), and utility functions.
@@ -119,7 +129,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 	// load(filename, ...) — load and execute a JS file.
 	// Synchronet supports load(true, filename, ...) for background thread loading.
 	// We return a stub Queue since goja is single-threaded.
-	vm.Set("load", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "load", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			panic(vm.NewTypeError("load() requires a filename"))
 		}
@@ -150,7 +160,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 
 	// require([scope], filename, symbol) — load and verify a symbol exists.
 	// If the first arg is an object (not a string), it's a scope to load into.
-	vm.Set("require", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "require", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) < 1 {
 			panic(vm.NewTypeError("require() requires a filename"))
 		}
@@ -182,7 +192,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 			if scope != nil {
 				slog.Warn("require failed", "filename", filename, "error", err)
 				if symbol != "" {
-					scope.Set(symbol, eng.newStubObject())
+					jsutil.Set(scope, symbol, eng.newStubObject())
 				}
 				return goja.Undefined()
 			}
@@ -194,21 +204,21 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 			if val == nil || goja.IsUndefined(val) {
 				if scope != nil {
 					slog.Warn("require: symbol not found", "filename", filename, "symbol", symbol)
-					scope.Set(symbol, eng.newStubObject())
+					jsutil.Set(scope, symbol, eng.newStubObject())
 					return goja.Undefined()
 				}
 				panic(vm.NewTypeError(fmt.Sprintf("require: symbol '%s' not found after loading '%s'", symbol, filename)))
 			}
 			// If scope provided, set the symbol on the scope object
 			if scope != nil {
-				scope.Set(symbol, val)
+				jsutil.Set(scope, symbol, val)
 			}
 		}
 		return goja.Undefined()
 	})
 
 	// exit(code) — terminate script execution via goja interrupt
-	vm.Set("exit", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "exit", func(call goja.FunctionCall) goja.Value {
 		eng.cancel()
 		eng.vm.Interrupt(exitCode(0))
 		// The interrupt is checked at the next JS instruction boundary.
@@ -217,7 +227,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// random(max) — return random integer 0 to max-1
-	vm.Set("random", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "random", func(call goja.FunctionCall) goja.Value {
 		max := int64(100)
 		if len(call.Arguments) > 0 {
 			max = call.Arguments[0].ToInteger()
@@ -229,12 +239,12 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// time() — current Unix timestamp
-	vm.Set("time", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "time", func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(time.Now().Unix())
 	})
 
 	// sleep(ms) — sleep for milliseconds
-	vm.Set("sleep", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "sleep", func(call goja.FunctionCall) goja.Value {
 		ms := int64(0)
 		if len(call.Arguments) > 0 {
 			ms = call.Arguments[0].ToInteger()
@@ -249,7 +259,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// format(fmt, ...) — printf-style string formatting
-	vm.Set("format", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "format", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue("")
 		}
@@ -259,7 +269,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// strftime(fmt, time) — format a timestamp
-	vm.Set("strftime", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "strftime", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue("")
 		}
@@ -272,7 +282,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// log([level,] msg) — log a message with optional syslog-style level
-	vm.Set("log", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "log", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return goja.Undefined()
 		}
@@ -288,18 +298,18 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// Syslog-level constants used by Synchronet's log() function
-	vm.Set("LOG_EMERG", 0)
-	vm.Set("LOG_ALERT", 1)
-	vm.Set("LOG_CRIT", 2)
-	vm.Set("LOG_ERR", 3)
-	vm.Set("LOG_ERROR", 3) // alias used by some scripts (e.g. lord2.js)
-	vm.Set("LOG_WARNING", 4)
-	vm.Set("LOG_NOTICE", 5)
-	vm.Set("LOG_INFO", 6)
-	vm.Set("LOG_DEBUG", 7)
+	jsutil.Set(vm, "LOG_EMERG", 0)
+	jsutil.Set(vm, "LOG_ALERT", 1)
+	jsutil.Set(vm, "LOG_CRIT", 2)
+	jsutil.Set(vm, "LOG_ERR", 3)
+	jsutil.Set(vm, "LOG_ERROR", 3) // alias used by some scripts (e.g. lord2.js)
+	jsutil.Set(vm, "LOG_WARNING", 4)
+	jsutil.Set(vm, "LOG_NOTICE", 5)
+	jsutil.Set(vm, "LOG_INFO", 6)
+	jsutil.Set(vm, "LOG_DEBUG", 7)
 
 	// alert(msg) — alias for log
-	vm.Set("alert", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "alert", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) > 0 {
 			slog.Info("script alert", "message", call.Arguments[0].String())
 		}
@@ -307,7 +317,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// ascii(str) — return ASCII code of first character (Synchronet built-in)
-	vm.Set("ascii", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "ascii", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue(0)
 		}
@@ -324,7 +334,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// ascii_str(code) — return character for ASCII code (Synchronet built-in)
-	vm.Set("ascii_str", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "ascii_str", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue("")
 		}
@@ -333,7 +343,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// truncsp(str) — truncate trailing spaces (Synchronet built-in)
-	vm.Set("truncsp", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "truncsp", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue("")
 		}
@@ -341,7 +351,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// backslash(path) — ensure path ends with directory separator (OS-native)
-	vm.Set("backslash", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "backslash", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue(string(filepath.Separator))
 		}
@@ -353,7 +363,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// mswait(ms) — alias for sleep (millisecond wait)
-	vm.Set("mswait", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "mswait", func(call goja.FunctionCall) goja.Value {
 		ms := int64(0)
 		if len(call.Arguments) > 0 {
 			ms = call.Arguments[0].ToInteger()
@@ -369,7 +379,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 
 	// file_mutex(filename [, text]) — atomically create a lock file.
 	// Returns true if created, false if already exists.
-	vm.Set("file_mutex", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "file_mutex", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue(false)
 		}
@@ -384,9 +394,13 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 			return vm.ToValue(false)
 		}
 		if content != "" {
-			f.WriteString(content)
+			if _, err := f.WriteString(content); err != nil {
+				slog.Warn("file_mutex: writing lock-file content", "path", path, "error", err)
+			}
 		}
-		f.Close()
+		if err := f.Close(); err != nil {
+			slog.Warn("file_mutex: closing lock file", "path", path, "error", err)
+		}
 		// Track for cleanup on engine close
 		eng.lockFiles = append(eng.lockFiles, path)
 		return vm.ToValue(true)
@@ -394,7 +408,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 
 	// file_getcase(path) — case-insensitive file lookup.
 	// Returns the actual path with correct case, or undefined if not found.
-	vm.Set("file_getcase", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "file_getcase", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return goja.Undefined()
 		}
@@ -420,7 +434,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// file_size(path) — return file size in bytes, or -1 if not found
-	vm.Set("file_size", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "file_size", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue(-1)
 		}
@@ -433,7 +447,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// file_isdir(path) — check if path is a directory
-	vm.Set("file_isdir", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "file_isdir", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue(false)
 		}
@@ -443,7 +457,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// mkdir(path) — create a directory (including parents)
-	vm.Set("mkdir", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "mkdir", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue(false)
 		}
@@ -453,7 +467,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// file_removecase(filename) — case-insensitive file removal (stub, just calls remove)
-	vm.Set("file_removecase", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "file_removecase", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue(false)
 		}
@@ -463,7 +477,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// file_rename(oldname, newname) — rename/move a file
-	vm.Set("file_rename", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "file_rename", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) < 2 {
 			return vm.ToValue(false)
 		}
@@ -474,7 +488,7 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 	})
 
 	// strerror(errno) — return string description of an error number
-	vm.Set("strerror", func(call goja.FunctionCall) goja.Value {
+	jsutil.Set(vm, "strerror", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) == 0 {
 			return vm.ToValue("Unknown error")
 		}
@@ -493,13 +507,13 @@ func registerGlobalFunctions(vm *goja.Runtime, eng *Engine) {
 			escaped = strings.ReplaceAll(escaped, `"`, `\"`)
 			parts[i] = `"` + escaped + `"`
 		}
-		vm.RunString(`var argv = [` + strings.Join(parts, ",") + `];`)
+		runInternalJS(vm, `var argv = [`+strings.Join(parts, ",")+`];`)
 	} else {
-		vm.RunString(`var argv = [];`)
+		runInternalJS(vm, `var argv = [];`)
 	}
 
 	// argc
-	vm.Set("argc", len(eng.cfg.Args))
+	jsutil.Set(vm, "argc", len(eng.cfg.Args))
 }
 
 // exitCode is a panic value used by exit() to halt script execution.
@@ -525,7 +539,7 @@ func (eng *Engine) loadModule(filename string, args []goja.Value) (goja.Value, e
 	// Set load arguments if provided
 	if len(args) > 0 {
 		for i, arg := range args {
-			eng.vm.Set(fmt.Sprintf("argv_%d", i), arg)
+			jsutil.Set(eng.vm, fmt.Sprintf("argv_%d", i), arg)
 		}
 	}
 

--- a/internal/syncjs/queue_class.go
+++ b/internal/syncjs/queue_class.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/dop251/goja"
 )
 
@@ -13,7 +14,7 @@ import (
 // When a Queue's poll/read find no data, they fall back to reading from the
 // session — this replaces Synchronet's background input thread model.
 func registerQueueClass(vm *goja.Runtime, eng *Engine) {
-	vm.Set("Queue", func(call goja.ConstructorCall) *goja.Object {
+	jsutil.Set(vm, "Queue", func(call goja.ConstructorCall) *goja.Object {
 		q := &jsQueue{
 			items: make([]goja.Value, 0),
 			eng:   eng,
@@ -21,7 +22,7 @@ func registerQueueClass(vm *goja.Runtime, eng *Engine) {
 		}
 
 		obj := call.This
-		obj.Set("write", func(fc goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "write", func(fc goja.FunctionCall) goja.Value {
 			val := goja.Undefined()
 			if len(fc.Arguments) > 0 {
 				val = fc.Arguments[0]
@@ -30,12 +31,12 @@ func registerQueueClass(vm *goja.Runtime, eng *Engine) {
 			return vm.ToValue(true)
 		})
 
-		obj.Set("read", func(fc goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "read", func(fc goja.FunctionCall) goja.Value {
 			return q.read()
 		})
 
 		// poll(timeout_ms) — returns true if data available, false on timeout.
-		obj.Set("poll", func(fc goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "poll", func(fc goja.FunctionCall) goja.Value {
 			timeout := int64(0)
 			if len(fc.Arguments) > 0 {
 				timeout = fc.Arguments[0].ToInteger()
@@ -43,7 +44,7 @@ func registerQueueClass(vm *goja.Runtime, eng *Engine) {
 			return vm.ToValue(q.poll(time.Duration(timeout) * time.Millisecond))
 		})
 
-		obj.Set("peek", func(fc goja.FunctionCall) goja.Value {
+		jsutil.Set(obj, "peek", func(fc goja.FunctionCall) goja.Value {
 			q.mu.Lock()
 			defer q.mu.Unlock()
 			if len(q.items) == 0 {
@@ -52,7 +53,7 @@ func registerQueueClass(vm *goja.Runtime, eng *Engine) {
 			return q.items[0]
 		})
 
-		obj.DefineAccessorProperty("data_waiting", vm.ToValue(func(fc goja.FunctionCall) goja.Value {
+		jsutil.DefineAccessor(obj, "data_waiting", vm.ToValue(func(fc goja.FunctionCall) goja.Value {
 			q.mu.Lock()
 			defer q.mu.Unlock()
 			return vm.ToValue(len(q.items) > 0)

--- a/internal/syncjs/server_client.go
+++ b/internal/syncjs/server_client.go
@@ -1,6 +1,9 @@
 package syncjs
 
-import "github.com/dop251/goja"
+import (
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
+	"github.com/dop251/goja"
+)
 
 // registerServerClient creates stub server and client global objects.
 // dorkit.js checks for these to detect 'sbbs' mode:
@@ -11,19 +14,19 @@ import "github.com/dop251/goja"
 func registerServerClient(vm *goja.Runtime, eng *Engine) {
 	// server object — minimal stub
 	server := vm.NewObject()
-	server.Set("version", "ViSiON/3 SyncJS")
-	server.Set("version_detail", "ViSiON/3 SyncJS Compatibility Layer")
-	vm.Set("server", server)
+	jsutil.Set(server, "version", "ViSiON/3 SyncJS")
+	jsutil.Set(server, "version_detail", "ViSiON/3 SyncJS Compatibility Layer")
+	jsutil.Set(vm, "server", server)
 
 	// client object — used by sbbs_console.js for connection info
 	client := vm.NewObject()
-	client.Set("protocol", "SSH")
+	jsutil.Set(client, "protocol", "SSH")
 
 	// client.socket with descriptor — sbbs_console.js reads client.socket.descriptor
 	sock := vm.NewObject()
-	sock.Set("descriptor", -1) // no real socket FD
-	client.Set("socket", sock)
+	jsutil.Set(sock, "descriptor", -1) // no real socket FD
+	jsutil.Set(client, "socket", sock)
 
-	client.Set("ip_address", "127.0.0.1")
-	vm.Set("client", client)
+	jsutil.Set(client, "ip_address", "127.0.0.1")
+	jsutil.Set(vm, "client", client)
 }

--- a/internal/syncjs/system_object.go
+++ b/internal/syncjs/system_object.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/dop251/goja"
 )
 
@@ -11,25 +12,25 @@ import (
 func registerSystem(vm *goja.Runtime, eng *Engine) {
 	obj := vm.NewObject()
 
-	obj.Set("name", eng.session.BoardName)
-	obj.Set("operator", eng.session.SysOpName)
-	obj.Set("qwk_id", makeQWKID(eng.session.BoardName))
+	jsutil.Set(obj, "name", eng.session.BoardName)
+	jsutil.Set(obj, "operator", eng.session.SysOpName)
+	jsutil.Set(obj, "qwk_id", makeQWKID(eng.session.BoardName))
 
 	// system.timer — current time in milliseconds (used for timing)
-	obj.DefineAccessorProperty("timer", vm.ToValue(func(call goja.FunctionCall) goja.Value {
+	jsutil.DefineAccessor(obj, "timer", vm.ToValue(func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(time.Now().UnixMilli())
 	}), nil, goja.FLAG_FALSE, goja.FLAG_FALSE)
 
 	// Directory paths
-	obj.Set("exec_dir", eng.cfg.ExecDir)
-	obj.Set("data_dir", eng.cfg.DataDir)
-	obj.Set("node_dir", eng.cfg.NodeDir)
-	obj.Set("ctrl_dir", eng.cfg.ExecDir)
-	obj.Set("text_dir", eng.cfg.DataDir)
+	jsutil.Set(obj, "exec_dir", eng.cfg.ExecDir)
+	jsutil.Set(obj, "data_dir", eng.cfg.DataDir)
+	jsutil.Set(obj, "node_dir", eng.cfg.NodeDir)
+	jsutil.Set(obj, "ctrl_dir", eng.cfg.ExecDir)
+	jsutil.Set(obj, "text_dir", eng.cfg.DataDir)
 
-	obj.Set("nodes", 4)
+	jsutil.Set(obj, "nodes", 4)
 
-	vm.Set("system", obj)
+	jsutil.Set(vm, "system", obj)
 }
 
 // makeQWKID derives a QWK ID from the BBS name.

--- a/internal/syncjs/user_object.go
+++ b/internal/syncjs/user_object.go
@@ -3,6 +3,7 @@ package syncjs
 import (
 	"time"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/dop251/goja"
 )
 
@@ -10,45 +11,45 @@ import (
 func registerUser(vm *goja.Runtime, eng *Engine) {
 	obj := vm.NewObject()
 
-	obj.Set("alias", eng.session.UserHandle)
-	obj.Set("name", eng.session.UserRealName)
-	obj.Set("number", eng.session.UserID)
+	jsutil.Set(obj, "alias", eng.session.UserHandle)
+	jsutil.Set(obj, "name", eng.session.UserRealName)
+	jsutil.Set(obj, "number", eng.session.UserID)
 
 	// user.security — nested object with level, etc.
 	security := vm.NewObject()
-	security.Set("level", eng.session.AccessLevel)
-	security.Set("password", "") // never expose real password
-	obj.Set("security", security)
+	jsutil.Set(security, "level", eng.session.AccessLevel)
+	jsutil.Set(security, "password", "") // never expose real password
+	jsutil.Set(obj, "security", security)
 
 	// Convenience aliases used by some games
-	obj.Set("level", eng.session.AccessLevel)
-	obj.Set("full_name", eng.session.UserRealName)
-	obj.Set("location", eng.session.Location)
-	obj.Set("handle", eng.session.UserHandle)
+	jsutil.Set(obj, "level", eng.session.AccessLevel)
+	jsutil.Set(obj, "full_name", eng.session.UserRealName)
+	jsutil.Set(obj, "location", eng.session.Location)
+	jsutil.Set(obj, "handle", eng.session.UserHandle)
 
 	// user.settings — user preference flags (USER_EXPERT=2)
-	obj.Set("settings", 2)
+	jsutil.Set(obj, "settings", 2)
 
 	// Date properties used by sbbs_console.js (Unix timestamps)
 	now := time.Now().Unix()
-	obj.Set("laston_date", now)
-	obj.Set("expiration_date", 0)
-	obj.Set("new_file_time", now)
-	obj.Set("birthdate", "01/01/90")
-	obj.Set("phone", "")
-	obj.Set("comment", "")
-	obj.Set("download_protocol", "")
+	jsutil.Set(obj, "laston_date", now)
+	jsutil.Set(obj, "expiration_date", 0)
+	jsutil.Set(obj, "new_file_time", now)
+	jsutil.Set(obj, "birthdate", "01/01/90")
+	jsutil.Set(obj, "phone", "")
+	jsutil.Set(obj, "comment", "")
+	jsutil.Set(obj, "download_protocol", "")
 
 	// user.stats — usage statistics
 	stats := vm.NewObject()
-	stats.Set("total_logons", eng.session.TimesCalled)
-	stats.Set("total_posts", 0)
-	stats.Set("total_emails", 0)
-	stats.Set("files_uploaded", 0)
-	stats.Set("files_downloaded", 0)
-	stats.Set("bytes_uploaded", 0)
-	stats.Set("bytes_downloaded", 0)
-	obj.Set("stats", stats)
+	jsutil.Set(stats, "total_logons", eng.session.TimesCalled)
+	jsutil.Set(stats, "total_posts", 0)
+	jsutil.Set(stats, "total_emails", 0)
+	jsutil.Set(stats, "files_uploaded", 0)
+	jsutil.Set(stats, "files_downloaded", 0)
+	jsutil.Set(stats, "bytes_uploaded", 0)
+	jsutil.Set(stats, "bytes_downloaded", 0)
+	jsutil.Set(obj, "stats", stats)
 
-	vm.Set("user", obj)
+	jsutil.Set(vm, "user", obj)
 }

--- a/internal/telnetserver/server.go
+++ b/internal/telnetserver/server.go
@@ -81,7 +81,7 @@ func (s *Server) handleConnection(conn net.Conn) {
 		if r := recover(); r != nil {
 			slog.Error("telnet panic handling connection", "remote", remoteAddr, "panic", r)
 		}
-		conn.Close()
+		_ = conn.Close() // best-effort close on teardown
 		slog.Info("telnet connection closed", "remote", remoteAddr)
 	}()
 

--- a/internal/telnetserver/telnet.go
+++ b/internal/telnetserver/telnet.go
@@ -123,9 +123,9 @@ func (tc *TelnetConn) Negotiate() error {
 	}
 
 	// Phase 1: wait for NAWS and WILL TERM_TYPE responses
-	tc.conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	_ = tc.conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond)) // best-effort negotiation deadline
 	tc.drainNegotiations()
-	tc.conn.SetReadDeadline(time.Time{})
+	_ = tc.conn.SetReadDeadline(time.Time{}) // best-effort negotiation deadline
 
 	// Phase 2: if client agreed to send terminal type, request it
 	if tc.willTermType {
@@ -138,9 +138,9 @@ func (tc *TelnetConn) Negotiate() error {
 		}
 
 		// Wait for the IS <string> subnegotiation response
-		tc.conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		_ = tc.conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond)) // best-effort negotiation deadline
 		tc.drainNegotiations()
-		tc.conn.SetReadDeadline(time.Time{})
+		_ = tc.conn.SetReadDeadline(time.Time{}) // best-effort negotiation deadline
 	}
 
 	return nil
@@ -306,7 +306,7 @@ func (tc *TelnetConn) SetReadInterrupt(ch <-chan struct{}) {
 
 	if ch == nil {
 		// Clear any deadline set by a previous interrupt
-		tc.conn.SetReadDeadline(time.Time{})
+		_ = tc.conn.SetReadDeadline(time.Time{}) // best-effort negotiation deadline
 		return
 	}
 
@@ -317,7 +317,7 @@ func (tc *TelnetConn) SetReadInterrupt(ch <-chan struct{}) {
 		stillCurrent := tc.readInterrupt == ch
 		tc.riMu.Unlock()
 		if stillCurrent {
-			tc.conn.SetReadDeadline(time.Now())
+			_ = tc.conn.SetReadDeadline(time.Now()) // best-effort negotiation deadline
 		}
 	}(ch)
 }
@@ -542,7 +542,7 @@ func (tc *TelnetConn) detectViaCursorPositioning() (width, height int, err error
 	defer func() {
 		if r := recover(); r != nil {
 			tc.writeMu.Lock()
-			tc.conn.Write([]byte("\033[u"))
+			_, _ = tc.conn.Write([]byte("\033[u")) // best-effort cursor restore
 			tc.writeMu.Unlock()
 		}
 	}()
@@ -570,10 +570,10 @@ func (tc *TelnetConn) detectViaCursorPositioning() (width, height int, err error
 			}
 		} else {
 			// Short read deadline to avoid blocking
-			tc.conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+			_ = tc.conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond)) // best-effort negotiation deadline
 			buf := make([]byte, 32)
 			n, readErr := tc.reader.Read(buf)
-			tc.conn.SetReadDeadline(time.Time{})
+			_ = tc.conn.SetReadDeadline(time.Time{}) // best-effort negotiation deadline
 
 			if n > 0 {
 				allData = append(allData, buf[:n]...)
@@ -598,7 +598,7 @@ func (tc *TelnetConn) detectViaCursorPositioning() (width, height int, err error
 
 	// Restore cursor position
 	tc.writeMu.Lock()
-	tc.conn.Write([]byte("\033[u"))
+	_, _ = tc.conn.Write([]byte("\033[u")) // best-effort cursor restore
 	tc.writeMu.Unlock()
 
 	// Process any telnet IAC commands that were in the raw response
@@ -615,8 +615,8 @@ func (tc *TelnetConn) detectViaCursorPositioning() (width, height int, err error
 	}
 
 	var rows, cols int
-	fmt.Sscanf(matches[1], "%d", &rows)
-	fmt.Sscanf(matches[2], "%d", &cols)
+	_, _ = fmt.Sscanf(matches[1], "%d", &rows) // regex guarantees digits
+	_, _ = fmt.Sscanf(matches[2], "%d", &cols) // regex guarantees digits
 
 	// Apply BBS-compatible limits
 	if cols > 80 {

--- a/internal/tosser/dupecheck.go
+++ b/internal/tosser/dupecheck.go
@@ -120,12 +120,12 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	tmpPath := tmp.Name()
 
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
+		_ = tmp.Close() // cleanup on error path
 		os.Remove(tmpPath)
 		return err
 	}
 	if err := tmp.Sync(); err != nil {
-		tmp.Close()
+		_ = tmp.Close() // cleanup on error path
 		os.Remove(tmpPath)
 		return err
 	}

--- a/internal/tosser/dupecheck.go
+++ b/internal/tosser/dupecheck.go
@@ -120,21 +120,21 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	tmpPath := tmp.Name()
 
 	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close() // cleanup on error path
-		os.Remove(tmpPath)
+		_ = tmp.Close()        // cleanup on error path
+		_ = os.Remove(tmpPath) // cleanup on error path
 		return err
 	}
 	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close() // cleanup on error path
-		os.Remove(tmpPath)
+		_ = tmp.Close()        // cleanup on error path
+		_ = os.Remove(tmpPath) // cleanup on error path
 		return err
 	}
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath) // cleanup on error path
 		return err
 	}
 	if err := os.Chmod(tmpPath, perm); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath) // cleanup on error path
 		return err
 	}
 	return os.Rename(tmpPath, path)

--- a/internal/tosser/export.go
+++ b/internal/tosser/export.go
@@ -47,7 +47,7 @@ func (t *Tosser) ScanAndExport() TossResult {
 	var openBases []*jam.Base
 	defer func() {
 		for _, b := range openBases {
-			b.Close()
+			_ = b.Close() // best-effort close of read-side bases
 		}
 	}()
 
@@ -177,7 +177,7 @@ func (t *Tosser) scanAndExportNetmail(result *TossResult) {
 	var openBases []*jam.Base
 	defer func() {
 		for _, b := range openBases {
-			b.Close()
+			_ = b.Close() // best-effort close of read-side bases
 		}
 	}()
 
@@ -373,11 +373,14 @@ func (t *Tosser) createOutboundNetmailPacket(link *linkConfig, msgs []pendingNet
 	pktPath := f.Name()
 
 	if err := ftn.WritePacket(f, hdr, packedMsgs); err != nil {
-		f.Close()
-		os.Remove(pktPath)
+		_ = f.Close()          // cleanup on error path
+		_ = os.Remove(pktPath) // cleanup on error path
 		return 0, fmt.Errorf("write packet: %w", err)
 	}
-	f.Close()
+	if err := f.Close(); err != nil {
+		_ = os.Remove(pktPath) // cleanup on error path
+		return 0, fmt.Errorf("close packet: %w", err)
+	}
 
 	finalName := fmt.Sprintf("%08x.pkt", time.Now().UnixNano()&0xFFFFFFFF)
 	finalPath := filepath.Join(t.paths.OutboundPath, finalName)
@@ -491,11 +494,14 @@ func (t *Tosser) createOutboundPacket(link *linkConfig, msgs []pendingMsg) (int,
 	pktPath := f.Name()
 
 	if err := ftn.WritePacket(f, hdr, packedMsgs); err != nil {
-		f.Close()
-		os.Remove(pktPath) // Clean up on error
+		_ = f.Close()          // cleanup on error path
+		_ = os.Remove(pktPath) // cleanup on error path
 		return 0, fmt.Errorf("write packet: %w", err)
 	}
-	f.Close()
+	if err := f.Close(); err != nil {
+		_ = os.Remove(pktPath) // cleanup on error path
+		return 0, fmt.Errorf("close packet: %w", err)
+	}
 
 	// Rename to a proper .pkt filename
 	finalName := fmt.Sprintf("%08x.pkt", time.Now().UnixNano()&0xFFFFFFFF)

--- a/internal/tosser/import.go
+++ b/internal/tosser/import.go
@@ -319,7 +319,7 @@ func (t *Tosser) isPacketFromKnownLink(hdr *ftn.PacketHeader) bool {
 }
 
 // tossMessage processes a single message from a packet.
-func (t *Tosser) tossMessage(msg *ftn.PackedMessage, pktHdr *ftn.PacketHeader) error {
+func (t *Tosser) tossMessage(msg *ftn.PackedMessage, pktHdr *ftn.PacketHeader) (retErr error) {
 	parsed := ftn.ParsePackedMessageBody(msg.Body)
 
 	// Extract MSGID and CHRS from kludges
@@ -390,9 +390,16 @@ func (t *Tosser) tossMessage(msg *ftn.PackedMessage, pktHdr *ftn.PacketHeader) e
 	if err != nil {
 		return fmt.Errorf("get base for area %d: %w", area.ID, err)
 	}
+	// A failed close means the JAM write may not be fully flushed, so treat
+	// it as a write failure — otherwise the packet would be acknowledged and
+	// removed while the message is potentially lost.
 	defer func() {
 		if cerr := base.Close(); cerr != nil {
-			slog.Warn("closing JAM base", "error", cerr)
+			if retErr == nil {
+				retErr = fmt.Errorf("closing JAM base: %w", cerr)
+			} else {
+				slog.Warn("closing JAM base", "error", cerr)
+			}
 		}
 	}()
 
@@ -489,7 +496,7 @@ func (t *Tosser) tossMessage(msg *ftn.PackedMessage, pktHdr *ftn.PacketHeader) e
 
 // writeMsgToArea writes a packet message to any JAM area by tag.
 // Used for netmail, bad-area, and dupe-area routing.
-func (t *Tosser) writeMsgToArea(areaTag string, msg *ftn.PackedMessage, pktHdr *ftn.PacketHeader, parsed *ftn.ParsedBody, msgID string) error {
+func (t *Tosser) writeMsgToArea(areaTag string, msg *ftn.PackedMessage, pktHdr *ftn.PacketHeader, parsed *ftn.ParsedBody, msgID string) (retErr error) {
 	area, found := t.msgMgr.GetAreaByTag(areaTag)
 	if !found {
 		return fmt.Errorf("area %q not configured", areaTag)
@@ -498,9 +505,15 @@ func (t *Tosser) writeMsgToArea(areaTag string, msg *ftn.PackedMessage, pktHdr *
 	if err != nil {
 		return fmt.Errorf("get base for area %q: %w", areaTag, err)
 	}
+	// Treat a failed close as a write failure so callers do not acknowledge
+	// a packet whose JAM finalization failed.
 	defer func() {
 		if cerr := base.Close(); cerr != nil {
-			slog.Warn("closing JAM base", "error", cerr)
+			if retErr == nil {
+				retErr = fmt.Errorf("closing JAM base: %w", cerr)
+			} else {
+				slog.Warn("closing JAM base", "error", cerr)
+			}
 		}
 	}()
 

--- a/internal/tosser/import.go
+++ b/internal/tosser/import.go
@@ -182,7 +182,7 @@ func (t *Tosser) processBundle(path, name string, result *TossResult) {
 	// bundle in place for the correct tosser and clean up extracted temp files.
 	if allSkipped && len(pktPaths) > 0 {
 		for _, pktPath := range pktPaths {
-			os.Remove(pktPath)
+			_ = os.Remove(pktPath) // best-effort cleanup of skipped packets
 		}
 		slog.Debug("skipping foreign bundle", "network", t.networkName, "bundle", name)
 		return
@@ -245,7 +245,7 @@ func (t *Tosser) tossPacket(path string) (imported, dupes int, errs []string, sk
 	if err != nil {
 		return 0, 0, []string{fmt.Sprintf("open %s: %v", path, err)}, false
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }() // read-only
 
 	pktHdr, msgs, err := ftn.ReadPacket(f)
 	if err != nil {
@@ -390,7 +390,11 @@ func (t *Tosser) tossMessage(msg *ftn.PackedMessage, pktHdr *ftn.PacketHeader) e
 	if err != nil {
 		return fmt.Errorf("get base for area %d: %w", area.ID, err)
 	}
-	defer base.Close()
+	defer func() {
+		if cerr := base.Close(); cerr != nil {
+			slog.Warn("closing JAM base", "error", cerr)
+		}
+	}()
 
 	// Update SEEN-BY and PATH with our address
 	own2D := t.ownAddr.String2D()
@@ -494,7 +498,11 @@ func (t *Tosser) writeMsgToArea(areaTag string, msg *ftn.PackedMessage, pktHdr *
 	if err != nil {
 		return fmt.Errorf("get base for area %q: %w", areaTag, err)
 	}
-	defer base.Close()
+	defer func() {
+		if cerr := base.Close(); cerr != nil {
+			slog.Warn("closing JAM base", "error", cerr)
+		}
+	}()
 
 	jamMsg := jam.NewMessage()
 	jamMsg.From = msg.From

--- a/internal/tosser/pack.go
+++ b/internal/tosser/pack.go
@@ -166,14 +166,15 @@ func writeFlowFile(dir string, destAddr *jam.FidoAddress, flavour, bundlePath st
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-
 	absPath, err := filepath.Abs(bundlePath)
 	if err != nil {
 		absPath = bundlePath
 	}
-	_, err = fmt.Fprintf(f, "^%s\n", absPath)
-	return err
+	if _, err := fmt.Fprintf(f, "^%s\n", absPath); err != nil {
+		_ = f.Close() // best-effort; the write error takes precedence
+		return err
+	}
+	return f.Close()
 }
 
 // resolveUniqueBundlePath returns a path that does not already exist. If the

--- a/internal/transfer/protocol.go
+++ b/internal/transfer/protocol.go
@@ -137,7 +137,7 @@ func (p *ProtocolConfig) ExecuteSend(ctx context.Context, s ssh.Session, filePat
 
 	args, listFile := expandArgs(p.SendArgs, filePaths, "")
 	if listFile != "" {
-		defer os.Remove(listFile)
+		defer func() { _ = os.Remove(listFile) }() // best-effort temp cleanup
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -176,7 +176,7 @@ func (p *ProtocolConfig) ExecuteReceive(ctx context.Context, s ssh.Session, targ
 
 	args, listFile := expandArgs(p.RecvArgs, nil, targetDir)
 	if listFile != "" {
-		defer os.Remove(listFile)
+		defer func() { _ = os.Remove(listFile) }() // best-effort temp cleanup
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -278,8 +278,17 @@ func writeFileList(paths []string) string {
 		return ""
 	}
 	for _, p := range paths {
-		fmt.Fprintln(f, p)
+		if _, err := fmt.Fprintln(f, p); err != nil {
+			slog.Error("failed to write file list", "error", err)
+			_ = f.Close()           // cleanup on error path
+			_ = os.Remove(f.Name()) // cleanup on error path
+			return ""
+		}
 	}
-	_ = f.Close()
+	if err := f.Close(); err != nil {
+		slog.Error("failed to finalize file list", "error", err)
+		_ = os.Remove(f.Name()) // cleanup on error path
+		return ""
+	}
 	return f.Name()
 }

--- a/internal/transfer/protocol.go
+++ b/internal/transfer/protocol.go
@@ -135,7 +135,10 @@ func (p *ProtocolConfig) ExecuteSend(ctx context.Context, s ssh.Session, filePat
 		}
 	}
 
-	args, listFile := expandArgs(p.SendArgs, filePaths, "")
+	args, listFile, err := expandArgs(p.SendArgs, filePaths, "")
+	if err != nil {
+		return fmt.Errorf("prepare send args for protocol %q: %w", p.Name, err)
+	}
 	if listFile != "" {
 		defer func() { _ = os.Remove(listFile) }() // best-effort temp cleanup
 	}
@@ -174,7 +177,10 @@ func (p *ProtocolConfig) ExecuteReceive(ctx context.Context, s ssh.Session, targ
 		}
 	}
 
-	args, listFile := expandArgs(p.RecvArgs, nil, targetDir)
+	args, listFile, err := expandArgs(p.RecvArgs, nil, targetDir)
+	if err != nil {
+		return fmt.Errorf("prepare recv args for protocol %q: %w", p.Name, err)
+	}
 	if listFile != "" {
 		defer func() { _ = os.Remove(listFile) }() // best-effort temp cleanup
 	}
@@ -216,7 +222,7 @@ func (p *ProtocolConfig) ExecuteReceive(ctx context.Context, s ssh.Session, targ
 //   - Inline occurrences (e.g. "@{fileListPath}") perform in-place substitution.
 //   - If {filePath} never appears as a standalone arg and {fileListPath} is not
 //     used either, filePaths are appended at the end.
-func expandArgs(template []string, filePaths []string, targetDir string) ([]string, string) {
+func expandArgs(template []string, filePaths []string, targetDir string) ([]string, string, error) {
 	var result []string
 	filePathUsed := false
 	var listFilePath string
@@ -239,7 +245,10 @@ func expandArgs(template []string, filePaths []string, targetDir string) ([]stri
 		case "{fileListPath}":
 			// Write a temp file with one path per line.
 			if listFilePath == "" && len(filePaths) > 0 {
-				listFilePath = writeFileList(filePaths)
+				var err error
+				if listFilePath, err = writeFileList(filePaths); err != nil {
+					return nil, "", err
+				}
 			}
 			result = append(result, listFilePath)
 			filePathUsed = true
@@ -247,7 +256,10 @@ func expandArgs(template []string, filePaths []string, targetDir string) ([]stri
 			a := arg
 			if strings.Contains(a, "{fileListPath}") && len(filePaths) > 0 {
 				if listFilePath == "" {
-					listFilePath = writeFileList(filePaths)
+					var err error
+					if listFilePath, err = writeFileList(filePaths); err != nil {
+						return nil, "", err
+					}
 				}
 				a = strings.ReplaceAll(a, "{fileListPath}", listFilePath)
 				filePathUsed = true
@@ -266,29 +278,28 @@ func expandArgs(template []string, filePaths []string, targetDir string) ([]stri
 		result = append(result, filePaths...)
 	}
 
-	return result, listFilePath
+	return result, listFilePath, nil
 }
 
 // writeFileList creates a temporary file containing one path per line and
-// returns the file path in the OS temp directory.  Returns "" on error.
-func writeFileList(paths []string) string {
+// returns the file path in the OS temp directory. Errors are propagated so
+// callers abort the transfer instead of launching the command with an empty
+// file list.
+func writeFileList(paths []string) (string, error) {
 	f, err := os.CreateTemp("", "sexyz-filelist-*.txt")
 	if err != nil {
-		slog.Error("failed to create file list temp file", "error", err)
-		return ""
+		return "", fmt.Errorf("create file list temp file: %w", err)
 	}
 	for _, p := range paths {
 		if _, err := fmt.Fprintln(f, p); err != nil {
-			slog.Error("failed to write file list", "error", err)
 			_ = f.Close()           // cleanup on error path
 			_ = os.Remove(f.Name()) // cleanup on error path
-			return ""
+			return "", fmt.Errorf("write file list: %w", err)
 		}
 	}
 	if err := f.Close(); err != nil {
-		slog.Error("failed to finalize file list", "error", err)
 		_ = os.Remove(f.Name()) // cleanup on error path
-		return ""
+		return "", fmt.Errorf("finalize file list: %w", err)
 	}
-	return f.Name()
+	return f.Name(), nil
 }

--- a/internal/transfer/protocol_test.go
+++ b/internal/transfer/protocol_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestExpandArgs_filePath_standalone(t *testing.T) {
 	tmpl := []string{"-b", "-e", "{filePath}"}
-	got, _ := expandArgs(tmpl, []string{"/files/a.zip", "/files/b.zip"}, "")
+	got, _, _ := expandArgs(tmpl, []string{"/files/a.zip", "/files/b.zip"}, "")
 	want := []string{"-b", "-e", "/files/a.zip", "/files/b.zip"}
 	assertStringSlice(t, want, got)
 }
@@ -20,7 +20,7 @@ func TestExpandArgs_filePath_standalone(t *testing.T) {
 func TestExpandArgs_filePath_appended_when_absent(t *testing.T) {
 	// No {filePath} placeholder: files are appended at the end.
 	tmpl := []string{"-b", "-e"}
-	got, _ := expandArgs(tmpl, []string{"/files/a.zip", "/files/b.zip"}, "")
+	got, _, _ := expandArgs(tmpl, []string{"/files/a.zip", "/files/b.zip"}, "")
 	want := []string{"-b", "-e", "/files/a.zip", "/files/b.zip"}
 	assertStringSlice(t, want, got)
 }
@@ -28,14 +28,14 @@ func TestExpandArgs_filePath_appended_when_absent(t *testing.T) {
 func TestExpandArgs_no_filePaths_no_placeholder(t *testing.T) {
 	// No filePaths and no placeholder: args returned unchanged (lrzsz rz style).
 	tmpl := []string{"-b", "-r"}
-	got, _ := expandArgs(tmpl, nil, "/upload")
+	got, _, _ := expandArgs(tmpl, nil, "/upload")
 	want := []string{"-b", "-r"}
 	assertStringSlice(t, want, got)
 }
 
 func TestExpandArgs_targetDir_standalone(t *testing.T) {
 	tmpl := []string{"-r", "{targetDir}"}
-	got, _ := expandArgs(tmpl, nil, "/upload/tmp")
+	got, _, _ := expandArgs(tmpl, nil, "/upload/tmp")
 	want := []string{"-r", "/upload/tmp/"}
 	assertStringSlice(t, want, got)
 }
@@ -44,13 +44,13 @@ func TestExpandArgs_inline_replacement(t *testing.T) {
 	// Inline replacement uses the first filePath only; remaining files are NOT appended
 	// (inline substitution marks {filePath} as consumed).
 	tmpl := []string{"send:{filePath}"}
-	got, _ := expandArgs(tmpl, []string{"/f/a.zip", "/f/b.zip"}, "")
+	got, _, _ := expandArgs(tmpl, []string{"/f/a.zip", "/f/b.zip"}, "")
 	want := []string{"send:/f/a.zip"}
 	assertStringSlice(t, want, got)
 }
 
 func TestExpandArgs_empty_template(t *testing.T) {
-	got, _ := expandArgs(nil, []string{"/f/a.zip"}, "")
+	got, _, _ := expandArgs(nil, []string{"/f/a.zip"}, "")
 	want := []string{"/f/a.zip"} // appended since no placeholder
 	assertStringSlice(t, want, got)
 }
@@ -59,7 +59,7 @@ func TestExpandArgs_fileListPath_inline(t *testing.T) {
 	// sexyz-style batch send with @{fileListPath}
 	tmpl := []string{"-raw", "-8", "sz", "@{fileListPath}"}
 	files := []string{"/files/a.zip", "/files/b.zip"}
-	got, listFile := expandArgs(tmpl, files, "")
+	got, listFile, _ := expandArgs(tmpl, files, "")
 	if listFile == "" {
 		t.Fatal("expected listFile path, got empty")
 	}
@@ -88,7 +88,7 @@ func TestExpandArgs_fileListPath_standalone(t *testing.T) {
 	// Standalone {fileListPath} (no @ prefix): bare temp file path is appended.
 	tmpl := []string{"-raw", "-8", "sz", "{fileListPath}"}
 	files := []string{"/files/a.zip", "/files/b.zip"}
-	got, listFile := expandArgs(tmpl, files, "")
+	got, listFile, _ := expandArgs(tmpl, files, "")
 	if listFile == "" {
 		t.Fatal("expected listFile path, got empty")
 	}
@@ -104,14 +104,14 @@ func TestExpandArgs_fileListPath_standalone(t *testing.T) {
 
 func TestExpandArgs_targetDir_already_has_separator(t *testing.T) {
 	tmpl := []string{"rz", "{targetDir}"}
-	got, _ := expandArgs(tmpl, nil, "/upload/tmp/")
+	got, _, _ := expandArgs(tmpl, nil, "/upload/tmp/")
 	want := []string{"rz", "/upload/tmp/"}
 	assertStringSlice(t, want, got)
 }
 
 func TestExpandArgs_targetDir_empty(t *testing.T) {
 	tmpl := []string{"rz", "{targetDir}"}
-	got, _ := expandArgs(tmpl, nil, "")
+	got, _, _ := expandArgs(tmpl, nil, "")
 	want := []string{"rz", ""}
 	assertStringSlice(t, want, got)
 }

--- a/internal/transfer/zmodem.go
+++ b/internal/transfer/zmodem.go
@@ -565,7 +565,7 @@ func RunCommandWithPTY(ctx context.Context, s ssh.Session, cmd *exec.Cmd, stdinI
 
 	// Set PTY to raw mode so binary protocol data passes through unmodified.
 	fd := int(ptmx.Fd())
-	var restoreTerminal func() = func() {}
+	restoreTerminal := func() {}
 	originalState, err := term.MakeRaw(fd)
 	if err != nil {
 		slog.Warn("failed to put PTY into raw mode", "fd", fd, "cmd", cmd.Path, "error", err)
@@ -700,7 +700,7 @@ func ExecuteZmodemReceive(ctx context.Context, s ssh.Session, targetDir string) 
 		return fmt.Errorf("failed to get absolute path for target directory '%s': %w", targetDir, err)
 	}
 	if err := os.MkdirAll(absTargetDir, 0755); err != nil {
-		if fileInfo, statErr := os.Stat(absTargetDir); !(statErr == nil && fileInfo.IsDir()) {
+		if fileInfo, statErr := os.Stat(absTargetDir); statErr != nil || !fileInfo.IsDir() {
 			return fmt.Errorf("failed to create or access target directory '%s': %w", absTargetDir, err)
 		}
 	}

--- a/internal/usereditor/fileio.go
+++ b/internal/usereditor/fileio.go
@@ -73,17 +73,17 @@ func SaveUsers(path string, users []*user.User) (time.Time, error) {
 	tmpPath := tmpFile.Name()
 
 	if _, err := tmpFile.Write(data); err != nil {
-		tmpFile.Close()
-		os.Remove(tmpPath)
+		_ = tmpFile.Close()    // cleanup on error path
+		_ = os.Remove(tmpPath) // cleanup on error path
 		return time.Time{}, fmt.Errorf("write temp file: %w", err)
 	}
 	if err := tmpFile.Close(); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath) // cleanup on error path
 		return time.Time{}, fmt.Errorf("close temp file: %w", err)
 	}
 
 	if err := os.Rename(tmpPath, path); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath) // cleanup on error path
 		return time.Time{}, fmt.Errorf("rename temp to %s: %w", path, err)
 	}
 

--- a/internal/usereditor/model.go
+++ b/internal/usereditor/model.go
@@ -987,13 +987,21 @@ func (m Model) executeConfirm() (tea.Model, tea.Cmd) {
 	case modeMassPurge:
 		// Purge all deleted users (iterate in reverse to keep indices stable)
 		purged := 0
+		failed := 0
 		for i := len(m.users) - 1; i >= 0; i-- {
 			if m.users[i].DeletedUser {
-				m.purgeUser(i)
-				purged++
+				if m.purgeUser(i) {
+					purged++
+				} else {
+					failed++
+				}
 			}
 		}
-		m.message = fmt.Sprintf("Purged %d deleted user(s)", purged)
+		if failed > 0 {
+			m.message = fmt.Sprintf("Purged %d deleted user(s), %d failed (data files not removed)", purged, failed)
+		} else {
+			m.message = fmt.Sprintf("Purged %d deleted user(s)", purged)
+		}
 		m.mode = modeList
 		return m, nil
 
@@ -1108,21 +1116,27 @@ func (m *Model) undeleteUser(idx int) {
 
 // purgeUser permanently removes a user from the list and deletes their data files
 // (infoform responses, etc.). The user record is removed from the in-memory list.
-func (m *Model) purgeUser(idx int) {
+// Returns false without removing the user when data-file cleanup fails, so the
+// purge stays retryable and is never reported as successful while the user's
+// responses remain on disk.
+func (m *Model) purgeUser(idx int) bool {
 	if idx < 0 || idx >= len(m.users) {
-		return
+		return false
 	}
 	u := m.users[idx]
 	handle := u.Handle
 	userID := u.ID
 
-	// Remove infoform responses for this user
+	// Remove infoform responses for this user before removing the record.
 	if m.dataDir != "" {
 		responsesDir := filepath.Join(m.dataDir, "infoforms", "responses")
 		pattern := filepath.Join(responsesDir, fmt.Sprintf("%d_*.json", userID))
 		matches, _ := filepath.Glob(pattern)
 		for _, f := range matches {
-			_ = os.Remove(f) // best-effort cleanup
+			if err := os.Remove(f); err != nil {
+				m.message = fmt.Sprintf("Purge of %s failed: %v", handle, err)
+				return false
+			}
 		}
 	}
 
@@ -1152,6 +1166,7 @@ func (m *Model) purgeUser(idx int) {
 	m.dirty = true
 	m.editDirty = true
 	m.message = fmt.Sprintf("Purged: %s", handle)
+	return true
 }
 
 // resortAndTrack re-sorts the user list and updates cursor/editIndex to follow the given user.

--- a/internal/usereditor/model.go
+++ b/internal/usereditor/model.go
@@ -1122,7 +1122,7 @@ func (m *Model) purgeUser(idx int) {
 		pattern := filepath.Join(responsesDir, fmt.Sprintf("%d_*.json", userID))
 		matches, _ := filepath.Glob(pattern)
 		for _, f := range matches {
-			os.Remove(f)
+			_ = os.Remove(f) // best-effort cleanup
 		}
 	}
 

--- a/internal/v3net/dedup/dedup.go
+++ b/internal/v3net/dedup/dedup.go
@@ -30,11 +30,11 @@ func Open(path string) (*Index, error) {
 	}
 	db.SetMaxOpenConns(1)
 	if _, err := db.Exec("PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000"); err != nil {
-		db.Close()
+		_ = db.Close() // cleanup on error path
 		return nil, fmt.Errorf("dedup: configure pragmas: %w", err)
 	}
 	if _, err := db.Exec(schema); err != nil {
-		db.Close()
+		_ = db.Close() // cleanup on error path
 		return nil, fmt.Errorf("dedup: create schema: %w", err)
 	}
 	return &Index{db: db}, nil

--- a/internal/v3net/hub/access_handler.go
+++ b/internal/v3net/hub/access_handler.go
@@ -79,7 +79,7 @@ func (ar *AccessRequestStore) ListPending(network, areaTag string) ([]protocol.A
 	if err != nil {
 		return nil, fmt.Errorf("hub: list access requests: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }() // read-only
 
 	var result []protocol.AccessRequest
 	for rows.Next() {

--- a/internal/v3net/hub/area_subscriptions.go
+++ b/internal/v3net/hub/area_subscriptions.go
@@ -80,7 +80,7 @@ func (as *AreaSubscriptionStore) ListForNode(nodeID, network string) ([]protocol
 	if err != nil {
 		return nil, fmt.Errorf("hub: list area subscriptions: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }() // read-only
 
 	var result []protocol.AreaSubscriptionStatus
 	for rows.Next() {

--- a/internal/v3net/hub/chat_handlers.go
+++ b/internal/v3net/hub/chat_handlers.go
@@ -44,7 +44,7 @@ func (h *Hub) handleChatJoin(w http.ResponseWriter, r *http.Request, network str
 		Users:   users,
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
+	_ = json.NewEncoder(w).Encode(resp) // best-effort response write
 }
 
 // handleChatLeave: POST /v3net/v1/{network}/chat/rooms/leave
@@ -178,7 +178,7 @@ func (h *Hub) handleChatTopic(w http.ResponseWriter, r *http.Request, network st
 // handleChatRooms: GET /v3net/v1/{network}/chat/rooms  (no auth required)
 func (h *Hub) handleChatRooms(w http.ResponseWriter, r *http.Request, network string) {
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(h.chatRooms.RoomList(network))
+	_ = json.NewEncoder(w).Encode(h.chatRooms.RoomList(network)) // best-effort response write
 }
 
 // handleChatHistory: GET /v3net/v1/{network}/chat/rooms/{room}/history  (no auth)
@@ -209,7 +209,7 @@ func (h *Hub) handleChatHistory(w http.ResponseWriter, r *http.Request, network 
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(msgs)
+	_ = json.NewEncoder(w).Encode(msgs) // best-effort response write
 }
 
 // subscriberBBSName looks up the BBS name for a node, falling back to nodeID.
@@ -224,5 +224,5 @@ func (h *Hub) subscriberBBSName(nodeID, network string) string {
 func jsonError(w http.ResponseWriter, msg string, code int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-	json.NewEncoder(w).Encode(map[string]string{"error": msg})
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg}) // best-effort response write
 }

--- a/internal/v3net/hub/chat_store.go
+++ b/internal/v3net/hub/chat_store.go
@@ -107,7 +107,7 @@ func (chs *ChatHistoryStore) RoomHistory(network, room string, limit int) ([]pro
 	if err != nil {
 		return nil, fmt.Errorf("hub: query room history: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }() // read-only
 
 	var results []protocol.ChatMsgPayload
 	for rows.Next() {

--- a/internal/v3net/hub/coordinator_handler.go
+++ b/internal/v3net/hub/coordinator_handler.go
@@ -121,7 +121,7 @@ func (h *Hub) handleCoordAccept(w http.ResponseWriter, r *http.Request) {
 	// Enforce 24-hour TTL on transfer tokens.
 	if t, parseErr := time.Parse("2006-01-02 15:04:05", createdAt); parseErr == nil {
 		if time.Since(t) > 24*time.Hour {
-			h.db.Exec("DELETE FROM coordinator_transfers WHERE network = ?", network)
+			_, _ = h.db.Exec("DELETE FROM coordinator_transfers WHERE network = ?", network) // best-effort cleanup; leftovers expire via TTL check
 			http.Error(w, `{"error":"transfer token expired"}`, http.StatusGone)
 			return
 		}
@@ -169,7 +169,7 @@ func (h *Hub) handleCoordAccept(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Clean up the transfer.
-	h.db.Exec("DELETE FROM coordinator_transfers WHERE network = ?", network)
+	_, _ = h.db.Exec("DELETE FROM coordinator_transfers WHERE network = ?", network) // best-effort cleanup; leftovers expire via TTL check
 
 	// Fan out nal_updated event.
 	ev, _ := protocol.NewEvent(protocol.EventNALUpdated, protocol.NALUpdatedPayload{

--- a/internal/v3net/hub/coordinator_handler.go
+++ b/internal/v3net/hub/coordinator_handler.go
@@ -152,6 +152,25 @@ func (h *Hub) handleCoordAccept(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Consume the one-time token atomically before applying the transfer:
+	// the guarded DELETE ensures a token can never be redeemed twice, even
+	// if a later step fails (the coordinator must then re-initiate). A
+	// concurrent redemption of the same token loses this race and is
+	// rejected below via RowsAffected.
+	res, err := h.db.Exec(
+		"DELETE FROM coordinator_transfers WHERE network = ? AND token = ? AND new_node_id = ?",
+		network, req.Token, nodeID,
+	)
+	if err != nil {
+		slog.Error("consume transfer token", "error", err)
+		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		return
+	}
+	if n, raErr := res.RowsAffected(); raErr != nil || n == 0 {
+		http.Error(w, `{"error":"invalid transfer credentials"}`, http.StatusForbidden)
+		return
+	}
+
 	currentNAL.CoordNodeID = newNodeID
 	currentNAL.CoordPubKeyB64 = newPubKeyB64
 
@@ -167,9 +186,6 @@ func (h *Hub) handleCoordAccept(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
 		return
 	}
-
-	// Clean up the transfer.
-	_, _ = h.db.Exec("DELETE FROM coordinator_transfers WHERE network = ?", network) // best-effort cleanup; leftovers expire via TTL check
 
 	// Fan out nal_updated event.
 	ev, _ := protocol.NewEvent(protocol.EventNALUpdated, protocol.NALUpdatedPayload{

--- a/internal/v3net/hub/events.go
+++ b/internal/v3net/hub/events.go
@@ -123,7 +123,8 @@ func (b *Broadcaster) ServeSSE(w http.ResponseWriter, r *http.Request, network s
 			if !ok {
 				return
 			}
-			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.Type, ev.Data)
+			// Best-effort: a dead connection is detected by the request context.
+			_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.Type, ev.Data)
 			flusher.Flush()
 		}
 	}

--- a/internal/v3net/hub/handlers.go
+++ b/internal/v3net/hub/handlers.go
@@ -95,14 +95,14 @@ func (h *Hub) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 	// Write raw JSON array of message objects.
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("["))
+	_, _ = w.Write([]byte("[")) // best-effort response write
 	for i, data := range results {
 		if i > 0 {
-			w.Write([]byte(","))
+			_, _ = w.Write([]byte(",")) // best-effort response write
 		}
-		w.Write([]byte(data))
+		_, _ = w.Write([]byte(data)) // best-effort response write
 	}
-	w.Write([]byte("]"))
+	_, _ = w.Write([]byte("]")) // best-effort response write
 }
 
 // handlePostMessage accepts a new message from a leaf node (auth required).
@@ -364,7 +364,9 @@ func (h *Hub) handleSubscribe(w http.ResponseWriter, r *http.Request) {
 
 		// Second pass: all validations passed, apply subscriptions and events.
 		for _, ps := range pending {
-			h.areaSubscriptions.Upsert(req.NodeID, req.Network, ps.tag, ps.status)
+			if err := h.areaSubscriptions.Upsert(req.NodeID, req.Network, ps.tag, ps.status); err != nil {
+				slog.Error("v3net hub: persist area subscription", "node", req.NodeID, "tag", ps.tag, "error", err)
+			}
 			areaStatuses = append(areaStatuses, protocol.AreaSubscriptionStatus{
 				Tag:    ps.tag,
 				Status: ps.status,
@@ -372,7 +374,9 @@ func (h *Hub) handleSubscribe(w http.ResponseWriter, r *http.Request) {
 		}
 
 		for _, pr := range pendingRequests {
-			h.accessRequests.Add(req.Network, pr.tag, req.NodeID, req.BBSName)
+			if _, err := h.accessRequests.Add(req.Network, pr.tag, req.NodeID, req.BBSName); err != nil {
+				slog.Error("v3net hub: persist access request", "node", req.NodeID, "tag", pr.tag, "error", err)
+			}
 			ev, _ := protocol.NewEvent(protocol.EventAreaAccessRequested, protocol.AreaAccessRequestedPayload{
 				Network: req.Network,
 				Tag:     pr.tag,
@@ -414,5 +418,5 @@ func (h *Hub) findNetwork(name string) *NetworkConfig {
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(v)
+	_ = json.NewEncoder(w).Encode(v) // best-effort response write
 }

--- a/internal/v3net/hub/handlers.go
+++ b/internal/v3net/hub/handlers.go
@@ -363,9 +363,14 @@ func (h *Hub) handleSubscribe(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Second pass: all validations passed, apply subscriptions and events.
+		// Persistence failures must not be reported as success: Upsert and
+		// Add are both idempotent, so the leaf can safely retry the whole
+		// subscribe request after a 500.
 		for _, ps := range pending {
 			if err := h.areaSubscriptions.Upsert(req.NodeID, req.Network, ps.tag, ps.status); err != nil {
 				slog.Error("v3net hub: persist area subscription", "node", req.NodeID, "tag", ps.tag, "error", err)
+				http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+				return
 			}
 			areaStatuses = append(areaStatuses, protocol.AreaSubscriptionStatus{
 				Tag:    ps.tag,
@@ -376,7 +381,11 @@ func (h *Hub) handleSubscribe(w http.ResponseWriter, r *http.Request) {
 		for _, pr := range pendingRequests {
 			if _, err := h.accessRequests.Add(req.Network, pr.tag, req.NodeID, req.BBSName); err != nil {
 				slog.Error("v3net hub: persist access request", "node", req.NodeID, "tag", pr.tag, "error", err)
+				http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+				return
 			}
+			// Publish only after the request is durably stored, so managers
+			// are never notified about a request that does not exist.
 			ev, _ := protocol.NewEvent(protocol.EventAreaAccessRequested, protocol.AreaAccessRequestedPayload{
 				Network: req.Network,
 				Tag:     pr.tag,

--- a/internal/v3net/hub/handlers.go
+++ b/internal/v3net/hub/handlers.go
@@ -418,5 +418,9 @@ func (h *Hub) findNetwork(name string) *NetworkConfig {
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(v) // best-effort response write
+	// Usually a client disconnect, but Encode can also fail on a marshal
+	// bug — log so server-side errors don't vanish silently.
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.Debug("hub: write JSON response", "error", err)
+	}
 }

--- a/internal/v3net/hub/hub.go
+++ b/internal/v3net/hub/hub.go
@@ -41,55 +41,55 @@ func New(cfg Config) (*Hub, error) {
 	}
 	db.SetMaxOpenConns(1)
 	if _, err := db.Exec("PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000"); err != nil {
-		db.Close()
+		_ = db.Close() // cleanup on error path
 		return nil, fmt.Errorf("hub: configure pragmas: %w", err)
 	}
 
 	subscribers, err := NewSubscriberStore(db)
 	if err != nil {
-		db.Close()
+		_ = db.Close() // cleanup on error path
 		return nil, err
 	}
 
 	messages, err := NewMessageStore(db)
 	if err != nil {
-		db.Close()
+		_ = db.Close() // cleanup on error path
 		return nil, err
 	}
 
 	nalStore, err := NewNALStore(db)
 	if err != nil {
-		db.Close()
+		_ = db.Close() // cleanup on error path
 		return nil, err
 	}
 
 	proposals, err := NewProposalStore(db)
 	if err != nil {
-		db.Close()
+		_ = db.Close() // cleanup on error path
 		return nil, err
 	}
 
 	accessReqs, err := NewAccessRequestStore(db)
 	if err != nil {
-		db.Close()
+		_ = db.Close() // cleanup on error path
 		return nil, err
 	}
 
 	areaSubs, err := NewAreaSubscriptionStore(db)
 	if err != nil {
-		db.Close()
+		_ = db.Close() // cleanup on error path
 		return nil, err
 	}
 
 	coordTransfers, err := NewCoordTransferStore(db)
 	if err != nil {
-		db.Close()
+		_ = db.Close() // cleanup on error path
 		return nil, err
 	}
 
 	chatStore, err := NewChatHistoryStore(db, 7)
 	if err != nil {
-		db.Close()
+		_ = db.Close() // cleanup on error path
 		return nil, err
 	}
 
@@ -125,7 +125,7 @@ func (h *Hub) Start(ctx context.Context) error {
 
 	go func() {
 		<-ctx.Done()
-		h.server.Close()
+		_ = h.server.Close() // best-effort shutdown
 	}()
 
 	slog.Info("v3net hub starting", "addr", h.cfg.ListenAddr)

--- a/internal/v3net/hub/hub_coordinator_test.go
+++ b/internal/v3net/hub/hub_coordinator_test.go
@@ -117,6 +117,63 @@ func TestCoordTransfer_FullFlow(t *testing.T) {
 	}
 }
 
+// TestCoordAccept_TokenNotReplayable verifies that a transfer token is a
+// strict one-time credential: after a successful accept, redeeming the same
+// token again must be rejected.
+func TestCoordAccept_TokenNotReplayable(t *testing.T) {
+	h, hubKS := setupTestHub(t)
+	ts := httptest.NewServer(h.newMux())
+	defer ts.Close()
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("load leaf keystore: %v", err)
+	}
+
+	registerAsLeaf(t, ts, hubKS)
+	registerAsLeaf(t, ts, leafKS)
+	seedCoordNAL(t, h, hubKS)
+
+	transferBody := fmt.Sprintf(`{"new_node_id":%q,"new_pubkey_b64":%q}`, leafKS.NodeID(), leafKS.PubKeyBase64())
+	req := signedRequest(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/coordinator/transfer", transferBody)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST transfer: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("transfer expected 200, got %d", resp.StatusCode)
+	}
+	var transferResp struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&transferResp); err != nil {
+		t.Fatalf("decode transfer response: %v", err)
+	}
+
+	acceptBody := fmt.Sprintf(`{"token":%q}`, transferResp.Token)
+	first := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/coordinator/accept", acceptBody)
+	firstResp, err := http.DefaultClient.Do(first)
+	if err != nil {
+		t.Fatalf("POST accept: %v", err)
+	}
+	firstResp.Body.Close()
+	if firstResp.StatusCode != http.StatusOK {
+		t.Fatalf("first accept expected 200, got %d", firstResp.StatusCode)
+	}
+
+	// Replay the exact same token: must be rejected.
+	second := signedRequest(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/coordinator/accept", acceptBody)
+	secondResp, err := http.DefaultClient.Do(second)
+	if err != nil {
+		t.Fatalf("POST replay accept: %v", err)
+	}
+	secondResp.Body.Close()
+	if secondResp.StatusCode == http.StatusOK {
+		t.Fatalf("replayed transfer token was accepted (status %d); tokens must be single-use", secondResp.StatusCode)
+	}
+}
+
 func TestCoordTransfer_NonCoordinator(t *testing.T) {
 	h, hubKS := setupTestHub(t)
 	ts := httptest.NewServer(h.newMux())

--- a/internal/v3net/hub/messages.go
+++ b/internal/v3net/hub/messages.go
@@ -115,7 +115,7 @@ func (ms *MessageStore) Fetch(network, sinceUUID string, limit int, areaTags []s
 	if err != nil {
 		return nil, false, fmt.Errorf("hub: fetch messages: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }() // read-only
 
 	var results []string
 	for rows.Next() {

--- a/internal/v3net/hub/proposal_handler.go
+++ b/internal/v3net/hub/proposal_handler.go
@@ -88,7 +88,7 @@ func (ps *ProposalStore) ListPending(network string) ([]protocol.AreaProposal, e
 	if err != nil {
 		return nil, fmt.Errorf("hub: list proposals: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }() // read-only
 
 	var result []protocol.AreaProposal
 	for rows.Next() {

--- a/internal/v3net/hub/subscribers.go
+++ b/internal/v3net/hub/subscribers.go
@@ -61,7 +61,7 @@ func (ss *SubscriberStore) loadCache() error {
 	if err != nil {
 		return fmt.Errorf("hub: load subscribers: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }() // read-only
 
 	for rows.Next() {
 		var s Subscriber

--- a/internal/v3net/keystore/keystore.go
+++ b/internal/v3net/keystore/keystore.go
@@ -95,26 +95,26 @@ func (ks *Keystore) save(path string) error {
 	tmpName := tmp.Name()
 
 	if err := tmp.Chmod(0600); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
+		_ = tmp.Close()        // cleanup on error path
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("keystore: chmod temp file: %w", err)
 	}
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
+		_ = tmp.Close()        // cleanup on error path
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("keystore: write temp file: %w", err)
 	}
 	if err := tmp.Sync(); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
+		_ = tmp.Close()        // cleanup on error path
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("keystore: sync temp file: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("keystore: close temp file: %w", err)
 	}
 	if err := os.Rename(tmpName, path); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName) // cleanup on error path
 		return fmt.Errorf("keystore: rename %s -> %s: %w", tmpName, path, err)
 	}
 	return nil

--- a/internal/v3net/leaf/chat.go
+++ b/internal/v3net/leaf/chat.go
@@ -47,7 +47,7 @@ func (r *chatSessionRegistry) dispatch(ev protocol.Event) {
 		var msg struct {
 			Room string `json:"room"`
 		}
-		json.Unmarshal(ev.Data, &msg)
+		_ = json.Unmarshal(ev.Data, &msg) // malformed payloads yield zero values, matching prior behavior
 		for _, s := range r.sessions {
 			if s.currentRoom == msg.Room {
 				s.deliver(ev)
@@ -56,7 +56,7 @@ func (r *chatSessionRegistry) dispatch(ev protocol.Event) {
 
 	case protocol.EventChatPrivate:
 		var msg protocol.ChatMsgPayload
-		json.Unmarshal(ev.Data, &msg)
+		_ = json.Unmarshal(ev.Data, &msg) // malformed payloads yield zero values, matching prior behavior
 		if msg.ToNode != "" && msg.ToNode != r.nodeID {
 			return
 		}
@@ -104,29 +104,29 @@ func (s *ChatSession) deliver(ev protocol.Event) {
 	switch ev.Type {
 	case protocol.EventChatMessage:
 		var p protocol.ChatMsgPayload
-		json.Unmarshal(ev.Data, &p)
+		_ = json.Unmarshal(ev.Data, &p) // malformed payloads yield zero values, matching prior behavior
 		ce = chat.ChatEvent{Type: chat.TypeMessage, Message: protoMsgToDomain(p)}
 	case protocol.EventChatPrivate:
 		var p protocol.ChatMsgPayload
-		json.Unmarshal(ev.Data, &p)
+		_ = json.Unmarshal(ev.Data, &p) // malformed payloads yield zero values, matching prior behavior
 		ce = chat.ChatEvent{Type: chat.TypePrivate, Message: protoMsgToDomain(p)}
 	case protocol.EventChatJoin:
 		var p protocol.ChatJoinPayload
-		json.Unmarshal(ev.Data, &p)
+		_ = json.Unmarshal(ev.Data, &p) // malformed payloads yield zero values, matching prior behavior
 		s.mu.Lock()
 		s.currentUsers = append(s.currentUsers, p.Handle)
 		s.mu.Unlock()
 		ce = chat.ChatEvent{Type: chat.TypeJoin, Join: &chat.ChatJoin{Room: p.Room, Handle: p.Handle, BBS: p.BBS}}
 	case protocol.EventChatLeave:
 		var p protocol.ChatLeavePayload
-		json.Unmarshal(ev.Data, &p)
+		_ = json.Unmarshal(ev.Data, &p) // malformed payloads yield zero values, matching prior behavior
 		s.mu.Lock()
 		s.currentUsers = removeString(s.currentUsers, p.Handle)
 		s.mu.Unlock()
 		ce = chat.ChatEvent{Type: chat.TypeLeave, Leave: &chat.ChatLeave{Room: p.Room, Handle: p.Handle, BBS: p.BBS}}
 	case protocol.EventChatTopic:
 		var p protocol.ChatTopicPayload
-		json.Unmarshal(ev.Data, &p)
+		_ = json.Unmarshal(ev.Data, &p) // malformed payloads yield zero values, matching prior behavior
 		ce = chat.ChatEvent{Type: chat.TypeTopic, Topic: &chat.ChatTopic{Room: p.Room, Topic: p.Topic, SetBy: p.SetBy}}
 	default:
 		return
@@ -170,7 +170,7 @@ func (s *ChatSession) Join(room string) ([]chat.RoomInfo, []chat.ChatMessage, er
 	if err != nil {
 		return nil, nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // read side
 	if resp.StatusCode/100 != 2 {
 		return nil, nil, fmt.Errorf("join chat: hub returned status %d", resp.StatusCode)
 	}

--- a/internal/v3net/leaf/chat.go
+++ b/internal/v3net/leaf/chat.go
@@ -47,7 +47,9 @@ func (r *chatSessionRegistry) dispatch(ev protocol.Event) {
 		var msg struct {
 			Room string `json:"room"`
 		}
-		_ = json.Unmarshal(ev.Data, &msg) // malformed payloads yield zero values, matching prior behavior
+		if err := json.Unmarshal(ev.Data, &msg); err != nil {
+			return // drop malformed event rather than routing it to the wrong room
+		}
 		for _, s := range r.sessions {
 			if s.currentRoom == msg.Room {
 				s.deliver(ev)
@@ -56,7 +58,9 @@ func (r *chatSessionRegistry) dispatch(ev protocol.Event) {
 
 	case protocol.EventChatPrivate:
 		var msg protocol.ChatMsgPayload
-		_ = json.Unmarshal(ev.Data, &msg) // malformed payloads yield zero values, matching prior behavior
+		if err := json.Unmarshal(ev.Data, &msg); err != nil {
+			return // drop malformed event rather than delivering partial data
+		}
 		if msg.ToNode != "" && msg.ToNode != r.nodeID {
 			return
 		}
@@ -104,29 +108,39 @@ func (s *ChatSession) deliver(ev protocol.Event) {
 	switch ev.Type {
 	case protocol.EventChatMessage:
 		var p protocol.ChatMsgPayload
-		_ = json.Unmarshal(ev.Data, &p) // malformed payloads yield zero values, matching prior behavior
+		if err := json.Unmarshal(ev.Data, &p); err != nil {
+			return // drop malformed event rather than delivering partial data
+		}
 		ce = chat.ChatEvent{Type: chat.TypeMessage, Message: protoMsgToDomain(p)}
 	case protocol.EventChatPrivate:
 		var p protocol.ChatMsgPayload
-		_ = json.Unmarshal(ev.Data, &p) // malformed payloads yield zero values, matching prior behavior
+		if err := json.Unmarshal(ev.Data, &p); err != nil {
+			return // drop malformed event rather than delivering partial data
+		}
 		ce = chat.ChatEvent{Type: chat.TypePrivate, Message: protoMsgToDomain(p)}
 	case protocol.EventChatJoin:
 		var p protocol.ChatJoinPayload
-		_ = json.Unmarshal(ev.Data, &p) // malformed payloads yield zero values, matching prior behavior
+		if err := json.Unmarshal(ev.Data, &p); err != nil {
+			return // drop malformed event rather than corrupting the user list
+		}
 		s.mu.Lock()
 		s.currentUsers = append(s.currentUsers, p.Handle)
 		s.mu.Unlock()
 		ce = chat.ChatEvent{Type: chat.TypeJoin, Join: &chat.ChatJoin{Room: p.Room, Handle: p.Handle, BBS: p.BBS}}
 	case protocol.EventChatLeave:
 		var p protocol.ChatLeavePayload
-		_ = json.Unmarshal(ev.Data, &p) // malformed payloads yield zero values, matching prior behavior
+		if err := json.Unmarshal(ev.Data, &p); err != nil {
+			return // drop malformed event rather than corrupting the user list
+		}
 		s.mu.Lock()
 		s.currentUsers = removeString(s.currentUsers, p.Handle)
 		s.mu.Unlock()
 		ce = chat.ChatEvent{Type: chat.TypeLeave, Leave: &chat.ChatLeave{Room: p.Room, Handle: p.Handle, BBS: p.BBS}}
 	case protocol.EventChatTopic:
 		var p protocol.ChatTopicPayload
-		_ = json.Unmarshal(ev.Data, &p) // malformed payloads yield zero values, matching prior behavior
+		if err := json.Unmarshal(ev.Data, &p); err != nil {
+			return // drop malformed event rather than delivering partial data
+		}
 		ce = chat.ChatEvent{Type: chat.TypeTopic, Topic: &chat.ChatTopic{Room: p.Room, Topic: p.Topic, SetBy: p.SetBy}}
 	default:
 		return

--- a/internal/v3net/leaf/nal.go
+++ b/internal/v3net/leaf/nal.go
@@ -57,7 +57,7 @@ func (l *Leaf) ProposeArea(req protocol.AreaProposalRequest) (*protocol.Proposal
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // read side
 
 	if resp.StatusCode != 200 {
 		// Diagnostic error body: truncation at the cap is acceptable here.

--- a/internal/v3net/leaf/poller.go
+++ b/internal/v3net/leaf/poller.go
@@ -31,7 +31,7 @@ func (l *Leaf) poll(ctx context.Context) (int, error) {
 		}
 
 		body, err := readBody(resp.Body, maxPollRespBytes)
-		resp.Body.Close()
+		_ = resp.Body.Close() // read side
 
 		if err != nil {
 			return total, fmt.Errorf("leaf: read response: %w", err)

--- a/internal/v3net/leaf/sender.go
+++ b/internal/v3net/leaf/sender.go
@@ -41,7 +41,7 @@ func (l *Leaf) subscribe(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("leaf: subscribe POST: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // read side
 
 	body, err := readBody(resp.Body, maxRespBytes)
 	if err != nil {
@@ -95,8 +95,8 @@ func (l *Leaf) SendChatCtx(ctx context.Context, text, handle string) error {
 	if err != nil {
 		return fmt.Errorf("leaf: chat join: %w", err)
 	}
-	io.Copy(io.Discard, joinResp.Body)
-	joinResp.Body.Close()
+	_, _ = io.Copy(io.Discard, joinResp.Body) // drain for connection reuse
+	_ = joinResp.Body.Close()                 // read side
 	if joinResp.StatusCode/100 != 2 {
 		return fmt.Errorf("leaf: chat join returned %d", joinResp.StatusCode)
 	}
@@ -110,8 +110,8 @@ func (l *Leaf) SendChatCtx(ctx context.Context, text, handle string) error {
 	if err != nil {
 		return fmt.Errorf("leaf: chat post: %w", err)
 	}
-	io.Copy(io.Discard, postResp.Body)
-	postResp.Body.Close()
+	_, _ = io.Copy(io.Discard, postResp.Body) // drain for connection reuse
+	_ = postResp.Body.Close()                 // read side
 	if postResp.StatusCode/100 != 2 {
 		return fmt.Errorf("leaf: chat post returned %d", postResp.StatusCode)
 	}
@@ -171,8 +171,8 @@ func (l *Leaf) signedPostCtx(ctx context.Context, path string, body []byte) erro
 	if err != nil {
 		return fmt.Errorf("leaf: POST %s: %w", path, err)
 	}
-	defer resp.Body.Close()
-	io.Copy(io.Discard, resp.Body)
+	defer func() { _ = resp.Body.Close() }() // read side
+	_, _ = io.Copy(io.Discard, resp.Body)    // drain for connection reuse
 
 	if resp.StatusCode/100 != 2 {
 		return fmt.Errorf("leaf: POST %s returned %d", path, resp.StatusCode)
@@ -241,7 +241,7 @@ func (l *Leaf) get(path string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("leaf: GET %s: %w", path, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // read side
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GET %s: status %d", path, resp.StatusCode)
 	}

--- a/internal/v3net/leaf/sender.go
+++ b/internal/v3net/leaf/sender.go
@@ -95,8 +95,8 @@ func (l *Leaf) SendChatCtx(ctx context.Context, text, handle string) error {
 	if err != nil {
 		return fmt.Errorf("leaf: chat join: %w", err)
 	}
-	_, _ = io.Copy(io.Discard, joinResp.Body) // drain for connection reuse
-	_ = joinResp.Body.Close()                 // read side
+	drainBody(joinResp.Body)  // drain for connection reuse
+	_ = joinResp.Body.Close() // read side
 	if joinResp.StatusCode/100 != 2 {
 		return fmt.Errorf("leaf: chat join returned %d", joinResp.StatusCode)
 	}
@@ -110,8 +110,8 @@ func (l *Leaf) SendChatCtx(ctx context.Context, text, handle string) error {
 	if err != nil {
 		return fmt.Errorf("leaf: chat post: %w", err)
 	}
-	_, _ = io.Copy(io.Discard, postResp.Body) // drain for connection reuse
-	_ = postResp.Body.Close()                 // read side
+	drainBody(postResp.Body)  // drain for connection reuse
+	_ = postResp.Body.Close() // read side
 	if postResp.StatusCode/100 != 2 {
 		return fmt.Errorf("leaf: chat post returned %d", postResp.StatusCode)
 	}
@@ -172,7 +172,7 @@ func (l *Leaf) signedPostCtx(ctx context.Context, path string, body []byte) erro
 		return fmt.Errorf("leaf: POST %s: %w", path, err)
 	}
 	defer func() { _ = resp.Body.Close() }() // read side
-	_, _ = io.Copy(io.Discard, resp.Body)    // drain for connection reuse
+	drainBody(resp.Body)                     // drain for connection reuse
 
 	if resp.StatusCode/100 != 2 {
 		return fmt.Errorf("leaf: POST %s returned %d", path, resp.StatusCode)
@@ -216,6 +216,13 @@ const (
 	// maxPollRespBytes bounds a message-page response.
 	maxPollRespBytes = 8 << 20 // 8MB
 )
+
+// drainBody discards a response body (capped at maxRespBytes) so the
+// underlying connection can be reused without letting a slow or oversized
+// hub response stall the request until the client timeout.
+func drainBody(body io.Reader) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(body, maxRespBytes))
+}
 
 // readBody reads an HTTP response body capped at limit bytes, erroring if
 // the body exceeds the cap (never parse truncated data as if complete).

--- a/internal/v3net/leaf/sse.go
+++ b/internal/v3net/leaf/sse.go
@@ -57,7 +57,7 @@ func (l *Leaf) connectSSE(ctx context.Context, reconnect bool) error {
 	if err != nil {
 		return fmt.Errorf("SSE connect: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // read side
 
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("SSE status: %d", resp.StatusCode)

--- a/internal/v3net/nal/nal.go
+++ b/internal/v3net/nal/nal.go
@@ -212,7 +212,7 @@ func Fetch(ctx context.Context, url string, client *http.Client) (*protocol.NAL,
 	if err != nil {
 		return nil, fmt.Errorf("nal: fetch: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // read side
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("nal: fetch status %d", resp.StatusCode)

--- a/internal/v3net/registry/registry.go
+++ b/internal/v3net/registry/registry.go
@@ -77,7 +77,7 @@ func fetchRemote(ctx context.Context, url string) ([]protocol.RegistryEntry, err
 	if err != nil {
 		return nil, fmt.Errorf("GET %s: %w", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // read side
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GET %s returned %d", url, resp.StatusCode)

--- a/internal/v3net/service.go
+++ b/internal/v3net/service.go
@@ -175,7 +175,7 @@ func New(cfg config.V3NetConfig) (*Service, error) {
 		}
 		// Create data dir before hub.New opens the SQLite database.
 		if err := os.MkdirAll(cfg.Hub.DataDir, 0755); err != nil {
-			ix.Close()
+			_ = ix.Close() // cleanup on error path
 			return nil, fmt.Errorf("v3net: create hub data dir: %w", err)
 		}
 		h, err := hub.New(hub.Config{
@@ -186,7 +186,7 @@ func New(cfg config.V3NetConfig) (*Service, error) {
 			Networks:    networks,
 		})
 		if err != nil {
-			ix.Close()
+			_ = ix.Close() // cleanup on error path
 			return nil, fmt.Errorf("v3net: create hub: %w", err)
 		}
 		hubAutoInit(cfg, h, ks)
@@ -256,7 +256,7 @@ func (s *Service) Close() error {
 		l.Close()
 	}
 	if s.hub != nil {
-		s.hub.Close()
+		_ = s.hub.Close() // best-effort shutdown
 	}
 	return s.dedupIdx.Close()
 }

--- a/internal/ziplab/config.go
+++ b/internal/ziplab/config.go
@@ -146,7 +146,7 @@ func archiverTypesFromConfig(cfg archiver.Config) []ArchiveType {
 		types = append(types, at)
 		// Also add additional extensions (e.g., .lzh for lha archiver)
 		for _, ext := range a.Extensions {
-			if strings.ToLower(ext) != strings.ToLower(a.Extension) {
+			if !strings.EqualFold(ext, a.Extension) {
 				extra := at
 				extra.Extension = ext
 				types = append(types, extra)

--- a/internal/ziplab/display.go
+++ b/internal/ziplab/display.go
@@ -91,7 +91,7 @@ func ParseNFO(filePath string) (*NFOConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open NFO file %s: %w", filePath, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }() // read-only
 
 	nfo := &NFOConfig{
 		Entries: make(map[string]NFOEntry),

--- a/internal/ziplab/diz.go
+++ b/internal/ziplab/diz.go
@@ -98,7 +98,7 @@ func ExtractDIZFromZip(archivePath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to open zip %s: %w", archivePath, err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }() // read-only zip reader
 
 	var dizFile *zip.File
 	for _, f := range r.File {
@@ -120,7 +120,7 @@ func ExtractDIZFromZip(archivePath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to read %s from %s: %w", dizFile.Name, archivePath, err)
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }() // read-only
 
 	data, readErr := io.ReadAll(io.LimitReader(rc, 10*1024))
 	if readErr != nil {
@@ -160,7 +160,7 @@ func ExtractDIZFromArchive(archivePath, configPath string) (string, error) {
 	if workDir == "" {
 		return "", nil
 	}
-	defer os.RemoveAll(workDir)
+	defer func() { _ = os.RemoveAll(workDir) }() // best-effort temp cleanup
 
 	return p.findAndReadDIZ(workDir), nil
 }

--- a/internal/ziplab/pipeline.go
+++ b/internal/ziplab/pipeline.go
@@ -85,7 +85,7 @@ func (p *Processor) RunPipeline(archivePath string, statusFn StatusCallback) Pip
 		}
 		// Clean up work directory when pipeline finishes
 		if workDir != "" {
-			defer os.RemoveAll(workDir)
+			defer func() { _ = os.RemoveAll(workDir) }() // best-effort temp cleanup
 		}
 	}
 
@@ -214,7 +214,7 @@ func (p *Processor) handleScanFailure(archivePath string) {
 func (p *Processor) DisplayPipeline(w io.Writer, nfo *NFOConfig, ansiContent []byte, archivePath string) PipelineResult {
 	// Display the ZIPLAB.ANS background
 	if ansiContent != nil {
-		w.Write(ansiContent)
+		_, _ = w.Write(ansiContent) // best-effort display
 	}
 
 	// Build the status callback that writes ANSI sequences to the terminal
@@ -224,7 +224,7 @@ func (p *Processor) DisplayPipeline(w io.Writer, nfo *NFOConfig, ansiContent []b
 		}
 		seq := nfo.BuildStatusSequence(int(step), status)
 		if seq != "" {
-			w.Write([]byte(seq))
+			_, _ = w.Write([]byte(seq)) // best-effort display
 		}
 	}
 
@@ -233,7 +233,7 @@ func (p *Processor) DisplayPipeline(w io.Writer, nfo *NFOConfig, ansiContent []b
 	// Move cursor below all NFO content so subsequent output doesn't overwrite
 	if nfo != nil {
 		if maxRow := nfo.MaxRow(); maxRow > 0 {
-			w.Write([]byte(fmt.Sprintf("\x1b[%d;1H", maxRow+1)))
+			_, _ = w.Write([]byte(fmt.Sprintf("\x1b[%d;1H", maxRow+1))) // best-effort display
 		}
 	}
 

--- a/internal/ziplab/pipeline.go
+++ b/internal/ziplab/pipeline.go
@@ -233,7 +233,7 @@ func (p *Processor) DisplayPipeline(w io.Writer, nfo *NFOConfig, ansiContent []b
 	// Move cursor below all NFO content so subsequent output doesn't overwrite
 	if nfo != nil {
 		if maxRow := nfo.MaxRow(); maxRow > 0 {
-			_, _ = w.Write([]byte(fmt.Sprintf("\x1b[%d;1H", maxRow+1))) // best-effort display
+			_, _ = fmt.Fprintf(w, "\x1b[%d;1H", maxRow+1) // best-effort display
 		}
 	}
 

--- a/internal/ziplab/processor.go
+++ b/internal/ziplab/processor.go
@@ -274,6 +274,8 @@ func (p *Processor) removeFilesFromZip(zipPath string, patterns []string) (retEr
 	}
 
 	if removed == 0 {
+		// Close before removing: some platforms can't delete open files.
+		_ = outFile.Close()    // discarding the file; close error is moot
 		_ = os.Remove(tmpPath) // nothing changed; discard temp copy
 		retErr = nil
 		return nil

--- a/internal/ziplab/processor.go
+++ b/internal/ziplab/processor.go
@@ -62,7 +62,7 @@ func (p *Processor) testZipIntegrity(zipPath string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open zip %s: %w", zipPath, err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }() // read-only zip reader
 
 	for _, f := range r.File {
 		rc, err := f.Open()
@@ -70,10 +70,10 @@ func (p *Processor) testZipIntegrity(zipPath string) error {
 			return fmt.Errorf("corrupt entry %s: %w", f.Name, err)
 		}
 		if _, err := io.Copy(io.Discard, rc); err != nil {
-			rc.Close()
+			_ = rc.Close() // read-only
 			return fmt.Errorf("corrupt data in %s: %w", f.Name, err)
 		}
-		rc.Close()
+		_ = rc.Close() // read-only
 	}
 	return nil
 }
@@ -98,14 +98,14 @@ func (p *Processor) StepExtract(archivePath string) (string, error) {
 
 	if at.Native {
 		if err := p.extractZip(archivePath, workDir); err != nil {
-			os.RemoveAll(workDir)
+			_ = os.RemoveAll(workDir) // cleanup on error path
 			return "", err
 		}
 		return workDir, nil
 	}
 
 	if err := p.runExternalCommand(at.ExtractCommand, at.ExtractArgs, archivePath, workDir, 0); err != nil {
-		os.RemoveAll(workDir)
+		_ = os.RemoveAll(workDir) // cleanup on error path
 		return "", err
 	}
 	return workDir, nil
@@ -117,7 +117,7 @@ func (p *Processor) extractZip(zipPath, destDir string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open zip %s: %w", zipPath, err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }() // read-only zip reader
 
 	for _, f := range r.File {
 		targetPath := filepath.Join(destDir, f.Name)
@@ -146,18 +146,20 @@ func (p *Processor) extractZip(zipPath, destDir string) error {
 
 		rc, err := f.Open()
 		if err != nil {
-			outFile.Close()
+			_ = outFile.Close() // cleanup on error path
 			return fmt.Errorf("failed to open zip entry %s: %w", f.Name, err)
 		}
 
 		if _, err := io.Copy(outFile, rc); err != nil {
-			rc.Close()
-			outFile.Close()
+			_ = rc.Close()      // cleanup on error path
+			_ = outFile.Close() // cleanup on error path
 			return fmt.Errorf("failed to extract %s: %w", f.Name, err)
 		}
 
-		rc.Close()
-		outFile.Close()
+		_ = rc.Close() // read side
+		if err := outFile.Close(); err != nil {
+			return fmt.Errorf("failed to finalize %s: %w", targetPath, err)
+		}
 	}
 	return nil
 }
@@ -229,7 +231,7 @@ func (p *Processor) removeFilesFromZip(zipPath string, patterns []string) (retEr
 	if err != nil {
 		return fmt.Errorf("failed to open zip: %w", err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }() // read-only zip reader
 
 	tmpPath := zipPath + ".tmp"
 	outFile, err := os.Create(tmpPath)
@@ -237,15 +239,15 @@ func (p *Processor) removeFilesFromZip(zipPath string, patterns []string) (retEr
 		return fmt.Errorf("failed to create temp zip: %w", err)
 	}
 	defer func() {
-		outFile.Close()
+		_ = outFile.Close() // no-op after the explicit Close on the success path
 		if retErr != nil {
-			os.Remove(tmpPath)
+			_ = os.Remove(tmpPath) // cleanup on error path
 		}
 	}()
 
 	w := zip.NewWriter(outFile)
 	if r.Comment != "" {
-		w.SetComment(r.Comment)
+		_ = w.SetComment(r.Comment) // came from a valid zip, so it always fits
 	}
 
 	removed := 0
@@ -262,7 +264,7 @@ func (p *Processor) removeFilesFromZip(zipPath string, patterns []string) (retEr
 		seen[f.Name] = true
 
 		if err := copyZipEntryRaw(w, f); err != nil {
-			w.Close()
+			_ = w.Close() // cleanup on error path
 			return fmt.Errorf("failed to copy entry %s: %w", f.Name, err)
 		}
 	}
@@ -272,11 +274,14 @@ func (p *Processor) removeFilesFromZip(zipPath string, patterns []string) (retEr
 	}
 
 	if removed == 0 {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath) // nothing changed; discard temp copy
 		retErr = nil
 		return nil
 	}
 
+	if err := outFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp zip: %w", err)
+	}
 	return os.Rename(tmpPath, zipPath)
 }
 
@@ -295,7 +300,7 @@ func shouldRemoveFile(name string, patterns []string) bool {
 // (case-insensitive) in the work directory and one level of subdirectories.
 func (p *Processor) findAndReadDIZ(workDir string) string {
 	var ansPath, dizPath string
-	filepath.WalkDir(workDir, func(path string, d os.DirEntry, err error) error {
+	_ = filepath.WalkDir(workDir, func(path string, d os.DirEntry, err error) error { // callback never returns an error
 		if err != nil {
 			return nil
 		}
@@ -342,7 +347,7 @@ func (p *Processor) loadRemovePatterns() []string {
 		slog.Warn("could not open patterns file", "path", patternsPath, "error", err)
 		return nil
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }() // read-only
 
 	var patterns []string
 	scanner := bufio.NewScanner(f)
@@ -404,7 +409,7 @@ func (p *Processor) setZipComment(zipPath, comment string) (retErr error) {
 	if err != nil {
 		return fmt.Errorf("failed to open zip: %w", err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }() // read-only zip reader
 
 	tmpPath := zipPath + ".tmp"
 	outFile, err := os.Create(tmpPath)
@@ -412,18 +417,21 @@ func (p *Processor) setZipComment(zipPath, comment string) (retErr error) {
 		return fmt.Errorf("failed to create temp zip: %w", err)
 	}
 	defer func() {
-		outFile.Close()
+		_ = outFile.Close() // no-op after the explicit Close on the success path
 		if retErr != nil {
-			os.Remove(tmpPath)
+			_ = os.Remove(tmpPath) // cleanup on error path
 		}
 	}()
 
 	w := zip.NewWriter(outFile)
-	w.SetComment(comment)
+	if err := w.SetComment(comment); err != nil {
+		_ = w.Close() // cleanup on error path
+		return fmt.Errorf("failed to set zip comment: %w", err)
+	}
 
 	for _, f := range r.File {
 		if err := copyZipEntryRaw(w, f); err != nil {
-			w.Close()
+			_ = w.Close() // cleanup on error path
 			return fmt.Errorf("failed to copy entry %s: %w", f.Name, err)
 		}
 	}
@@ -432,6 +440,9 @@ func (p *Processor) setZipComment(zipPath, comment string) (retErr error) {
 		return fmt.Errorf("failed to finalize zip: %w", err)
 	}
 
+	if err := outFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp zip: %w", err)
+	}
 	return os.Rename(tmpPath, zipPath)
 }
 
@@ -465,7 +476,7 @@ func (p *Processor) addFileToZip(zipPath, name string, data []byte) (retErr erro
 	if err != nil {
 		return fmt.Errorf("failed to open zip: %w", err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }() // read-only zip reader
 
 	tmpPath := zipPath + ".tmp"
 	outFile, err := os.Create(tmpPath)
@@ -473,16 +484,16 @@ func (p *Processor) addFileToZip(zipPath, name string, data []byte) (retErr erro
 		return fmt.Errorf("failed to create temp zip: %w", err)
 	}
 	defer func() {
-		outFile.Close()
+		_ = outFile.Close() // no-op after the explicit Close on the success path
 		if retErr != nil {
-			os.Remove(tmpPath)
+			_ = os.Remove(tmpPath) // cleanup on error path
 		}
 	}()
 
 	w := zip.NewWriter(outFile)
 
 	if r.Comment != "" {
-		w.SetComment(r.Comment)
+		_ = w.SetComment(r.Comment) // came from a valid zip, so it always fits
 	}
 
 	seen := make(map[string]bool)
@@ -493,22 +504,22 @@ func (p *Processor) addFileToZip(zipPath, name string, data []byte) (retErr erro
 		seen[f.Name] = true
 
 		if err := copyZipEntryRaw(w, f); err != nil {
-			w.Close()
+			_ = w.Close() // cleanup on error path
 			return fmt.Errorf("failed to copy entry %s: %w", f.Name, err)
 		}
 	}
 
 	if seen[name] {
-		w.Close()
+		_ = w.Close() // cleanup on error path
 		return fmt.Errorf("entry %s already exists in archive", name)
 	}
 	fw, err := w.Create(name)
 	if err != nil {
-		w.Close()
+		_ = w.Close() // cleanup on error path
 		return fmt.Errorf("failed to add %s: %w", name, err)
 	}
 	if _, err := fw.Write(data); err != nil {
-		w.Close()
+		_ = w.Close() // cleanup on error path
 		return fmt.Errorf("failed to write %s: %w", name, err)
 	}
 
@@ -516,6 +527,9 @@ func (p *Processor) addFileToZip(zipPath, name string, data []byte) (retErr erro
 		return fmt.Errorf("failed to finalize zip: %w", err)
 	}
 
+	if err := outFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp zip: %w", err)
+	}
 	return os.Rename(tmpPath, zipPath)
 }
 

--- a/internal/ziplab/viewer.go
+++ b/internal/ziplab/viewer.go
@@ -52,14 +52,14 @@ func formatArchiveListing(w io.Writer, zipPath string, filename string, termHeig
 	if err != nil {
 		return 0, fmt.Errorf("failed to open archive: %w", err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }() // read-only zip reader
 
 	// Header — sanitize filename to prevent terminal/pipe code injection
-	fmt.Fprintf(w, "\r\n|15--- Archive Contents: %s ---|07\r\n\r\n", sanitizeEntryName(filename))
+	_, _ = fmt.Fprintf(w, "\r\n|15--- Archive Contents: %s ---|07\r\n\r\n", sanitizeEntryName(filename)) // best-effort display
 
 	// Column headers
-	fmt.Fprintf(w, "|14  #   Size       Date       Name|07\r\n")
-	fmt.Fprintf(w, "|08 ---  ---------  ---------- --------------------------------|07\r\n")
+	_, _ = fmt.Fprintf(w, "|14  #   Size       Date       Name|07\r\n")                             // best-effort display
+	_, _ = fmt.Fprintf(w, "|08 ---  ---------  ---------- --------------------------------|07\r\n") // best-effort display
 
 	var totalSize uint64
 	fileCount := 0
@@ -69,18 +69,18 @@ func formatArchiveListing(w io.Writer, zipPath string, filename string, termHeig
 		sizeStr := util.FormatFileSize(int64(f.UncompressedSize64))
 		dateStr := f.Modified.Format("01/02/2006")
 
-		fmt.Fprintf(w, "|07 %3d  %9s  %s  |15%s|07\r\n",
+		_, _ = fmt.Fprintf(w, "|07 %3d  %9s  %s  |15%s|07\r\n", // best-effort display
 			fileCount, sizeStr, dateStr, sanitizeEntryName(f.Name))
 
 		totalSize += f.UncompressedSize64
 	}
 
 	// Summary
-	fmt.Fprintf(w, "\r\n|07 %d file(s), %s total\r\n",
+	_, _ = fmt.Fprintf(w, "\r\n|07 %d file(s), %s total\r\n", // best-effort display
 		fileCount, util.FormatFileSize(int64(totalSize)))
 
 	// Prompt
-	fmt.Fprintf(w, "\r\n|07[|15#|07]=Extract  [|15Q|07]=Quit\r\n")
+	_, _ = fmt.Fprintf(w, "\r\n|07[|15#|07]=Extract  [|15Q|07]=Quit\r\n") // best-effort display
 
 	return fileCount, nil
 }
@@ -100,7 +100,7 @@ func extractSingleEntry(zipPath string, entryNum int) (string, func(), error) {
 	if err != nil {
 		return "", noop, fmt.Errorf("failed to open archive: %w", err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }() // read-only zip reader
 
 	if entryNum > len(r.File) {
 		return "", noop, fmt.Errorf("entry %d out of range (archive has %d entries)", entryNum, len(r.File))
@@ -117,7 +117,7 @@ func extractSingleEntry(zipPath string, entryNum int) (string, func(), error) {
 		return "", noop, fmt.Errorf("failed to create temp dir: %w", err)
 	}
 
-	cleanup := func() { os.RemoveAll(tmpDir) }
+	cleanup := func() { _ = os.RemoveAll(tmpDir) } // best-effort temp cleanup
 
 	// Use Base to prevent zip slip
 	destPath := filepath.Join(tmpDir, filepath.Base(entry.Name))
@@ -127,18 +127,21 @@ func extractSingleEntry(zipPath string, entryNum int) (string, func(), error) {
 		cleanup()
 		return "", noop, fmt.Errorf("failed to open entry: %w", err)
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }() // read-only
 
 	outFile, err := os.Create(destPath)
 	if err != nil {
 		cleanup()
 		return "", noop, fmt.Errorf("failed to create output file: %w", err)
 	}
-	defer outFile.Close()
-
 	if _, err := io.Copy(outFile, rc); err != nil {
+		_ = outFile.Close() // cleanup on error path
 		cleanup()
 		return "", noop, fmt.Errorf("failed to extract file: %w", err)
+	}
+	if err := outFile.Close(); err != nil {
+		cleanup()
+		return "", noop, fmt.Errorf("failed to finalize extracted file: %w", err)
 	}
 
 	return destPath, cleanup, nil

--- a/internal/ziplab/viewer.go
+++ b/internal/ziplab/viewer.go
@@ -170,7 +170,7 @@ func RunZipLabView(ctx context.Context, s ssh.Session, terminal *term.Terminal, 
 	terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes(buf.Bytes()), outputMode)
 
 	for {
-		prompt := fmt.Sprintf("\r\n|07ZipLab [|15#|07/|15Q|07]: |15")
+		prompt := "\r\n|07ZipLab [|15#|07/|15Q|07]: |15"
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(prompt)), outputMode)
 
 		line, err := readLine()

--- a/internal/ziplab/viewer_test.go
+++ b/internal/ziplab/viewer_test.go
@@ -3,12 +3,18 @@ package ziplab
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gliderlabs/ssh"
+	"golang.org/x/term"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 )
 
 // createTestZipWithTimes creates a ZIP with entries that have specific modification times.
@@ -262,6 +268,9 @@ func TestFormatArchiveListing_ManyFiles(t *testing.T) {
 }
 
 func TestRunZipLabView_Exists(t *testing.T) {
-	fn := RunZipLabView
+	// Explicit function type so any signature change fails compilation.
+	var fn func(ctx context.Context, s ssh.Session, terminal *term.Terminal,
+		filePath, filename string, outputMode ansi.OutputMode,
+		readLine ReadLineFunc, readKey ReadKeyFunc) = RunZipLabView
 	_ = fn
 }

--- a/internal/ziplab/viewer_test.go
+++ b/internal/ziplab/viewer_test.go
@@ -3,18 +3,12 @@ package ziplab
 import (
 	"archive/zip"
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/gliderlabs/ssh"
-	"golang.org/x/term"
-
-	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 )
 
 // createTestZipWithTimes creates a ZIP with entries that have specific modification times.
@@ -268,7 +262,6 @@ func TestFormatArchiveListing_ManyFiles(t *testing.T) {
 }
 
 func TestRunZipLabView_Exists(t *testing.T) {
-	var fn func(context.Context, ssh.Session, *term.Terminal, string, string, ansi.OutputMode, ReadLineFunc, ReadKeyFunc)
-	fn = RunZipLabView
+	fn := RunZipLabView
 	_ = fn
 }

--- a/internal/ziplab/viewer_test.go
+++ b/internal/ziplab/viewer_test.go
@@ -267,10 +267,13 @@ func TestFormatArchiveListing_ManyFiles(t *testing.T) {
 	}
 }
 
+// zipLabViewSig pins RunZipLabView's signature so any change fails compilation.
+type zipLabViewSig = func(ctx context.Context, s ssh.Session, terminal *term.Terminal,
+	filePath, filename string, outputMode ansi.OutputMode,
+	readLine ReadLineFunc, readKey ReadKeyFunc)
+
 func TestRunZipLabView_Exists(t *testing.T) {
-	// Explicit function type so any signature change fails compilation.
-	var fn func(ctx context.Context, s ssh.Session, terminal *term.Terminal,
-		filePath, filename string, outputMode ansi.OutputMode,
-		readLine ReadLineFunc, readKey ReadKeyFunc) = RunZipLabView
-	_ = fn
+	// The conversion compiles only while RunZipLabView matches the pinned
+	// signature exactly.
+	_ = zipLabViewSig(RunZipLabView)
 }


### PR DESCRIPTION
## Summary
Step 8 of the refactoring plan. The scorecard's "~50 errcheck findings" turned out to be golangci-lint's 50-per-linter **display cap** — the real count was **1,092**. This PR takes errcheck to **zero** and staticcheck from 93 to 16 (the remainder are QF100x De Morgan/tagged-switch style rewrites, deliberately skipped as churn).

## Real bugs found and fixed (each with reasoning; QWK one TDD'd)
- **`qwk/writer.go`**: `defer zw.Close()` swallowed zip-finalize errors — a truncated QWK packet could be reported as a successful download. Regression test added (failed before the fix).
- **`menu/qwk_handler.go`**: temp-file close error could offer a truncated packet — now aborts.
- **`jam/message.go`**: `DeleteMessage` ignored 20 `binary.Write` errors and crash-consistency `Sync`s during header rewrite — now propagated.
- Write-side closes before atomic renames now surface errors in `ziplab`, `ftn/bundle`, `tosser` export/pack, and the vision3 blocklist writer.

## Approach
- Errors are handled (wrapped return or slog) wherever a sane path exists; intentional discards use `_ =` with a rationale comment (cleanup-on-error, read-only closes, best-effort display writes, shutdown teardown).
- New `internal/jsutil` helper (Set/DefineAccessor with slog) cleared ~345 goja-binding registration findings in scripting/syncjs.
- `.golangci.yml`: `terminalio.WriteStringCP437` added to the documented terminal-write exclusion family.
- V3Net/FTN wire behavior untouched; no exported signature changes.

## Testing
Full suite 1693 pass in 56 packages (jsutil is new); `-race` clean on jam/qwk/tosser/ftn/ziplab; gofmt/vet clean; lint verified independently: **0 errcheck / 16 staticcheck / 2 unused** (the 2 `unused` are the staged NAL handlers, wired in PR #91).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of file transfers, message storage, archives, networking, and database operations through more consistent cleanup and error handling.
  * Preserved terminal output and interactive behavior when individual display or connection operations fail.
  * Improved QWK archive finalization so write and packaging failures are reported more accurately.
  * Fixed a word-wrapping cursor-mapping issue affecting editor display.

* **Compatibility**
  * Improved consistency and resilience of JavaScript scripting interfaces and legacy SSH algorithm support.

* **Tests**
  * Added coverage for archive-finalization failures and updated related test expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->