### PR TITLE
fix(v3net/hub): close SSE publish-before-subscribe race (flaky TestSSEHTTPStream)

### DIFF
--- a/internal/v3net/hub/events.go
+++ b/internal/v3net/hub/events.go
@@ -105,14 +105,20 @@ func (b *Broadcaster) ServeSSE(w http.ResponseWriter, r *http.Request, network s
 		return
 	}
 
+	// Subscribe BEFORE announcing readiness to the client. The client's
+	// request returns as soon as these headers are flushed, so if we
+	// subscribed afterward a caller could publish an event in the window
+	// between receiving the headers and this handler registering its
+	// channel — that event would fan out to zero subscribers and be lost.
+	// Registering first closes that publish-before-subscribe race.
+	ch, cancel := b.Subscribe(network)
+	defer cancel()
+
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
-
-	ch, cancel := b.Subscribe(network)
-	defer cancel()
 
 	ctx := r.Context()
 	for {

--- a/internal/v3net/hub/hub_test.go
+++ b/internal/v3net/hub/hub_test.go
@@ -372,10 +372,13 @@ func TestSSEHTTPStream(t *testing.T) {
 		if eventType != "chat" {
 			t.Errorf("expected chat event, got %q", eventType)
 		}
-	// Generous deadline: 2s flaked repeatedly on loaded CI runners under
-	// -race. Passing runs aren't delayed (the done case wins as soon as
-	// the event arrives); only failing runs wait out the full deadline.
-	case <-time.After(15 * time.Second):
+	// ServeSSE registers its subscriber before returning the response
+	// headers, so by the time the SSE request above completes the
+	// subscription is guaranteed live and the Publish below cannot be
+	// missed. The event therefore arrives promptly; this deadline only
+	// bounds a genuine hang. (A publish-before-subscribe race previously
+	// forced this up to 15s — see ServeSSE.)
+	case <-time.After(5 * time.Second):
 		t.Error("timed out waiting for SSE event over HTTP")
 	}
 }

--- a/internal/v3net/hub/hub_test.go
+++ b/internal/v3net/hub/hub_test.go
@@ -373,9 +373,9 @@ func TestSSEHTTPStream(t *testing.T) {
 			t.Errorf("expected chat event, got %q", eventType)
 		}
 	// ServeSSE registers its subscriber before returning the response
-	// headers, so by the time the SSE request above completes the
-	// subscription is guaranteed live and the Publish below cannot be
-	// missed. The event therefore arrives promptly; this deadline only
+	// headers, so the subscription is guaranteed live by the time the SSE
+	// request above returns — the event published just above therefore
+	// cannot be missed. The event arrives promptly; this deadline only
 	// bounds a genuine hang. (A publish-before-subscribe race previously
 	// forced this up to 15s — see ServeSSE.)
 	case <-time.After(5 * time.Second):


### PR DESCRIPTION
## Problem
`TestSSEHTTPStream` (`internal/v3net/hub`) intermittently times out on loaded CI runners ("timed out waiting for SSE event over HTTP"). It flakes on `main` too and was recently papered over by inflating its deadline from 2s → 15s. It is unrelated to any feature branch.

## Root cause
A **publish-before-subscribe race** in `Broadcaster.ServeSSE`. The handler flushed the `200 text/event-stream` response headers **before** registering its subscriber channel:

```go
w.WriteHeader(http.StatusOK)
flusher.Flush()                    // client's http.Do() returns here
ch, cancel := b.Subscribe(network) // subscription registered only after
```

A client's request returns the instant those headers arrive, so any event published in the window between the client receiving headers and the handler reaching `Subscribe` fans out to zero subscribers and is lost. The test publishes immediately after connecting, so on an unlucky schedule the event never arrives and the `select` waits out the full deadline.

### Proven, not guessed
Injecting a 300ms delay into that exact window (after the flush, before `Subscribe`) makes the timeout **deterministic**. After the fix, re-injecting the same delay (now after `Subscribe`) passes — the perturbation that broke it no longer can.

## Fix
Register the subscriber **before** writing/flushing the response headers. Within the handler goroutine `Subscribe` (a mutex-guarded append) completes before the header bytes hit the socket, so by the time the client's request returns the subscription is guaranteed live and no subsequent publish can be missed. One-line reorder + explanatory comment; no protocol or API change.

Also restores the test deadline to a fail-fast **5s** (the 15s was purely to mask this flake).

## Verification
- Reproduced deterministically via injected delay; confirmed the fix defeats it.
- `GOMAXPROCS=1 go test -race -run TestSSEHTTPStream -count=40` — all pass (worst-case scheduling).
- Full `go test -race ./internal/v3net/hub/` — green.
- `gofmt`/`go vet` clean.

Follow-up to #107 (whose CI surfaced this pre-existing flake).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time event delivery by ensuring subscriptions are established before the SSE connection begins.
  * Prevented events from being missed during the initial connection process.

* **Tests**
  * Updated SSE connection testing to detect genuine hangs more quickly with a shorter timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->