### PR TITLE
chore(setup): stop pre-seeding template binkd.conf

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,12 +22,9 @@ do
     mkdir -p "$d"
 done
 
-# Copy binkd.conf template to data/ftn/ if not present, rewriting paths
-# for the Docker layout (/vision3 instead of /opt/vision3)
-if [ ! -f "/vision3/data/ftn/binkd.conf" ] && [ -f "/vision3/templates/configs/binkd.conf" ]; then
-    echo "Copying binkd.conf template to data/ftn/ (adjusting paths for Docker)..."
-    sed 's|/opt/vision3|/vision3|g' /vision3/templates/configs/binkd.conf > /vision3/data/ftn/binkd.conf
-fi
+# Note: data/ftn/binkd.conf is intentionally NOT created here. The FTN Setup
+# Wizard (in the BBS config editor) generates a fully-configured binkd.conf;
+# pre-seeding the raw template left placeholder values the mailer refuses.
 
 # Create per-node temp directories (used by doors and session temp files)
 for i in $(seq 1 10); do

--- a/docs/sysop/messages/ftn-echomail.md
+++ b/docs/sysop/messages/ftn-echomail.md
@@ -51,7 +51,7 @@ Restart the BBS afterward. On startup, Vision/3 launches `bin/binkd` as a superv
 
 These same fields appear in the Configuration Editor under **Server Setup** as "Binkd Mailer", "Binkd Port", "Binkd Binary", "Binkd Log Lvl", and "Export Secs". Saving from the config editor also re-syncs identity fields, link passwords, `iport`, and `loglevel` into `binkd.conf`.
 
-**Preflight checks:** before starting binkd, Vision/3 verifies the binary is present and executable, that `data/ftn/binkd.conf` exists (the wizard creates it — hub hostnames live only there, not in `ftn.json`), and that at least one configured network has an `own_address` set. If any check fails, the BBS logs a warning and continues running without the mailer — it never blocks startup.
+**Preflight checks:** before starting binkd, Vision/3 verifies the binary is present and executable, that `data/ftn/binkd.conf` exists and contains no unconfigured template placeholders (the wizard creates and fills it — hub hostnames live only there, not in `ftn.json`), and that at least one configured network has an `own_address` set. If any check fails, the BBS logs a warning and continues running without the mailer — it never blocks startup.
 
 **Inbound and outbound flow with the integrated mailer:**
 

--- a/setup.sh
+++ b/setup.sh
@@ -120,11 +120,9 @@ mkdir -p data/ftn/{in,secure_in,temp_in,temp_out,out,dupehist,dloads,dloads/pass
 mkdir -p data/infoforms/{templates,responses}
 mkdir -p configs
 
-# Copy binkd.conf template to data/ftn/ if not present
-if [ -f "templates/configs/binkd.conf" ] && [ ! -f "data/ftn/binkd.conf" ]; then
-    echo "  Creating data/ftn/binkd.conf from template..."
-    cp templates/configs/binkd.conf data/ftn/binkd.conf
-fi
+# Note: data/ftn/binkd.conf is intentionally NOT created here. The FTN Setup
+# Wizard (in the BBS config editor) generates a fully-configured binkd.conf;
+# pre-seeding the raw template left placeholder values the mailer refuses.
 mkdir -p bin
 mkdir -p scripts
 echo "Directories created."


### PR DESCRIPTION
## Problem

Follow-up to #118, from a real install: `setup.sh` (and `docker-entrypoint.sh`) copy the raw `templates/configs/binkd.conf` into `data/ftn/` at install time. That file is full of template placeholders, so the system creates a conf that its own mailer preflight then refuses ("still contains template placeholders") — and that binkd itself would exit 1 on. Confusing: one part of the system scaffolds a file another part rejects.

## Changes

- Remove the template-copy blocks from `setup.sh` and `docker-entrypoint.sh` (with a comment explaining why). The FTN Setup Wizard's `UpdateBinkdConf` already generates a complete, fully-configured `binkd.conf` from scratch when the file doesn't exist, so pre-seeding adds nothing.
- With no file present, the mailer's existing preflight message points straight at the wizard: `binkd.conf not found (run the FTN Setup Wizard first)`.
- `templates/configs/binkd.conf` stays in the repo as a reference for sysops who prefer to hand-write a conf.
- Docs: FTN preflight section now mentions the placeholder check from #118.

## Testing

- `bash -n` on both scripts (syntax clean); no Go changes.
- Windows setup (`setup.ps1`) never copied the template, so behavior is now consistent across platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented creation of incomplete mailer configuration files during setup and startup.
  * The FTN Setup Wizard now generates the fully configured mailer configuration required for operation.

* **Documentation**
  * Updated the FTN echomail guide with preflight checks for unconfigured placeholders.
  * Clarified that the mailer is skipped with a warning when configuration checks fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->