### PR TITLE
feat(configeditor): close TUI-only gaps for manually created FTN networks

### DIFF
--- a/docs/sysop/messages/ftn-echomail.md
+++ b/docs/sysop/messages/ftn-echomail.md
@@ -113,7 +113,9 @@ then initialize the message bases and test the connection (see
 > Identity fields and link details are re-synced to `binkd.conf` whenever you
 > save from the config editor: each link's hostname, port, and session password
 > (Echomail Links is the source of truth) update or create the matching `node`
-> line, and the network's poll event follows a changed hub address. If
+> line, and the network's poll event follows a changed hub address (created
+> automatically if missing when the link has a hostname — manually created
+> networks poll without any Events-editor setup). If
 > `binkd.conf` has been deleted, saving from the config editor regenerates a
 > complete file from your configuration — deleting it is a supported reset.
 

--- a/internal/configeditor/fields_ftn.go
+++ b/internal/configeditor/fields_ftn.go
@@ -27,10 +27,13 @@ func (m *Model) fieldsFTNLink() []fieldDef {
 
 	return []fieldDef{
 		{
-			Label: "Network Name", Help: "Network identifier (e.g. FSXNET, FIDONET)", Type: ftString, Col: 3, Row: 1, Width: 30,
+			Label: "Network Name", Help: "Network identifier (e.g. fsxnet, fidonet) — also the binkd domain; stored lowercase", Type: ftString, Col: 3, Row: 1, Width: 30,
 			Get: func() string { return key },
 			Set: func(val string) error {
-				val = strings.TrimSpace(val)
+				// The key is the binkd domain (addresses are <addr>@<key> and
+				// binkd.conf gets "domain <key> ..."); hubs expect lowercase,
+				// and the FTN wizard lowercases too.
+				val = strings.ToLower(strings.TrimSpace(val))
 				if val == "" {
 					return fmt.Errorf("network name cannot be empty")
 				}

--- a/internal/configeditor/ftn_manual_test.go
+++ b/internal/configeditor/ftn_manual_test.go
@@ -1,0 +1,79 @@
+package configeditor
+
+import (
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+)
+
+// newFTNModel returns a Model editing the first (sorted) FTN network record.
+func newFTNModel(networks map[string]config.FTNNetworkConfig) *Model {
+	return &Model{
+		configs:       &allConfigs{FTN: config.FTNConfig{Networks: networks}},
+		recordEditIdx: 0,
+	}
+}
+
+func setField(t *testing.T, fields []fieldDef, label, val string) {
+	t.Helper()
+	for _, f := range fields {
+		if f.Label == label {
+			if err := f.Set(val); err != nil {
+				t.Fatalf("Set(%q, %q): %v", label, val, err)
+			}
+			return
+		}
+	}
+	t.Fatalf("field %q not found", label)
+}
+
+func TestNetworkNameLowercasedToMatchBinkdDomain(t *testing.T) {
+	// The network key IS the binkd domain; the wizard lowercases it and hubs
+	// expect lowercase (fsxnet), so a manually typed FSXNET must normalize.
+	m := newFTNModel(map[string]config.FTNNetworkConfig{
+		"zz_new_1": {OwnAddress: "21:4/999"},
+	})
+	setField(t, m.fieldsFTNLink(), "Network Name", "FSXNET")
+
+	if _, ok := m.configs.FTN.Networks["fsxnet"]; !ok {
+		t.Fatalf("want lowercased key fsxnet, have keys %v", m.ftnNetworkKeys())
+	}
+	if _, ok := m.configs.FTN.Networks["FSXNET"]; ok {
+		t.Fatal("uppercase key must not be stored")
+	}
+}
+
+func TestSyncPollEventsCreatesForManualNetworkWithHub(t *testing.T) {
+	// A manually created network (never through the wizard) with a hub
+	// hostname must get an enabled poll event on save — the TUI-only goal
+	// means no trip to the Events editor should be required.
+	ev := config.EventsConfig{}
+	nets := map[string]config.FTNNetworkConfig{
+		"fsxnet": {
+			OwnAddress: "21:4/999",
+			Links: []config.FTNLinkConfig{{
+				Address: "21:4/158", Hostname: "pointhub.example.org", Port: 24556,
+			}},
+		},
+		// No hostname on the link: nothing to poll, no event invented.
+		"othernet": {OwnAddress: "1:2/3", Links: []config.FTNLinkConfig{{Address: "1:2/1"}}},
+	}
+	refreshPollEvents(&ev, nets)
+
+	poll := findEvent(ev, "echomail_poll_fsxnet")
+	if poll == nil {
+		t.Fatal("poll event must be created for a network with a hub hostname")
+	}
+	if !poll.Enabled {
+		t.Error("created poll event must be enabled")
+	}
+	if !containsArg(poll.Args, "21:4/158@fsxnet") {
+		t.Errorf("poll args wrong: %v", poll.Args)
+	}
+	if poll.Schedule == "" {
+		t.Error("created poll event must have a schedule")
+	}
+	if findEvent(ev, "echomail_poll_othernet") != nil {
+		t.Error("no poll event for a network whose link has no hostname")
+	}
+}

--- a/internal/configeditor/ftn_wizard_events.go
+++ b/internal/configeditor/ftn_wizard_events.go
@@ -56,16 +56,7 @@ func wireFTNEvents(events *config.EventsConfig, netKey, hubAddress string) {
 		break
 	}
 	if !updated {
-		events.Events = append(events.Events, config.EventConfig{
-			ID:               pollID,
-			Name:             fmt.Sprintf("Poll Hub (%s)", hubAddress),
-			Schedule:         "*/15 * * * *",
-			Command:          "{BBS_ROOT}/bin/binkd",
-			Args:             []string{"-p", "-P", hubFull, "{BBS_ROOT}/data/ftn/binkd.conf"},
-			WorkingDirectory: "{BBS_ROOT}",
-			TimeoutSeconds:   300,
-			Enabled:          true,
-		})
+		events.Events = append(events.Events, newPollEvent(netKey, hubAddress))
 	}
 
 	// Enable supporting seeded events where present.
@@ -83,20 +74,37 @@ func wireFTNEvents(events *config.EventsConfig, netKey, hubAddress string) {
 	}
 }
 
-// refreshPollEvents updates each existing per-network poll event to point at
-// the network's current first-link hub address, so a hub change in the
-// Echomail Links editor propagates on save. It never creates events — only
-// the wizard does that.
+// newPollEvent builds the standard enabled hub-poll event for a network.
+func newPollEvent(netKey, hubAddress string) config.EventConfig {
+	return config.EventConfig{
+		ID:               "echomail_poll_" + netKey,
+		Name:             fmt.Sprintf("Poll Hub (%s)", hubAddress),
+		Schedule:         "*/15 * * * *",
+		Command:          "{BBS_ROOT}/bin/binkd",
+		Args:             []string{"-p", "-P", fmt.Sprintf("%s@%s", hubAddress, netKey), "{BBS_ROOT}/data/ftn/binkd.conf"},
+		WorkingDirectory: "{BBS_ROOT}",
+		TimeoutSeconds:   300,
+		Enabled:          true,
+	}
+}
+
+// refreshPollEvents keeps per-network poll events in step with the networks
+// on save: an existing event is retargeted to the first link's current hub
+// address, and a network whose first link has a hostname (a real, pollable
+// hub — including manually created networks that never went through the
+// wizard) gets an enabled poll event created if none exists.
 func refreshPollEvents(events *config.EventsConfig, networks map[string]config.FTNNetworkConfig) {
 	for netKey, nc := range networks {
 		if len(nc.Links) == 0 {
 			continue
 		}
 		hub := nc.Links[0].Address
+		found := false
 		for i := range events.Events {
 			if events.Events[i].ID != "echomail_poll_"+netKey {
 				continue
 			}
+			found = true
 			e := &events.Events[i]
 			e.Name = fmt.Sprintf("Poll Hub (%s)", hub)
 			hubFull := fmt.Sprintf("%s@%s", hub, netKey)
@@ -113,6 +121,9 @@ func refreshPollEvents(events *config.EventsConfig, networks map[string]config.F
 			if !retargeted {
 				e.Args = []string{"-p", "-P", hubFull, "{BBS_ROOT}/data/ftn/binkd.conf"}
 			}
+		}
+		if !found && nc.Links[0].HostPort() != "" {
+			events.Events = append(events.Events, newPollEvent(netKey, hub))
 		}
 	}
 }


### PR DESCRIPTION
## Context

Goal: a sysop never has to hand-edit a JSON config or binkd.conf — everything from the TUI. After #124, manually created networks (Echomail Networks/Links, no wizard) produce a complete `binkd.conf`, but two traps remained.

## Changes

- **Network Name lowercased on input.** The network map key *is* the binkd domain (`domain <key>`, `<addr>@<key>`); hubs expect lowercase and the wizard lowercases, but the manual field stored input verbatim — and its help text even suggested `FSXNET`. Typing that would produce a domain the hub rejects. Help text now says lowercase and shows `fsxnet`.
- **Poll event auto-created for manual networks.** `refreshPollEvents` now also *creates* an enabled `echomail_poll_<net>` when the network's first link has a hostname (i.e. a real pollable hub) and no event exists — previously only the wizard created poll events, so a manual network silently never polled. Networks whose links lack a hostname get nothing invented. Poll-event construction shared via `newPollEvent`.

## Testing

- New: `TestNetworkNameLowercasedToMatchBinkdDomain`, `TestSyncPollEventsCreatesForManualNetworkWithHub` (TDD, watched fail first); existing follows-hub-change and preserves-custom-args tests still pass
- `go test ./...`: 1987 passed in 57 packages; `gofmt`/`go vet` clean