### PR TITLE
feat(scheduler): always run the event scheduler; deprecate global enabled flag

### DIFF
--- a/cmd/vision3/main.go
+++ b/cmd/vision3/main.go
@@ -1703,15 +1703,19 @@ func main() {
 	// Load event scheduler configuration
 	eventsConfig, eventsErr := config.LoadEventsConfig(rootConfigPath)
 	if eventsErr != nil {
-		slog.Warn("failed to load events config", "error", eventsErr)
-		eventsConfig = config.EventsConfig{Enabled: false}
+		slog.Warn("failed to load events config, scheduler not started", "error", eventsErr)
 	}
 
-	// Start event scheduler if enabled
+	// The scheduler always runs; individual events are enabled/disabled per
+	// entry. The legacy global "enabled" flag is ignored (it silently kept
+	// TUI-enabled events from ever firing).
 	var eventScheduler *scheduler.Scheduler
 	var schedulerCtx context.Context
 	var schedulerCancel context.CancelFunc
-	if eventsConfig.Enabled {
+	if eventsErr == nil {
+		if !eventsConfig.Enabled {
+			slog.Info("events.json global 'enabled' flag is deprecated and ignored; disable individual events instead")
+		}
 		historyPath := filepath.Join(dataPath, "logs", "event_history.json")
 		eventScheduler = scheduler.NewScheduler(eventsConfig, historyPath)
 		schedulerCtx, schedulerCancel = context.WithCancel(context.Background())
@@ -1724,8 +1728,6 @@ func main() {
 
 		go eventScheduler.Start(schedulerCtx)
 		slog.Info("event scheduler started", "count", len(eventsConfig.Events))
-	} else {
-		slog.Info("event scheduler disabled")
 	}
 
 	// Load V3Net configuration from v3net.json (separate from main config, like ftn.json).

--- a/docs/sysop/advanced/event-scheduler.md
+++ b/docs/sysop/advanced/event-scheduler.md
@@ -49,7 +49,7 @@ Event scheduling is configured in `configs/events.json`.
 
 #### Root Configuration
 
-- **enabled** (boolean): Enable/disable the entire scheduler
+- **enabled** (boolean): Deprecated and ignored — the scheduler always runs; enable/disable individual events instead (kept for compatibility with older versions)
 - **max_concurrent_events** (integer): Maximum number of events that can run simultaneously (default: 3)
 - **events** (array): List of event configurations
 

--- a/docs/sysop/messages/ftn-echomail.md
+++ b/docs/sysop/messages/ftn-echomail.md
@@ -104,8 +104,7 @@ then go to **Echomail Networking → FTN Setup Wizard**. The wizard walks you th
      mailer/inbound/outbound paths, and the hub node)
    - an enabled scheduler event that polls your hub every 15 minutes (the
      daemon only calls out when outbound mail is queued), and it enables the
-     seeded toss safety-net and nightly message-base maintenance events and
-     the scheduler itself
+     seeded toss safety-net and nightly message-base maintenance events
 
 After saving, **restart the BBS** so the new `ftn.json` settings take effect,
 then initialize the message bases and test the connection (see

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1108,6 +1108,9 @@ type EventConfig struct {
 
 // EventsConfig is the root configuration for the event scheduler
 type EventsConfig struct {
+	// Enabled is deprecated and ignored: the scheduler always runs, and
+	// events are enabled/disabled individually. The field is kept so older
+	// binaries reading the same events.json still start their scheduler.
 	Enabled             bool          `json:"enabled"`
 	MaxConcurrentEvents int           `json:"max_concurrent_events"`
 	Events              []EventConfig `json:"events"`
@@ -1398,7 +1401,7 @@ func LoadEventsConfig(configPath string) (EventsConfig, error) {
 	slog.Info("loading event scheduler configuration", "path", filePath)
 
 	defaultConfig := EventsConfig{
-		Enabled:             false,
+		Enabled:             true,
 		MaxConcurrentEvents: 3,
 		Events:              []EventConfig{},
 	}
@@ -1406,7 +1409,7 @@ func LoadEventsConfig(configPath string) (EventsConfig, error) {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			slog.Info("events.json not found, event scheduler disabled", "path", filePath)
+			slog.Info("events.json not found, no events to schedule", "path", filePath)
 			return defaultConfig, nil
 		}
 		return defaultConfig, fmt.Errorf("failed to read events config file %s: %w", filePath, err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -302,8 +302,8 @@ func TestLoadEventsConfig_Defaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result.Enabled {
-		t.Error("expected events disabled by default")
+	if !result.Enabled {
+		t.Error("expected events enabled by default (global flag is deprecated; events disable individually)")
 	}
 	if result.MaxConcurrentEvents != 3 {
 		t.Errorf("expected default max concurrent 3, got %d", result.MaxConcurrentEvents)

--- a/templates/configs/events.json
+++ b/templates/configs/events.json
@@ -1,6 +1,6 @@
 {
-  "_comment": "Event Scheduler Configuration - IMPORTANT: Update command paths and arguments for your system. {BBS_ROOT} will be replaced with the BBS installation directory at runtime.",
-  "enabled": false,
+  "_comment": "Event Scheduler Configuration - IMPORTANT: Update command paths and arguments for your system. {BBS_ROOT} will be replaced with the BBS installation directory at runtime. The top-level enabled flag is deprecated and ignored; enable/disable individual events instead.",
+  "enabled": true,
   "max_concurrent_events": 3,
   "events": [
     {


### PR DESCRIPTION
## Problem

Field-discovered UX trap: the events TUI only exposes per-event `Enabled`, while the whole scheduler was gated behind a top-level `"enabled"` flag in `events.json` that ships `false` and is editable only by hand. A sysop can enable events in the TUI that then silently never fire — the only hint is one `event scheduler disabled` info line at startup.

## Policy change

The scheduler now **always runs**; individual events are the enable/disable control.

- `cmd/vision3/main.go`: scheduler starts whenever `events.json` loads (a parse error still skips it, with a clearer warning). A legacy `"enabled": false` is ignored and logged as deprecated — existing installs self-heal with no config edit.
- `EventsConfig.Enabled` is kept (deprecated) so older binaries reading the same `events.json` still work; `LoadEventsConfig` missing-file default flips to `true` for consistency.
- Template `events.json` ships `"enabled": true` with a deprecation note. All seeded events remain individually disabled, so nothing fires on a fresh install until the sysop (or the FTN wizard) enables specific events.
- Docs updated (event-scheduler field reference, FTN wizard bullet).

## Testing

- `TestLoadEventsConfig_Defaults` updated to the new policy (enabled by default)
- `go test ./...`: 1973 passed in 57 packages; `gofmt`/`go vet` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The event scheduler now starts whenever its configuration loads successfully.
  * Scheduling can be controlled for each event individually; the global scheduler setting is deprecated and ignored.
  * Updated default configuration and templates to reflect the new behavior.

* **Documentation**
  * Updated setup guidance and configuration references for per-event scheduling controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->