### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/docs/sysop/README.md
+++ b/docs/sysop/README.md
@@ -2,7 +2,7 @@
 
 Welcome, SysOp. This wiki covers everything you need to install, configure, and run a l33t ViSiON/3 BBS like it's 1992 all over again.
 
-> **Current Version: v0.1.1** | [GitHub Releases](https://github.com/ViSiON-3/vision-3-bbs/releases)
+> **Current Version: v0.2.0** | [GitHub Releases](https://github.com/ViSiON-3/vision-3-bbs/releases)
 >
 > ⚠️ **Early Development:** ViSiON/3 is under active development and not yet feature-complete. Expect rough edges and missing features. Use at your own risk.
 

--- a/docs/sysop/getting-started/README.md
+++ b/docs/sysop/getting-started/README.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-> **Current Version: v0.1.1** — [GitHub Releases](https://github.com/ViSiON-3/vision-3-bbs/releases)
+> **Current Version: v0.2.0** — [GitHub Releases](https://github.com/ViSiON-3/vision-3-bbs/releases)
 >
 > ⚠️ **Early Development:** ViSiON/3 is under active development and not yet feature-complete. Use at your own risk.
 

--- a/docs/sysop/getting-started/installation.md
+++ b/docs/sysop/getting-started/installation.md
@@ -1,6 +1,6 @@
 # ViSiON/3 Installation Guide
 
-> **Current Version: v0.1.1** — [GitHub Releases](https://github.com/ViSiON-3/vision-3-bbs/releases)
+> **Current Version: v0.2.0** — [GitHub Releases](https://github.com/ViSiON-3/vision-3-bbs/releases)
 >
 > ⚠️ **Early Development:** ViSiON/3 is under active development and not yet feature-complete. Expect rough edges and missing features. Use at your own risk. Check the [releases page](https://github.com/ViSiON-3/vision-3-bbs/releases) and the [README](https://github.com/ViSiON-3/vision-3-bbs) for the current status of features.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,4 +3,4 @@ package version
 // Number is the global ViSiON/3 version.
 // Set this at build time with:
 // -ldflags "-X github.com/ViSiON-3/vision-3-bbs/internal/version.Number=1.0.0"
-var Number = "0.1.1"
+var Number = "0.2.0"


### PR DESCRIPTION
Bumps `internal/version/version.go` to 0.2.0 and the sysop docs "Current Version" lines ahead of the v0.2.0 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the displayed current version across system operator documentation to v0.2.0.
  * Kept release links unchanged.
* **Maintenance**
  * Updated the application’s reported version to 0.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->