### PR TITLE
fix(ftn): blank sysop fallback no longer trips the placeholder check

### DIFF
--- a/internal/ftn/binkd_ensure_test.go
+++ b/internal/ftn/binkd_ensure_test.go
@@ -224,3 +224,25 @@ func TestEnsureBinkdConfDeterministicOrder(t *testing.T) {
 	inOrder("address", "address 21:4/999@aanet", "address 3:2/7@mmnet", "address 2:1/5@zznet")
 	inOrder("node", "node 21:4/158@aanet", "node 3:2/1@mmnet", "node 2:1/1@zznet")
 }
+
+func TestEnsureBinkdConfEmptyIdentityPassesPlaceholderCheck(t *testing.T) {
+	// A blank sysOpName must not regenerate a conf that HasPlaceholders
+	// rejects: the fallback sysop value may not collide with the shipped
+	// template's "SysOp" placeholder token, or the mailer would refuse the
+	// file it just regenerated (and never regenerate again, since it exists).
+	root := t.TempDir()
+	created, err := EnsureBinkdConf(root, ensureTestFTNConfig(), config.ServerConfig{})
+	if err != nil {
+		t.Fatalf("EnsureBinkdConf: %v", err)
+	}
+	if !created {
+		t.Fatal("expected binkd.conf to be created")
+	}
+	data, err := os.ReadFile(filepath.Join(root, "data", "ftn", "binkd.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if HasPlaceholders(string(data), root) {
+		t.Errorf("conf regenerated with empty identity must pass the placeholder check:\n%s", data)
+	}
+}

--- a/internal/ftn/binkd_regen.go
+++ b/internal/ftn/binkd_regen.go
@@ -21,7 +21,10 @@ func RegenerateBinkdConf(confPath string, cfg BinkdConfig, nodes []BinkdNode) er
 
 	sysop := cfg.SysopName
 	if sysop == "" {
-		sysop = "SysOp"
+		// Not "SysOp": that exact quoted string is a placeholder token in
+		// the shipped template, and HasPlaceholders would reject the
+		// regenerated conf (see binkd_placeholder.go).
+		sysop = "Sysop"
 	}
 	boardName := cfg.BoardName
 	if boardName == "" {


### PR DESCRIPTION
## Summary

Follow-up flagged in the PR #127 review: `RegenerateBinkdConf` defaults an empty sysop name to `"SysOp"`, but that exact quoted string is one of `HasPlaceholders`' template tokens. A sysop with FTN networks configured and a blank `sysOpName` would get a regenerated `binkd.conf` that the mailer preflight immediately rejects as "still contains template placeholders" — and since the file now exists, later startups would never regenerate it.

The fallback is now `"Sysop"`, which doesn't collide with the token list. The token itself stays, so detection of the actual shipped template is unchanged.

## Testing

New `TestEnsureBinkdConfEmptyIdentityPassesPlaceholderCheck` regenerates with an entirely empty `ServerConfig` and asserts `HasPlaceholders` accepts the result (failed before the fix). Full `go test ./...` passes; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)