### PR TITLE
fix(ftn): wizard path shares the safe blank-sysop fallback

### DIFF
--- a/internal/ftn/binkd.go
+++ b/internal/ftn/binkd.go
@@ -33,6 +33,26 @@ type BinkdConfig struct {
 	Node BinkdNode
 }
 
+// identityOrDefaults fills fallback values for blank BBS identity fields.
+// The sysop fallback is deliberately not "SysOp": that exact quoted string
+// is a placeholder token in the shipped template, and HasPlaceholders would
+// reject a conf carrying it (see binkd_placeholder.go).
+func identityOrDefaults(cfg BinkdConfig) (boardName, sysop, location string) {
+	boardName = cfg.BoardName
+	if boardName == "" {
+		boardName = "Vision3 BBS"
+	}
+	sysop = cfg.SysopName
+	if sysop == "" {
+		sysop = "Sysop"
+	}
+	location = cfg.Location
+	if location == "" {
+		location = "Earth"
+	}
+	return boardName, sysop, location
+}
+
 // sectionMarker returns the comment line used to identify a wizard-managed block.
 func sectionMarker(networkName string) string {
 	return fmt.Sprintf("# --- %s (added by FTN Setup Wizard) ---", networkName)
@@ -59,18 +79,7 @@ func UpdateBinkdConf(confPath string, cfg BinkdConfig) error {
 	insecureIn := filepath.Join(cfg.BBSRoot, "data", "ftn", "in")
 	v3mailPath := filepath.Join(cfg.BBSRoot, "v3mail")
 
-	sysop := cfg.SysopName
-	if sysop == "" {
-		sysop = "SysOp"
-	}
-	boardName := cfg.BoardName
-	if boardName == "" {
-		boardName = "Vision3 BBS"
-	}
-	location := cfg.Location
-	if location == "" {
-		location = "Earth"
-	}
+	boardName, sysop, location := identityOrDefaults(cfg)
 
 	var out strings.Builder
 

--- a/internal/ftn/binkd_placeholder_test.go
+++ b/internal/ftn/binkd_placeholder_test.go
@@ -160,3 +160,31 @@ inbound /opt/vision3/data/ftn/secure_in
 		t.Fatal("paths under the real BBS root must not be flagged as placeholders")
 	}
 }
+
+func TestUpdateBinkdConfEmptyIdentityPassesPlaceholderCheck(t *testing.T) {
+	// A blank sysop name must not make the wizard write a conf that
+	// HasPlaceholders rejects: the fallback may not collide with the
+	// template's "SysOp" placeholder token, or the mailer would refuse
+	// the file the wizard just generated.
+	dir := t.TempDir()
+	confPath := filepath.Join(dir, "binkd.conf")
+	cfg := BinkdConfig{
+		BBSRoot:   "/real/root",
+		Domains:   map[string]int{"fsxnet": 21},
+		Addresses: []string{"21:4/999@fsxnet"},
+		Node: BinkdNode{
+			Address: "21:1/100@fsxnet", Hostname: "hub.fsxnet.nz:24556",
+			SessionPwd: "secret", NetworkName: "fsxnet",
+		},
+	}
+	if err := UpdateBinkdConf(confPath, cfg); err != nil {
+		t.Fatalf("UpdateBinkdConf: %v", err)
+	}
+	got, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if HasPlaceholders(string(got), "/real/root") {
+		t.Errorf("wizard conf with empty identity must pass the placeholder check:\n%s", got)
+	}
+}

--- a/internal/ftn/binkd_regen.go
+++ b/internal/ftn/binkd_regen.go
@@ -19,21 +19,7 @@ func RegenerateBinkdConf(confPath string, cfg BinkdConfig, nodes []BinkdNode) er
 	insecureIn := filepath.Join(cfg.BBSRoot, "data", "ftn", "in")
 	v3mailPath := filepath.Join(cfg.BBSRoot, "v3mail")
 
-	sysop := cfg.SysopName
-	if sysop == "" {
-		// Not "SysOp": that exact quoted string is a placeholder token in
-		// the shipped template, and HasPlaceholders would reject the
-		// regenerated conf (see binkd_placeholder.go).
-		sysop = "Sysop"
-	}
-	boardName := cfg.BoardName
-	if boardName == "" {
-		boardName = "Vision3 BBS"
-	}
-	location := cfg.Location
-	if location == "" {
-		location = "Earth"
-	}
+	boardName, sysop, location := identityOrDefaults(cfg)
 
 	var out strings.Builder
 	writeFreshBinkdConf(&out, cfg, outPath, logPath, secureIn, insecureIn, v3mailPath, boardName, sysop, location)


### PR DESCRIPTION
## Summary

Follow-up to #128: `UpdateBinkdConf` (the FTN Setup Wizard path) had its own duplicated copy of the blank-identity fallbacks, still defaulting sysop to `"SysOp"` — the exact quoted string `HasPlaceholders` treats as a template token. A wizard run with a blank sysop name would write a conf the mailer preflight rejects.

Rather than patching the second copy in place, the identity fallbacks are extracted into `identityOrDefaults`, used by both `UpdateBinkdConf` and `RegenerateBinkdConf`, so the two paths can't drift apart again.

## Testing

New `TestUpdateBinkdConfEmptyIdentityPassesPlaceholderCheck` generates a fresh wizard conf with an empty identity and asserts `HasPlaceholders` accepts it (failed before the fix). Full `go test ./...` passes; gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Binkd configuration generation when identity details are missing.
  * Prevented valid configurations from being incorrectly flagged as containing placeholders.
  * Standardized default values for board name, sysop, and location across configuration creation and regeneration.

* **Tests**
  * Added regression coverage for generating configurations with an empty identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->