### PR TITLE
fix: four run-loop behavior issues found during the executor refactor

### DIFF
--- a/internal/menu/executor_run.go
+++ b/internal/menu/executor_run.go
@@ -218,7 +218,10 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 		input, act, retErr := st.readMenuInput(ansiProcessResult, menuRec)
 		switch act {
 		case loopReturn:
-			return input, nil, retErr
+			// Propagate the user like every other loopReturn site: nil here dropped
+			// an authenticated user on the disconnect paths, and main.go reads a nil
+			// user as "authentication did not happen".
+			return input, st.currentUser, retErr
 		case loopContinue:
 			continue
 		}
@@ -249,12 +252,13 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 		} else {
 			slog.Debug("input did not match any commands in menu", "input", st.userInput, "menu", st.currentMenuName)
 
-			// If it was a lightbar menu and input was ignored (st.userInput == ""), just loop again
-			if st.isLightbarMenu {
-				continue
-			}
-
-			// Empty Enter should just redisplay the current menu, not fall through to fallback
+			// Empty Enter should just redisplay the current menu, not fall through
+			// to fallback. This also covers ignored lightbar keypresses, which
+			// yield empty input. Non-empty unmatched input gets the fallback /
+			// undefined-command treatment even on a lightbar menu: runLightbarInput
+			// only ever returns a hotkey defined in the .BAR file, so reaching here
+			// with input means that hotkey has no command in the menu's .CFG, and
+			// silently redisplaying hid the misconfiguration.
 			if st.userInput == "" {
 				continue
 			}

--- a/internal/menu/executor_run_input_mode.go
+++ b/internal/menu/executor_run_input_mode.go
@@ -1,10 +1,7 @@
 package menu
 
 import (
-	"fmt"
-	"io"
 	"log/slog"
-	"strings"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 )
@@ -13,42 +10,30 @@ import (
 // dispatch. Run sets st.isLightbarMenu via HasBarFile immediately before
 // calling this (that check stays inline in Run, out of scope here). For a
 // lightbar-capable menu, this loads and draws the lightbar options and reads
-// a selection via runLightbarInput, falling back to an inline
-// prompt-and-readline path when option loading/drawing fails or no
-// selection was made; for a non-lightbar menu it delegates entirely to
-// readStandardInput.
+// a selection via runLightbarInput, falling back to readStandardInput when
+// option loading/drawing fails or no selection was made; for a non-lightbar
+// menu it delegates to readStandardInput directly.
 //
 // The three `st.isLightbarMenu = false` toggles (failed option load, empty
 // option list, failed draw) and the drawLightbarMenu call itself move here
 // verbatim, together and in their original relative order, exactly as they
 // were inline in Run — this method is their only home now.
 //
-// The inline fallback path (deliverPendingPages/displayPrompt/
-// readLineFromSessionIH, reached when the lightbar path yields no input) is
-// deliberately NOT unified with readStandardInput: it has its own bare `err
-// == io.EOF` check and no idle-timeout or ^P handling, unlike
-// readStandardInput's errors.Is(err, io.EOF)/errors.Is(err,
-// editor.ErrIdleTimeout)/^P logic. That distinction is preserved exactly, as
-// it was a deliberate difference in the original code, not an oversight.
+// The lightbar fallback path previously duplicated readStandardInput inline,
+// with a bare `err == io.EOF` check and no idle-timeout or ^P handling. That
+// duplication meant a user idling at the fallback prompt of a .BAR menu was
+// never timed out. Both paths now share readStandardInput.
 //
 // act is loopReturn on any of the disconnect/error paths (from the lightbar
-// input loop, the inline fallback prompt+read, or readStandardInput), with
-// input/retErr carrying the exact values Run's original inline `return`
-// statements produced for the caller — always paired with a literal nil
-// user at the call site, matching the original code, since no
-// user-mutating call happens anywhere in this part of Run. act is
-// loopContinue when readStandardInput signals ^P back-navigation (its own
-// st.currentMenuName/st.previousMenuName mutations already applied inside
-// readStandardInput). Otherwise act is loopFallthrough and st.userInput
-// already holds the final value for command matching, exactly as before.
+// input loop or readStandardInput), with input/retErr carrying the values the
+// caller returns. act is loopContinue when readStandardInput signals ^P
+// back-navigation (its own st.currentMenuName/st.previousMenuName mutations
+// already applied inside readStandardInput). Otherwise act is loopFallthrough
+// and st.userInput already holds the final value for command matching.
 func (st *runLoopState) readMenuInput(ansiProcessResult ansi.ProcessAnsiResult, menuRec *MenuRecord) (input string, act loopAction, retErr error) {
 	e := st.e
-	s := st.s
 	terminal := st.terminal
 	outputMode := st.outputMode
-	userManager := st.userManager
-	nodeNumber := st.nodeNumber
-	sessionStartTime := st.sessionStartTime
 
 	// 4. Determine Input Mode / Method
 	if st.isLightbarMenu {
@@ -88,31 +73,17 @@ func (st *runLoopState) readMenuInput(ansiProcessResult ansi.ProcessAnsiResult, 
 		}
 
 		if !st.isLightbarMenu || st.userInput == "" {
-			// Fallback to standard input if lightbar loading failed or no valid selection made
-			e.deliverPendingPages(terminal, nodeNumber, outputMode)
-			// Display Prompt (Skip if USEPROMPT is false)
-			if menuRec.GetUsePrompt() { // Condition changed: Only check UsePrompt
-				err := e.displayPrompt(terminal, menuRec, st.currentUser, userManager, nodeNumber, st.currentMenuName, sessionStartTime, outputMode, st.currentAreaName) // Pass st.currentAreaName
-				if err != nil {
-					return "", loopReturn, err // Propagate the error
-				}
-			} else {
-				// Log message remains the same, but the condition causing it is now just UsePrompt==false
-				slog.Debug("skipping prompt display", "menu", st.currentMenuName, "usePrompt", menuRec.GetUsePrompt(), "prompt1Empty", menuRec.Prompt1 == "")
+			// Fall back to standard input if lightbar loading failed or no valid
+			// selection was made. Shares readStandardInput so this path also gets
+			// idle-timeout enforcement, ^P back-navigation and wrapped-EOF
+			// detection, which the previous inline copy lacked.
+			input, act, retErr := st.readStandardInput(menuRec)
+			switch act {
+			case loopReturn:
+				return input, loopReturn, retErr
+			case loopContinue:
+				return input, loopContinue, retErr
 			}
-
-			// Read User Input Line via shared InputHandler to avoid reader races.
-			input, err := readLineFromSessionIH(s, terminal)
-			if err != nil {
-				if err == io.EOF {
-					slog.Info("user disconnected during menu input", "menu", st.currentMenuName)
-					return "LOGOFF", loopReturn, nil // Signal logoff
-				}
-				slog.Error("failed to read input for menu", "menu", st.currentMenuName, "error", err)
-				return "", loopReturn, fmt.Errorf("failed reading input: %w", err)
-			}
-			st.userInput = strings.ToUpper(strings.TrimSpace(input))
-			slog.Debug("user input", "input", st.userInput)
 		}
 	} else {
 		input, act, retErr := st.readStandardInput(menuRec)

--- a/internal/menu/executor_run_login_menu.go
+++ b/internal/menu/executor_run_login_menu.go
@@ -30,35 +30,16 @@ func (st *runLoopState) handleLoginMenu(res ansi.ProcessAnsiResult) (act loopAct
 	termHeight := st.termHeight
 	userManager := st.userManager
 	nodeNumber := st.nodeNumber
-	sessionStartTime := st.sessionStartTime
 	ansiProcessResult := res
 
 	if st.currentUser != nil {
 		slog.Warn("attempting to run LOGIN menu for already authenticated user, skipping login, going to MAIN", "handle", st.currentUser.Handle)
 
-		// Set default message area if not already set (e.g., SSH auto-login)
-		if st.currentUser.CurrentMessageAreaID == 0 && e.MessageMgr != nil {
-			for _, area := range e.MessageMgr.ListAreas() {
-				if checkACS(area.ACSRead, st.currentUser, s, terminal, sessionStartTime) {
-					st.currentUser.CurrentMessageAreaID = area.ID
-					st.currentUser.CurrentMessageAreaTag = area.Tag
-					e.setUserMsgConference(st.currentUser, area.ConferenceID)
-					break
-				}
-			}
-		}
-
-		// Set default file area if not already set
-		if st.currentUser.CurrentFileAreaID == 0 && e.FileMgr != nil {
-			for _, area := range e.FileMgr.ListAreas() {
-				if checkACS(area.ACSList, st.currentUser, s, terminal, sessionStartTime) {
-					st.currentUser.CurrentFileAreaID = area.ID
-					st.currentUser.CurrentFileAreaTag = area.Tag
-					e.setUserFileConference(st.currentUser, area.ConferenceID)
-					break
-				}
-			}
-		}
+		// Seed default areas if not already set (e.g., SSH auto-login). Shares
+		// setDefaultArea with the post-authentication path so both log the
+		// selection and clear a stale tag when no area is accessible.
+		st.setDefaultArea("message")
+		st.setDefaultArea("file")
 
 		// Persist defaults
 		if userManager != nil {

--- a/internal/menu/executor_run_login_menu_test.go
+++ b/internal/menu/executor_run_login_menu_test.go
@@ -1,0 +1,88 @@
+package menu
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/file"
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+// newFileAreaExecutor builds a MenuExecutor whose FileMgr serves the given
+// file_areas.json content, for exercising setDefaultArea's file branch.
+func newFileAreaExecutor(t *testing.T, areasJSON string) *MenuExecutor {
+	t.Helper()
+	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	if err := os.WriteFile(filepath.Join(cfgDir, "file_areas.json"), []byte(areasJSON), 0644); err != nil {
+		t.Fatalf("write areas: %v", err)
+	}
+	fm, err := file.NewFileManager(dataDir, cfgDir)
+	if err != nil {
+		t.Fatalf("NewFileManager: %v", err)
+	}
+	return &MenuExecutor{FileMgr: fm}
+}
+
+// newAreaSeedState wires a runLoopState with a test session/terminal so
+// checkACS can be evaluated against u.
+func newAreaSeedState(t *testing.T, e *MenuExecutor, u *user.User) *runLoopState {
+	t.Helper()
+	ts := newTestSession("")
+	return &runLoopState{
+		e:                e,
+		s:                ts,
+		terminal:         newTestTerminal(ts),
+		currentUser:      u,
+		nodeNumber:       1,
+		sessionStartTime: time.Now(),
+	}
+}
+
+func TestSetDefaultAreaSeedsFirstAccessibleFileArea(t *testing.T) {
+	// Area 1 requires level 255; area 2 is open. A level-10 user must land on 2.
+	e := newFileAreaExecutor(t, `[
+		{"id":1,"tag":"STAFF","name":"Staff","path":"staff","acs_list":"s255"},
+		{"id":2,"tag":"PUBLIC","name":"Public","path":"public","acs_list":""}
+	]`)
+	u := &user.User{Handle: "Tester", AccessLevel: 10}
+	st := newAreaSeedState(t, e, u)
+
+	st.setDefaultArea("file")
+
+	if u.CurrentFileAreaID != 2 || u.CurrentFileAreaTag != "PUBLIC" {
+		t.Fatalf("seeded area = %d/%q, want 2/PUBLIC (first accessible)", u.CurrentFileAreaID, u.CurrentFileAreaTag)
+	}
+}
+
+func TestSetDefaultAreaClearsStaleTagWhenNoAccess(t *testing.T) {
+	// Every area is out of reach, and the user carries a stale tag with ID 0.
+	// Seeding must clear the tag rather than leave it pointing at nothing.
+	e := newFileAreaExecutor(t, `[
+		{"id":1,"tag":"STAFF","name":"Staff","path":"staff","acs_list":"s255"}
+	]`)
+	u := &user.User{Handle: "Tester", AccessLevel: 10, CurrentFileAreaTag: "GONE"}
+	st := newAreaSeedState(t, e, u)
+
+	st.setDefaultArea("file")
+
+	if u.CurrentFileAreaID != 0 || u.CurrentFileAreaTag != "" {
+		t.Fatalf("area after denial = %d/%q, want 0/\"\"", u.CurrentFileAreaID, u.CurrentFileAreaTag)
+	}
+}
+
+func TestSetDefaultAreaKeepsSavedArea(t *testing.T) {
+	// A user with a saved area keeps it, even when another area is accessible.
+	e := newFileAreaExecutor(t, `[
+		{"id":1,"tag":"PUBLIC","name":"Public","path":"public","acs_list":""}
+	]`)
+	u := &user.User{Handle: "Tester", AccessLevel: 10, CurrentFileAreaID: 7, CurrentFileAreaTag: "SAVED"}
+	st := newAreaSeedState(t, e, u)
+
+	st.setDefaultArea("file")
+
+	if u.CurrentFileAreaID != 7 || u.CurrentFileAreaTag != "SAVED" {
+		t.Fatalf("saved area = %d/%q, want 7/SAVED untouched", u.CurrentFileAreaID, u.CurrentFileAreaTag)
+	}
+}


### PR DESCRIPTION
## Summary

The four behavior issues the review bots surfaced during PRs #136–#139 and that were deliberately deferred, since fixing them in a behavior-preserving refactor would have muddied the diff. Each is a separate commit.

## The fixes

**1. Lightbar fallback duplicated `readStandardInput`** (`349c26f`) — the fallback path was an inline copy missing three behaviors. Most consequential: no `editor.ErrIdleTimeout` case, so **a user idling at the fallback prompt of a `.BAR` menu was never timed out** and held the node open indefinitely. Also a bare `err == io.EOF` (a wrapped EOF reported "failed reading input" instead of a clean `LOGOFF`) and no `^P` back-navigation. Both paths now share `readStandardInput`; the file drops 128 → 99 lines.

**2. Unmatched lightbar input was silently swallowed** (`86c0777`) — the `isLightbarMenu` guard in the no-match branch suppressed `menuRec.Fallback` and the undefined-command message for *all* input on a `.BAR` menu. The following empty-input check already covers ignored keypresses, and `runLightbarInput` only ever returns a hotkey defined in the `.BAR` file — so reaching the no-match branch with input means that hotkey has no command in the `.CFG`. That's a misconfiguration, now surfaced instead of hidden.

**3. Disconnect path dropped the user** (`86c0777`) — the `readMenuInput` `loopReturn` site returned `nil` where the loop's three other `loopReturn` sites propagate `st.currentUser`. `main.go` reads a nil user as "authentication did not happen".

**4. `setDefaultArea` divergence** (`be0914c`) — the already-authenticated LOGIN branch (SSH auto-login) re-implemented area seeding and had drifted: no selection/denial logging, and no clearing of a stale area tag left with ID 0. Now calls the shared helper.

## Tests

Three characterization tests pin `setDefaultArea`'s contract — first ACS-accessible area wins, a saved area is left untouched, no accessible area clears both ID and tag — using the existing `newTestSession` / real `file.FileManager` harness.

Fixes 1–3 have no unit coverage: they sit in session-read/prompt-write paths with no test seam, so they were verified by diff review against the pre-refactor source plus the gate below. Worth stating plainly rather than implying coverage that isn't there.

## Verification

- `go test ./...` exit 0; `go test -race -count=1 ./internal/menu/` exit 0
- `gofmt -l` empty; `go vet` clean; `staticcheck` exit 0, zero findings
- Server binary builds and boots pre-flight cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu behavior when pressing Enter or using unsupported lightbar input, ensuring menus redisplay consistently.
  * Standardized fallback input handling, including idle timeouts, disconnects, and back-navigation.
  * Preserved authenticated session state during menu transitions.
  * Improved selection of default file areas based on access permissions.
  * Cleared invalid saved file-area selections when no accessible area is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->