### PR TITLE
fix(ftn): never inject duplicate domain/address lines in binkd.conf rewrite

### DIFF
--- a/internal/ftn/binkd.go
+++ b/internal/ftn/binkd.go
@@ -174,6 +174,30 @@ percents
 // rewriteBinkdConf filters an existing binkd.conf, replacing placeholder
 // lines with real values and injecting missing domain/address lines.
 func rewriteBinkdConf(out *strings.Builder, content string, cfg BinkdConfig, outPath, logPath, secureIn, insecureIn, v3mailPath, boardName, sysop, location string) {
+	// Collect domain names and addresses on lines that will be kept, so
+	// injection never duplicates them — binkd aborts on "duplicate domain".
+	// This matters when the real BBS root matches a placeholder path (e.g. a
+	// default /opt/vision3 install): the template's domain lines are then
+	// legitimate-looking and are kept rather than stripped.
+	kept := keptDirectives(content, cfg.BBSRoot)
+
+	writeDomains := func() {
+		for name, zone := range cfg.Domains {
+			if kept["domain "+name] {
+				continue
+			}
+			fmt.Fprintf(out, "domain %s %s %d\n", name, outPath, zone)
+		}
+	}
+	writeAddresses := func() {
+		for _, addr := range cfg.Addresses {
+			if kept["address "+addr] {
+				continue
+			}
+			fmt.Fprintf(out, "address %s\n", addr)
+		}
+	}
+
 	scanner := bufio.NewScanner(strings.NewReader(content))
 	injectedDomains := false
 	injectedAddresses := false
@@ -186,16 +210,12 @@ func rewriteBinkdConf(out *strings.Builder, content string, cfg BinkdConfig, out
 		if isPlaceholderLine(line, cfg.BBSRoot) {
 			// If this is a domain placeholder, inject real domains once.
 			if strings.HasPrefix(trimmed, "domain ") && !injectedDomains {
-				for name, zone := range cfg.Domains {
-					fmt.Fprintf(out, "domain %s %s %d\n", name, outPath, zone)
-				}
+				writeDomains()
 				injectedDomains = true
 			}
 			// If this is an address placeholder, inject real addresses once.
 			if strings.HasPrefix(trimmed, "address ") && !injectedAddresses {
-				for _, addr := range cfg.Addresses {
-					fmt.Fprintf(out, "address %s\n", addr)
-				}
+				writeAddresses()
 				injectedAddresses = true
 			}
 			// Replace sysname/sysop/log/inbound/exec placeholders.
@@ -236,19 +256,53 @@ func rewriteBinkdConf(out *strings.Builder, content string, cfg BinkdConfig, out
 		out.WriteByte('\n')
 	}
 
-	// If we never hit a domain/address placeholder, inject at the end.
-	if !injectedDomains {
+	// If we never hit a domain/address placeholder, inject at the end —
+	// but only what isn't already present in kept lines.
+	if !injectedDomains && anyMissing(kept, "domain ", domainNames(cfg.Domains)) {
 		out.WriteString("\n#\n# Domains:\n#\n")
-		for name, zone := range cfg.Domains {
-			fmt.Fprintf(out, "domain %s %s %d\n", name, outPath, zone)
-		}
+		writeDomains()
 	}
-	if !injectedAddresses {
+	if !injectedAddresses && anyMissing(kept, "address ", cfg.Addresses) {
 		out.WriteString("\n#\n# Your Addresses:\n#\n")
-		for _, addr := range cfg.Addresses {
-			fmt.Fprintf(out, "address %s\n", addr)
+		writeAddresses()
+	}
+}
+
+// keptDirectives returns a set of "domain <name>" and "address <addr>" keys
+// for non-placeholder lines in content — directives that a rewrite will keep.
+func keptDirectives(content, bbsRoot string) map[string]bool {
+	kept := make(map[string]bool)
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if isPlaceholderLine(line, bbsRoot) {
+			continue
+		}
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) >= 2 && (fields[0] == "domain" || fields[0] == "address") {
+			kept[fields[0]+" "+fields[1]] = true
 		}
 	}
+	return kept
+}
+
+// domainNames returns the keys of a domain->zone map.
+func domainNames(domains map[string]int) []string {
+	names := make([]string, 0, len(domains))
+	for name := range domains {
+		names = append(names, name)
+	}
+	return names
+}
+
+// anyMissing reports whether any of names is absent from kept under prefix.
+func anyMissing(kept map[string]bool, prefix string, names []string) bool {
+	for _, n := range names {
+		if !kept[prefix+n] {
+			return true
+		}
+	}
+	return false
 }
 
 // BinkdIdentity holds BBS identity fields synced to binkd.conf.

--- a/internal/ftn/binkd.go
+++ b/internal/ftn/binkd.go
@@ -198,12 +198,12 @@ func rewriteBinkdConf(out *strings.Builder, content string, cfg BinkdConfig, out
 		}
 	}
 
-	scanner := bufio.NewScanner(strings.NewReader(content))
 	injectedDomains := false
 	injectedAddresses := false
 
-	for scanner.Scan() {
-		line := scanner.Text()
+	// strings.Split rather than bufio.Scanner: a pathological over-64KB line
+	// would make the scanner stop early and silently drop the rest of the file.
+	for _, line := range confLines(content) {
 		trimmed := strings.TrimSpace(line)
 
 		// Strip placeholder lines entirely.
@@ -272,9 +272,7 @@ func rewriteBinkdConf(out *strings.Builder, content string, cfg BinkdConfig, out
 // for non-placeholder lines in content — directives that a rewrite will keep.
 func keptDirectives(content, bbsRoot string) map[string]bool {
 	kept := make(map[string]bool)
-	scanner := bufio.NewScanner(strings.NewReader(content))
-	for scanner.Scan() {
-		line := scanner.Text()
+	for _, line := range confLines(content) {
 		if isPlaceholderLine(line, bbsRoot) {
 			continue
 		}
@@ -284,6 +282,12 @@ func keptDirectives(content, bbsRoot string) map[string]bool {
 		}
 	}
 	return kept
+}
+
+// confLines splits conf content into lines without bufio.Scanner's 64KB
+// per-line limit; a trailing newline does not yield a spurious empty line.
+func confLines(content string) []string {
+	return strings.Split(strings.TrimSuffix(content, "\n"), "\n")
 }
 
 // domainNames returns the keys of a domain->zone map.

--- a/internal/ftn/binkd_placeholder_test.go
+++ b/internal/ftn/binkd_placeholder_test.go
@@ -19,7 +19,7 @@ func TestUpdateBinkdConfKeepsRealRootLinesMatchingPlaceholder(t *testing.T) {
 	cfg := BinkdConfig{
 		BBSRoot:   "/opt/vision3",
 		Domains:   map[string]int{"fsxnet": 21},
-		Addresses: []string{"21:4/158@fsxnet"},
+		Addresses: []string{"21:4/999@fsxnet"},
 		Node: BinkdNode{
 			Address: "21:1/100@fsxnet", Hostname: "hub.fsxnet.nz:24556",
 			SessionPwd: "secret", NetworkName: "fsxnet",
@@ -46,7 +46,7 @@ func TestUpdateBinkdConfNoDuplicateDomainsWhenRootMatchesPlaceholder(t *testing.
 	confPath := filepath.Join(dir, "binkd.conf")
 	existing := `domain fsxnet /opt/vision3/data/ftn/out 21
 domain fidonet /opt/vision3/data/ftn/out 3
-address 21:4/158@fsxnet
+address 21:4/999@fsxnet
 sysname "My BBS"
 iport 24554
 `
@@ -57,7 +57,7 @@ iport 24554
 		BBSRoot:   "/opt/vision3",
 		BoardName: "Real Board",
 		Domains:   map[string]int{"fsxnet": 21},
-		Addresses: []string{"21:4/158@fsxnet"},
+		Addresses: []string{"21:4/999@fsxnet"},
 		Node: BinkdNode{
 			Address: "21:1/100@fsxnet", Hostname: "hub.fsxnet.nz:24556",
 			SessionPwd: "secret", NetworkName: "fsxnet",
@@ -73,11 +73,46 @@ iport 24554
 	if n := strings.Count(string(got), "domain fsxnet "); n != 1 {
 		t.Errorf("want exactly 1 'domain fsxnet' line, got %d:\n%s", n, got)
 	}
-	if n := strings.Count(string(got), "address 21:4/158@fsxnet"); n != 1 {
+	if n := strings.Count(string(got), "address 21:4/999@fsxnet"); n != 1 {
 		t.Errorf("want exactly 1 real address line, got %d:\n%s", n, got)
 	}
 	if !strings.Contains(string(got), "node 21:1/100@fsxnet hub.fsxnet.nz:24556 secret") {
 		t.Errorf("hub node line missing:\n%s", got)
+	}
+}
+
+func TestUpdateBinkdConfSurvivesOversizedLines(t *testing.T) {
+	// A pathological very long line must not silently truncate the rewrite:
+	// lines after it must survive, and dedup must still see them.
+	dir := t.TempDir()
+	confPath := filepath.Join(dir, "binkd.conf")
+	existing := "# " + strings.Repeat("x", 128*1024) + "\n" +
+		"domain fsxnet /real/root/data/ftn/out 21\n" +
+		"iport 24555\n"
+	if err := os.WriteFile(confPath, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := BinkdConfig{
+		BBSRoot:   "/real/root",
+		Domains:   map[string]int{"fsxnet": 21},
+		Addresses: []string{"21:4/999@fsxnet"},
+		Node: BinkdNode{
+			Address: "21:1/100@fsxnet", Hostname: "hub.fsxnet.nz:24556",
+			SessionPwd: "secret", NetworkName: "fsxnet",
+		},
+	}
+	if err := UpdateBinkdConf(confPath, cfg); err != nil {
+		t.Fatalf("UpdateBinkdConf: %v", err)
+	}
+	got, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "iport 24555") {
+		t.Errorf("line after oversized line was dropped:\n%.300s...", got)
+	}
+	if n := strings.Count(string(got), "domain fsxnet "); n != 1 {
+		t.Errorf("want exactly 1 'domain fsxnet' line, got %d", n)
 	}
 }
 
@@ -98,7 +133,7 @@ func TestHasPlaceholdersCleanConf(t *testing.T) {
 sysname "My Board"
 log /bbs/data/logs/binkd.log
 inbound /bbs/data/ftn/secure_in
-node 21:4/158@fsxnet agency.bbs.nz:24556 secret
+node 21:4/999@fsxnet agency.bbs.nz:24556 secret
 `
 	if HasPlaceholders(clean, "/bbs") {
 		t.Fatal("wizard-generated conf must not be flagged")

--- a/internal/ftn/binkd_placeholder_test.go
+++ b/internal/ftn/binkd_placeholder_test.go
@@ -46,7 +46,7 @@ func TestUpdateBinkdConfNoDuplicateDomainsWhenRootMatchesPlaceholder(t *testing.
 	confPath := filepath.Join(dir, "binkd.conf")
 	existing := `domain fsxnet /opt/vision3/data/ftn/out 21
 domain fidonet /opt/vision3/data/ftn/out 3
-address 21:1/123@fsxnet
+address 21:4/158@fsxnet
 sysname "My BBS"
 iport 24554
 `

--- a/internal/ftn/binkd_placeholder_test.go
+++ b/internal/ftn/binkd_placeholder_test.go
@@ -37,6 +37,50 @@ func TestUpdateBinkdConfKeepsRealRootLinesMatchingPlaceholder(t *testing.T) {
 	}
 }
 
+func TestUpdateBinkdConfNoDuplicateDomainsWhenRootMatchesPlaceholder(t *testing.T) {
+	// Regression: on an install whose real root is /opt/vision3 (the default),
+	// the template's domain lines are exempt from placeholder stripping, so
+	// the wizard must not inject a second "domain fsxnet" (binkd aborts on
+	// "duplicate domain") and must not duplicate kept address lines either.
+	dir := t.TempDir()
+	confPath := filepath.Join(dir, "binkd.conf")
+	existing := `domain fsxnet /opt/vision3/data/ftn/out 21
+domain fidonet /opt/vision3/data/ftn/out 3
+address 21:1/123@fsxnet
+sysname "My BBS"
+iport 24554
+`
+	if err := os.WriteFile(confPath, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := BinkdConfig{
+		BBSRoot:   "/opt/vision3",
+		BoardName: "Real Board",
+		Domains:   map[string]int{"fsxnet": 21},
+		Addresses: []string{"21:4/158@fsxnet"},
+		Node: BinkdNode{
+			Address: "21:1/100@fsxnet", Hostname: "hub.fsxnet.nz:24556",
+			SessionPwd: "secret", NetworkName: "fsxnet",
+		},
+	}
+	if err := UpdateBinkdConf(confPath, cfg); err != nil {
+		t.Fatalf("UpdateBinkdConf: %v", err)
+	}
+	got, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(string(got), "domain fsxnet "); n != 1 {
+		t.Errorf("want exactly 1 'domain fsxnet' line, got %d:\n%s", n, got)
+	}
+	if n := strings.Count(string(got), "address 21:4/158@fsxnet"); n != 1 {
+		t.Errorf("want exactly 1 real address line, got %d:\n%s", n, got)
+	}
+	if !strings.Contains(string(got), "node 21:1/100@fsxnet hub.fsxnet.nz:24556 secret") {
+		t.Errorf("hub node line missing:\n%s", got)
+	}
+}
+
 func TestHasPlaceholdersDetectsTemplate(t *testing.T) {
 	template := `# binkd.conf template
 log /opt/vision3/data/logs/binkd.log


### PR DESCRIPTION
## Problem

Field failure on a fresh install rooted at `/opt/vision3` (the default install path, which is also the template placeholder token). After running the FTN Setup Wizard, binkd crash-looped with:

```
/opt/vision3/data/ftn/binkd.conf: line 68: error in configuration files
fsxnet: duplicate domain
```

Cause: #118's real-root exemption means the pre-seeded template's `domain fsxnet` / `domain fidonet` lines are no longer placeholder-stripped on such installs — they're kept. The rewrite then never saw a domain placeholder, so it appended its real `domain fsxnet` block at EOF: a duplicate binkd refuses. (The stray `fidonet` the sysop never configured is the template's other kept domain line.)

## Changes

`rewriteBinkdConf` now pre-collects the `domain`/`address` directives on lines it will keep, and injects only what's missing — at the placeholder position or at EOF (headers written only when something is actually injected). Helpers: `keptDirectives`, `domainNames`, `anyMissing`.

## Notes

- #119 already stopped pre-seeding the template, so new installs won't hit this path at all; this hardens the rewrite for installs that already have a pre-#119 conf.
- Existing affected confs need a one-time manual cleanup (remove the duplicate/unwanted domain lines) — the wizard won't re-run for an already-configured network.

## Testing

- New regression test `TestUpdateBinkdConfNoDuplicateDomainsWhenRootMatchesPlaceholder` reproducing the field failure (TDD, watched fail with exactly 2 `domain fsxnet` lines first)
- `go test ./...`: 1967 passed in 57 packages; `gofmt`/`go vet` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate domain and address entries when updating Binkd configuration files.
  * Preserved existing configuration directives while adding only missing entries.
  * Improved handling when expected placeholder sections are absent.

* **Tests**
  * Added regression coverage to verify duplicate directives are not created and expected node settings remain present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->