### PR TITLE
fix(mailer): surface binkd stderr on crash and create runtime dirs

### DIFF
--- a/internal/mailer/supervisor.go
+++ b/internal/mailer/supervisor.go
@@ -31,13 +31,18 @@ type stderrTail struct {
 }
 
 func (t *stderrTail) Write(p []byte) (int, error) {
+	n := len(p)
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	if len(p) > stderrTailCap {
+		p = p[len(p)-stderrTailCap:]
+	}
 	t.buf = append(t.buf, p...)
 	if len(t.buf) > stderrTailCap {
-		t.buf = t.buf[len(t.buf)-stderrTailCap:]
+		// Copy down in place so the backing array stays bounded too.
+		t.buf = append(t.buf[:0], t.buf[len(t.buf)-stderrTailCap:]...)
 	}
-	return len(p), nil
+	return n, nil
 }
 
 func (t *stderrTail) String() string {

--- a/internal/mailer/supervisor.go
+++ b/internal/mailer/supervisor.go
@@ -2,8 +2,13 @@ package mailer
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -12,6 +17,50 @@ import (
 
 // termGrace is how long binkd gets after SIGTERM before being killed.
 const termGrace = 5 * time.Second
+
+// stderrTailCap bounds how much of binkd's stderr is retained for error
+// reporting; only the most recent bytes are kept.
+const stderrTailCap = 2048
+
+// stderrTail is an io.Writer that keeps only the last stderrTailCap bytes
+// written, so a crashing binkd's final stderr output can be logged without
+// unbounded buffering.
+type stderrTail struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+func (t *stderrTail) Write(p []byte) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.buf = append(t.buf, p...)
+	if len(t.buf) > stderrTailCap {
+		t.buf = t.buf[len(t.buf)-stderrTailCap:]
+	}
+	return len(p), nil
+}
+
+func (t *stderrTail) String() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return strings.TrimSpace(string(t.buf))
+}
+
+// ensureRuntimeDirs creates the directories binkd needs at startup (log dir
+// and inbound/outbound queues). binkd exits immediately if its log file's
+// directory is missing, and nothing else in the launch path creates these.
+func (s *Service) ensureRuntimeDirs() {
+	for _, d := range []string{
+		filepath.Join(s.cfg.BBSRoot, "data", "logs"),
+		filepath.Join(s.cfg.BBSRoot, "data", "ftn", "in"),
+		filepath.Join(s.cfg.BBSRoot, "data", "ftn", "secure_in"),
+		filepath.Join(s.cfg.BBSRoot, "data", "ftn", "out"),
+	} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			slog.Warn("creating binkd runtime dir failed", "dir", d, "error", err)
+		}
+	}
+}
 
 // superviseLoop keeps binkd running until ctx is cancelled, restarting with
 // exponential backoff on unexpected exits.
