### PR TITLE
docs: refresh sysop docs and README for integrated binkd, WFC toggle, QWK API status

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ There's detailed SysOp documentation [here](https://vision-3.github.io/vision-3-
 
 ## Companion Projects
 
-- **[ViSiON/3 QWK Mobile](https://github.com/ViSiON-3/vision-3-qwk-mobile)** — a React Native offline mail client for ViSiON/3. It consumes the experimental [QWK Packet API](docs/sysop/messages/qwk-api.md) to download `.QWK` packets, read and reply entirely offline, and upload `.REP` packets back to the board. The full offline loop (connect → sync → read → compose/reply → upload → import report) is implemented.
+- **[ViSiON/3 QWK Mobile](https://github.com/ViSiON-3/vision-3-qwk-mobile)** — a React Native offline mail client for ViSiON/3. It consumes the experimental [QWK Packet API](docs/sysop/messages/qwk-api.md) to download `.QWK` packets, read and reply entirely offline, and upload `.REP` packets back to the board. The full offline loop (connect → sync → read → compose/reply → upload → import report) is implemented in-repo, but the app is **not yet available for download** — there's currently nothing end-users can connect to the QWK Packet API with, so sysops should leave it disabled for now.
 
 ## Community
 
@@ -112,7 +112,7 @@ Your reward? The satisfaction of knowing that somewhere, someone is reliving the
 | NUV (New User Verification)   | ✅ Working | Voting-based approval system for new user accounts                                                                  |
 | Info Forms                    | ✅ Working | Up to 5 configurable forms; required form enforcement on login; user fill/view; SysOp browse and management         |
 | TUI User Editor (`ue`)        | ✅ Working | Full-screen terminal user management                                                                                |
-| WFC Sysop Console (`wfc`)     | ✅ Working | Remote read-only monitor of live nodes/callers + event feed over SSH ([guide](docs/sysop/how-to-guides/wfc-console.md)) |
+| WFC Sysop Console (`wfc`)     | ✅ Working | Remote read-only monitor of live nodes/callers + event feed over SSH, gated by a hot-reloadable WFC Access toggle in Access Levels ([guide](docs/sysop/how-to-guides/wfc-console.md)) |
 | **Menus**                     |           |                                                                                                                     |
 | Menu System                   | ✅ Working | `.MNU`, `.CFG`, `.ANS` files, ACS evaluation, password protection                                                   |
 | TUI Menu Editor (`menuedit`)  | ✅ Working | Full-screen menu configuration editor                                                                               |
@@ -121,7 +121,7 @@ Your reward? The satisfaction of knowing that somewhere, someone is reliving the
 | Private Mail                  | ✅ Working | User-to-user messaging, send/read/list                                                                              |
 | Message List View (scan)      | ✅ Working | Title/subject scan view                                                                                             |
 | QWK Offline Mail              | ✅ Working | QWK/REP packet download/upload, stable conference map, reply threading, HEADERS.DAT extended headers, REP upload dedup, configurable BBS ID |
-| QWK Packet API                | 🧪 Experimental | REST API for offline mail clients (off by default) — see the [QWK API docs](docs/sysop/messages/qwk-api.md) and the [QWK Mobile client](https://github.com/ViSiON-3/vision-3-qwk-mobile) |
+| QWK Packet API                | 🧪 Experimental | REST API for offline mail clients (off by default — companion app not yet released) — see the [QWK API docs](docs/sysop/messages/qwk-api.md) and the [QWK Mobile client](https://github.com/ViSiON-3/vision-3-qwk-mobile) |
 | **Files**                     |           |                                                                                                                     |
 | File Areas                    | ✅ Working | List/select areas, list files, search, file info, newscan, configurable columns, extended listing                   |
 | File Transfers                | ✅ Working | ZMODEM upload/download via `sexyz`, batch download with per-area ACS validation                                     |
@@ -132,6 +132,7 @@ Your reward? The satisfaction of knowing that somewhere, someone is reliving the
 | V3 Scripting Engine           | ✅ Working | goja-based JavaScript runtime for native V3 script doors                                                            |
 | **Networking/FTN**            |           |                                                                                                                     |
 | FTN Echomail/Netmail          | ✅ Working | JAM-backed, tosser, import/export, dupe checking                                                                    |
+| Integrated Binkd Mailer       | ✅ Working | Bundled `bin/binkd` supervised as a child process (auto-restart on crash, clean shutdown); one-toggle echomail — inbound tosses automatically, outbound exports on a timer. See [FTN Echomail](docs/sysop/messages/ftn-echomail.md). |
 | FTN Setup Wizard              | ✅ Working | Guided setup in `./config`: pick network, download echo list, auto-create areas + `binkd.conf`                     |
 | V3Net Networking              | 🧪 Experimental | Native inter-BBS message networking via REST+SSE (hub/leaf, signed area lists) — see the [V3Net docs](docs/sysop/v3net/message-areas.md)                                 |
 | **Community Features**        |           |                                                                                                                     |

--- a/docs/sysop/_sidebar.md
+++ b/docs/sysop/_sidebar.md
@@ -55,6 +55,7 @@
 * [Message Areas](messages/message-areas.md)
 * [Private Mail](messages/private-mail.md)
 * [QWK Offline Mail](messages/qwk.md)
+* [QWK Packet API (experimental)](messages/qwk-api.md)
 * [FTN Echomail](messages/ftn-echomail.md)
 * [Tosser (v3mail)](messages/ftn-echomail.md#tosser-internal--v3mail)
 * [Mailer (binkd)](messages/ftn-echomail.md#mailer-external--binkd)

--- a/docs/sysop/messages/qwk-api.md
+++ b/docs/sysop/messages/qwk-api.md
@@ -1,10 +1,12 @@
 # QWK Packet API (Experimental)
 
 > ⚠️ **Experimental — do not enable in production yet.** This HTTP API exists to
-> support a future ViSiON/3 mobile client (offline QWK mail on a phone). Until
-> that client ships there is nothing to connect to it, and its security surface
-> and behavior may still change. Leave `qwkAPI.enabled` set to `false` unless you
-> are actively developing or testing against it.
+> support the [ViSiON/3 QWK Mobile](https://github.com/ViSiON-3/vision-3-qwk-mobile)
+> companion client (offline QWK mail on a phone). That app is **not yet
+> available for download**, so there is currently nothing end-users can
+> connect to this API with, and its security surface and behavior may still
+> change. Leave `qwkAPI.enabled` set to `false` unless you are actively
+> developing or testing against it.
 
 ## What it is
 

--- a/docs/sysop/messages/qwk.md
+++ b/docs/sysop/messages/qwk.md
@@ -178,10 +178,11 @@ detection). See [Upload safety](#upload-safety-destination-check-and-duplicate-d
 
 ## Packet API (experimental)
 
-An optional HTTPS API can expose QWK download/upload to a future ViSiON/3 mobile
-client, without a terminal session. It is **off by default and experimental** —
-do not enable it in production until a mobile client exists. See
-[QWK Packet API](qwk-api.md).
+An optional HTTPS API can expose QWK download/upload to the ViSiON/3 QWK Mobile
+companion client, without a terminal session. It is **off by default and
+experimental** — the companion app is **not yet available for download**, so
+there is nothing to connect to it yet. Leave it disabled until the app ships.
+See [QWK Packet API](qwk-api.md).
 
 ## Troubleshooting
 

--- a/docs/sysop/messages/v3mail.md
+++ b/docs/sysop/messages/v3mail.md
@@ -153,6 +153,15 @@ The recommended nightly sequence (configured via the event scheduler):
 
 `v3mail` is designed to run as scheduled events. See `configs/events.json` and [Event Scheduler](advanced/event-scheduler.md) for full examples. A typical configuration:
 
+> **Integrated mailer alternative:** the scheduler-driven `toss`/`scan`/`ftn-pack`
+> workflow below is one way to run FTN mail. If you enable the integrated
+> **binkd** mailer instead (Server Setup → **Binkd Mailer** — see
+> [FTN Echomail](ftn-echomail.md#enabling-the-integrated-mailer-recommended)),
+> Vision/3 tosses inbound mail automatically via binkd's `exec` hook and
+> exports outbound mail on a timer, so these `binkd_poll`/`v3mail toss`/
+> `v3mail scan`/`v3mail ftn-pack` scheduler events should be **disabled** to
+> avoid double-exporting.
+
 ```json
 {
   "id": "v3mail_toss",


### PR DESCRIPTION
## Summary
- **Integrated binkd mailer**: README feature table now calls out the bundled, supervised `bin/binkd` child process (auto-restart, clean shutdown, one-toggle echomail); `v3mail.md` adds a note that the scheduler-driven toss/scan workflow is unnecessary (and should be disabled) when the integrated mailer is enabled.
- **WFC access toggle**: README's WFC row now mentions the hot-reloadable WFC Access toggle in Access Levels. (`docs/sysop/how-to-guides/wfc-console.md` already documented `WFCEnabled` correctly from PR #98 — no changes needed there.)
- **QWK Mobile API status**: `qwk-api.md` and `qwk.md` now state plainly that the companion mobile app is not yet available for download and there is nothing to connect to the API yet; README's QWK Packet API row and Companion Projects blurb updated to match. Added a sidebar nav entry for the QWK Packet API page (previously missing).

`ftn-echomail.md`, `docs/sysop/reference/architecture.md`, and `docs/sysop/advanced/event-scheduler.md` were already updated for the binkd integration in prior PRs and needed no changes.

## Test plan
- [x] `git diff --stat` against main touches only `.md` files
- [x] `go build ./...` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added navigation and guidance for the experimental QWK Packet API.
  * Clarified that the QWK Mobile companion app is not yet available and the API remains off by default.
  * Expanded documentation for the integrated Binkd mailer, including automatic inbound/outbound echomail handling and scheduler configuration.
  * Refined feature descriptions for the WFC Sysop Console, ViSiON/3 QWK Mobile, and integrated mailer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->