### PR TITLE
fix(configeditor): make door Name the editable key in door editor

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -644,16 +644,20 @@ func LoadDoors(filePath string) (map[string]DoorConfig, error) {
 		return nil, fmt.Errorf("failed to unmarshal doors JSON from %s: %w", filePath, err)
 	}
 
-	// Key by uppercased Name: menu lookups uppercase the door name before
-	// consulting the registry, so mixed-case names must normalize or the
-	// door is unreachable.
+	// Normalize Name to uppercase and key by it: menu lookups uppercase the
+	// door name before consulting the registry, so mixed-case names must
+	// normalize or the door is unreachable. Key and Name stay in sync.
 	doorMap := make(map[string]DoorConfig)
 	for _, door := range doors {
-		key := strings.ToUpper(door.Name)
-		if _, exists := doorMap[key]; exists {
+		name := strings.ToUpper(strings.TrimSpace(door.Name))
+		if name == "" {
+			return nil, fmt.Errorf("door with empty name in %s", filePath)
+		}
+		if _, exists := doorMap[name]; exists {
 			return nil, fmt.Errorf("duplicate door name found in %s: %s", filePath, door.Name)
 		}
-		doorMap[key] = door
+		door.Name = name
+		doorMap[name] = door
 	}
 
 	return doorMap, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -644,12 +644,16 @@ func LoadDoors(filePath string) (map[string]DoorConfig, error) {
 		return nil, fmt.Errorf("failed to unmarshal doors JSON from %s: %w", filePath, err)
 	}
 
+	// Key by uppercased Name: menu lookups uppercase the door name before
+	// consulting the registry, so mixed-case names must normalize or the
+	// door is unreachable.
 	doorMap := make(map[string]DoorConfig)
 	for _, door := range doors {
-		if _, exists := doorMap[door.Name]; exists {
+		key := strings.ToUpper(door.Name)
+		if _, exists := doorMap[key]; exists {
 			return nil, fmt.Errorf("duplicate door name found in %s: %s", filePath, door.Name)
 		}
-		doorMap[door.Name] = door
+		doorMap[key] = door
 	}
 
 	return doorMap, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -46,6 +46,42 @@ func TestLoadDoors_ValidFile(t *testing.T) {
 	}
 }
 
+// Menu lookups uppercase the door name (GetDoorConfig(ToUpper(input))), so
+// mixed-case names in a hand-edited doors.json must be keyed uppercase or
+// the door is unreachable.
+func TestLoadDoors_UppercasesKeys(t *testing.T) {
+	tmpDir := t.TempDir()
+	doors := []DoorConfig{
+		{Name: "Lord", Commands: []string{"/usr/bin/lord"}},
+	}
+	data, _ := json.Marshal(doors)
+	os.WriteFile(filepath.Join(tmpDir, "doors.json"), data, 0644)
+
+	result, err := LoadDoors(filepath.Join(tmpDir, "doors.json"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := result["LORD"]; !ok {
+		t.Errorf("expected key LORD for door named Lord, got keys %v", result)
+	}
+}
+
+// Duplicate detection must be case-insensitive since keys are uppercased.
+func TestLoadDoors_DuplicateNamesCaseInsensitive(t *testing.T) {
+	tmpDir := t.TempDir()
+	doors := []DoorConfig{
+		{Name: "Lord", Commands: []string{"/usr/bin/lord"}},
+		{Name: "LORD", Commands: []string{"/usr/bin/lord2"}},
+	}
+	data, _ := json.Marshal(doors)
+	os.WriteFile(filepath.Join(tmpDir, "doors.json"), data, 0644)
+
+	_, err := LoadDoors(filepath.Join(tmpDir, "doors.json"))
+	if err == nil {
+		t.Error("expected error for case-insensitive duplicate door names")
+	}
+}
+
 func TestLoadDoors_MissingFile(t *testing.T) {
 	result, err := LoadDoors("/nonexistent/doors.json")
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -61,8 +61,25 @@ func TestLoadDoors_UppercasesKeys(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if _, ok := result["LORD"]; !ok {
-		t.Errorf("expected key LORD for door named Lord, got keys %v", result)
+	d, ok := result["LORD"]
+	if !ok {
+		t.Fatalf("expected key LORD for door named Lord, got keys %v", result)
+	}
+	if d.Name != "LORD" {
+		t.Errorf("Name = %q, want LORD (key and Name must stay in sync)", d.Name)
+	}
+}
+
+func TestLoadDoors_RejectsEmptyName(t *testing.T) {
+	tmpDir := t.TempDir()
+	doors := []DoorConfig{
+		{Name: "  ", Commands: []string{"/usr/bin/lord"}},
+	}
+	data, _ := json.Marshal(doors)
+	os.WriteFile(filepath.Join(tmpDir, "doors.json"), data, 0644)
+
+	if _, err := LoadDoors(filepath.Join(tmpDir, "doors.json")); err == nil {
+		t.Error("expected error for door with blank name")
 	}
 }
 

--- a/internal/configeditor/fields_doors.go
+++ b/internal/configeditor/fields_doors.go
@@ -180,9 +180,6 @@ func (m *Model) fieldsDoor() []fieldDef {
 				if val == "" {
 					return fmt.Errorf("door name cannot be empty")
 				}
-				if val == key {
-					return nil
-				}
 				for k := range m.configs.Doors {
 					if k != key && strings.EqualFold(k, val) {
 						return fmt.Errorf("door %q already exists", k)
@@ -191,7 +188,9 @@ func (m *Model) fieldsDoor() []fieldDef {
 				cfg := m.configs.Doors[key]
 				cfg.Name = val
 				m.configs.Doors[val] = cfg
-				delete(m.configs.Doors, key)
+				if val != key {
+					delete(m.configs.Doors, key)
+				}
 				dPtr.Name = val // keep display current until fields are rebuilt
 				return nil
 			},

--- a/internal/configeditor/fields_doors.go
+++ b/internal/configeditor/fields_doors.go
@@ -170,9 +170,43 @@ func (m *Model) fieldsDoor() []fieldDef {
 	row := 1
 	fields := []fieldDef{
 		{
-			Label: "Name", Help: "Door name used in DOOR:NAME menu commands", Type: ftString, Col: 3, Row: row, Width: 30,
+			// Name is the door's identity: doors.json is saved as an array and
+			// re-keyed by Name on load, and DOOR:NAME menu lookups uppercase the
+			// input — so renaming re-keys the map and normalizes to uppercase.
+			Label: "Name", Help: "Door name used in DOOR:NAME menu commands (uppercased)", Type: ftString, Col: 3, Row: row, Width: 30,
 			Get: func() string { return dPtr.Name },
-			Set: func(val string) error { dPtr.Name = val; save(); return nil },
+			Set: func(val string) error {
+				val = strings.ToUpper(strings.TrimSpace(val))
+				if val == "" {
+					return fmt.Errorf("door name cannot be empty")
+				}
+				if val == key {
+					return nil
+				}
+				for k := range m.configs.Doors {
+					if k != key && strings.EqualFold(k, val) {
+						return fmt.Errorf("door %q already exists", k)
+					}
+				}
+				cfg := m.configs.Doors[key]
+				cfg.Name = val
+				m.configs.Doors[val] = cfg
+				delete(m.configs.Doors, key)
+				dPtr.Name = val // keep display current until fields are rebuilt
+				return nil
+			},
+			// AfterSet runs on the current model (not the stale captured pointer), so index
+			// updates here are correctly applied before buildRecordFields is called.
+			AfterSet: func(cur *Model, val string) {
+				val = strings.ToUpper(strings.TrimSpace(val))
+				newKeys := cur.doorKeys()
+				idx := sort.SearchStrings(newKeys, val)
+				if idx < len(newKeys) && newKeys[idx] == val {
+					cur.recordEditIdx = idx
+					cur.recordCursor = idx // keep list selection in sync for when user exits edit
+				}
+				cur.stayOnField = true // Stay on Name so user can see the updated value
+			},
 		},
 	}
 

--- a/internal/configeditor/fields_doors_test.go
+++ b/internal/configeditor/fields_doors_test.go
@@ -1,0 +1,96 @@
+package configeditor
+
+import (
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+)
+
+// newDoorModel builds a Model seeded with the given doors map, on the door screen.
+func newDoorModel(doors map[string]config.DoorConfig) *Model {
+	return &Model{
+		configs:    &allConfigs{Doors: doors},
+		recordType: "door",
+	}
+}
+
+// Doors are persisted as a JSON array keyed by Name on load, so a new door's
+// map key must equal its Name — otherwise the list shows a stale slug like
+// "newdoor1" that silently disappears on reload.
+func TestInsertDoorKeyedByName(t *testing.T) {
+	m := newDoorModel(map[string]config.DoorConfig{})
+	m.insertRecord()
+	d, ok := m.configs.Doors["NEWDOOR1"]
+	if !ok {
+		t.Fatalf("expected key NEWDOOR1, got keys %v", m.doorKeys())
+	}
+	if d.Name != "NEWDOOR1" {
+		t.Errorf("Name = %q, want NEWDOOR1 (key and Name must match)", d.Name)
+	}
+	m.insertRecord()
+	if d2, ok := m.configs.Doors["NEWDOOR2"]; !ok || d2.Name != "NEWDOOR2" {
+		t.Errorf("second insert: got keys %v, NEWDOOR2.Name = %q", m.doorKeys(), d2.Name)
+	}
+}
+
+func TestFieldsDoorNameRenamesKey(t *testing.T) {
+	m := newDoorModel(map[string]config.DoorConfig{
+		"LORD":   {Name: "LORD", WorkingDirectory: "doors/lord"},
+		"TW2002": {Name: "TW2002"},
+	})
+	m.recordEditIdx = 0 // sorted keys: LORD, TW2002
+	fields := m.buildRecordFields()
+	name := findField(t, fields, "Name")
+
+	// Renaming uppercases (DOOR:NAME menu lookups are uppercase) and re-keys the map.
+	if err := name.Set("legend"); err != nil {
+		t.Fatalf("Set(legend): %v", err)
+	}
+	if _, ok := m.configs.Doors["LORD"]; ok {
+		t.Error("old key LORD still present after rename")
+	}
+	d, ok := m.configs.Doors["LEGEND"]
+	if !ok {
+		t.Fatalf("renamed key LEGEND missing, keys = %v", m.doorKeys())
+	}
+	if d.Name != "LEGEND" {
+		t.Errorf("Name = %q, want LEGEND", d.Name)
+	}
+	if d.WorkingDirectory != "doors/lord" {
+		t.Errorf("rename dropped config: WorkingDirectory = %q", d.WorkingDirectory)
+	}
+
+	// AfterSet re-syncs the edit index to the renamed entry and stays on the field.
+	if name.AfterSet == nil {
+		t.Fatal("Name field must have AfterSet to re-sync indices after rename")
+	}
+	name.AfterSet(m, "LEGEND")
+	if m.recordEditIdx != 0 { // sorted: LEGEND, TW2002
+		t.Errorf("recordEditIdx = %d, want 0", m.recordEditIdx)
+	}
+	if !m.stayOnField {
+		t.Error("stayOnField should be true after rename")
+	}
+}
+
+func TestFieldsDoorNameValidation(t *testing.T) {
+	m := newDoorModel(map[string]config.DoorConfig{
+		"LORD":   {Name: "LORD"},
+		"TW2002": {Name: "TW2002"},
+	})
+	m.recordEditIdx = 0
+	name := findField(t, m.buildRecordFields(), "Name")
+
+	if err := name.Set(""); err == nil {
+		t.Error("empty name should be rejected")
+	}
+	if err := name.Set("tw2002"); err == nil {
+		t.Error("duplicate name (case-insensitive) should be rejected")
+	}
+	if err := name.Set("LORD"); err != nil {
+		t.Errorf("re-setting the same name should be a no-op, got %v", err)
+	}
+	if _, ok := m.configs.Doors["LORD"]; !ok {
+		t.Error("LORD should still exist after no-op rename")
+	}
+}

--- a/internal/configeditor/fields_doors_test.go
+++ b/internal/configeditor/fields_doors_test.go
@@ -94,3 +94,25 @@ func TestFieldsDoorNameValidation(t *testing.T) {
 		t.Error("LORD should still exist after no-op rename")
 	}
 }
+
+// A door keyed uppercase but carrying a mixed-case Name (possible in a
+// hand-edited doors.json before load normalization existed) must have its
+// Name normalized even when the key itself doesn't change.
+func TestFieldsDoorNameSameKeyNormalizesName(t *testing.T) {
+	m := newDoorModel(map[string]config.DoorConfig{
+		"LORD": {Name: "Lord"},
+	})
+	m.recordEditIdx = 0
+	name := findField(t, m.buildRecordFields(), "Name")
+
+	if err := name.Set("lord"); err != nil {
+		t.Fatalf("Set(lord): %v", err)
+	}
+	d, ok := m.configs.Doors["LORD"]
+	if !ok {
+		t.Fatalf("key LORD missing, keys = %v", m.doorKeys())
+	}
+	if d.Name != "LORD" {
+		t.Errorf("Name = %q, want LORD (same-key set must still normalize Name)", d.Name)
+	}
+}

--- a/internal/configeditor/update_save.go
+++ b/internal/configeditor/update_save.go
@@ -183,11 +183,13 @@ func (m *Model) insertRecord() {
 			Name:     "New Conference",
 		})
 	case "door":
+		// Key and Name must match: doors.json is saved as an array and re-keyed
+		// by Name on load, so a divergent key would vanish on reload.
 		for i := 1; ; i++ {
-			name := fmt.Sprintf("newdoor%d", i)
+			name := fmt.Sprintf("NEWDOOR%d", i)
 			if _, exists := m.configs.Doors[name]; !exists {
 				m.configs.Doors[name] = config.DoorConfig{
-					Name: "New Door",
+					Name: name,
 				}
 				break
 			}

--- a/internal/configeditor/view_list.go
+++ b/internal/configeditor/view_list.go
@@ -194,7 +194,7 @@ func (m Model) recordColumnHeader(boxW int) string {
 	case "conference":
 		return " Pos  #  Tag               Name                         ACS"
 	case "door":
-		return "  Key                     Name                         I/O Mode"
+		return "  Name                    Working Dir                  Type"
 	case "event":
 		return "  #  Name                                                     Enabled"
 	case "ftn":
@@ -241,7 +241,7 @@ func (m Model) renderRecordRow(idx, boxW int) string {
 		if idx < len(keys) {
 			k := keys[idx]
 			d := m.configs.Doors[k]
-			content = fmt.Sprintf("  %-22s %-28s %s", padRight(k, 22), padRight(d.Name, 28), doorTypeLabel(&d))
+			content = fmt.Sprintf("  %-22s %-28s %s", padRight(d.Name, 22), padRight(d.WorkingDirectory, 28), doorTypeLabel(&d))
 		}
 	case "event":
 		if idx < len(m.configs.Events.Events) {


### PR DESCRIPTION
## Problem

Adding a door via the CONFIG TUI left the user with an uneditable auto-generated key like `newdoor1`. There was no "Key" field because the key was never real: `doors.json` is saved as an array and re-keyed by `Name` on load, so the invented slug silently vanished on reload while the list kept displaying it.

## Changes

- **New doors are keyed by their Name** (`NEWDOOR1`), so the list always shows the real identifier.
- **Editing Name renames the map key in place** — case-insensitive dupe check, cursor re-sync via `AfterSet`, stays on the field so the user sees the updated value (same pattern as the FTN network rename in `fields_ftn.go`).
- **Names normalize to uppercase**, since `DOOR:NAME` menu lookups do `GetDoorConfig(strings.ToUpper(input))`.
- **`LoadDoors` keys the registry by uppercased Name**, so mixed-case names in a hand-edited `doors.json` remain reachable from menus (previously such doors were silently unreachable).
- **Door list shows Name / Working Dir / Type** instead of the redundant key column; the old header also mislabeled the type column as "I/O Mode".

## Testing

- New tests: insert keys by Name, rename re-keys map + preserves config + re-syncs indices, validation (empty/dupe/no-op), `LoadDoors` uppercase keying + case-insensitive dupe detection.
- All tests written first and observed failing (TDD).
- `go test ./...`: 1875 passed in 57 packages; `gofmt`/`go vet` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Door names are now trimmed and normalized to uppercase during load and editing.
  * Renaming a door re-keys it consistently and keeps the editor focused on the name field.
  * Newly created doors use consistent name-based keys to persist correctly across reloads.
  * Door list views now show the door name (and working directory) instead of the internal key.
* **Bug Fixes**
  * Empty door names are rejected.
  * Duplicate door names are detected case-insensitively.
* **Tests**
  * Added coverage for normalization, validation, duplicate detection, and rename/key behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->