### PR TITLE
feat(doors): per-door dropfile filename case + Commands placeholder docs

### DIFF
--- a/docs/sysop/configuration/configuration.md
+++ b/docs/sysop/configuration/configuration.md
@@ -259,8 +259,8 @@ Configures external door programs that can be launched from the BBS. The file co
 - `{USERID}` - User ID number
 - `{REALNAME}` - User's real name
 - `{LEVEL}` - Access level
-- `{DROPFILE}` - Linux path to the generated dropfile (full path incl. filename)
-- `{NODEDIR}` - Linux path to the dropfile's directory, **no trailing slash**. Some door libraries (e.g. godoors) concatenate the filename directly and need a trailing slash — pass `{NODEDIR}/` in that case.
+- `{DROPFILE}` - Host OS path to the generated dropfile (full path incl. filename)
+- `{NODEDIR}` - Host OS path to the dropfile's directory, **no trailing slash**. Some door libraries (e.g. godoors) concatenate the filename directly and need a trailing slash — pass `{NODEDIR}/` in that case.
 - `{DOSDROPFILE}` / `{DOSNODEDIR}` - DOS paths (e.g., `C:\NODES\TEMP1\DOOR.SYS`)
 
 ## archivers.json

--- a/docs/sysop/configuration/configuration.md
+++ b/docs/sysop/configuration/configuration.md
@@ -229,6 +229,7 @@ Configures external door programs that can be launched from the BBS. The file co
 - `working_directory` - Native: Linux directory to run the command in. DOS: DOS path to cd into before running commands
 - `dropfile_type` - Dropfile format: `DOOR.SYS`, `DOOR32.SYS`, `CHAIN.TXT`, `DORINFO1.DEF`, or blank
 - `dropfile_location` - Where to write dropfile: `startup` (working dir) or `node` (per-node temp dir)
+- `dropfile_case` - Filename case for the generated dropfile: `upper` (default, e.g. `DOOR32.SYS`) or `lower` (e.g. `door32.sys`). Use `lower` for native Linux doors whose library opens a lowercase dropfile name on a case-sensitive filesystem. Does not affect DOS doors.
 - `min_access_level` - Minimum user access level (0 = no restriction)
 - `single_instance` - Only allow one node to run this door at a time
 - `cleanup_command` / `cleanup_args` - Post-exit cleanup command (supports placeholders)
@@ -258,7 +259,8 @@ Configures external door programs that can be launched from the BBS. The file co
 - `{USERID}` - User ID number
 - `{REALNAME}` - User's real name
 - `{LEVEL}` - Access level
-- `{DROPFILE}` / `{NODEDIR}` - Linux paths to dropfile and its directory
+- `{DROPFILE}` - Linux path to the generated dropfile (full path incl. filename)
+- `{NODEDIR}` - Linux path to the dropfile's directory, **no trailing slash**. Some door libraries (e.g. godoors) concatenate the filename directly and need a trailing slash — pass `{NODEDIR}/` in that case.
 - `{DOSDROPFILE}` / `{DOSNODEDIR}` - DOS paths (e.g., `C:\NODES\TEMP1\DOOR.SYS`)
 
 ## archivers.json

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -606,6 +606,7 @@ type DoorConfig struct {
 	Commands            []string          `json:"commands,omitempty"`              // Commands to execute (native: [0]=executable, [1:]=args; DOS: batch lines)
 	DropfileType        string            `json:"dropfile_type,omitempty"`         // Type of dropfile ("DOOR.SYS", "CHAIN.TXT", "NONE") (optional, defaults to NONE)
 	DropfileLocation    string            `json:"dropfile_location,omitempty"`     // Where to write dropfile: "startup" (working dir, default) or "node" (per-node temp dir)
+	DropfileCase        string            `json:"dropfile_case,omitempty"`         // Dropfile filename case: "upper" (default) or "lower"
 	IOMode              string            `json:"io_mode,omitempty"`               // I/O handling ("STDIO", "SOCKET") (optional, defaults to STDIO)
 	RequiresRawTerminal bool              `json:"requires_raw_terminal,omitempty"` // Whether the BBS should attempt to put the terminal in raw mode (optional, defaults to false)
 	UseShell            bool              `json:"use_shell,omitempty"`             // Wrap command in /bin/sh -c (Linux) or cmd /c (Windows)

--- a/internal/configeditor/fields_doors.go
+++ b/internal/configeditor/fields_doors.go
@@ -344,6 +344,19 @@ func (m *Model) fieldsDoor() []fieldDef {
 				}
 			},
 		})
