### PR TITLE
feat(configeditor): make Echomail Links the source of truth for hub host/port

### DIFF
--- a/docs/sysop/messages/ftn-echomail.md
+++ b/docs/sysop/messages/ftn-echomail.md
@@ -51,7 +51,7 @@ Restart the BBS afterward. On startup, Vision/3 launches `bin/binkd` as a superv
 
 These same fields appear in the Configuration Editor under **Server Setup** as "Binkd Mailer", "Binkd Port", "Binkd Binary", "Binkd Log Lvl", and "Export Secs". Saving from the config editor also re-syncs identity fields, link passwords, `iport`, and `loglevel` into `binkd.conf`.
 
-**Preflight checks:** before starting binkd, Vision/3 verifies the binary is present and executable, that `data/ftn/binkd.conf` exists and contains no unconfigured template placeholders (the wizard creates and fills it — hub hostnames live only there, not in `ftn.json`), and that at least one configured network has an `own_address` set. If any check fails, the BBS logs a warning and continues running without the mailer — it never blocks startup.
+**Preflight checks:** before starting binkd, Vision/3 verifies the binary is present and executable, that `data/ftn/binkd.conf` exists and contains no unconfigured template placeholders (the wizard creates and fills it), and that at least one configured network has an `own_address` set. If any check fails, the BBS logs a warning and continues running without the mailer — it never blocks startup.
 
 **Inbound and outbound flow with the integrated mailer:**
 
