### PR TITLE
feat(configeditor): split out Access & Security top-level menu

### DIFF
--- a/internal/configeditor/dialogs.go
+++ b/internal/configeditor/dialogs.go
@@ -1,8 +1,9 @@
 package configeditor
 
 import (
-	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 	"strings"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 )
 
 // overlayConfirmDialog renders a confirmation dialog centered over the background.
@@ -67,7 +68,7 @@ func (m Model) overlayConfirmDialog(background, title, question string) string {
 		side
 
 	// ESC hint line
-	escHint := "ESC - Cancel"
+	escHint := "[ESC] Cancel"
 	escPad := (dialogW - 2 - len(escHint)) / 2
 	escLine := side +
 		dialogTextStyle.Render(strings.Repeat(" ", maxInt(0, escPad))+escHint+strings.Repeat(" ", maxInt(0, dialogW-2-escPad-len(escHint)))) +

--- a/internal/configeditor/fields_logging_test.go
+++ b/internal/configeditor/fields_logging_test.go
@@ -106,12 +106,12 @@ func TestSysFieldsLogging_RollingTypeLabelMapping(t *testing.T) {
 }
 
 func TestBuildSysFields_LoggingScreenWired(t *testing.T) {
-	m := &Model{configs: &allConfigs{}}
+	m := &Model{configs: &allConfigs{}, sysMenuItems: systemConfigMenuItems()}
 	m.configs.Server.Logging = config.LoggingConfig{Dir: "data/logs", Level: "INFO"}
 
-	fields := m.buildSysFields(8)
+	fields := m.buildSysFields(4)
 	if len(fields) != 6 {
-		t.Fatalf("buildSysFields(8) returned %d fields, want 6 (Logging screen)", len(fields))
+		t.Fatalf("buildSysFields(4) returned %d fields, want 6 (Logging screen)", len(fields))
 	}
 	// Sanity: it's the logging screen, not some other screen's fields.
 	fieldByLabel(t, fields, "Rolling Type")

--- a/internal/configeditor/fields_records_test.go
+++ b/internal/configeditor/fields_records_test.go
@@ -84,15 +84,15 @@ func TestSysFieldGetSetIdempotence(t *testing.T) {
 	m.configs.Server = config.ServerConfig{
 		BoardName: "Test BBS", SysOpName: "sysop", QWKID: "TEST",
 	}
-	for screen := 0; screen <= 9; screen++ {
-		fields := m.buildSysFields(screen)
+	for _, it := range append(systemConfigMenuItems(), securityMenuItems()...) {
+		fields := it.Build(m)
 		if len(fields) == 0 {
-			t.Errorf("no fields for sys screen %d", screen)
+			t.Errorf("no fields for sys screen %q", it.Label)
 			continue
 		}
 		for _, f := range fields {
 			if f.Get == nil {
-				t.Errorf("screen %d field %q has no Get", screen, f.Label)
+				t.Errorf("screen %q field %q has no Get", it.Label, f.Label)
 				continue
 			}
 			v1 := f.Get()
@@ -100,11 +100,11 @@ func TestSysFieldGetSetIdempotence(t *testing.T) {
 				continue
 			}
 			if err := f.Set(v1); err != nil {
-				t.Errorf("screen %d field %q: Set(Get()) = %v", screen, f.Label, err)
+				t.Errorf("screen %q field %q: Set(Get()) = %v", it.Label, f.Label, err)
 				continue
 			}
 			if v2 := f.Get(); v2 != v1 {
-				t.Errorf("screen %d field %q: Get after Set = %q, want %q", screen, f.Label, v2, v1)
+				t.Errorf("screen %q field %q: Get after Set = %q, want %q", it.Label, f.Label, v2, v1)
 			}
 		}
 	}

--- a/internal/configeditor/fields_system.go
+++ b/internal/configeditor/fields_system.go
@@ -75,34 +75,38 @@ func buildTimezoneLookupItems() []LookupItem {
 	return items
 }
 
-// buildSysFields returns field definitions for the given system config sub-screen.
+// buildSysFields returns the field definitions for the currently loaded inner
+// menu's sub-screen at the given index.
 func (m *Model) buildSysFields(screen int) []fieldDef {
-	cfg := &m.configs.Server
-	switch screen {
-	case 0:
-		return sysFieldsRegistration(cfg)
-	case 1:
-		return m.sysFieldsNetwork(cfg)
-	case 2:
-		return sysFieldsLimits(cfg)
-	case 3:
-		return sysFieldsLevels(cfg)
-	case 4:
-		return sysFieldsDefaults(cfg)
-	case 5:
-		return sysFieldsIPLists(cfg)
-	case 6:
-		return sysFieldsNUV(cfg)
-	case 7:
-		return sysFieldsDOS(cfg)
-	case 8:
-		return sysFieldsLogging(cfg)
-	case 9:
-		return sysFieldsQWKAPI(cfg)
-	case 10:
-		return sysFieldsBotDefense(cfg)
+	if screen < 0 || screen >= len(m.sysMenuItems) {
+		return nil
 	}
-	return nil
+	return m.sysMenuItems[screen].Build(m)
+}
+
+// systemConfigMenuItems returns the System Setup inner menu (general board and
+// server settings).
+func systemConfigMenuItems() []sysConfigMenuItem {
+	return []sysConfigMenuItem{
+		{Label: "BBS Registration", Build: func(m *Model) []fieldDef { return sysFieldsRegistration(&m.configs.Server) }},
+		{Label: "Server Setup", Build: func(m *Model) []fieldDef { return m.sysFieldsNetwork(&m.configs.Server) }},
+		{Label: "Default Settings", Build: func(m *Model) []fieldDef { return sysFieldsDefaults(&m.configs.Server) }},
+		{Label: "DOS Emulation", Build: func(m *Model) []fieldDef { return sysFieldsDOS(&m.configs.Server) }},
+		{Label: "Logging", Build: func(m *Model) []fieldDef { return sysFieldsLogging(&m.configs.Server) }},
+		{Label: "QWK Mobile API", Build: func(m *Model) []fieldDef { return sysFieldsQWKAPI(&m.configs.Server) }},
+	}
+}
+
+// securityMenuItems returns the Access & Security inner menu (access control and
+// abuse-defense settings).
+func securityMenuItems() []sysConfigMenuItem {
+	return []sysConfigMenuItem{
+		{Label: "Access Levels", Build: func(m *Model) []fieldDef { return sysFieldsLevels(&m.configs.Server) }},
+		{Label: "Connection Limits", Build: func(m *Model) []fieldDef { return sysFieldsLimits(&m.configs.Server) }},
+		{Label: "Bot Defense", Build: func(m *Model) []fieldDef { return sysFieldsBotDefense(&m.configs.Server) }},
+		{Label: "IP Blocklist/Allowlist", Build: func(m *Model) []fieldDef { return sysFieldsIPLists(&m.configs.Server) }},
+		{Label: "New User Voting (NUV)", Build: func(m *Model) []fieldDef { return sysFieldsNUV(&m.configs.Server) }},
+	}
 }
 
 // sysFieldsBotDefense returns fields for the Bot Defense sub-screen

--- a/internal/configeditor/fields_system_test.go
+++ b/internal/configeditor/fields_system_test.go
@@ -1,6 +1,7 @@
 package configeditor
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/config"
@@ -99,6 +100,49 @@ func TestSysFieldsLevels_WFCAccess(t *testing.T) {
 	}
 	if got := f.Get(); got != "N" {
 		t.Errorf("Get after Set(N): want N, got %q", got)
+	}
+}
+
+func TestMenuListsPartitionAllScreens(t *testing.T) {
+	sys := systemConfigMenuItems()
+	sec := securityMenuItems()
+
+	wantSys := []string{
+		"BBS Registration", "Server Setup", "Default Settings",
+		"DOS Emulation", "Logging", "QWK Mobile API",
+	}
+	wantSec := []string{
+		"Access Levels", "Connection Limits", "Bot Defense",
+		"IP Blocklist/Allowlist", "New User Voting (NUV)",
+	}
+
+	gotSys := make([]string, len(sys))
+	for i, it := range sys {
+		gotSys[i] = it.Label
+	}
+	gotSec := make([]string, len(sec))
+	for i, it := range sec {
+		gotSec[i] = it.Label
+	}
+	if !reflect.DeepEqual(gotSys, wantSys) {
+		t.Errorf("systemConfigMenuItems labels = %v, want %v", gotSys, wantSys)
+	}
+	if !reflect.DeepEqual(gotSec, wantSec) {
+		t.Errorf("securityMenuItems labels = %v, want %v", gotSec, wantSec)
+	}
+}
+
+func TestMenuItemBuildersNonEmpty(t *testing.T) {
+	m := newRecordModel()
+	m.configs.Server = config.ServerConfig{BoardName: "Test BBS", QWKID: "TEST"}
+	for _, it := range append(systemConfigMenuItems(), securityMenuItems()...) {
+		if it.Build == nil {
+			t.Errorf("item %q has nil Build", it.Label)
+			continue
+		}
+		if len(it.Build(m)) == 0 {
+			t.Errorf("item %q Build returned no fields", it.Label)
+		}
 	}
 }
 

--- a/internal/configeditor/model.go
+++ b/internal/configeditor/model.go
@@ -72,9 +72,11 @@ type categoryMenuItem struct {
 	Mode       editorMode // If non-zero, transitions to this mode instead
 }
 
-// sysConfigMenuItem defines an entry in the system config inner menu.
+// sysConfigMenuItem defines an entry in a system-config-style inner menu.
+// Build returns the field definitions for the item's sub-screen.
 type sysConfigMenuItem struct {
 	Label string
+	Build func(m *Model) []fieldDef
 }
 
 // wizardArea is a single area entry in the hub setup wizard.
@@ -148,6 +150,7 @@ type Model struct {
 	// System config inner menu
 	sysMenuCursor int
 	sysMenuItems  []sysConfigMenuItem
+	sysMenuTitle  string     // header for the active inner menu
 	sysSubScreen  int        // which sub-screen (0-5)
 	sysFields     []fieldDef // current sub-screen fields
 
@@ -298,19 +301,7 @@ func New(configPath string) (Model, error) {
 		{"Q", "Quit Program"},
 	}
 
-	sysMenuItems := []sysConfigMenuItem{
-		{"BBS Registration"},
-		{"Server Setup"},
-		{"Connection Limits"},
-		{"Access Levels"},
-		{"Default Settings"},
-		{"IP Blocklist/Allowlist"},
-		{"New User Voting (NUV)"},
-		{"DOS Emulation"},
-		{"Logging"},
-		{"QWK Mobile API"},
-		{"Bot Defense"},
-	}
+	sysMenuItems := systemConfigMenuItems()
 
 	// Choose the backdrop screen once per startup; the bytes are reused on
 	// resize so the screen stays consistent for the session.
@@ -322,6 +313,7 @@ func New(configPath string) (Model, error) {
 		configPath:   configPath,
 		topItems:     topItems,
 		sysMenuItems: sysMenuItems,
+		sysMenuTitle: "System Setup",
 		textInput:    ti,
 		wizard:       &wizardState{},
 		width:        minWidth,
@@ -500,7 +492,9 @@ func (m Model) updateTopMenu(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // selectTopMenuItem activates the currently highlighted top-menu item.
 func (m Model) selectTopMenuItem() (Model, tea.Cmd) {
 	switch m.topCursor {
-	case 0: // System Configuration
+	case 0: // System Setup
+		m.sysMenuItems = systemConfigMenuItems()
+		m.sysMenuTitle = "System Setup"
 		m.mode = modeSysConfigMenu
 		m.sysMenuCursor = 0
 		return m, nil

--- a/internal/configeditor/model.go
+++ b/internal/configeditor/model.go
@@ -151,7 +151,7 @@ type Model struct {
 	sysMenuCursor int
 	sysMenuItems  []sysConfigMenuItem
 	sysMenuTitle  string     // header for the active inner menu
-	sysSubScreen  int        // which sub-screen (0-5)
+	sysSubScreen  int        // index of the active sub-screen within sysMenuItems
 	sysFields     []fieldDef // current sub-screen fields
 
 	// Record list state
@@ -289,15 +289,16 @@ func New(configPath string) (Model, error) {
 	ti.Width = 40
 
 	topItems := []topMenuItem{
-		{"1", "System Configuration"},
-		{"2", "Areas and Conferences"},
-		{"3", "Echomail Networking"},
-		{"4", "ViSiON/3 Networking (V3Net)"},
-		{"5", "Door Programs"},
-		{"6", "Transfer Protocols"},
-		{"7", "Archivers"},
-		{"8", "Event Scheduler"},
-		{"9", "Login Sequence"},
+		{"1", "System Setup"},
+		{"2", "Access & Security"},
+		{"3", "Areas and Conferences"},
+		{"4", "Echomail Networking"},
+		{"5", "ViSiON/3 Networking (V3Net)"},
+		{"6", "Door Programs"},
+		{"7", "Transfer Protocols"},
+		{"8", "Archivers"},
+		{"9", "Event Scheduler"},
+		{"0", "Login Sequence"},
 		{"Q", "Quit Program"},
 	}
 
@@ -499,7 +500,14 @@ func (m Model) selectTopMenuItem() (Model, tea.Cmd) {
 		m.sysMenuCursor = 0
 		return m, nil
 
-	case 1: // Areas and Conferences
+	case 1: // Access & Security
+		m.sysMenuItems = securityMenuItems()
+		m.sysMenuTitle = "Access & Security"
+		m.mode = modeSysConfigMenu
+		m.sysMenuCursor = 0
+		return m, nil
+
+	case 2: // Areas and Conferences
 		m.catMenuTitle = "Areas and Conferences"
 		m.catMenuItems = []categoryMenuItem{
 			{Label: "Message Areas", RecordType: "msgarea"},
@@ -510,7 +518,7 @@ func (m Model) selectTopMenuItem() (Model, tea.Cmd) {
 		m.mode = modeCategoryMenu
 		return m, nil
 
-	case 2: // Echomail Networking
+	case 3: // Echomail Networking
 		m.catMenuTitle = "Echomail Networking"
 		m.catMenuItems = []categoryMenuItem{
 			{Label: "Echomail Networks", RecordType: "ftn"},
@@ -521,7 +529,7 @@ func (m Model) selectTopMenuItem() (Model, tea.Cmd) {
 		m.mode = modeCategoryMenu
 		return m, nil
 
-	case 3: // V3Net Networking
+	case 4: // V3Net Networking
 		m.catMenuTitle = "ViSiON/3 Networking (V3Net)"
 		m.catMenuItems = []categoryMenuItem{
 			{Label: "Node Identity", Mode: modeV3NetIdentity},
@@ -532,7 +540,7 @@ func (m Model) selectTopMenuItem() (Model, tea.Cmd) {
 		m.mode = modeCategoryMenu
 		return m, nil
 
-	case 4: // Door Programs (direct)
+	case 5: // Door Programs (direct)
 		m.recordType = "door"
 		m.recordCursor = 0
 		m.recordScroll = 0
@@ -540,7 +548,7 @@ func (m Model) selectTopMenuItem() (Model, tea.Cmd) {
 		m.mode = modeRecordList
 		return m, nil
 
-	case 5: // Transfer Protocols (direct)
+	case 6: // Transfer Protocols (direct)
 		m.recordType = "protocol"
 		m.recordCursor = 0
 		m.recordScroll = 0
@@ -548,7 +556,7 @@ func (m Model) selectTopMenuItem() (Model, tea.Cmd) {
 		m.mode = modeRecordList
 		return m, nil
 
-	case 6: // Archivers (direct)
+	case 7: // Archivers (direct)
 		m.recordType = "archiver"
 		m.recordCursor = 0
 		m.recordScroll = 0
@@ -556,7 +564,7 @@ func (m Model) selectTopMenuItem() (Model, tea.Cmd) {
 		m.mode = modeRecordList
 		return m, nil
 
-	case 7: // Event Scheduler (direct)
+	case 8: // Event Scheduler (direct)
 		m.recordType = "event"
 		m.recordCursor = 0
 		m.recordScroll = 0
@@ -564,7 +572,7 @@ func (m Model) selectTopMenuItem() (Model, tea.Cmd) {
 		m.mode = modeRecordList
 		return m, nil
 
-	case 8: // Login Sequence (direct)
+	case 9: // Login Sequence (direct)
 		m.recordType = "login"
 		m.recordCursor = 0
 		m.recordScroll = 0
@@ -572,7 +580,7 @@ func (m Model) selectTopMenuItem() (Model, tea.Cmd) {
 		m.mode = modeRecordList
 		return m, nil
 
-	case 9: // Quit
+	case 10: // Quit
 		return m.tryExit()
 	}
 	return m, nil

--- a/internal/configeditor/model_test.go
+++ b/internal/configeditor/model_test.go
@@ -71,9 +71,9 @@ func TestTopMenuNavigationAndSelect(t *testing.T) {
 		t.Fatalf("mode = %v, want sysConfigMenu", m.mode)
 	}
 
-	// Hotkey selection: "6" jumps straight to the protocols record list.
+	// Hotkey selection: "7" jumps straight to the protocols record list.
 	m.mode = modeTopMenu
-	m = hit(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("6")})
+	m = hit(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("7")})
 	if m.mode != modeRecordList || m.recordType != "protocol" {
 		t.Errorf("mode/type = %v/%q, want recordList/protocol", m.mode, m.recordType)
 	}
@@ -87,8 +87,8 @@ func TestTopMenuNavigationAndSelect(t *testing.T) {
 func TestCategoryMenuToRecordEdit(t *testing.T) {
 	m := newTUIModel(t)
 
-	// Item 1: Areas and Conferences → category menu.
-	m.topCursor = 1
+	// Item 2: Areas and Conferences → category menu.
+	m.topCursor = 2
 	m = hit(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 	if m.mode != modeCategoryMenu || len(m.catMenuItems) != 3 {
 		t.Fatalf("mode/items = %v/%d, want categoryMenu/3", m.mode, len(m.catMenuItems))
@@ -193,5 +193,40 @@ func TestConfigEditorViewSmoke(t *testing.T) {
 		if out := mm.View(); out == "" {
 			t.Errorf("View() in mode %v returned empty output", mode)
 		}
+	}
+}
+
+func TestTopMenuAccessSecurityEntry(t *testing.T) {
+	m, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Item 2 is Access & Security.
+	if got := m.topItems[1].Label; got != "Access & Security" {
+		t.Fatalf("topItems[1].Label = %q, want %q", got, "Access & Security")
+	}
+
+	// Selecting it loads the 5 security screens with the right title.
+	m.topCursor = 1
+	updated, _ := m.selectTopMenuItem()
+	m = updated
+	if m.mode != modeSysConfigMenu {
+		t.Fatalf("mode = %v, want modeSysConfigMenu", m.mode)
+	}
+	if m.sysMenuTitle != "Access & Security" {
+		t.Errorf("sysMenuTitle = %q, want %q", m.sysMenuTitle, "Access & Security")
+	}
+	if len(m.sysMenuItems) != 5 {
+		t.Fatalf("len(sysMenuItems) = %d, want 5", len(m.sysMenuItems))
+	}
+	if m.sysMenuItems[0].Label != "Access Levels" {
+		t.Errorf("first security item = %q, want %q", m.sysMenuItems[0].Label, "Access Levels")
+	}
+
+	// Login Sequence is the 10th functional item, keyed "0".
+	login := m.topItems[9]
+	if login.Label != "Login Sequence" || login.Key != "0" {
+		t.Errorf("topItems[9] = %+v, want {Key:0 Label:Login Sequence}", login)
 	}
 }

--- a/internal/configeditor/view.go
+++ b/internal/configeditor/view.go
@@ -264,7 +264,7 @@ func (m Model) viewSysConfigMenu() string {
 
 	// Header
 	headerLine := menuBorderStyle.Render("│") +
-		menuHeaderStyle.Render(centerText("System Configuration", boxW)) +
+		menuHeaderStyle.Render(centerText(m.sysMenuTitle, boxW)) +
 		menuBorderStyle.Render("│")
 	b.WriteString(m.backdrop.segment(row, 0, padL) + headerLine +
 		m.backdrop.segment(row, m.width-maxInt(0, padR), maxInt(0, padR)))


### PR DESCRIPTION
## Summary

Splits the config editor's flat 11-item **System Configuration** inner menu into two focused top-level menus:

- **System Setup** (renamed) — BBS Registration · Server Setup · Default Settings · DOS Emulation · Logging · QWK Mobile API
- **Access & Security** (new, main-menu item 2) — Access Levels · Connection Limits · Bot Defense · IP Blocklist/Allowlist · New User Voting (NUV)

The trailing main-menu items shift down; **Login Sequence** takes hotkey `0`, **Quit** stays `Q`.

## Changes

- **Data-driven menu items** — `sysConfigMenuItem` now carries its own `Build func(m *Model) []fieldDef` closure; the fragile 11-case `buildSysFields(screen int)` switch is replaced with a bounds-checked index into `m.sysMenuItems`. This eliminates the prior hand-synced pairing of the display list and the switch.
- **Two list constructors** — `systemConfigMenuItems()` (6) and `securityMenuItems()` (5).
- **Dynamic menu header** — new `sysMenuTitle` field replaces the hardcoded "System Configuration" title.
- New top-menu entry routes to the security list; both menus reuse the existing sys-config modes and views (no new modes).

No changes to `config.ServerConfig` or persisted JSON — this is a pure menu-navigation reorganization.

## Testing

- `go test ./internal/configeditor/...` — 134 tests pass; `gofmt` and `go vet` clean.
- New tests assert exact menu labels/order for both lists, non-empty field builders for all 11 screens, and top-menu routing (label, mode, title, item count, shifted Login `0` key). Existing sweep/navigation tests re-anchored to the new layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an **Access & Security** section to the configuration editor.
  - Reorganized system configuration into labeled submenus (including **System Setup** and security settings).
  - Updated the system menu header to match the currently selected section.
- **Bug Fixes**
  - Improved consistency of system-menu navigation and which screens/record lists open from the top menu.
- **Tests**
  - Expanded coverage for menu ordering, submenu loading, non-empty field generation, and navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->