+
+		row++
+		fields = append(fields, fieldDef{
+			Label: "Dropfile Case", Help: "Filename case for the dropfile", Type: ftLookup, Col: 3, Row: row, Width: 10,
+			Get: func() string { return dPtr.DropfileCase },
+			Set: func(val string) error { dPtr.DropfileCase = val; save(); return nil },
+			LookupItems: func() []LookupItem {
+				return []LookupItem{
+					{Value: "upper", Display: "upper - DOOR32.SYS (default)"},
+					{Value: "lower", Display: "lower - door32.sys"},
+				}
+			},
+		})
 	}
 
 	// Common fields for all door types

--- a/internal/configeditor/fields_doors.go
+++ b/internal/configeditor/fields_doors.go
@@ -345,32 +345,36 @@ func (m *Model) fieldsDoor() []fieldDef {
 			},
 		})
 
-		row++
-		fields = append(fields, fieldDef{
-			Label: "Dropfile Case", Help: "Filename case for the dropfile (native/Windows only)", Type: ftLookup, Col: 3, Row: row, Width: 10,
-			Get: func() string {
-				if dPtr.DropfileCase == "" {
-					return "upper"
-				}
-				return dPtr.DropfileCase
-			},
-			Set: func(val string) error {
-				if strings.EqualFold(val, "upper") {
-					// Preserve byte-identical legacy configs: empty means the default "upper".
-					dPtr.DropfileCase = ""
-				} else {
-					dPtr.DropfileCase = val
-				}
-				save()
-				return nil
-			},
-			LookupItems: func() []LookupItem {
-				return []LookupItem{
-					{Value: "upper", Display: "upper - DOOR32.SYS (default)"},
-					{Value: "lower", Display: "lower - door32.sys"},
-				}
-			},
-		})
+		// Dropfile Case only affects native/Windows doors; DOS doors use a
+		// separate dosDropfileName path that ignores it, so hide it for DOS.
+		if !dPtr.IsDOS {
+			row++
+			fields = append(fields, fieldDef{
+				Label: "Dropfile Case", Help: "Filename case for the dropfile (native/Windows only)", Type: ftLookup, Col: 3, Row: row, Width: 10,
+				Get: func() string {
+					if dPtr.DropfileCase == "" {
+						return "upper"
+					}
+					return dPtr.DropfileCase
+				},
+				Set: func(val string) error {
+					if strings.EqualFold(val, "upper") {
+						// Preserve byte-identical legacy configs: empty means the default "upper".
+						dPtr.DropfileCase = ""
+					} else {
+						dPtr.DropfileCase = val
+					}
+					save()
+					return nil
+				},
+				LookupItems: func() []LookupItem {
+					return []LookupItem{
+						{Value: "upper", Display: "upper - DOOR32.SYS (default)"},
+						{Value: "lower", Display: "lower - door32.sys"},
+					}
+				},
+			})
+		}
 	}
 
 	// Common fields for all door types