@@ -110,8 +110,10 @@ After saving, **restart the BBS** so the new `ftn.json` settings take effect,
 then initialize the message bases and test the connection (see
 [Step 7](#step-7-initialize-message-bases) and [Step 8](#step-8-test-the-connection)).
 
-> Identity fields and link passwords are also re-synced to `binkd.conf` whenever
-> you save from the config editor.
+> Identity fields and link details are re-synced to `binkd.conf` whenever you
+> save from the config editor: each link's hostname, port, and session password
+> (Echomail Links is the source of truth) update or create the matching `node`
+> line, and the network's poll event follows a changed hub address.
 
 For networks **not** in the registry — or to understand exactly what the wizard
 configures — follow the manual steps below.

--- a/docs/sysop/messages/ftn-echomail.md
+++ b/docs/sysop/messages/ftn-echomail.md
@@ -113,7 +113,9 @@ then initialize the message bases and test the connection (see
 > Identity fields and link details are re-synced to `binkd.conf` whenever you
 > save from the config editor: each link's hostname, port, and session password
 > (Echomail Links is the source of truth) update or create the matching `node`
-> line, and the network's poll event follows a changed hub address.
+> line, and the network's poll event follows a changed hub address. If
+> `binkd.conf` has been deleted, saving from the config editor regenerates a
+> complete file from your configuration — deleting it is a supported reset.
 
 For networks **not** in the registry — or to understand exactly what the wizard
 configures — follow the manual steps below.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -809,6 +809,21 @@ type FTNLinkConfig struct {
 	AreafixPassword string `json:"areafix_password,omitempty"` // Password for AreaFix netmail (subject line)
 	Name            string `json:"name"`                       // Human-readable name
 	Flavour         string `json:"flavour,omitempty"`          // Delivery flavour: Normal (default), Crash, Hold, Direct
+	Hostname        string `json:"hostname,omitempty"`         // Hub BinkP hostname; source of truth for the binkd.conf node line
+	Port            int    `json:"port,omitempty"`             // Hub BinkP port (default 24554 when Hostname is set)
+}
+
+// HostPort returns "hostname:port" for the link, defaulting the port to
+// 24554. Empty when no hostname is configured.
+func (c FTNLinkConfig) HostPort() string {
+	if c.Hostname == "" {
+		return ""
+	}
+	port := c.Port
+	if port <= 0 {
+		port = 24554
+	}
+	return fmt.Sprintf("%s:%d", c.Hostname, port)
 }
 
 // UnmarshalJSON supports backward compatibility: "password" is read into PacketPassword
@@ -821,6 +836,8 @@ func (c *FTNLinkConfig) UnmarshalJSON(data []byte) error {
 		AreafixPassword string  `json:"areafix_password,omitempty"`
 		Name            string  `json:"name"`
 		Flavour         string  `json:"flavour,omitempty"`
+		Hostname        string  `json:"hostname,omitempty"`
+		Port            int     `json:"port,omitempty"`
 		LegacyPassword  string  `json:"password"`
 	}
 	if err := json.Unmarshal(data, &r); err != nil {
@@ -831,6 +848,8 @@ func (c *FTNLinkConfig) UnmarshalJSON(data []byte) error {
 	c.AreafixPassword = r.AreafixPassword
 	c.Name = r.Name
 	c.Flavour = r.Flavour
+	c.Hostname = r.Hostname
+	c.Port = r.Port
 	if r.PacketPassword != nil {
 		c.PacketPassword = *r.PacketPassword
 	} else if r.LegacyPassword != "" {

--- a/internal/configeditor/binkd_regen.go
+++ b/internal/configeditor/binkd_regen.go
@@ -1,0 +1,49 @@
+package configeditor
+
+import (
+	"fmt"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+	"github.com/ViSiON-3/vision-3-bbs/internal/ftn"
+)
+
+// buildBinkdRegen derives everything needed to regenerate a missing
+// binkd.conf from configuration alone: identity from the server config,
+// domains (zone parsed from each network's own address), address lines, and
+// one node per link with a hostname. ok is false when no network has a
+// parseable own address — then there is nothing meaningful to write.
+func buildBinkdRegen(ftnCfg config.FTNConfig, server config.ServerConfig, bbsRoot string) (ftn.BinkdConfig, []ftn.BinkdNode, bool) {
+	cfg := ftn.BinkdConfig{
+		BBSRoot:   bbsRoot,
+		BoardName: server.BoardName,
+		SysopName: server.SysOpName,
+		Location:  server.BBSLocation,
+		Domains:   make(map[string]int),
+	}
+	var nodes []ftn.BinkdNode
+
+	for netKey, nc := range ftnCfg.Networks {
+		if nc.OwnAddress == "" {
+			continue
+		}
+		addr, err := ftn.ParseAddress(nc.OwnAddress)
+		if err != nil {
+			continue
+		}
+		cfg.Domains[netKey] = addr.Zone
+		cfg.Addresses = append(cfg.Addresses, fmt.Sprintf("%s@%s", nc.OwnAddress, netKey))
+		for _, lnk := range nc.Links {
+			if lnk.HostPort() == "" {
+				continue
+			}
+			nodes = append(nodes, ftn.BinkdNode{
+				Address:     fmt.Sprintf("%s@%s", lnk.Address, netKey),
+				Hostname:    lnk.HostPort(),
+				SessionPwd:  lnk.SessionPassword,
+				NetworkName: netKey,
+			})
+		}
+	}
+
+	return cfg, nodes, len(cfg.Domains) > 0
+}

--- a/internal/configeditor/binkd_regen_test.go
+++ b/internal/configeditor/binkd_regen_test.go
@@ -1,0 +1,73 @@
+package configeditor
+
+import (
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+)
+
+func TestBuildBinkdRegenDerivesEverythingFromConfig(t *testing.T) {
+	ftnCfg := config.FTNConfig{
+		Networks: map[string]config.FTNNetworkConfig{
+			"fsxnet": {
+				OwnAddress: "21:4/999",
+				Links: []config.FTNLinkConfig{{
+					Address: "21:4/158", SessionPassword: "s3cret",
+					Hostname: "pointhub.example.org", Port: 24556,
+				}},
+			},
+			// A link without a hostname cannot produce a node line.
+			"othernet": {
+				OwnAddress: "1:2/3",
+				Links:      []config.FTNLinkConfig{{Address: "1:2/1"}},
+			},
+		},
+	}
+	server := config.ServerConfig{BoardName: "Test Board", SysOpName: "Sysop", BBSLocation: "Testville"}
+
+	cfg, nodes, ok := buildBinkdRegen(ftnCfg, server, "/real/root")
+	if !ok {
+		t.Fatal("expected regeneration data to be available")
+	}
+	if cfg.Domains["fsxnet"] != 21 || cfg.Domains["othernet"] != 1 {
+		t.Errorf("zones not derived from own addresses: %v", cfg.Domains)
+	}
+	found := false
+	for _, a := range cfg.Addresses {
+		if a == "21:4/999@fsxnet" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("own address missing: %v", cfg.Addresses)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("want 1 node (only links with hostnames), got %d: %v", len(nodes), nodes)
+	}
+	n := nodes[0]
+	if n.Address != "21:4/158@fsxnet" || n.Hostname != "pointhub.example.org:24556" || n.SessionPwd != "s3cret" {
+		t.Errorf("node not built from link: %+v", n)
+	}
+	if cfg.BoardName != "Test Board" {
+		t.Errorf("identity not carried: %+v", cfg)
+	}
+}
+
+func TestBuildBinkdRegenNoNetworksNotOK(t *testing.T) {
+	_, _, ok := buildBinkdRegen(config.FTNConfig{}, config.ServerConfig{}, "/root")
+	if ok {
+		t.Error("no configured networks must not claim regeneration data")
+	}
+}
+
+func TestBuildBinkdRegenBadOwnAddressSkipped(t *testing.T) {
+	ftnCfg := config.FTNConfig{
+		Networks: map[string]config.FTNNetworkConfig{
+			"badnet": {OwnAddress: "notanaddress"},
+		},
+	}
+	_, _, ok := buildBinkdRegen(ftnCfg, config.ServerConfig{}, "/root")
+	if ok {
+		t.Error("network with unparseable own address must not count")
+	}
+}

--- a/internal/configeditor/fields_ftn.go
+++ b/internal/configeditor/fields_ftn.go
@@ -285,14 +285,14 @@ func (m *Model) fieldsFTNLinkEdit() []fieldDef {
 			},
 			Set: func(val string) error {
 				val = strings.TrimSpace(val)
-				if val == "" {
-					linkPtr.Port = 0
+				if val == "" || val == "0" {
+					linkPtr.Port = 0 // unset: HostPort() defaults to 24554
 					save()
 					return nil
 				}
 				p, err := strconv.Atoi(val)
 				if err != nil || p < 1 || p > 65535 {
-					return fmt.Errorf("port must be 1-65535")
+					return fmt.Errorf("port must be 1-65535 (or 0/empty for default)")
 				}
 				linkPtr.Port = p
 				save()

--- a/internal/configeditor/fields_ftn.go
+++ b/internal/configeditor/fields_ftn.go
@@ -271,7 +271,36 @@ func (m *Model) fieldsFTNLinkEdit() []fieldDef {
 			Set: func(val string) error { linkPtr.Name = val; save(); return nil },
 		},
 		{
-			Label: "Flavour", Help: "Delivery flavour: Normal, Crash, Hold, Direct", Type: ftLookup, Col: 3, Row: 7, Width: 10,
+			Label: "Hostname", Help: "Hub BinkP hostname; synced to the binkd.conf node line on save", Type: ftString, Col: 3, Row: 7, Width: 40,
+			Get: func() string { return linkPtr.Hostname },
+			Set: func(val string) error { linkPtr.Hostname = strings.TrimSpace(val); save(); return nil },
+		},
+		{
+			Label: "Port", Help: "Hub BinkP port (default 24554)", Type: ftInteger, Col: 3, Row: 8, Width: 6, Min: 0, Max: 65535,
+			Get: func() string {
+				if linkPtr.Port == 0 {
+					return ""
+				}
+				return strconv.Itoa(linkPtr.Port)
+			},
+			Set: func(val string) error {
+				val = strings.TrimSpace(val)
+				if val == "" {
+					linkPtr.Port = 0
+					save()
+					return nil
+				}
+				p, err := strconv.Atoi(val)
+				if err != nil || p < 1 || p > 65535 {
+					return fmt.Errorf("port must be 1-65535")
+				}
+				linkPtr.Port = p
+				save()
+				return nil
+			},
+		},
+		{
+			Label: "Flavour", Help: "Delivery flavour: Normal, Crash, Hold, Direct", Type: ftLookup, Col: 3, Row: 9, Width: 10,
 			Get: func() string {
 				if linkPtr.Flavour == "" {
 					return "Normal"

--- a/internal/configeditor/ftn_wizard_events.go
+++ b/internal/configeditor/ftn_wizard_events.go
@@ -99,7 +99,20 @@ func refreshPollEvents(events *config.EventsConfig, networks map[string]config.F
 			}
 			e := &events.Events[i]
 			e.Name = fmt.Sprintf("Poll Hub (%s)", hub)
-			e.Args = []string{"-p", "-P", fmt.Sprintf("%s@%s", hub, netKey), "{BBS_ROOT}/data/ftn/binkd.conf"}
+			hubFull := fmt.Sprintf("%s@%s", hub, netKey)
+			// Retarget only the -P value so sysop-added flags survive; if
+			// the args no longer contain -P, rebuild the standard set.
+			retargeted := false
+			for j := 0; j < len(e.Args)-1; j++ {
+				if e.Args[j] == "-P" {
+					e.Args[j+1] = hubFull
+					retargeted = true
+					break
+				}
+			}
+			if !retargeted {
+				e.Args = []string{"-p", "-P", hubFull, "{BBS_ROOT}/data/ftn/binkd.conf"}
+			}
 		}
 	}
 }

--- a/internal/configeditor/ftn_wizard_events.go
+++ b/internal/configeditor/ftn_wizard_events.go
@@ -83,6 +83,27 @@ func wireFTNEvents(events *config.EventsConfig, netKey, hubAddress string) {
 	}
 }
 
+// refreshPollEvents updates each existing per-network poll event to point at
+// the network's current first-link hub address, so a hub change in the
+// Echomail Links editor propagates on save. It never creates events — only
+// the wizard does that.
+func refreshPollEvents(events *config.EventsConfig, networks map[string]config.FTNNetworkConfig) {
+	for netKey, nc := range networks {
+		if len(nc.Links) == 0 {
+			continue
+		}
+		hub := nc.Links[0].Address
+		for i := range events.Events {
+			if events.Events[i].ID != "echomail_poll_"+netKey {
+				continue
+			}
+			e := &events.Events[i]
+			e.Name = fmt.Sprintf("Poll Hub (%s)", hub)
+			e.Args = []string{"-p", "-P", fmt.Sprintf("%s@%s", hub, netKey), "{BBS_ROOT}/data/ftn/binkd.conf"}
+		}
+	}
+}
+
 // containsArg reports whether args contains the exact value s.
 func containsArg(args []string, s string) bool {
 	for _, a := range args {

--- a/internal/configeditor/ftn_wizard_events_test.go
+++ b/internal/configeditor/ftn_wizard_events_test.go
@@ -157,6 +157,31 @@ func TestRefreshPollEventsFollowsHubChange(t *testing.T) {
 	}
 }
 
+func TestRefreshPollEventsPreservesCustomArgs(t *testing.T) {
+	// A sysop may add extra binkd flags to the poll event; refresh must only
+	// retarget the -P value (and name), not clobber the rest of the args.
+	ev := templateEvents()
+	wireFTNEvents(&ev, "fsxnet", "21:4/100")
+	poll := findEvent(ev, "echomail_poll_fsxnet")
+	poll.Args = []string{"-p", "-q", "-P", "21:4/100@fsxnet", "{BBS_ROOT}/data/ftn/binkd.conf"}
+
+	nets := map[string]config.FTNNetworkConfig{
+		"fsxnet": {Links: []config.FTNLinkConfig{{Address: "21:4/158"}}},
+	}
+	refreshPollEvents(&ev, nets)
+
+	poll = findEvent(ev, "echomail_poll_fsxnet")
+	want := []string{"-p", "-q", "-P", "21:4/158@fsxnet", "{BBS_ROOT}/data/ftn/binkd.conf"}
+	if len(poll.Args) != len(want) {
+		t.Fatalf("args = %v, want %v", poll.Args, want)
+	}
+	for i := range want {
+		if poll.Args[i] != want[i] {
+			t.Fatalf("args = %v, want %v", poll.Args, want)
+		}
+	}
+}
+
 func TestWireFTNEventsMissingOptionalEventsNotCreated(t *testing.T) {
 	// A trimmed events.json without the toss/maintenance entries: the wizard
 	// must not invent them, only the poll event.

--- a/internal/configeditor/ftn_wizard_events_test.go
+++ b/internal/configeditor/ftn_wizard_events_test.go
@@ -129,6 +129,34 @@ func TestWireFTNEventsPreservesUserTunedPollFields(t *testing.T) {
 	}
 }
 
+func TestRefreshPollEventsFollowsHubChange(t *testing.T) {
+	// Hub change scenario: the sysop edits the fsxnet link's address in the
+	// TUI; on save the existing poll event must follow, but no event is
+	// created for networks without one.
+	ev := templateEvents()
+	wireFTNEvents(&ev, "fsxnet", "21:4/100")
+
+	nets := map[string]config.FTNNetworkConfig{
+		"fsxnet":   {Links: []config.FTNLinkConfig{{Address: "21:4/158"}}},
+		"othernet": {Links: []config.FTNLinkConfig{{Address: "1:2/3"}}},
+	}
+	refreshPollEvents(&ev, nets)
+
+	poll := findEvent(ev, "echomail_poll_fsxnet")
+	if poll == nil {
+		t.Fatal("poll event missing")
+	}
+	if !containsArg(poll.Args, "21:4/158@fsxnet") {
+		t.Errorf("poll -P arg not refreshed: %v", poll.Args)
+	}
+	if poll.Name != "Poll Hub (21:4/158)" {
+		t.Errorf("poll name not refreshed: %q", poll.Name)
+	}
+	if findEvent(ev, "echomail_poll_othernet") != nil {
+		t.Error("refresh must not create events for networks without one")
+	}
+}
+
 func TestWireFTNEventsMissingOptionalEventsNotCreated(t *testing.T) {
 	// A trimmed events.json without the toss/maintenance entries: the wizard
 	// must not invent them, only the poll event.

--- a/internal/configeditor/ftn_wizard_save.go
+++ b/internal/configeditor/ftn_wizard_save.go
@@ -60,6 +60,8 @@ func (m Model) confirmFTNWizard() (Model, tea.Cmd) {
 		AreafixPassword: w.areafixPassword,
 		Name:            w.networkName + " Hub",
 		Flavour:         "Crash",
+		Hostname:        w.hubHostname,
+		Port:            w.hubPort,
 	}
 
 	m.configs.FTN.Networks[netKey] = config.FTNNetworkConfig{

--- a/internal/configeditor/update_save.go
+++ b/internal/configeditor/update_save.go
@@ -2,6 +2,8 @@ package configeditor
 
 import (
 	"fmt"
+	"log/slog"
+	"os"
 	"path/filepath"
 	"sort"
 
@@ -58,6 +60,9 @@ func (m *Model) saveAll() {
 	var binkdSyncErr error
 	{
 		bbsRoot := filepath.Join(m.configPath, "..")
+		if abs, absErr := filepath.Abs(bbsRoot); absErr == nil {
+			bbsRoot = abs // regenerated conf paths must be absolute
+		}
 		binkdPath := filepath.Join(bbsRoot, "data", "ftn", "binkd.conf")
 		identity := ftn.BinkdIdentity{
 			BoardName: m.configs.Server.BoardName,
@@ -74,7 +79,21 @@ func (m *Model) saveAll() {
 				}
 			}
 		}
-		binkdSyncErr = ftn.SyncBinkdConf(binkdPath, identity, links) // non-fatal; surfaced below
+		// A deleted binkd.conf is regenerated from configuration (the wizard
+		// refuses to re-run for an existing network, so this is the only
+		// recovery path); the syncs below then apply port/loglevel.
+		if _, statErr := os.Stat(binkdPath); os.IsNotExist(statErr) {
+			if regenCfg, nodes, ok := buildBinkdRegen(m.configs.FTN, m.configs.Server, bbsRoot); ok {
+				if err := ftn.RegenerateBinkdConf(binkdPath, regenCfg, nodes); err != nil {
+					binkdSyncErr = err
+				} else {
+					slog.Info("binkd.conf regenerated from configuration", "path", binkdPath)
+				}
+			}
+		}
+		if binkdSyncErr == nil {
+			binkdSyncErr = ftn.SyncBinkdConf(binkdPath, identity, links) // non-fatal; surfaced below
+		}
 		if binkdSyncErr == nil {
 			binkdSyncErr = ftn.SyncBinkdSettings(binkdPath, m.configs.FTN.Binkd.Port, m.configs.FTN.Binkd.LogLevel)
 		}

--- a/internal/configeditor/update_save.go
+++ b/internal/configeditor/update_save.go
@@ -47,6 +47,9 @@ func (m *Model) saveAll() {
 		m.message = fmt.Sprintf("SAVE ERROR: %v", err)
 		return
 	}
+	// Follow hub changes: existing per-network poll events track the
+	// network's first link address.
+	refreshPollEvents(&m.configs.Events, m.configs.FTN.Networks)
 	if err := saveEventsConfig(m.configPath, m.configs.Events); err != nil {
 		m.message = fmt.Sprintf("SAVE ERROR: %v", err)
 		return
@@ -61,11 +64,14 @@ func (m *Model) saveAll() {
 			SysopName: m.configs.Server.SysOpName,
 			Location:  m.configs.Server.BBSLocation,
 		}
-		links := make(map[string]string)
+		links := make(map[string]ftn.BinkdLinkSync)
 		for netKey, nc := range m.configs.FTN.Networks {
 			for _, lnk := range nc.Links {
 				addr := fmt.Sprintf("%s@%s", lnk.Address, netKey)
-				links[addr] = lnk.SessionPassword
+				links[addr] = ftn.BinkdLinkSync{
+					SessionPwd: lnk.SessionPassword,
+					HostPort:   lnk.HostPort(),
+				}
 			}
 		}
 		binkdSyncErr = ftn.SyncBinkdConf(binkdPath, identity, links) // non-fatal; surfaced below

--- a/internal/ftn/binkd.go
+++ b/internal/ftn/binkd.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -418,10 +419,16 @@ func SyncBinkdConf(confPath string, identity BinkdIdentity, links map[string]Bin
 
 	// Append node lines for configured links that have a hostname but no
 	// line yet (new link, or the link's address was changed in the TUI).
+	// Sorted so repeated syncs produce identical files.
+	var missing []string
 	for addr, link := range links {
-		if seenNodes[addr] || link.HostPort == "" {
-			continue
+		if !seenNodes[addr] && link.HostPort != "" {
+			missing = append(missing, addr)
 		}
+	}
+	sort.Strings(missing)
+	for _, addr := range missing {
+		link := links[addr]
 		pwd := link.SessionPwd
 		if pwd == "" {
 			pwd = "-"

--- a/internal/ftn/binkd.go
+++ b/internal/ftn/binkd.go
@@ -1,7 +1,6 @@
 package ftn
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -98,9 +97,8 @@ func UpdateBinkdConf(confPath string, cfg BinkdConfig) error {
 
 // nodeExists checks whether a node address is already defined in the config.
 func nodeExists(content, address string) bool {
-	scanner := bufio.NewScanner(strings.NewReader(content))
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
+	for _, l := range confLines(content) {
+		line := strings.TrimSpace(l)
 		if strings.HasPrefix(line, "node ") {
 			fields := strings.Fields(line)
 			if len(fields) >= 2 && fields[1] == address {
@@ -345,10 +343,10 @@ func SyncBinkdConf(confPath string, identity BinkdIdentity, links map[string]Bin
 	var out strings.Builder
 	changed := false
 	seenNodes := make(map[string]bool)
-	scanner := bufio.NewScanner(strings.NewReader(string(existing)))
 
-	for scanner.Scan() {
-		line := scanner.Text()
+	// confLines, not bufio.Scanner: an over-64KB line would stop a scanner
+	// early and the append path below would then persist a truncated file.
+	for _, line := range confLines(string(existing)) {
 		trimmed := strings.TrimSpace(line)
 
 		// Sync sysname.
@@ -453,10 +451,8 @@ func SyncBinkdSettings(confPath string, port, logLevel int) error {
 
 	var out strings.Builder
 	changed := false
-	scanner := bufio.NewScanner(strings.NewReader(string(existing)))
 
-	for scanner.Scan() {
-		line := scanner.Text()
+	for _, line := range confLines(string(existing)) {
 		trimmed := strings.TrimSpace(line)
 
 		if strings.HasPrefix(trimmed, "iport ") && port > 0 {

--- a/internal/ftn/binkd.go
+++ b/internal/ftn/binkd.go
@@ -316,13 +316,24 @@ type BinkdIdentity struct {
 	Location  string // location
 }
 
-// SyncBinkdConf updates binkd.conf to reflect the current FTN link passwords
-// and BBS identity fields (sysname, sysop, location). Only lines that differ
-// from the current config are rewritten; if nothing changed the file is not
-// touched. Called from saveAll so TUI edits are reflected automatically.
+// BinkdLinkSync carries the per-link values synced into a binkd.conf node
+// line. HostPort is "hostname:port"; when empty only the password of an
+// existing line is synced and no new line is created (host unknown).
+type BinkdLinkSync struct {
+	SessionPwd string
+	HostPort   string
+}
+
+// SyncBinkdConf updates binkd.conf to reflect the current FTN links and BBS
+// identity fields (sysname, sysop, location). Node lines are upserted from
+// links: an existing line (matched by address) gets its hostname and password
+// refreshed, and a configured link with a hostname but no node line has one
+// appended — so a hub change in the TUI fully propagates. Only lines that
+// differ are rewritten; if nothing changed the file is not touched. Called
+// from saveAll so TUI edits are reflected automatically.
 //
-// links maps "address@network" (e.g. "21:1/100@fsxnet") to the session password.
-func SyncBinkdConf(confPath string, identity BinkdIdentity, links map[string]string) error {
+// links maps "address@network" (e.g. "21:1/100@fsxnet") to its sync values.
+func SyncBinkdConf(confPath string, identity BinkdIdentity, links map[string]BinkdLinkSync) error {
 	existing, err := os.ReadFile(confPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -333,6 +344,7 @@ func SyncBinkdConf(confPath string, identity BinkdIdentity, links map[string]str
 
 	var out strings.Builder
 	changed := false
+	seenNodes := make(map[string]bool)
 	scanner := bufio.NewScanner(strings.NewReader(string(existing)))
 
 	for scanner.Scan() {
@@ -372,17 +384,27 @@ func SyncBinkdConf(confPath string, identity BinkdIdentity, links map[string]str
 			}
 		}
 
-		// Sync node session passwords.
+		// Sync node hostname and session password.
 		if strings.HasPrefix(trimmed, "node ") {
 			fields := strings.Fields(trimmed)
 			if len(fields) >= 4 {
 				addr := fields[1] // e.g. "21:1/100@fsxnet"
-				if newPwd, ok := links[addr]; ok {
+				if link, ok := links[addr]; ok {
+					seenNodes[addr] = true
+					newPwd := link.SessionPwd
 					if newPwd == "" {
 						newPwd = "-"
 					}
+					lineChanged := false
+					if link.HostPort != "" && fields[2] != link.HostPort {
+						fields[2] = link.HostPort
+						lineChanged = true
+					}
 					if fields[3] != newPwd {
 						fields[3] = newPwd
+						lineChanged = true
+					}
+					if lineChanged {
 						out.WriteString(strings.Join(fields, " "))
 						out.WriteByte('\n')
 						changed = true
@@ -394,6 +416,20 @@ func SyncBinkdConf(confPath string, identity BinkdIdentity, links map[string]str
 
 		out.WriteString(line)
 		out.WriteByte('\n')
+	}
+
+	// Append node lines for configured links that have a hostname but no
+	// line yet (new link, or the link's address was changed in the TUI).
+	for addr, link := range links {
+		if seenNodes[addr] || link.HostPort == "" {
+			continue
+		}
+		pwd := link.SessionPwd
+		if pwd == "" {
+			pwd = "-"
+		}
+		fmt.Fprintf(&out, "node %s %s %s\n", addr, link.HostPort, pwd)
+		changed = true
 	}
 
 	if !changed {

--- a/internal/ftn/binkd_regen.go
+++ b/internal/ftn/binkd_regen.go
@@ -1,0 +1,45 @@
+package ftn
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// RegenerateBinkdConf writes a complete binkd.conf from configuration alone:
+// identity, domains, addresses, derived paths, and one node line per hub.
+// Used when binkd.conf is missing (e.g. deleted for a reset) — the FTN Setup
+// Wizard refuses to re-run for an existing network, so without this the file
+// could not be recreated. The caller supplies real values; iport/loglevel are
+// template defaults here and are corrected by SyncBinkdSettings afterwards.
+func RegenerateBinkdConf(confPath string, cfg BinkdConfig, nodes []BinkdNode) error {
+	outPath := filepath.Join(cfg.BBSRoot, "data", "ftn", "out")
+	logPath := filepath.Join(cfg.BBSRoot, "data", "logs", "binkd.log")
+	secureIn := filepath.Join(cfg.BBSRoot, "data", "ftn", "secure_in")
+	insecureIn := filepath.Join(cfg.BBSRoot, "data", "ftn", "in")
+	v3mailPath := filepath.Join(cfg.BBSRoot, "v3mail")
+
+	sysop := cfg.SysopName
+	if sysop == "" {
+		sysop = "SysOp"
+	}
+	boardName := cfg.BoardName
+	if boardName == "" {
+		boardName = "Vision3 BBS"
+	}
+	location := cfg.Location
+	if location == "" {
+		location = "Earth"
+	}
+
+	var out strings.Builder
+	writeFreshBinkdConf(&out, cfg, outPath, logPath, secureIn, insecureIn, v3mailPath, boardName, sysop, location)
+	for _, n := range nodes {
+		pwd := n.SessionPwd
+		if pwd == "" {
+			pwd = "-"
+		}
+		fmt.Fprintf(&out, "\n%s\nnode %s %s %s\n", sectionMarker(n.NetworkName), n.Address, n.Hostname, pwd)
+	}
+	return writeFileAtomic(confPath, out.String(), 0600)
+}

--- a/internal/ftn/binkd_sync_test.go
+++ b/internal/ftn/binkd_sync_test.go
@@ -1,0 +1,85 @@
+package ftn
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func readConf(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func TestSyncBinkdConfUpdatesNodeHostAndPassword(t *testing.T) {
+	// Hub change scenario: the link's hostname/port and password now live in
+	// ftn.json; sync must rewrite the matching node line in place.
+	path := writeConf(t, "iport 24554\nnode 21:4/999@fsxnet oldhub.example.org:24554 oldpwd\n")
+	links := map[string]BinkdLinkSync{
+		"21:4/999@fsxnet": {SessionPwd: "newpwd", HostPort: "pointhub.example.org:24556"},
+	}
+	if err := SyncBinkdConf(path, BinkdIdentity{}, links); err != nil {
+		t.Fatalf("SyncBinkdConf: %v", err)
+	}
+	got := readConf(t, path)
+	if !strings.Contains(got, "node 21:4/999@fsxnet pointhub.example.org:24556 newpwd") {
+		t.Errorf("node line not rewritten:\n%s", got)
+	}
+	if strings.Contains(got, "oldhub") {
+		t.Errorf("old host survived:\n%s", got)
+	}
+}
+
+func TestSyncBinkdConfAppendsMissingNode(t *testing.T) {
+	// A link configured in the TUI with a hostname but no node line yet
+	// (e.g. address changed, or link added without the wizard) must get a
+	// node line appended.
+	path := writeConf(t, "iport 24554\n")
+	links := map[string]BinkdLinkSync{
+		"21:4/999@fsxnet": {SessionPwd: "s3cret", HostPort: "pointhub.example.org:24556"},
+	}
+	if err := SyncBinkdConf(path, BinkdIdentity{}, links); err != nil {
+		t.Fatalf("SyncBinkdConf: %v", err)
+	}
+	if !strings.Contains(readConf(t, path), "node 21:4/999@fsxnet pointhub.example.org:24556 s3cret") {
+		t.Errorf("missing node line not appended:\n%s", readConf(t, path))
+	}
+}
+
+func TestSyncBinkdConfPasswordOnlyLinkDoesNotCreateNode(t *testing.T) {
+	// A link with no hostname configured keeps the legacy behavior: update
+	// an existing line's password, never invent a node line (no host known).
+	path := writeConf(t, "iport 24554\n")
+	links := map[string]BinkdLinkSync{
+		"21:4/999@fsxnet": {SessionPwd: "s3cret"},
+	}
+	if err := SyncBinkdConf(path, BinkdIdentity{}, links); err != nil {
+		t.Fatalf("SyncBinkdConf: %v", err)
+	}
+	if strings.Contains(readConf(t, path), "node ") {
+		t.Errorf("node line invented without a hostname:\n%s", readConf(t, path))
+	}
+}
+
+func TestSyncBinkdConfNoChangeLeavesFileUntouched(t *testing.T) {
+	content := "iport 24554\nnode 21:4/999@fsxnet pointhub.example.org:24556 s3cret\n"
+	path := writeConf(t, content)
+	info1, _ := os.Stat(path)
+	links := map[string]BinkdLinkSync{
+		"21:4/999@fsxnet": {SessionPwd: "s3cret", HostPort: "pointhub.example.org:24556"},
+	}
+	if err := SyncBinkdConf(path, BinkdIdentity{}, links); err != nil {
+		t.Fatalf("SyncBinkdConf: %v", err)
+	}
+	if readConf(t, path) != content {
+		t.Errorf("file content changed on no-op sync")
+	}
+	info2, _ := os.Stat(path)
+	if info1.ModTime() != info2.ModTime() {
+		t.Errorf("file rewritten on no-op sync")
+	}
+}

--- a/internal/ftn/binkd_sync_test.go
+++ b/internal/ftn/binkd_sync_test.go
@@ -65,6 +65,68 @@ func TestSyncBinkdConfPasswordOnlyLinkDoesNotCreateNode(t *testing.T) {
 	}
 }
 
+func TestSyncBinkdConfSurvivesOversizedLines(t *testing.T) {
+	// An over-64KB line must not truncate the rewrite: content after it
+	// survives and the node line past it is still found (not re-appended).
+	content := "# " + strings.Repeat("x", 128*1024) + "\n" +
+		"node 21:4/999@fsxnet oldhub.example.org:24554 oldpwd\n" +
+		"iport 24555\n"
+	path := writeConf(t, content)
+	links := map[string]BinkdLinkSync{
+		"21:4/999@fsxnet": {SessionPwd: "newpwd", HostPort: "pointhub.example.org:24556"},
+	}
+	if err := SyncBinkdConf(path, BinkdIdentity{}, links); err != nil {
+		t.Fatalf("SyncBinkdConf: %v", err)
+	}
+	got := readConf(t, path)
+	if !strings.Contains(got, "iport 24555") {
+		t.Errorf("content after oversized line truncated:\n%.200s...", got)
+	}
+	if n := strings.Count(got, "node 21:4/999@fsxnet"); n != 1 {
+		t.Errorf("want exactly 1 node line, got %d", n)
+	}
+	if !strings.Contains(got, "pointhub.example.org:24556 newpwd") {
+		t.Errorf("node line not updated:\n%s", got)
+	}
+}
+
+func TestRegenerateBinkdConfFromConfig(t *testing.T) {
+	// Deleting binkd.conf must not be a dead end: everything needed to
+	// rebuild it lives in ftn.json + server config.
+	dir := t.TempDir()
+	confPath := dir + "/binkd.conf"
+	cfg := BinkdConfig{
+		BBSRoot:   "/real/root",
+		BoardName: "Test Board",
+		SysopName: "Test Sysop",
+		Location:  "Testville",
+		Domains:   map[string]int{"fsxnet": 21},
+		Addresses: []string{"21:4/999@fsxnet"},
+	}
+	nodes := []BinkdNode{{
+		Address: "21:4/158@fsxnet", Hostname: "pointhub.example.org:24556",
+		SessionPwd: "s3cret", NetworkName: "fsxnet",
+	}}
+	if err := RegenerateBinkdConf(confPath, cfg, nodes); err != nil {
+		t.Fatalf("RegenerateBinkdConf: %v", err)
+	}
+	got := readConf(t, confPath)
+	for _, want := range []string{
+		"domain fsxnet /real/root/data/ftn/out 21",
+		"address 21:4/999@fsxnet",
+		"sysname \"Test Board\"",
+		"node 21:4/158@fsxnet pointhub.example.org:24556 s3cret",
+		"log /real/root/data/logs/binkd.log",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("regenerated conf missing %q:\n%s", want, got)
+		}
+	}
+	if HasPlaceholders(got, "/real/root") {
+		t.Error("regenerated conf must not contain template placeholders")
+	}
+}
+
 func TestSyncBinkdConfNoChangeLeavesFileUntouched(t *testing.T) {
 	content := "iport 24554\nnode 21:4/999@fsxnet pointhub.example.org:24556 s3cret\n"
 	path := writeConf(t, content)

--- a/internal/ftn/binkd_sync_test.go
+++ b/internal/ftn/binkd_sync_test.go
@@ -127,6 +127,27 @@ func TestRegenerateBinkdConfFromConfig(t *testing.T) {
 	}
 }
 
+func TestSyncBinkdConfAppendsMissingNodesDeterministically(t *testing.T) {
+	// Multiple appended node lines must come out in a stable (sorted) order
+	// so repeated syncs don't churn the file.
+	links := map[string]BinkdLinkSync{
+		"21:4/999@fsxnet": {SessionPwd: "a", HostPort: "h1:24554"},
+		"1:2/3@othernet":  {SessionPwd: "b", HostPort: "h2:24554"},
+	}
+	for i := 0; i < 5; i++ {
+		path := writeConf(t, "iport 24554\n")
+		if err := SyncBinkdConf(path, BinkdIdentity{}, links); err != nil {
+			t.Fatalf("SyncBinkdConf: %v", err)
+		}
+		got := readConf(t, path)
+		first := strings.Index(got, "node 1:2/3@othernet")
+		second := strings.Index(got, "node 21:4/999@fsxnet")
+		if first == -1 || second == -1 || first > second {
+			t.Fatalf("appended nodes not in stable sorted order:\n%s", got)
+		}
+	}
+}
+
 func TestSyncBinkdConfNoChangeLeavesFileUntouched(t *testing.T) {
 	content := "iport 24554\nnode 21:4/999@fsxnet pointhub.example.org:24556 s3cret\n"
 	path := writeConf(t, content)


### PR DESCRIPTION
## Problem

Changing hubs (e.g. moving from the network hub to your own point hub) was a three-place manual edit:

1. TUI Echomail Links: address + passwords only
2. `binkd.conf`: hub hostname/port live *only* in the node line, and the sync matches by address — so changing the link's address orphans the old node line and nothing creates one for the new hub
3. `events.json`: the poll event keeps polling the old `-P` target

## Changes

- **`FTNLinkConfig` gains `Hostname`/`Port`** (json `hostname`/`port`, omitempty; `HostPort()` defaults the port to 24554). The FTN wizard now captures both from its form; the Echomail Links editor exposes both fields.
- **`SyncBinkdConf` upserts node lines** from `BinkdLinkSync{SessionPwd, HostPort}`: existing lines (matched by address) get hostname + password refreshed; a configured link with a hostname but no line — new link, or address just changed — has one appended. Links without a hostname keep the old password-only behavior (never invent a line with no host).
- **`saveAll` refreshes poll events**: each network's existing `echomail_poll_<net>` event follows the first link's address (name + `-P` arg). Events are never created outside the wizard.
- Docs updated: Echomail Links is documented as the source of truth; removed the "hub hostnames live only in binkd.conf" caveat.

Result: a hub change is now a single edit in Echomail Links (address, hostname, port, password) — save propagates to `binkd.conf` and the poll event.

## Testing

- 5 new tests (TDD, watched fail first): node host+password rewrite, missing-node append, password-only no-invent, no-op leaves file untouched, poll event follows hub change without creating events
- `go test ./...`: 1978 passed in 57 packages; `gofmt`/`go vet` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FTN link hub `Hostname`/`Port` fields with input validation and automatic defaulting for binkp ports.
  * Extended FTN setup so saves keep `binkd.conf` hub connection and polling data in sync.
  * If `binkd.conf` is missing, saving regenerates it and updates/extends node entries deterministically.

* **Documentation**
  * Refined FTN wizard and binkd preflight/sync explanations.

* **Tests**
  * Expanded synchronization and wizard-related test coverage, including hub changes, custom poll args preservation, missing entries, oversized input, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Addendum: binkd.conf regeneration

Second commit adds the capability this PR unlocks: with hostname/port stored on links, `ftn.json` + server config now hold everything `binkd.conf` needs. When the file is missing at save time, `saveAll` regenerates it completely (identity, domains with zones parsed from own addresses, address lines, node line per link with a hostname) — so deleting `binkd.conf` becomes a supported reset instead of a dead end (the wizard refuses to re-run for existing networks). Plus the review fix: all conf parsing now uses `confLines` instead of `bufio.Scanner`. 1983 tests green.