### PR TITLE
feat: WFC access toggle in config TUI

### DIFF
--- a/cmd/vision3/main.go
+++ b/cmd/vision3/main.go
@@ -1527,6 +1527,7 @@ func main() {
 	// Initialize and start the WFC admin server.
 	// adminMinLevel is a live getter so config hot-reloads take effect immediately.
 	adminMinLevel = func() int { return menuExecutor.GetServerConfig().CoSysOpLevel }
+	wfcEnabled = func() bool { return menuExecutor.GetServerConfig().WFCEnabled }
 	adminServer = admin.NewServer(admin.ServerConfig{
 		Reg:        sessionRegistry,
 		SystemName: serverConfig.BoardName,

--- a/cmd/vision3/wfc_admin.go
+++ b/cmd/vision3/wfc_admin.go
@@ -18,6 +18,11 @@ var adminServer *admin.Server
 // a restart. Set once at startup; tests may replace it with a stub.
 var adminMinLevel func() int
 
+// wfcEnabled reports whether remote WFC admin access is allowed at all.
+// Like adminMinLevel it is a live getter so config hot-reloads take effect
+// without a restart. Nil (not yet wired, or a test that left it unset) denies.
+var wfcEnabled func() bool
+
 // wfcAdminHandleKey is the context key used to stash the admin handle during
 // public-key authentication so wfcAdminSubsystem can re-verify it.
 type wfcAdminHandleKey struct{}
@@ -36,6 +41,11 @@ func wfcPublicKeyHandler(ctx ssh.Context, key ssh.PublicKey) bool {
 		return false
 	}
 	if !authorizeAdmin(u.Handle) {
+		if wfcEnabled == nil || !wfcEnabled() {
+			slog.Info("wfc-admin: public key rejected, wfc access disabled",
+				"user", u.Handle, "addr", ctx.RemoteAddr())
+			return false
+		}
 		minLevel := 0
 		if adminMinLevel != nil {
 			minLevel = adminMinLevel()
@@ -49,12 +59,12 @@ func wfcPublicKeyHandler(ctx ssh.Context, key ssh.PublicKey) bool {
 	return true
 }
 
-// authorizeAdmin returns true when the user identified by handle exists and
-// has an access level >= the live adminMinLevel threshold. It denies access if
-// the getter is nil (daemon not yet initialised or running in a test that
-// deliberately left it unset).
+// authorizeAdmin returns true when WFC admin access is enabled and the user
+// identified by handle exists with an access level >= the live adminMinLevel
+// threshold. It denies access if either live getter is nil (daemon not yet
+// initialised or running in a test that deliberately left it unset).
 func authorizeAdmin(handle string) bool {
-	if userMgr == nil || adminMinLevel == nil {
+	if userMgr == nil || adminMinLevel == nil || wfcEnabled == nil || !wfcEnabled() {
 		return false
 	}
 	u, found := userMgr.GetUser(handle)

--- a/cmd/vision3/wfc_admin_test.go
+++ b/cmd/vision3/wfc_admin_test.go
@@ -13,6 +13,7 @@ func TestAuthorizeAdmin(t *testing.T) {
 		&user.User{Handle: "boss", AccessLevel: 255},
 	)
 	adminMinLevel = func() int { return 250 }
+	wfcEnabled = func() bool { return true }
 
 	if authorizeAdmin("lowly") {
 		t.Error("expected lowly (level 10) to be denied admin access")
@@ -25,8 +26,26 @@ func TestAuthorizeAdmin(t *testing.T) {
 func TestAuthorizeAdmin_UnknownUser(t *testing.T) {
 	userMgr = user.NewUserMgrForTest()
 	adminMinLevel = func() int { return 250 }
+	wfcEnabled = func() bool { return true }
 
 	if authorizeAdmin("ghost") {
 		t.Error("expected unknown user to be denied admin access")
+	}
+}
+
+func TestAuthorizeAdmin_WFCDisabled(t *testing.T) {
+	userMgr = user.NewUserMgrForTest(
+		&user.User{Handle: "boss", AccessLevel: 255},
+	)
+	adminMinLevel = func() int { return 250 }
+
+	wfcEnabled = func() bool { return false }
+	if authorizeAdmin("boss") {
+		t.Error("expected admin access denied when WFC is disabled")
+	}
+
+	wfcEnabled = nil
+	if authorizeAdmin("boss") {
+		t.Error("expected admin access denied when wfcEnabled getter is nil")
 	}
 }

--- a/cmd/vision3/wfc_admin_test.go
+++ b/cmd/vision3/wfc_admin_test.go
@@ -14,6 +14,7 @@ func TestAuthorizeAdmin(t *testing.T) {
 	)
 	adminMinLevel = func() int { return 250 }
 	wfcEnabled = func() bool { return true }
+	t.Cleanup(func() { userMgr, adminMinLevel, wfcEnabled = nil, nil, nil })
 
 	if authorizeAdmin("lowly") {
 		t.Error("expected lowly (level 10) to be denied admin access")
@@ -27,6 +28,7 @@ func TestAuthorizeAdmin_UnknownUser(t *testing.T) {
 	userMgr = user.NewUserMgrForTest()
 	adminMinLevel = func() int { return 250 }
 	wfcEnabled = func() bool { return true }
+	t.Cleanup(func() { userMgr, adminMinLevel, wfcEnabled = nil, nil, nil })
 
 	if authorizeAdmin("ghost") {
 		t.Error("expected unknown user to be denied admin access")
@@ -38,6 +40,7 @@ func TestAuthorizeAdmin_WFCDisabled(t *testing.T) {
 		&user.User{Handle: "boss", AccessLevel: 255},
 	)
 	adminMinLevel = func() int { return 250 }
+	t.Cleanup(func() { userMgr, adminMinLevel, wfcEnabled = nil, nil, nil })
 
 	wfcEnabled = func() bool { return false }
 	if authorizeAdmin("boss") {

--- a/docs/superpowers/plans/2026-07-16-wfc-access-toggle.md
+++ b/docs/superpowers/plans/2026-07-16-wfc-access-toggle.md
@@ -1,0 +1,347 @@
+# WFC Access Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the sysop enable/disable remote WFC (Waiting For Call) console access from the `./config` TUI, hot-reloadable, defaulting to enabled.
+
+**Architecture:** A `WFCEnabled bool` on `config.ServerConfig` (default true via the unmarshal-over-defaults loader). The `vision3` daemon enforces it in `authorizeAdmin` via a live getter (`wfcEnabled func() bool`), mirroring the existing `adminMinLevel` pattern, so both SSH public-key auth and the `wfc-admin` subsystem re-check reject when disabled. The config TUI exposes it as a Y/N field on the Access Levels sub-screen.
+
+**Tech Stack:** Go stdlib, `slog` logging, existing `configeditor` bubbletea TUI, `uitext.BoolToYN`/`YNToBool` helpers.
+
+**Spec:** `docs/superpowers/specs/2026-07-16-wfc-access-toggle-design.md`
+
+## Global Constraints
+
+- Go stdlib only; no new dependencies.
+- Structured logging via `slog` only.
+- Run `gofmt -w` and `go vet` on every changed file before each commit.
+- All tests in affected packages must pass before each commit (`go test ./internal/config/... ./cmd/vision3/... ./internal/configeditor/...`).
+- Keep files under 300 lines where practical (all edits here are small insertions into existing files).
+
+---
+
+### Task 1: `WFCEnabled` config field with default true
+
+**Files:**
+- Modify: `internal/config/config.go` (struct ~line 847, defaults ~line 1073)
+- Test: `internal/config/config_test.go` (extend `TestLoadServerConfig_Defaults` ~line 124, `TestLoadServerConfig_CustomValues` ~line 142)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `config.ServerConfig.WFCEnabled bool` (JSON `wfcEnabled`), default `true` when absent from `config.json`. Tasks 2 and 3 read/write this exact field.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `internal/config/config_test.go`, add to the end of `TestLoadServerConfig_Defaults` (before its closing brace, after the `BoardName` check at line ~139):
+
+```go
+	if !result.WFCEnabled {
+		t.Error("expected WFCEnabled to default to true")
+	}
+```
+
+Add to `TestLoadServerConfig_CustomValues`: extend the `cfg` map literal with an explicit override, and assert it:
+
+```go
+	cfg := map[string]interface{}{
+		"boardName":  "Test BBS",
+		"sshPort":    3333,
+		"maxNodes":   50,
+		"wfcEnabled": false,
+	}
+```
+
+and at the end of the function:
+
+```go
+	if result.WFCEnabled {
+		t.Error("expected WFCEnabled false when explicitly disabled in config.json")
+	}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/config/ -run 'TestLoadServerConfig_Defaults|TestLoadServerConfig_CustomValues' -v`
+Expected: compile FAIL — `result.WFCEnabled undefined (type ServerConfig has no field or method WFCEnabled)`
+
+- [ ] **Step 3: Add the field and default**
+
+In `internal/config/config.go`, in the `ServerConfig` struct, insert directly after the `CoSysOpLevel` line (~847):
+
+```go
+	WFCEnabled          bool   `json:"wfcEnabled"` // Allow remote WFC sysop console (wfc-admin subsystem)
+```
+
+In `LoadServerConfig`'s `defaultConfig` literal (~line 1069), insert after `CoSysOpLevel: 250,`:
+
+```go
+		WFCEnabled:                true,
+```
+
+(Match the literal's existing alignment; run `gofmt -w internal/config/config.go` to settle it.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/config/ -v -run TestLoadServerConfig`
+Expected: PASS (all `TestLoadServerConfig_*` tests, including the partial-overlay test which must still pass — it proves files without the key keep the default).
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+gofmt -l internal/config/ && go vet ./internal/config/
+git add internal/config/config.go internal/config/config_test.go
+git commit -m "feat(config): add WFCEnabled server setting, default true"
+```
+
+---
+
+### Task 2: Daemon enforcement via live getter
+
+**Files:**
+- Modify: `cmd/vision3/wfc_admin.go` (getter var ~line 19, `wfcPublicKeyHandler` ~line 30, `authorizeAdmin` ~line 53)
+- Modify: `cmd/vision3/main.go` (~line 1529, next to the `adminMinLevel` wiring)
+- Test: `cmd/vision3/wfc_admin_test.go`
+
+**Interfaces:**
+- Consumes: `config.ServerConfig.WFCEnabled` from Task 1, via `menuExecutor.GetServerConfig()`.
+- Produces: package-level `var wfcEnabled func() bool` in `cmd/vision3`; `authorizeAdmin(handle string) bool` now also requires `wfcEnabled != nil && wfcEnabled()`.
+
+- [ ] **Step 1: Update existing tests and write the failing test**
+
+Replace the body of `cmd/vision3/wfc_admin_test.go` with (existing tests gain `wfcEnabled` setup since a nil getter now denies; new test covers the disabled path):
+
+```go
+package main
+
+import (
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+func TestAuthorizeAdmin(t *testing.T) {
+	// Seed userMgr with a low-access user and a sysop.
+	userMgr = user.NewUserMgrForTest(
+		&user.User{Handle: "lowly", AccessLevel: 10},
+		&user.User{Handle: "boss", AccessLevel: 255},
+	)
+	adminMinLevel = func() int { return 250 }
+	wfcEnabled = func() bool { return true }
+
+	if authorizeAdmin("lowly") {
+		t.Error("expected lowly (level 10) to be denied admin access")
+	}
+	if !authorizeAdmin("boss") {
+		t.Error("expected boss (level 255) to be granted admin access")
+	}
+}
+
+func TestAuthorizeAdmin_UnknownUser(t *testing.T) {
+	userMgr = user.NewUserMgrForTest()
+	adminMinLevel = func() int { return 250 }
+	wfcEnabled = func() bool { return true }
+
+	if authorizeAdmin("ghost") {
+		t.Error("expected unknown user to be denied admin access")
+	}
+}
+
+func TestAuthorizeAdmin_WFCDisabled(t *testing.T) {
+	userMgr = user.NewUserMgrForTest(
+		&user.User{Handle: "boss", AccessLevel: 255},
+	)
+	adminMinLevel = func() int { return 250 }
+
+	wfcEnabled = func() bool { return false }
+	if authorizeAdmin("boss") {
+		t.Error("expected admin access denied when WFC is disabled")
+	}
+
+	wfcEnabled = nil
+	if authorizeAdmin("boss") {
+		t.Error("expected admin access denied when wfcEnabled getter is nil")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify the new test fails**
+
+Run: `go test ./cmd/vision3/ -run TestAuthorizeAdmin -v`
+Expected: compile FAIL — `undefined: wfcEnabled`
+
+- [ ] **Step 3: Implement the gate**
+
+In `cmd/vision3/wfc_admin.go`, add directly below the `adminMinLevel` declaration (~line 19):
+
+```go
+// wfcEnabled reports whether remote WFC admin access is allowed at all.
+// Like adminMinLevel it is a live getter so config hot-reloads take effect
+// without a restart. Nil (not yet wired, or a test that left it unset) denies.
+var wfcEnabled func() bool
+```
+
+Replace the body of `authorizeAdmin` so the flag is checked first:
+
+```go
+func authorizeAdmin(handle string) bool {
+	if userMgr == nil || adminMinLevel == nil || wfcEnabled == nil || !wfcEnabled() {
+		return false
+	}
+	u, found := userMgr.GetUser(handle)
+	if !found || u == nil {
+		return false
+	}
+	return u.AccessLevel >= adminMinLevel()
+}
+```
+
+Also update its doc comment's last sentence to mention the flag, e.g.:
+
+```go
+// authorizeAdmin returns true when WFC admin access is enabled and the user
+// identified by handle exists with an access level >= the live adminMinLevel
+// threshold. It denies access if either live getter is nil (daemon not yet
+// initialised or running in a test that deliberately left it unset).
+```
+
+In `wfcPublicKeyHandler`, distinguish the disabled case in the rejection branch so the log line isn't misleading. Replace the `if !authorizeAdmin(u.Handle) { ... }` block with:
+
+```go
+	if !authorizeAdmin(u.Handle) {
+		if wfcEnabled == nil || !wfcEnabled() {
+			slog.Info("wfc-admin: public key rejected, wfc access disabled",
+				"user", u.Handle, "addr", ctx.RemoteAddr())
+			return false
+		}
+		minLevel := 0
+		if adminMinLevel != nil {
+			minLevel = adminMinLevel()
+		}
+		slog.Info("wfc-admin: public key rejected, insufficient access level",
+			"user", u.Handle, "level", u.AccessLevel, "required", minLevel)
+		return false
+	}
+```
+
+In `cmd/vision3/main.go`, directly after the `adminMinLevel = ...` line (~1529), add:
+
+```go
+	wfcEnabled = func() bool { return menuExecutor.GetServerConfig().WFCEnabled }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./cmd/vision3/ -v -run TestAuthorizeAdmin`
+Expected: PASS (all three tests). Then run the whole package: `go test ./cmd/vision3/` — expected: ok.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+gofmt -l cmd/vision3/ && go vet ./cmd/vision3/
+git add cmd/vision3/wfc_admin.go cmd/vision3/wfc_admin_test.go cmd/vision3/main.go
+git commit -m "feat(wfc): gate wfc-admin access on WFCEnabled config flag"
+```
+
+---
+
+### Task 3: Config TUI field on Access Levels screen
+
+**Files:**
+- Modify: `internal/configeditor/fields_system.go` (`sysFieldsLevels`, ~lines 355–441)
+- Test: `internal/configeditor/fields_system_test.go`
+
+**Interfaces:**
+- Consumes: `config.ServerConfig.WFCEnabled` from Task 1; existing `uitext.BoolToYN` / `uitext.YNToBool` helpers (already imported in `fields_system.go`).
+- Produces: a `WFC Access` field (Type `ftYesNo`) in the slice returned by `sysFieldsLevels`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/configeditor/fields_system_test.go`:
+
+```go
+func TestSysFieldsLevels_WFCAccess(t *testing.T) {
+	cfg := &config.ServerConfig{WFCEnabled: true}
+	fields := sysFieldsLevels(cfg)
+
+	var f *fieldDef
+	for i := range fields {
+		if fields[i].Label == "WFC Access" {
+			f = &fields[i]
+			break
+		}
+	}
+	if f == nil {
+		t.Fatal("WFC Access field not found in Access Levels screen")
+	}
+	if f.Type != ftYesNo {
+		t.Errorf("WFC Access type: want ftYesNo, got %v", f.Type)
+	}
+	if got := f.Get(); got != "Y" {
+		t.Errorf("Get with WFCEnabled=true: want Y, got %q", got)
+	}
+	if err := f.Set("N"); err != nil {
+		t.Fatalf("Set(N): %v", err)
+	}
+	if cfg.WFCEnabled {
+		t.Error("Set(N) should clear cfg.WFCEnabled")
+	}
+	if got := f.Get(); got != "N" {
+		t.Errorf("Get after Set(N): want N, got %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/configeditor/ -run TestSysFieldsLevels_WFCAccess -v`
+Expected: FAIL — `WFC Access field not found in Access Levels screen`
+
+- [ ] **Step 3: Add the field**
+
+In `sysFieldsLevels` in `internal/configeditor/fields_system.go`, insert a new field directly after the `CoSysOp Level` entry (Row 2) and renumber the rows of every subsequent field in the slice (+1 each):
+
+```go
+		{
+			Label: "WFC Access", Help: "Allow remote WFC sysop console connections", Type: ftYesNo, Col: 3, Row: 3, Width: 1,
+			Get: func() string { return uitext.BoolToYN(cfg.WFCEnabled) },
+			Set: func(val string) error { cfg.WFCEnabled = uitext.YNToBool(val); return nil },
+		},
+```
+
+Row renumbering in the same function: `Invisible Lvl` 3→4, `New User Level` 4→5, `Regular Level` 5→6, `Logon Level` 6→7, `Anonymous Lvl` 7→8. (The Access Levels box auto-sizes from the max Row, so no view changes are needed.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/configeditor/`
+Expected: ok (new test passes; golden/view tests still pass since the box height is derived from max row — if a golden test for the system screen fails, inspect the diff: it should only show the added row, then regenerate per that test's documented `-update` flag if it has one, otherwise update the golden expectation by hand).
+
+- [ ] **Step 5: Lint, full test sweep, and commit**
+
+```bash
+gofmt -l internal/configeditor/ && go vet ./internal/configeditor/
+go test ./internal/config/... ./cmd/vision3/... ./internal/configeditor/...
+git add internal/configeditor/fields_system.go internal/configeditor/fields_system_test.go
+git commit -m "feat(configeditor): add WFC Access toggle to Access Levels screen"
+```
+
+---
+
+### Task 4: Full verification
+
+**Files:** none new.
+
+**Interfaces:** n/a — verification only.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `go test ./...`
+Expected: all packages ok.
+
+- [ ] **Step 2: Build both binaries**
+
+Run: `go build ./cmd/vision3 ./cmd/wfc ./cmd/config`
+Expected: clean build, no output. Remove any produced binaries from the repo root afterwards (`rm -f vision3 wfc config`).
+
+- [ ] **Step 3: Commit (only if anything changed)**
+
+Nothing should need committing; if a golden file was regenerated in Task 3 it was already committed there.

--- a/docs/superpowers/plans/2026-07-16-wfc-access-toggle.md
+++ b/docs/superpowers/plans/2026-07-16-wfc-access-toggle.md
@@ -88,7 +88,7 @@ Expected: PASS (all `TestLoadServerConfig_*` tests, including the partial-overla
 - [ ] **Step 5: Lint and commit**
 
 ```bash
-gofmt -l internal/config/ && go vet ./internal/config/
+gofmt -w internal/config/ && go vet ./internal/config/
 git add internal/config/config.go internal/config/config_test.go
 git commit -m "feat(config): add WFCEnabled server setting, default true"
 ```

--- a/docs/superpowers/specs/2026-07-16-wfc-access-toggle-design.md
+++ b/docs/superpowers/specs/2026-07-16-wfc-access-toggle-design.md
@@ -1,0 +1,72 @@
+# WFC Access Toggle — Design
+
+**Date:** 2026-07-16
+**Status:** Approved
+
+## Goal
+
+Let the sysop enable or disable remote WFC (Waiting For Call) console access
+from the `./config` TUI, without restarting the BBS.
+
+WFC access is the SSH `wfc-admin` subsystem served by the `vision3` daemon
+(`cmd/vision3/wfc_admin.go`) and consumed by the standalone `wfc` client
+binary. Today it is gated only by public-key registration plus
+`ServerConfig.CoSysOpLevel`.
+
+## Behavior
+
+- **Enabled (default):** current behavior, unchanged.
+- **Disabled:** admin public-key authentication is rejected at the SSH auth
+  layer, so `wfc` clients cannot connect at all. The key falls through to the
+  normal caller password-login flow, exactly like any non-admin key today.
+  The subsystem handler's re-check also enforces the flag (defense in depth).
+- Toggling takes effect on the next connection attempt via the existing
+  live-getter / config hot-reload pattern; no daemon restart. Already-open WFC
+  sessions are not force-dropped (consistent with how `CoSysOpLevel` changes
+  behave).
+
+## Changes
+
+### 1. Config — `internal/config/config.go`
+
+- Add `WFCEnabled bool` with JSON tag `wfcEnabled` to `ServerConfig`, placed
+  near the access-level fields.
+- Set `WFCEnabled: true` in the `LoadServerConfig` defaults struct. Because
+  the loader unmarshals the file over the defaults, existing `config.json`
+  files without the key keep WFC enabled (same pattern as `SSHEnabled`).
+
+### 2. Daemon gate — `cmd/vision3/wfc_admin.go` + `cmd/vision3/main.go`
+
+- Add a live getter `wfcEnabled func() bool` alongside `adminMinLevel`,
+  wired in `main.go` as
+  `wfcEnabled = func() bool { return menuExecutor.GetServerConfig().WFCEnabled }`.
+- `authorizeAdmin` returns false when the getter is nil or returns false.
+  Since both `wfcPublicKeyHandler` and `wfcAdminSubsystem` call
+  `authorizeAdmin`, this covers auth-time rejection and the in-session
+  re-check.
+- `wfcPublicKeyHandler` logs the rejection reason (`wfc disabled`) at Info,
+  matching the existing insufficient-level log line.
+
+### 3. Config TUI — `internal/configeditor/fields_system.go`
+
+- Add a boolean field to the **Access Levels** sub-screen
+  (`sysFieldsLevels`), next to CoSysOp Level:
+  - Label: `WFC Access`
+  - Help: `Allow remote WFC sysop console connections`
+  - Type: `ftYesNo` (the editor's existing Y/N toggle); Get/Set map to
+    `cfg.WFCEnabled`.
+
+## Testing
+
+- `cmd/vision3`: table test for `authorizeAdmin` covering flag on/off and
+  nil getter (extend the existing wfc_admin tests if present, else add).
+- `internal/config`: assert `LoadServerConfig` defaults `WFCEnabled` to true
+  when the key is absent from `config.json`.
+- `internal/configeditor`: field round-trip test following the
+  `fields_system_test.go` pattern.
+
+## Out of Scope
+
+- Force-disconnecting live WFC sessions when the flag is turned off.
+- Per-user WFC toggles (already achievable via key removal / access level).
+- Any change to the `wfc` client binary itself.

--- a/docs/sysop/configuration/security.md
+++ b/docs/sysop/configuration/security.md
@@ -18,7 +18,7 @@ ViSiON/3 includes built-in connection management to prevent resource exhaustion 
 > it adds no new open port and accepts no password. It can also be disabled
 > entirely with the `wfcEnabled` config flag (**WFC Access** in the config TUI's
 > Access Levels sub-screen, default on, hot-reloaded). See the
-> [WFC Sysop Console](how-to-guides/wfc-console.md) guide for key registration.
+> [WFC Sysop Console](../how-to-guides/wfc-console.md) guide for key registration.
 
 ### Configuring Connection Limits
 

--- a/docs/sysop/configuration/security.md
+++ b/docs/sysop/configuration/security.md
@@ -15,7 +15,9 @@ ViSiON/3 includes built-in connection management to prevent resource exhaustion 
 
 > **Sysop remote console (WFC):** the `wfc` admin console rides the existing SSH
 > server and is gated by per-user SSH **public keys** (CoSysOp level or above) —
-> it adds no new open port and accepts no password. See the
+> it adds no new open port and accepts no password. It can also be disabled
+> entirely with the `wfcEnabled` config flag (**WFC Access** in the config TUI's
+> Access Levels sub-screen, default on, hot-reloaded). See the
 > [WFC Sysop Console](how-to-guides/wfc-console.md) guide for key registration.
 
 ### Configuring Connection Limits

--- a/docs/sysop/how-to-guides/wfc-console.md
+++ b/docs/sysop/how-to-guides/wfc-console.md
@@ -11,7 +11,7 @@ or start sysop chat. Those are planned for a later release.
 
 ## Requirements to access WFC
 
-A user account can open the WFC console only when **both** of these are true:
+A user account can open the WFC console only when **all** of these are true:
 
 1. **Access level ≥ the CoSysOp level** (`coSysOpLevel` in `config.json`,
    default **250**). SysOp (255) and CoSysOp (≥250) qualify; regular users do
@@ -19,10 +19,14 @@ A user account can open the WFC console only when **both** of these are true:
    numeric access level that matters.
 2. **A registered SSH public key** on the account. WFC authenticates with your
    SSH key (no password), and the key must be listed on a qualifying account.
+3. **WFC access enabled** — the `wfcEnabled` config flag (default **true**).
+   Toggle it in the config TUI under **System Configuration → Access Levels**
+   as **WFC Access**. This is hot-reloaded: the change takes effect on the
+   *next* connection attempt, no restart needed.
 
-A key that isn't registered — or that belongs to a below-CoSysOp user — simply
-falls through to the **normal caller login**. Adding WFC access never affects
-regular logins.
+A key that isn't registered, belongs to a below-CoSysOp user, or arrives while
+WFC Access is disabled simply falls through to the **normal caller login**.
+Adding WFC access never affects regular logins.
 
 ## Enabling access for a sysop
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -845,6 +845,7 @@ type ServerConfig struct {
 	Timezone            string `json:"timezone,omitempty"`
 	SysOpLevel          int    `json:"sysOpLevel"`
 	CoSysOpLevel        int    `json:"coSysOpLevel"`
+	WFCEnabled          bool   `json:"wfcEnabled"`     // Allow remote WFC sysop console (wfc-admin subsystem)
 	InvisibleLevel      int    `json:"invisibleLevel"` // Access level for invisible logon prompt; 0 = use coSysOpLevel
 	NewUserLevel        int    `json:"newUserLevel"`   // Access level assigned to new signups
 	RegularUserLevel    int    `json:"regularUserLevel"`
@@ -1071,6 +1072,7 @@ func LoadServerConfig(configPath string) (ServerConfig, error) {
 		Timezone:                  "",
 		SysOpLevel:                255,
 		CoSysOpLevel:              250,
+		WFCEnabled:                true,
 		NewUserLevel:              1,
 		RegularUserLevel:          10,
 		LogonLevel:                10,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -137,14 +137,18 @@ func TestLoadServerConfig_Defaults(t *testing.T) {
 	if result.BoardName != "ViSiON/3 BBS" {
 		t.Errorf("expected default board name, got %s", result.BoardName)
 	}
+	if !result.WFCEnabled {
+		t.Error("expected WFCEnabled to default to true")
+	}
 }
 
 func TestLoadServerConfig_CustomValues(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := map[string]interface{}{
-		"boardName": "Test BBS",
-		"sshPort":   3333,
-		"maxNodes":  50,
+		"boardName":  "Test BBS",
+		"sshPort":    3333,
+		"maxNodes":   50,
+		"wfcEnabled": false,
 	}
 	data, _ := json.Marshal(cfg)
 	os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644)
@@ -161,6 +165,9 @@ func TestLoadServerConfig_CustomValues(t *testing.T) {
 	}
 	if result.MaxNodes != 50 {
 		t.Errorf("expected MaxNodes 50, got %d", result.MaxNodes)
+	}
+	if result.WFCEnabled {
+		t.Error("expected WFCEnabled false when explicitly disabled in config.json")
 	}
 }
 

--- a/internal/configeditor/fields_system.go
+++ b/internal/configeditor/fields_system.go
@@ -379,7 +379,12 @@ func sysFieldsLevels(cfg *config.ServerConfig) []fieldDef {
 			},
 		},
 		{
-			Label: "Invisible Lvl", Help: "Level at which user is hidden from who's online", Type: ftInteger, Col: 3, Row: 3, Width: 3, Min: 0, Max: 255,
+			Label: "WFC Access", Help: "Allow remote WFC sysop console connections", Type: ftYesNo, Col: 3, Row: 3, Width: 1,
+			Get: func() string { return uitext.BoolToYN(cfg.WFCEnabled) },
+			Set: func(val string) error { cfg.WFCEnabled = uitext.YNToBool(val); return nil },
+		},
+		{
+			Label: "Invisible Lvl", Help: "Level at which user is hidden from who's online", Type: ftInteger, Col: 3, Row: 4, Width: 3, Min: 0, Max: 255,
 			Get: func() string { return strconv.Itoa(cfg.InvisibleLevel) },
 			Set: func(val string) error {
 				n, err := strconv.Atoi(val)
@@ -391,7 +396,7 @@ func sysFieldsLevels(cfg *config.ServerConfig) []fieldDef {
 			},
 		},
 		{
-			Label: "New User Level", Help: "Level assigned to new signups", Type: ftInteger, Col: 3, Row: 4, Width: 3, Min: 0, Max: 255,
+			Label: "New User Level", Help: "Level assigned to new signups", Type: ftInteger, Col: 3, Row: 5, Width: 3, Min: 0, Max: 255,
 			Get: func() string { return strconv.Itoa(cfg.NewUserLevel) },
 			Set: func(val string) error {
 				n, err := strconv.Atoi(val)
@@ -403,7 +408,7 @@ func sysFieldsLevels(cfg *config.ServerConfig) []fieldDef {
 			},
 		},
 		{
-			Label: "Regular Level", Help: "Level assigned when user is validated", Type: ftInteger, Col: 3, Row: 5, Width: 3, Min: 0, Max: 255,
+			Label: "Regular Level", Help: "Level assigned when user is validated", Type: ftInteger, Col: 3, Row: 6, Width: 3, Min: 0, Max: 255,
 			Get: func() string { return strconv.Itoa(cfg.RegularUserLevel) },
 			Set: func(val string) error {
 				n, err := strconv.Atoi(val)
@@ -415,7 +420,7 @@ func sysFieldsLevels(cfg *config.ServerConfig) []fieldDef {
 			},
 		},
 		{
-			Label: "Logon Level", Help: "Minimum access level required to log in (0=disabled)", Type: ftInteger, Col: 3, Row: 6, Width: 3, Min: 0, Max: 255,
+			Label: "Logon Level", Help: "Minimum access level required to log in (0=disabled)", Type: ftInteger, Col: 3, Row: 7, Width: 3, Min: 0, Max: 255,
 			Get: func() string { return strconv.Itoa(cfg.LogonLevel) },
 			Set: func(val string) error {
 				n, err := strconv.Atoi(val)
@@ -427,7 +432,7 @@ func sysFieldsLevels(cfg *config.ServerConfig) []fieldDef {
 			},
 		},
 		{
-			Label: "Anonymous Lvl", Help: "Minimum level required to post anonymously (0=disabled)", Type: ftInteger, Col: 3, Row: 7, Width: 3, Min: 0, Max: 255,
+			Label: "Anonymous Lvl", Help: "Minimum level required to post anonymously (0=disabled)", Type: ftInteger, Col: 3, Row: 8, Width: 3, Min: 0, Max: 255,
 			Get: func() string { return strconv.Itoa(cfg.AnonymousLevel) },
 			Set: func(val string) error {
 				n, err := strconv.Atoi(val)

--- a/internal/configeditor/fields_system_test.go
+++ b/internal/configeditor/fields_system_test.go
@@ -70,3 +70,34 @@ func TestSysFieldsQWKAPI(t *testing.T) {
 		t.Errorf("Token TTL for negative value: want 24, got %q", got)
 	}
 }
+
+func TestSysFieldsLevels_WFCAccess(t *testing.T) {
+	cfg := &config.ServerConfig{WFCEnabled: true}
+	fields := sysFieldsLevels(cfg)
+
+	var f *fieldDef
+	for i := range fields {
+		if fields[i].Label == "WFC Access" {
+			f = &fields[i]
+			break
+		}
+	}
+	if f == nil {
+		t.Fatal("WFC Access field not found in Access Levels screen")
+	}
+	if f.Type != ftYesNo {
+		t.Errorf("WFC Access type: want ftYesNo, got %v", f.Type)
+	}
+	if got := f.Get(); got != "Y" {
+		t.Errorf("Get with WFCEnabled=true: want Y, got %q", got)
+	}
+	if err := f.Set("N"); err != nil {
+		t.Fatalf("Set(N): %v", err)
+	}
+	if cfg.WFCEnabled {
+		t.Error("Set(N) should clear cfg.WFCEnabled")
+	}
+	if got := f.Get(); got != "N" {
+		t.Errorf("Get after Set(N): want N, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
Adds a sysop-configurable toggle to enable/disable remote WFC (Waiting For Call) console access, exposed in the `./config` TUI.

- **Config**: `ServerConfig.WFCEnabled` (JSON `wfcEnabled`), default `true` — existing `config.json` files are unaffected (unmarshal-over-defaults, same pattern as `sshEnabled`).
- **Daemon**: `wfcEnabled` live getter in `cmd/vision3`, checked first in `authorizeAdmin`, so both the SSH public-key auth path and the `wfc-admin` subsystem re-check fail closed when disabled (or when the getter is unwired). Rejected keys fall through to normal caller login; hot-reload takes effect on the next connection attempt with no restart. Distinct slog line for the disabled rejection.
- **Config TUI**: "WFC Access" Y/N field on System Configuration → Access Levels, next to CoSysOp Level.
- **Docs**: wfc-console.md access requirements + security.md callout updated.

Design spec: `docs/superpowers/specs/2026-07-16-wfc-access-toggle-design.md`
Plan: `docs/superpowers/plans/2026-07-16-wfc-access-toggle.md`

## Review
Per-task reviews clean; final whole-branch review verified no bypass path to the admin RPC, fail-closed nil-getter behavior, and the hot-reload chain (fsnotify → `LoadServerConfig` → `SetServerConfig`, RWMutex-guarded). Findings (docs gap, test-global hygiene) fixed and re-approved.

## Test plan
- `go test ./...` — 1850 pass / 56 packages
- New tests: config default + explicit-false override; `authorizeAdmin` with flag off and nil getter; TUI field round-trip
- `vision3`, `wfc`, `config` binaries build clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hot-reloadable **WFC Access** toggle (default: enabled) to control remote WFC console availability.
  * When disabled, admin/WFC access is rejected on new connection attempts; regular logins continue to function normally.
* **Documentation**
  * Updated sysop security and WFC console documentation to describe the **WFC Access** flag, its default, and that changes apply on the next connection attempt.
* **Tests**
  * Extended authorization and configuration-editor tests to cover the enabled/disabled and unset cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->