--- a/internal/configeditor/fields_doors.go
+++ b/internal/configeditor/fields_doors.go
@@ -347,7 +347,7 @@ func (m *Model) fieldsDoor() []fieldDef {
 
 		row++
 		fields = append(fields, fieldDef{
-			Label: "Dropfile Case", Help: "Filename case for the dropfile", Type: ftLookup, Col: 3, Row: row, Width: 10,
+			Label: "Dropfile Case", Help: "Filename case for the dropfile (native/Windows only)", Type: ftLookup, Col: 3, Row: row, Width: 10,
 			Get: func() string { return dPtr.DropfileCase },
 			Set: func(val string) error { dPtr.DropfileCase = val; save(); return nil },
 			LookupItems: func() []LookupItem {

--- a/internal/configeditor/fields_doors.go
+++ b/internal/configeditor/fields_doors.go
@@ -348,8 +348,22 @@ func (m *Model) fieldsDoor() []fieldDef {
 		row++
 		fields = append(fields, fieldDef{
 			Label: "Dropfile Case", Help: "Filename case for the dropfile (native/Windows only)", Type: ftLookup, Col: 3, Row: row, Width: 10,
-			Get: func() string { return dPtr.DropfileCase },
-			Set: func(val string) error { dPtr.DropfileCase = val; save(); return nil },
+			Get: func() string {
+				if dPtr.DropfileCase == "" {
+					return "upper"
+				}
+				return dPtr.DropfileCase
+			},
+			Set: func(val string) error {
+				if strings.EqualFold(val, "upper") {
+					// Preserve byte-identical legacy configs: empty means the default "upper".
+					dPtr.DropfileCase = ""
+				} else {
+					dPtr.DropfileCase = val
+				}
+				save()
+				return nil
+			},
 			LookupItems: func() []LookupItem {
 				return []LookupItem{
 					{Value: "upper", Display: "upper - DOOR32.SYS (default)"},

--- a/internal/configeditor/fields_doors.go
+++ b/internal/configeditor/fields_doors.go
@@ -311,7 +311,7 @@ func (m *Model) fieldsDoor() []fieldDef {
 		// Native and DOS doors have commands and dropfiles
 		row++
 		fields = append(fields, fieldDef{
-			Label: "Commands", Help: "Native: command args / DOS: comma-separated DOS commands", Type: ftString, Col: 3, Row: row, Width: 45,
+			Label: "Commands", Help: "Native: cmd + comma-sep args. Placeholders: {NODEDIR} {DROPFILE} {NODE} {PORT} — add trailing / if the door needs it, e.g. {NODEDIR}/", Type: ftString, Col: 3, Row: row, Width: 45,
 			Get: func() string { return doorCommandsGet(dPtr) },
 			Set: func(val string) error { doorCommandsSet(dPtr, val); save(); return nil },
 		})

--- a/internal/configeditor/fields_doors_test.go
+++ b/internal/configeditor/fields_doors_test.go
@@ -129,13 +129,19 @@ func TestFieldsDoorNamePreservesCase(t *testing.T) {
 }
 
 func TestDropfileCaseField(t *testing.T) {
-	d := &doorEditProxy{}
-	d.DropfileCase = "lower"
-	if d.DropfileCase != "lower" {
-		t.Fatalf("setup failed")
+	m := newDoorModel(map[string]config.DoorConfig{
+		"LORD": {Code: "LORD", Name: "LORD"},
+	})
+	m.recordEditIdx = 0
+	fld := findField(t, m.buildRecordFields(), "Dropfile Case")
+
+	if err := fld.Set("lower"); err != nil {
+		t.Fatalf("Set(lower): %v", err)
 	}
-	d.DropfileCase = "upper"
-	if got := d.DropfileCase; got != "upper" {
-		t.Errorf("DropfileCase = %q, want upper", got)
+	if got := m.configs.Doors["LORD"].DropfileCase; got != "lower" {
+		t.Errorf("persisted DropfileCase = %q, want lower", got)
+	}
+	if got := fld.Get(); got != "lower" {
+		t.Errorf("Get() = %q, want lower", got)
 	}
 }

--- a/internal/configeditor/fields_doors_test.go
+++ b/internal/configeditor/fields_doors_test.go
@@ -127,3 +127,15 @@ func TestFieldsDoorNamePreservesCase(t *testing.T) {
 		t.Errorf("Name = %q, want case preserved", d.Name)
 	}
 }
+
+func TestDropfileCaseField(t *testing.T) {
+	d := &doorEditProxy{}
+	d.DropfileCase = "lower"
+	if d.DropfileCase != "lower" {
+		t.Fatalf("setup failed")
+	}
+	d.DropfileCase = "upper"
+	if got := d.DropfileCase; got != "upper" {
+		t.Errorf("DropfileCase = %q, want upper", got)
+	}
+}

--- a/internal/configeditor/fields_doors_test.go
+++ b/internal/configeditor/fields_doors_test.go
@@ -145,3 +145,17 @@ func TestDropfileCaseField(t *testing.T) {
 		t.Errorf("Get() = %q, want lower", got)
 	}
 }
+
+// Dropfile Case only affects native/Windows doors, so the field is hidden for
+// DOS doors (which use a separate dosDropfileName path that ignores it).
+func TestDropfileCaseFieldHiddenForDOS(t *testing.T) {
+	m := newDoorModel(map[string]config.DoorConfig{
+		"DOSGAME": {Code: "DOSGAME", Name: "DOSGAME", IsDOS: true},
+	})
+	m.recordEditIdx = 0
+	for _, f := range m.buildRecordFields() {
+		if f.Label == "Dropfile Case" {
+			t.Error("Dropfile Case field should be hidden for DOS doors")
+		}
+	}
+}

--- a/internal/menu/door_handler_dropfiles.go
+++ b/internal/menu/door_handler_dropfiles.go
@@ -85,6 +85,16 @@ func buildDoorCtx(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 
 // --- Dropfile Generators ---
 
+// dropfileName resolves the on-disk filename for a dropfile type, applying the
+// configured case. dropfileCase == "lower" (case-insensitive) yields a lowercase
+// name (e.g. "door32.sys"); an empty or unrecognized value defaults to uppercase.
+func dropfileName(dropfileType, dropfileCase string) string {
+	if strings.EqualFold(dropfileCase, "lower") {
+		return strings.ToLower(dropfileType)
+	}
+	return strings.ToUpper(dropfileType)
+}
+
 // generateDoorSys writes a full 52-line PCBoard DOOR.SYS file.
 func generateDoorSys(ctx *DoorCtx, dir string) error {
 	path := filepath.Join(dir, "DOOR.SYS")

--- a/internal/menu/door_handler_dropfiles.go
+++ b/internal/menu/door_handler_dropfiles.go
@@ -233,8 +233,7 @@ func generateDorInfo(ctx *DoorCtx, dir, filename string) error {
 // generateChainTxt writes a CHAIN.TXT file (WWIV format).
 func generateChainTxt(ctx *DoorCtx, dir, filename string) error {
 	path := filepath.Join(dir, filename)
-	slog.Info("generating CHAIN.TXT", "path", path)
-
+	slog.Info("generating dropfile", "type", "CHAIN.TXT", "filename", filename, "path", path)
 	bbsName := ctx.Executor.ServerCfg.BoardName
 	timeLeftSecs := ctx.TimeLeftMin * 60
 	crlf := "\r\n"

--- a/internal/menu/door_handler_dropfiles.go
+++ b/internal/menu/door_handler_dropfiles.go
@@ -193,8 +193,7 @@ func generateDoor32Sys(ctx *DoorCtx, dir, filename string) error {
 // generateDorInfo writes a 13-line DORINFO1.DEF file.
 func generateDorInfo(ctx *DoorCtx, dir, filename string) error {
 	path := filepath.Join(dir, filename)
-	slog.Info("generating DORINFO1.DEF", "path", path)
-
+	slog.Info("generating dropfile", "type", "DORINFO1.DEF", "filename", filename, "path", path)
 	bbsName := ctx.Executor.ServerCfg.BoardName
 	crlf := "\r\n"
 

--- a/internal/menu/door_handler_dropfiles.go
+++ b/internal/menu/door_handler_dropfiles.go
@@ -98,8 +98,7 @@ func dropfileName(dropfileType, dropfileCase string) string {
 // generateDoorSys writes a full 52-line PCBoard DOOR.SYS file.
 func generateDoorSys(ctx *DoorCtx, dir, filename string) error {
 	path := filepath.Join(dir, filename)
-	slog.Info("generating DOOR.SYS", "path", path)
-
+	slog.Info("generating dropfile", "type", "DOOR.SYS", "filename", filename, "path", path)
 	bbsName := ctx.Executor.ServerCfg.BoardName
 	timeLeftSecs := ctx.TimeLeftMin * 60
 

--- a/internal/menu/door_handler_dropfiles.go
+++ b/internal/menu/door_handler_dropfiles.go
@@ -96,8 +96,8 @@ func dropfileName(dropfileType, dropfileCase string) string {
 }
 
 // generateDoorSys writes a full 52-line PCBoard DOOR.SYS file.
-func generateDoorSys(ctx *DoorCtx, dir string) error {
-	path := filepath.Join(dir, "DOOR.SYS")
+func generateDoorSys(ctx *DoorCtx, dir, filename string) error {
+	path := filepath.Join(dir, filename)
 	slog.Info("generating DOOR.SYS", "path", path)
 
 	bbsName := ctx.Executor.ServerCfg.BoardName
@@ -169,8 +169,8 @@ func generateDoorSys(ctx *DoorCtx, dir string) error {
 }
 
 // generateDoor32Sys writes an 11-line DOOR32.SYS file.
-func generateDoor32Sys(ctx *DoorCtx, dir string) error {
-	path := filepath.Join(dir, "DOOR32.SYS")
+func generateDoor32Sys(ctx *DoorCtx, dir, filename string) error {
+	path := filepath.Join(dir, filename)
 	slog.Info("generating DOOR32.SYS", "path", path)
 
 	bbsName := ctx.Executor.ServerCfg.BoardName
@@ -193,8 +193,8 @@ func generateDoor32Sys(ctx *DoorCtx, dir string) error {
 }
 
 // generateDorInfo writes a 13-line DORINFO1.DEF file.
-func generateDorInfo(ctx *DoorCtx, dir string) error {
-	path := filepath.Join(dir, "DORINFO1.DEF")
+func generateDorInfo(ctx *DoorCtx, dir, filename string) error {
+	path := filepath.Join(dir, filename)
 	slog.Info("generating DORINFO1.DEF", "path", path)
 
 	bbsName := ctx.Executor.ServerCfg.BoardName
@@ -234,8 +234,8 @@ func generateDorInfo(ctx *DoorCtx, dir string) error {
 }
 
 // generateChainTxt writes a CHAIN.TXT file (WWIV format).
-func generateChainTxt(ctx *DoorCtx, dir string) error {
-	path := filepath.Join(dir, "CHAIN.TXT")
+func generateChainTxt(ctx *DoorCtx, dir, filename string) error {
+	path := filepath.Join(dir, filename)
 	slog.Info("generating CHAIN.TXT", "path", path)
 
 	bbsName := ctx.Executor.ServerCfg.BoardName
@@ -293,16 +293,16 @@ func generateAllDropfiles(ctx *DoorCtx, dir string) error {
 		return fmt.Errorf("failed to create dropfile directory %s: %w", dir, err)
 	}
 
-	if err := generateDoorSys(ctx, dir); err != nil {
+	if err := generateDoorSys(ctx, dir, "DOOR.SYS"); err != nil {
 		return fmt.Errorf("failed to generate DOOR.SYS: %w", err)
 	}
-	if err := generateDoor32Sys(ctx, dir); err != nil {
+	if err := generateDoor32Sys(ctx, dir, "DOOR32.SYS"); err != nil {
 		return fmt.Errorf("failed to generate DOOR32.SYS: %w", err)
 	}
-	if err := generateDorInfo(ctx, dir); err != nil {
+	if err := generateDorInfo(ctx, dir, "DORINFO1.DEF"); err != nil {
 		return fmt.Errorf("failed to generate DORINFO1.DEF: %w", err)
 	}
-	if err := generateChainTxt(ctx, dir); err != nil {
+	if err := generateChainTxt(ctx, dir, "CHAIN.TXT"); err != nil {
 		return fmt.Errorf("failed to generate CHAIN.TXT: %w", err)
 	}
 

--- a/internal/menu/door_handler_dropfiles.go
+++ b/internal/menu/door_handler_dropfiles.go
@@ -170,8 +170,7 @@ func generateDoorSys(ctx *DoorCtx, dir, filename string) error {
 // generateDoor32Sys writes an 11-line DOOR32.SYS file.
 func generateDoor32Sys(ctx *DoorCtx, dir, filename string) error {
 	path := filepath.Join(dir, filename)
-	slog.Info("generating DOOR32.SYS", "path", path)
-
+	slog.Info("generating dropfile", "type", "DOOR32.SYS", "filename", filename, "path", path)
 	bbsName := ctx.Executor.ServerCfg.BoardName
 	crlf := "\r\n"
 

--- a/internal/menu/door_handler_dropfiles_test.go
+++ b/internal/menu/door_handler_dropfiles_test.go
@@ -1,0 +1,28 @@
+package menu
+
+import "testing"
+
+func TestDropfileName(t *testing.T) {
+	tests := []struct {
+		name         string
+		dropfileType string
+		dropfileCase string
+		want         string
+	}{
+		{"default empty is upper", "DOOR32.SYS", "", "DOOR32.SYS"},
+		{"explicit upper", "DOOR32.SYS", "upper", "DOOR32.SYS"},
+		{"lower", "DOOR32.SYS", "lower", "door32.sys"},
+		{"lower case-insensitive key", "DOOR32.SYS", "Lower", "door32.sys"},
+		{"unknown case defaults upper", "DOOR32.SYS", "weird", "DOOR32.SYS"},
+		{"door.sys lower", "DOOR.SYS", "lower", "door.sys"},
+		{"chain.txt lower", "CHAIN.TXT", "lower", "chain.txt"},
+		{"dorinfo lower", "DORINFO1.DEF", "lower", "dorinfo1.def"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dropfileName(tt.dropfileType, tt.dropfileCase); got != tt.want {
+				t.Errorf("dropfileName(%q, %q) = %q, want %q", tt.dropfileType, tt.dropfileCase, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/menu/door_handler_dropfiles_test.go
+++ b/internal/menu/door_handler_dropfiles_test.go
@@ -1,6 +1,12 @@
 package menu
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+)
 
 func TestDropfileName(t *testing.T) {
 	tests := []struct {
@@ -24,5 +30,27 @@ func TestDropfileName(t *testing.T) {
 				t.Errorf("dropfileName(%q, %q) = %q, want %q", tt.dropfileType, tt.dropfileCase, got, tt.want)
 			}
 		})
+	}
+}
+
+func newTestDoorCtx() *DoorCtx {
+	return &DoorCtx{
+		Executor:    &MenuExecutor{ServerCfg: config.ServerConfig{BoardName: "Test BBS"}},
+		User:        doorUserInfo{ID: 1, Handle: "Neo", RealName: "Thomas Anderson", AccessLevel: 50, ScreenWidth: 80, ScreenHeight: 25},
+		NodeNumStr:  "1",
+		UserIDStr:   "1",
+		TimeLeftMin: 30,
+	}
+}
+
+func TestGenerateDoor32SysCase(t *testing.T) {
+	dir := t.TempDir()
+	ctx := newTestDoorCtx()
+
+	if err := generateDoor32Sys(ctx, dir, "door32.sys"); err != nil {
+		t.Fatalf("generateDoor32Sys: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "door32.sys")); err != nil {
+		t.Errorf("expected lowercase door32.sys to exist: %v", err)
 	}
 }

--- a/internal/menu/door_handler_native.go
+++ b/internal/menu/door_handler_native.go
@@ -53,20 +53,21 @@ func executeNativeDoor(ctx *DoorCtx) error {
 	dropfileTypeUpper := strings.ToUpper(doorConfig.DropfileType)
 
 	if dropfileTypeUpper == "DOOR.SYS" || dropfileTypeUpper == "CHAIN.TXT" || dropfileTypeUpper == "DOOR32.SYS" || dropfileTypeUpper == "DORINFO1.DEF" {
-		dropfilePath = filepath.Join(dropfileDir, dropfileTypeUpper)
+		fname := dropfileName(dropfileTypeUpper, doorConfig.DropfileCase)
+		dropfilePath = filepath.Join(dropfileDir, fname)
 		slog.Info("generating dropfile", "type", dropfileTypeUpper, "path", dropfilePath)
 
 		// Use full-format dropfile generators (standard BBS formats)
 		var genErr error
 		switch dropfileTypeUpper {
 		case "DOOR.SYS":
-			genErr = generateDoorSys(ctx, dropfileDir)
+			genErr = generateDoorSys(ctx, dropfileDir, fname)
 		case "DOOR32.SYS":
-			genErr = generateDoor32Sys(ctx, dropfileDir)
+			genErr = generateDoor32Sys(ctx, dropfileDir, fname)
 		case "CHAIN.TXT":
-			genErr = generateChainTxt(ctx, dropfileDir)
+			genErr = generateChainTxt(ctx, dropfileDir, fname)
 		case "DORINFO1.DEF":
-			genErr = generateDorInfo(ctx, dropfileDir)
+			genErr = generateDorInfo(ctx, dropfileDir, fname)
 		}
 
 		if genErr != nil {

--- a/internal/menu/door_handler_windows.go
+++ b/internal/menu/door_handler_windows.go
@@ -54,19 +54,20 @@ func executeNativeDoorWindows(ctx *DoorCtx) error {
 	dropfileTypeUpper := strings.ToUpper(doorConfig.DropfileType)
 
 	if dropfileTypeUpper == "DOOR.SYS" || dropfileTypeUpper == "CHAIN.TXT" || dropfileTypeUpper == "DOOR32.SYS" || dropfileTypeUpper == "DORINFO1.DEF" {
-		dropfilePath = filepath.Join(dropfileDir, dropfileTypeUpper)
+		fname := dropfileName(dropfileTypeUpper, doorConfig.DropfileCase)
+		dropfilePath = filepath.Join(dropfileDir, fname)
 		slog.Info("generating dropfile", "type", dropfileTypeUpper, "path", dropfilePath)
 
 		var genErr error
 		switch dropfileTypeUpper {
 		case "DOOR.SYS":
-			genErr = generateDoorSys(ctx, dropfileDir)
+			genErr = generateDoorSys(ctx, dropfileDir, fname)
 		case "DOOR32.SYS":
-			genErr = generateDoor32Sys(ctx, dropfileDir)
+			genErr = generateDoor32Sys(ctx, dropfileDir, fname)
 		case "CHAIN.TXT":
-			genErr = generateChainTxt(ctx, dropfileDir)
+			genErr = generateChainTxt(ctx, dropfileDir, fname)
 		case "DORINFO1.DEF":
-			genErr = generateDorInfo(ctx, dropfileDir)
+			genErr = generateDorInfo(ctx, dropfileDir, fname)
 		}
 
 		if genErr != nil {


### PR DESCRIPTION
## Summary

Native/Windows doors now write their dropfile in a configurable filename **case**, so doors on case-sensitive Linux filesystems can find them. This came out of running a native Linux door (`xw-vs-tf`, which uses the `godoors` library) — godoors opens a lowercase `door32.sys`, but ViSiON/3 always wrote uppercase `DOOR32.SYS`. On macOS (case-insensitive FS) the mismatch is invisible; on Linux the door fails with `open .../door32.sys: no such file or directory`.

Also documents the door **Commands** placeholders and the `{NODEDIR}` trailing-slash gotcha (godoors concatenates `path + "door32.sys"` with no separator, so it needs `{NODEDIR}/`).

## Changes

- **`DropfileCase` config field** (`internal/config`): `"upper"` (default) or `"lower"`. Empty ⇒ uppercase, so **every existing door config is byte-identical to before**.
- **`dropfileName(type, case)` helper** + threading a resolved `filename` through the four dropfile generators and the native/Windows handlers, so the written file **and** the `{DROPFILE}` placeholder always agree on case (and cleanup removes the correctly-cased file).
- **Config editor**: new `Dropfile Case` lookup field (upper/lower) in the door editor, help text notes it's native/Windows only.
- **Docs**: `configuration.md` — expanded `{DROPFILE}`/`{NODEDIR}` placeholder docs with the trailing-slash note, plus the new `dropfile_case` field.

## Scope / non-goals

- **DOS doors untouched** — DOSBox is case-insensitive and uses a separate `dosDropfileName` path.
- No auto-append of a trailing slash to `{NODEDIR}` (would silently change existing configs).

## Testing

- New: `TestDropfileName` (table-driven, all four types × case) and `TestGenerateDoor32SysCase`; `TestDropfileCaseField` drives the editor field's Get/Set closures.
- `go test ./...` passes; `gofmt`/`go vet` clean; `GOOS=windows go build ./...` verified.

## Config example

```
Dropfile Type: DOOR32.SYS
Dropfile Location: node
Dropfile Case: lower
Commands: xw-vs-tf -path, {NODEDIR}/
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable dropfile filename casing option (uppercase default; lowercase when required).
  - Added a matching setting in the configuration editor for native/Windows dropfile filename casing.
  - Enhanced native door help text with clearer command formatting and supported placeholders.

- **Documentation**
  - Expanded guidance for `{DROPFILE}` and `{NODEDIR}`, including path formatting expectations.
  - Documented when lowercase dropfile names are needed for case-sensitive systems.

- **Bug Fixes**
  - Improved native and Windows dropfile generation to use the correct filename casing and full path layout.

- **Tests**
  - Added coverage for the new casing setting and filename generation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->