### PR TITLE
test(hub): deflake TestSSEHTTPStream (2s → 15s deadline)

### DIFF
--- a/internal/v3net/hub/hub_test.go
+++ b/internal/v3net/hub/hub_test.go
@@ -372,7 +372,10 @@ func TestSSEHTTPStream(t *testing.T) {
 		if eventType != "chat" {
 			t.Errorf("expected chat event, got %q", eventType)
 		}
-	case <-time.After(2 * time.Second):
+	// Generous deadline: 2s flaked repeatedly on loaded CI runners under
+	// -race. The event either arrives or this fails at the timeout, so a
+	// long deadline costs nothing on the passing path.
+	case <-time.After(15 * time.Second):
 		t.Error("timed out waiting for SSE event over HTTP")
 	}
 }

--- a/internal/v3net/hub/hub_test.go
+++ b/internal/v3net/hub/hub_test.go
@@ -373,8 +373,8 @@ func TestSSEHTTPStream(t *testing.T) {
 			t.Errorf("expected chat event, got %q", eventType)
 		}
 	// Generous deadline: 2s flaked repeatedly on loaded CI runners under
-	// -race. The event either arrives or this fails at the timeout, so a
-	// long deadline costs nothing on the passing path.
+	// -race. Passing runs aren't delayed (the done case wins as soon as
+	// the event arrives); only failing runs wait out the full deadline.
 	case <-time.After(15 * time.Second):
 		t.Error("timed out waiting for SSE event over HTTP")
 	}


### PR DESCRIPTION
## Summary
`TestSSEHTTPStream` failed three times today on unrelated PRs (#88, #89, #95) with "timed out waiting for SSE event over HTTP" — a 2-second hard deadline that's too tight on loaded CI runners under `-race`. Each rerun passed, confirming flake.

The deadline goes to 15s: the SSE event either arrives (fast path unchanged) or the test still fails, so the longer timeout only removes false negatives.

## Testing
`go test -race -run TestSSEHTTPStream -count=3` passes locally; gofmt clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of the SSE streaming test by increasing the event wait deadline to 15 seconds (from 2 seconds).
  * Added an in-test note clarifying why the longer timeout is used for awaiting SSE events over HTTP.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->