@@ -31,6 +80,7 @@ func (s *Service) superviseLoop(ctx context.Context) {
 		if err := ftn.SyncBinkdSettings(s.confPath, b.Port, b.LogLevel); err != nil {
 			slog.Warn("binkd.conf settings sync failed", "error", err)
 		}
+		s.ensureRuntimeDirs()
 
 		started := time.Now()
 		err := s.runOnce(ctx)
@@ -64,7 +114,15 @@ func (s *Service) runOnce(ctx context.Context) error {
 	// can otherwise outlive its parent.
 	cmd := exec.Command(s.binkdPath, s.confPath)
 	cmd.Stdout = nil // binkd logs to file per binkd.conf
-	cmd.Stderr = nil
+	// Startup failures (config errors, unopenable log file, port in use) go
+	// to stderr before binkd ever opens its log file, so keep a bounded tail
+	// of it for the exit error.
+	tail := &stderrTail{}
+	cmd.Stderr = tail
+	// The stderr pipe is inherited by any children binkd spawns (exec'd
+	// tossers); WaitDelay stops Wait from blocking on the pipe after binkd
+	// itself has exited.
+	cmd.WaitDelay = termGrace
 
 	if err := cmd.Start(); err != nil {
 		return err
@@ -76,6 +134,11 @@ func (s *Service) runOnce(ctx context.Context) error {
 
 	select {
 	case err := <-waitErr:
+		if err != nil {
+			if msg := tail.String(); msg != "" {
+				return fmt.Errorf("%w (stderr: %s)", err, msg)
+			}
+		}
 		return err
 	case <-ctx.Done():
 		if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {

--- a/internal/mailer/supervisor_test.go
+++ b/internal/mailer/supervisor_test.go
@@ -110,6 +110,28 @@ func TestRunOnceReportsStderrOnCrash(t *testing.T) {
 	}
 }
 
+func TestStderrTailKeepsOnlyLastBytes(t *testing.T) {
+	tail := &stderrTail{}
+	// One oversized write followed by a small one: only the newest
+	// stderrTailCap bytes may survive, ending with the small write.
+	big := strings.Repeat("x", stderrTailCap*3) + "MARKER-A"
+	for _, chunk := range []string{big, "MARKER-B"} {
+		if _, err := tail.Write([]byte(chunk)); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	got := tail.String()
+	if len(got) > stderrTailCap {
+		t.Fatalf("tail length %d exceeds cap %d", len(got), stderrTailCap)
+	}
+	if !strings.HasSuffix(got, "MARKER-A"+"MARKER-B") {
+		t.Fatalf("tail must end with the most recent writes, got tail of %q", got[len(got)-40:])
+	}
+	if len(tail.buf) > stderrTailCap || cap(tail.buf) > 2*stderrTailCap {
+		t.Fatalf("backing storage unbounded: len=%d cap=%d", len(tail.buf), cap(tail.buf))
+	}
+}
+
 func TestSuperviseLoopCreatesRuntimeDirs(t *testing.T) {
 	svc, pidFile := newSupervisedService(t, true)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/mailer/supervisor_test.go
+++ b/internal/mailer/supervisor_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -79,6 +80,56 @@ func TestSupervisorStartsAndStops(t *testing.T) {
 	}
 	if err := svc.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestRunOnceReportsStderrOnCrash(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("supervisor tests use shell scripts; skipped on windows")
+	}
+	root := newTestRoot(t)
+	script := "#!/bin/sh\necho 'config error: boom' >&2\nexit 1\n"
+	if err := os.WriteFile(filepath.Join(root, "bin", "binkd"), []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := testFTNConfig()
+	cfg.Networks = map[string]config.FTNNetworkConfig{
+		"fsxnet": {OwnAddress: "21:4/158"},
+	}
+	svc, err := New(Config{BBSRoot: root, FTN: cfg})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	runErr := svc.runOnce(context.Background())
+	if runErr == nil {
+		t.Fatal("expected error from crashing binkd")
+	}
+	if !strings.Contains(runErr.Error(), "config error: boom") {
+		t.Fatalf("error must include binkd's stderr, got: %v", runErr)
+	}
+}
+
+func TestSuperviseLoopCreatesRuntimeDirs(t *testing.T) {
+	svc, pidFile := newSupervisedService(t, true)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { svc.Start(ctx); close(done) }()
+
+	waitForLines(t, pidFile, 1)
+	cancel()
+	<-done
+
+	for _, d := range []string{
+		filepath.Join(svc.cfg.BBSRoot, "data", "logs"),
+		filepath.Join(svc.cfg.BBSRoot, "data", "ftn", "in"),
+		filepath.Join(svc.cfg.BBSRoot, "data", "ftn", "secure_in"),
+		filepath.Join(svc.cfg.BBSRoot, "data", "ftn", "out"),
+	} {
+		info, err := os.Stat(d)
+		if err != nil || !info.IsDir() {
+			t.Errorf("runtime dir %s must exist before binkd launch: %v", d, err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

When binkd fails at startup on a deployed system, the supervisor log shows only:

```
ERROR binkd exited unexpectedly, restarting error="exit status 1" backoff=5s
```

binkd prints the actual failure reason (config parse error, unopenable log file, port in use) to stderr **before** it ever opens its log file — and the supervisor discarded stderr, so the reason was lost.

## Changes

- **Capture stderr**: `runOnce` attaches a bounded 2KB tail buffer to binkd's stderr and wraps it into the exit error, so the restart log line now reads e.g. `exit status 1 (stderr: cannot open log file ...)`.
- **Create runtime dirs**: before each launch the supervisor creates `data/logs`, `data/ftn/in`, `data/ftn/secure_in`, and `data/ftn/out` (best-effort). binkd exits 1 if its log file's directory is missing, and nothing else in the launch path created these.
- **`cmd.WaitDelay = termGrace`**: with stderr now a pipe, `Wait` would block until every process holding the pipe exits; WaitDelay prevents a child left behind by binkd (e.g. an exec'd tosser) from hanging shutdown. Caught by the existing `TestSupervisorStartsAndStops` during development.

## Testing

- New: `TestRunOnceReportsStderrOnCrash`, `TestSuperviseLoopCreatesRuntimeDirs` (TDD, watched fail first)
- `go test ./...`: 1958 passed in 57 packages; mailer package clean under `-race`; `gofmt`/`go vet` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup/shutdown diagnostics by capturing and reporting the most recent stderr output when the mailer child fails.
  * Ensured required runtime directories (logs and inbound/outbound queues) are created automatically before startup/restart.
  * Adjusted process waiting behavior to avoid stalls on stderr after the child exits.
* **Tests**
  * Added coverage for stderr tail reporting, bounded stderr truncation, and runtime directory creation during supervise/restart behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->