### PR TITLE
fix(configeditor): propagate doors.json load errors instead of showing empty list

### DIFF
--- a/internal/configeditor/fileio.go
+++ b/internal/configeditor/fileio.go
@@ -64,11 +64,12 @@ func loadAllConfigs(configPath string) (allConfigs, error) {
 		return ac, fmt.Errorf("loading file areas: %w", err)
 	}
 
-	// Doors
+	// Doors (LoadDoors returns an empty map, not an error, for a missing file).
+	// A real load error must propagate: silently editing an empty list would
+	// overwrite the existing doors.json on save.
 	ac.Doors, err = config.LoadDoors(filepath.Join(configPath, "doors.json"))
 	if err != nil {
-		// Doors file may not exist; initialize empty
-		ac.Doors = make(map[string]config.DoorConfig)
+		return ac, fmt.Errorf("loading doors: %w", err)
 	}
 
 	// Events

--- a/internal/configeditor/fileio_test.go
+++ b/internal/configeditor/fileio_test.go
@@ -1,0 +1,35 @@
+package configeditor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A doors.json that fails to load (e.g. old format without the required
+// "code" field) must surface an error — not silently present an empty door
+// list that would wipe the file on the next save.
+func TestLoadAllConfigsPropagatesDoorsError(t *testing.T) {
+	dir := t.TempDir()
+	bad := `[{"name": "LORD", "commands": ["/usr/bin/lord"]}]`
+	if err := os.WriteFile(filepath.Join(dir, "doors.json"), []byte(bad), 0644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	if _, err := loadAllConfigs(dir); err == nil {
+		t.Error("expected error for invalid doors.json, got nil")
+	}
+}
+
+// A missing doors.json is fine (doors are optional): loadAllConfigs must
+// succeed with an empty map.
+func TestLoadAllConfigsMissingDoorsOK(t *testing.T) {
+	dir := t.TempDir()
+	ac, err := loadAllConfigs(dir)
+	if err != nil {
+		t.Fatalf("loadAllConfigs with no doors.json: %v", err)
+	}
+	if ac.Doors == nil || len(ac.Doors) != 0 {
+		t.Errorf("Doors = %v, want empty non-nil map", ac.Doors)
+	}
+}


### PR DESCRIPTION
## Problem

After the door code/name split (#104), a `doors.json` in the old format fails to load — but the config editor silently swallowed the error and presented an **empty door list** (`fileio.go`'s fallback). Saving from that state would overwrite the file with `[]`. This is how "all doors are empty" manifested on a live install.

`LoadDoors` already returns an empty map with no error for a *missing* file, so the fallback never served its stated purpose — it only masked real errors.

## Changes

- `loadAllConfigs` now propagates `LoadDoors` errors like every other config section, so the editor refuses to start with a corrupt/outdated `doors.json` instead of silently offering to wipe it.
- Tests: invalid doors.json → error surfaces; missing doors.json → still fine (empty map).

Note: live installs with an old-format `doors.json` need it regenerated from `templates/configs/doors.json` (pre-release, no migration path per project direction).

## Testing

TDD (both tests observed failing/passing appropriately first). `go test ./...`: 1887 passed in 57 packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration loading now reports errors when the doors configuration is invalid instead of silently ignoring them.
  * Missing doors configuration files are handled as empty configurations, allowing loading to continue successfully.

* **Tests**
  * Added coverage for invalid and missing doors configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->