### PR TITLE
refactor: decompose the file lightbar browser

### DIFF
--- a/internal/menu/file_lightbar.go
+++ b/internal/menu/file_lightbar.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"io"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/gliderlabs/ssh"
@@ -97,68 +96,13 @@ func runListFilesLightbar(st *fileListState) (*user.User, string, error) {
 	showSysopBar := false
 
 	// Determine terminal dimensions.
-	termHeight := 24
-	termWidth := 80
-	if ptyReq, _, ok := st.s.Pty(); ok && ptyReq.Window.Height > 0 {
-		termHeight = ptyReq.Window.Height
-		if ptyReq.Window.Width > 0 {
-			termWidth = ptyReq.Window.Width
-		}
-	}
+	termHeight, termWidth := resolveTermSize(st.s)
 
-	// Count header lines from top template (line count is invariant to page/file counts).
 	fconfpath := st.e.resolveFileConferencePath(st.currentUser)
-	processedTopSample := ansi.ReplacePipeCodes(processFileListPlaceholders(st.topTemplateBytes, 1, 1, st.totalFiles, fconfpath))
-	headerLines := strings.Count(string(processedTopSample), "\n")
-	if headerLines < 1 {
-		headerLines = 1
-	}
+	headerLines, botContent, botLineCount, reservedBottom, visibleRows, fileAreaStartRow, cmdBarRow, separatorRow :=
+		computeVerticalLayout(termHeight, st.topTemplateBytes, st.processedBotTemplate, st.totalFiles, fconfpath)
 
-	// Reserve rows for the separator, command bar, and optional BOT template.
-	// Derive botLineCount from the expanded string (after placeholder + pipe-code
-	// processing) so it matches what renderPageIndicator actually renders.
-	botContent := strings.TrimRight(string(st.processedBotTemplate), "\r\n")
-	botLineCount := 0
-	if len(botContent) > 0 {
-		expandedBotSample := string(ansi.ReplacePipeCodes(processFileListPlaceholders([]byte(botContent), 1, 1, st.totalFiles, fconfpath)))
-		expandedBotSample = strings.ReplaceAll(expandedBotSample, "^PAGE", "1")
-		expandedBotSample = strings.ReplaceAll(expandedBotSample, "^TOTALPAGES", "1")
-		botLineCount = len(strings.Split(expandedBotSample, "\n"))
-	}
-	reservedBottom := 2 // separator + command bar
-	if botLineCount > 0 {
-		reservedBottom = 2 + botLineCount // separator + command bar + BOT lines
-	}
-	visibleRows := termHeight - headerLines - reservedBottom - 1
-	if visibleRows < 3 {
-		visibleRows = 3
-	}
-
-	// stripAnsi removes all ANSI escape sequences from a string.
-	ansiRe := regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
-
-	// All template placeholders are fixed-width, so the description column
-	// width is constant across all file entries. Precompute once for both
-	// fileEntryHeight and buildFileEntry.
-	sample := strings.ReplaceAll(st.processedMidTemplate, "^MARK", " ")
-	sample = strings.ReplaceAll(sample, "^NUM", "  1")
-	sample = strings.ReplaceAll(sample, "^NAME", "            ")
-	sample = strings.ReplaceAll(sample, "^DATE", "01/01/00")
-	sample = strings.ReplaceAll(sample, "^SIZE", "     ")
-	sample = strings.ReplaceAll(sample, "^DESC", "")
-	descPrefixLen := len(ansiRe.ReplaceAllString(string(ansi.ReplacePipeCodes([]byte(sample))), ""))
-	descColWidth := termWidth - descPrefixLen - 1
-	if descColWidth < 20 {
-		descColWidth = 20
-	}
-	descIndentStr := strings.Repeat(" ", descPrefixLen)
-
-	// fileAreaStartRow is the absolute terminal row where file entries begin.
-	fileAreaStartRow := headerLines + 2
-
-	// Layout: separator row, then command bar, then optional BOT.
-	cmdBarRow := max(1, termHeight-botLineCount)
-	separatorRow := max(1, cmdBarRow-1)
+	ansiRe, descPrefixLen, descColWidth, descIndentStr := computeDescMetrics(st.processedMidTemplate, termWidth)
 
 	lb := &fileLightbar{
 		e:                    st.e,

--- a/internal/menu/file_lightbar.go
+++ b/internal/menu/file_lightbar.go
@@ -151,54 +151,12 @@ func runListFilesLightbar(st *fileListState) (*user.User, string, error) {
 	}
 	descIndentStr := strings.Repeat(" ", descPrefixLen)
 
-	// fileEntryHeight returns the number of screen lines a file at idx takes:
-	// first line (metadata + first DIZ line) + continuation DIZ lines.
-
-	// filesVisibleFrom counts how many files fit in visibleRows starting from startIdx,
-	// accounting for each entry's variable height (DIZ lines).
-
-	// topIndexForPrevPage walks backward from the current topIndex to find where
-	// the previous page should start, filling visibleRows from bottom to top.
-
-	// calculatePageInfo walks all files with variable heights to determine
-	// which page topIndex falls on and how many total pages exist.
-
-	// --- Rendering helpers for smart refresh ---
-
 	// fileAreaStartRow is the absolute terminal row where file entries begin.
 	fileAreaStartRow := headerLines + 2
-
-	// buildFileEntry produces the ANSI output for a single file entry at the
-	// given file index, returning the rendered lines (first line + continuations)
-	// already processed through pipe codes.  If highlighted is true the first
-	// line uses the highlight color with stripped ANSI (lightbar style).
-	// The caller specifies how many screen lines are available (maxLines) so the
-	// function can truncate continuation lines to fit.
-
-	// screenRowForFile returns the absolute terminal row a file entry starts on,
-	// given the current topIndex.  Returns -1 if the file is not in the viewport.
-
-	// writeFileRow renders a single file entry at the given absolute screen row,
-	// clearing the lines it occupies first.
-
-	// renderFileArea redraws only the file list rows using absolute cursor
-	// positioning and line-clear (no full screen clear).
 
 	// Layout: separator row, then command bar, then optional BOT.
 	cmdBarRow := max(1, termHeight-botLineCount)
 	separatorRow := max(1, cmdBarRow-1)
-
-	// renderSeparator draws the separator line above the command bar.
-	// Uses CP437 0xFA (·) and 0xC4 (─) to match the header separator style.
-
-	// renderCmdBar redraws only the horizontal command bar.
-
-	// renderPageIndicator redraws only the page/bot indicator row(s).
-
-	// renderTop writes the TOP template with |FPAGE, |FTOTAL, @FPAGE@, @FTOTAL@ substituted.
-
-	// renderFull performs a complete screen redraw (used on first display and
-	// after overlay commands that clobber the screen).
 
 	lb := &fileLightbar{
 		e:                    st.e,

--- a/internal/menu/file_lightbar.go
+++ b/internal/menu/file_lightbar.go
@@ -2,17 +2,12 @@ package menu
 
 import (
 	"errors"
-	"fmt"
 	"io"
-	"log/slog"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
 
 	"github.com/gliderlabs/ssh"
-	"github.com/google/uuid"
 	"golang.org/x/term"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
@@ -20,7 +15,6 @@ import (
 	"github.com/ViSiON-3/vision-3-bbs/internal/file"
 	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
-	"github.com/ViSiON-3/vision-3-bbs/internal/ziplab"
 )
 
 // fileLightbar holds the state for the interactive file-area browser.
@@ -232,458 +226,29 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			return nil, "", err
 		}
 
-		keyInt, err := lb.ih.ReadKey()
-		if err != nil {
-			if logoffIfDisconnected(err) {
-				return nil, "LOGOFF", io.EOF
-			}
-			return nil, "", err
+		keyInt, exit, action, err := lb.readKeyOrLogoff()
+		if exit {
+			return nil, action, err
 		}
 
-		// Navigation keys — matched directly on integer key codes so that
-		// multi-byte escape sequences (PageUp/PageDown etc.) are handled
-		// atomically by the InputHandler and can never be split by the
-		// 100 ms inter-byte ESC timeout, which previously caused bare ESC
-		// to be returned and the lightbar to exit unexpectedly.
-		var key string
-		switch keyInt {
-		case editor.KeyArrowUp: // Up
-			lb.selectedIndex--
+		key, dispatch, exit, result, action, err := lb.handleNavKey(keyInt)
+		if exit {
+			return result, action, err
+		}
+		if !dispatch {
 			continue
-		case editor.KeyArrowDown: // Down
-			lb.selectedIndex++
-			continue
-		case editor.KeyArrowRight: // Right — command bar
-			lb.cmdIndex++
-			if lb.cmdIndex >= len(lb.cmdEntries) {
-				lb.cmdIndex = 0
-			}
-			continue
-		case editor.KeyArrowLeft: // Left — command bar
-			lb.cmdIndex--
-			if lb.cmdIndex < 0 {
-				lb.cmdIndex = len(lb.cmdEntries) - 1
-			}
-			continue
-		case editor.KeyPageUp, editor.KeyCtrlR: // Page Up
-			newTop := lb.topIndexForPrevPage()
-			lb.topIndex = newTop
-			lb.selectedIndex = newTop
-			continue
-		case editor.KeyPageDown: // Page Down
-			count := lb.filesVisibleFrom(lb.topIndex)
-			nextTop := lb.topIndex + count
-			if nextTop >= len(lb.allFiles) {
-				if len(lb.allFiles) > 0 {
-					lb.selectedIndex = len(lb.allFiles) - 1
-				}
-			} else {
-				lb.topIndex = nextTop
-				lb.selectedIndex = nextTop
-			}
-			continue
-		case editor.KeyHome: // Home
-			lb.selectedIndex = 0
-			continue
-		case editor.KeyEnd: // End
-			if len(lb.allFiles) > 0 {
-				lb.selectedIndex = len(lb.allFiles) - 1
-			}
-			continue
-		case editor.KeyEsc: // Bare Esc
-			return nil, "", nil
-		case editor.KeyEnter: // Enter: execute selected command bar item
-			key = lb.cmdEntries[lb.cmdIndex].hotkey
-		default:
-			if keyInt >= 32 && keyInt < 127 {
-				key = strings.ToLower(string(rune(keyInt)))
-			} else {
-				continue // Ignore non-printable, non-navigation keys
-			}
 		}
 
 		// Toggle sysop command bar with *
 		if key == "*" && lb.isSysop {
-			lb.showSysopBar = !lb.showSysopBar
-			if lb.showSysopBar {
-				lb.cmdEntries = make([]cmdEntry, len(lb.sysopEntries))
-				copy(lb.cmdEntries, lb.sysopEntries)
-			} else {
-				lb.cmdEntries = make([]cmdEntry, len(lb.userEntries))
-				copy(lb.cmdEntries, lb.userEntries)
-			}
-			lb.cmdIndex = 0
+			lb.toggleSysopBar()
 			frame.needFullRedraw = true
 			continue
 		}
 
-		// Command dispatch (direct hotkeys or Enter-selected command).
-		switch key {
-		case " ": // Space: toggle mark
-			if len(lb.allFiles) > 0 {
-				fileID := lb.allFiles[lb.selectedIndex].ID
-				found := false
-				newTaggedIDs := make([]uuid.UUID, 0, len(lb.currentUser.TaggedFileIDs))
-				for _, taggedID := range lb.currentUser.TaggedFileIDs {
-					if taggedID == fileID {
-						found = true
-					} else {
-						newTaggedIDs = append(newTaggedIDs, taggedID)
-					}
-				}
-				if !found {
-					newTaggedIDs = append(newTaggedIDs, fileID)
-				}
-				lb.currentUser.TaggedFileIDs = newTaggedIDs
-				if err := lb.userManager.UpdateUser(lb.currentUser); err != nil {
-					slog.Error("failed to save user after tag toggle", "node", lb.nodeNumber, "error", err)
-				}
-				// Redraw just the toggled row to show/hide the mark.
-				if row, h := lb.screenRowForFile(lb.selectedIndex); row >= 0 {
-					_ = lb.writeFileRow(row, lb.selectedIndex, true, h)
-				}
-			}
-
-		case "q":
-			return nil, "", nil
-
-		case "i": // Info: show file detail overlay
-			refresh, exit, result, action, infoErr := lb.showFileInfo()
-			if exit {
-				return result, action, infoErr
-			}
-			if refresh {
-				frame.needFullRedraw = true
-			}
-
-		case "v":
-			if len(lb.allFiles) > 0 {
-				sel := &lb.allFiles[lb.selectedIndex]
-				filePath, pathErr := lb.e.FileMgr.GetFilePath(sel.ID)
-				if pathErr != nil {
-					slog.Error("failed to get path for file", "node", lb.nodeNumber, "id", sel.ID, "error", pathErr)
-					continue
-				}
-				// Show cursor for the viewer.
-				_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
-				if lb.e.FileMgr.IsSupportedArchive(sel.Filename) {
-					ctx, cancel := lb.e.transferContext(lb.s.Context())
-					ziplab.RunZipLabView(ctx, lb.s, lb.terminal, filePath, sel.Filename, lb.outputMode, sessionReadLine(lb.s, lb.terminal), sessionReadKey(lb.s))
-					cancel()
-				} else {
-					tw, th := getTerminalSize(lb.s)
-					viewFileByRecord(lb.e, lb.s, lb.terminal, sel, lb.outputMode, tw, th)
-				}
-				// Hide cursor again.
-				lb.endFooterPrompt()
-				frame.needFullRedraw = true
-			}
-
-		case "d":
-			if len(lb.currentUser.TaggedFileIDs) == 0 {
-				msg := "\r\n|07No files marked for download. Use |15Space|07 to mark files.|07\r\n"
-				_ = lb.writePipe(msg)
-				time.Sleep(1 * time.Second)
-				frame.needFullRedraw = true
-				continue
-			}
-
-			confirmPrompt := fmt.Sprintf("Download %d marked file(s)?", len(lb.currentUser.TaggedFileIDs))
-			// Replace the footer lightbar with the confirm prompt instead of printing over the file list.
-			lb.beginFooterPrompt()
-
-			tw, th := getTerminalSize(lb.s)
-			proceed, promptErr := lb.e.PromptYesNo(lb.s, lb.terminal, confirmPrompt, lb.outputMode, lb.nodeNumber, tw, th, false)
-			if promptErr != nil {
-				if logoffIfDisconnected(promptErr) {
-					return nil, "LOGOFF", io.EOF
-				}
-				slog.Error("error getting download confirmation", "node", lb.nodeNumber, "error", promptErr)
-				lb.endFooterPrompt()
-				frame.needFullRedraw = true
-				continue
-			}
-
-			if !proceed {
-				lb.endFooterPrompt()
-				frame.needFullRedraw = true
-				continue
-			}
-
-			slog.Info("starting download", "node", lb.nodeNumber, "handle", lb.currentUser.Handle, "count", len(lb.currentUser.TaggedFileIDs))
-			// Clear the screen before the download process begins.
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[2J\x1b[H"), lb.outputMode)
-			_ = lb.writePipe("|07Preparing download...\r\n")
-			time.Sleep(500 * time.Millisecond)
-
-			successCount := 0
-			failCount := 0
-			filesToDownload := make([]string, 0, len(lb.currentUser.TaggedFileIDs))
-			fileIDsToDownload := make([]uuid.UUID, 0, len(lb.currentUser.TaggedFileIDs))
-
-			for _, fileID := range lb.currentUser.TaggedFileIDs {
-				fp, pathErr := lb.e.FileMgr.GetFilePath(fileID)
-				if pathErr != nil {
-					slog.Error("failed to get path for file ID", "node", lb.nodeNumber, "id", fileID, "error", pathErr)
-					failCount++
-					continue
-				}
-				if _, statErr := os.Stat(fp); os.IsNotExist(statErr) {
-					slog.Error("file path for ID does not exist", "node", lb.nodeNumber, "path", fp, "id", fileID)
-					failCount++
-					continue
-				} else if statErr != nil {
-					slog.Error("error stating file path for ID", "node", lb.nodeNumber, "path", fp, "id", fileID, "error", statErr)
-					failCount++
-					continue
-				}
-				filesToDownload = append(filesToDownload, fp)
-				fileIDsToDownload = append(fileIDsToDownload, fileID)
-			}
-
-			if len(filesToDownload) > 0 {
-				slog.Info("initiating transfer", "node", lb.nodeNumber, "count", len(filesToDownload))
-
-				// Use protocol selection (respects connection type - SSH vs Telnet)
-				proto, protoOK, protoErr := lb.e.selectTransferProtocol(lb.s, lb.terminal, lb.outputMode)
-				if protoErr != nil {
-					if logoffIfDisconnected(protoErr) {
-						return nil, "LOGOFF", io.EOF
-					}
-					slog.Error("protocol selection error", "node", lb.nodeNumber, "error", protoErr)
-					_ = lb.writePipe("\r\n|01Error: No transfer protocols configured on this system.|07\r\n")
-					failCount += len(filesToDownload)
-				} else if !protoOK {
-					_ = lb.writePipe("\r\n|07Download cancelled.|07\r\n")
-				} else {
-					sentCount, sendFails := lb.e.runTransferSend(lb.s, lb.terminal, proto, filesToDownload, fileIDsToDownload, lb.outputMode, lb.nodeNumber)
-					successCount = sentCount
-					failCount += sendFails
-					lb.ih = getSessionIH(lb.s)
-				}
-				time.Sleep(1 * time.Second)
-			} else {
-				slog.Warn("no valid file paths found for tagged files", "node", lb.nodeNumber)
-				_ = lb.writePipe("\r\n|01Could not find any of the marked files on the server.|07\r\n")
-				// failCount already equals the number of missing files (every
-				// tagged ID incremented it in the collection loop above).
-			}
-
-			// Clear tags, update download count, and save.
-			lb.currentUser.TaggedFileIDs = nil
-			lb.currentUser.NumDownloads += successCount
-			if saveErr := lb.userManager.UpdateUser(lb.currentUser); saveErr != nil {
-				slog.Error("failed to save user data after download", "node", lb.nodeNumber, "error", saveErr)
-			}
-
-			statusMsg := fmt.Sprintf("|07Download finished. Success: %d, Failed: %d.|07\r\n", successCount, failCount)
-			_ = lb.writePipe(statusMsg)
-			time.Sleep(2 * time.Second)
-
-			// Refresh file list.
-			lb.refreshFileList()
-			lb.endFooterPrompt()
-			frame.needFullRedraw = true
-
-		case "u":
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
-			uploadErr := lb.e.runUploadFiles(lb.s, lb.terminal, lb.currentUser, lb.userManager, lb.currentAreaID, lb.currentAreaTag, lb.outputMode, lb.nodeNumber, lb.sessionStartTime)
-			if uploadErr != nil {
-				slog.Error("upload error", "node", lb.nodeNumber, "error", uploadErr)
-			}
-			// runUploadFiles calls resetSessionIH/getSessionIH internally,
-			// so the local ih is now stale — refresh it.
-			lb.ih = getSessionIH(lb.s)
-			// Refresh file list after upload.
-			lb.refreshFileList()
-			lb.endFooterPrompt()
-			frame.needFullRedraw = true
-
-		case "e": // Edit description (sysop only)
-			if !lb.isSysop || len(lb.allFiles) == 0 {
-				continue
-			}
-			rec := lb.allFiles[lb.selectedIndex]
-			lb.beginFooterPrompt()
-			_ = lb.writePipe("|15New description: |07")
-			newDesc, readErr := readLineFromSessionIHAllowAbort(lb.s, lb.terminal)
-			lb.endFooterPrompt()
-			if readErr == nil && newDesc != "" {
-				if updErr := lb.e.FileMgr.UpdateFileDescription(rec.ID, newDesc); updErr != nil {
-					slog.Error("failed to update description", "node", lb.nodeNumber, "file", rec.Filename, "error", updErr)
-				} else {
-					lb.allFiles = lb.e.FileMgr.GetFilesForArea(lb.currentAreaID)
-				}
-			}
-			frame.needFullRedraw = true
-
-		case "k": // Kill/delete file (sysop only)
-			if !lb.isSysop || len(lb.allFiles) == 0 {
-				continue
-			}
-			rec := lb.allFiles[lb.selectedIndex]
-			confirmPrompt := fmt.Sprintf("Delete %s from disk?", rec.Filename)
-			lb.beginFooterPrompt()
-			tw, th := getTerminalSize(lb.s)
-			proceed, promptErr := lb.e.PromptYesNo(lb.s, lb.terminal, confirmPrompt, lb.outputMode, lb.nodeNumber, tw, th, false)
-			lb.endFooterPrompt()
-			if promptErr != nil {
-				if logoffIfDisconnected(promptErr) {
-					return nil, "LOGOFF", io.EOF
-				}
-				frame.needFullRedraw = true
-				continue
-			}
-			if proceed {
-				if delErr := lb.e.FileMgr.DeleteFileRecord(rec.ID, true); delErr != nil {
-					slog.Error("failed to delete file", "node", lb.nodeNumber, "file", rec.Filename, "error", delErr)
-				} else {
-					slog.Info("sysop deleted file from area", "node", lb.nodeNumber, "file", rec.Filename, "area", lb.currentAreaID)
-					// Remove from user's tag list so stale IDs don't reach batch download.
-					filtered := lb.currentUser.TaggedFileIDs[:0]
-					for _, tid := range lb.currentUser.TaggedFileIDs {
-						if tid != rec.ID {
-							filtered = append(filtered, tid)
-						}
-					}
-					lb.currentUser.TaggedFileIDs = filtered
-					lb.refreshFileList()
-				}
-			}
-			frame.needFullRedraw = true
-
-		case "m": // Move file to another area (sysop only)
-			if !lb.isSysop || len(lb.allFiles) == 0 {
-				continue
-			}
-			rec := lb.allFiles[lb.selectedIndex]
-			lb.beginFooterPrompt()
-			_ = lb.writePipe("|15Move to area (# or tag): |07")
-			areaInput, readErr := readLineFromSessionIHAllowAbort(lb.s, lb.terminal)
-			lb.endFooterPrompt()
-			if readErr != nil || strings.TrimSpace(areaInput) == "" {
-				frame.needFullRedraw = true
-				continue
-			}
-			// Resolve area by ID or tag.
-			var targetAreaID int
-			var targetArea *file.FileArea
-			if n, parseErr := fmt.Sscanf(strings.TrimSpace(areaInput), "%d", &targetAreaID); n == 1 && parseErr == nil {
-				if a, ok := lb.e.FileMgr.GetAreaByID(targetAreaID); ok {
-					targetArea = a
-				}
-			} else {
-				if a, ok := lb.e.FileMgr.GetAreaByTag(strings.TrimSpace(areaInput)); ok {
-					targetArea = a
-					targetAreaID = a.ID
-				}
-			}
-			if targetArea == nil {
-				lb.errMsgPause("\r\n|01Area not found.|07\r\n")
-				frame.needFullRedraw = true
-				continue
-			}
-			confirmPrompt := fmt.Sprintf("Move %s to %s?", rec.Filename, targetArea.Name)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
-			tw, th := getTerminalSize(lb.s)
-			proceed, promptErr := lb.e.PromptYesNo(lb.s, lb.terminal, confirmPrompt, lb.outputMode, lb.nodeNumber, tw, th, false)
-			lb.endFooterPrompt()
-			if promptErr != nil {
-				if logoffIfDisconnected(promptErr) {
-					return nil, "LOGOFF", io.EOF
-				}
-				frame.needFullRedraw = true
-				continue
-			}
-			if proceed {
-				if mvErr := lb.e.FileMgr.MoveFileRecord(rec.ID, targetAreaID); mvErr != nil {
-					slog.Error("failed to move file to area", "node", lb.nodeNumber, "file", rec.Filename, "area", targetAreaID, "error", mvErr)
-				} else {
-					slog.Info("sysop moved file to area", "node", lb.nodeNumber, "file", rec.Filename, "area", targetAreaID, "tag", targetArea.Tag)
-					lb.refreshFileList()
-				}
-			}
-			frame.needFullRedraw = true
-
-		case "r": // Rename file on disk (sysop only)
-			if !lb.isSysop || len(lb.allFiles) == 0 {
-				continue
-			}
-			rec := lb.allFiles[lb.selectedIndex]
-			lb.beginFooterPrompt()
-			_ = lb.writePipe("|15New filename: |07")
-			newName, readErr := readLineFromSessionIHAllowAbort(lb.s, lb.terminal)
-			lb.endFooterPrompt()
-			if readErr != nil || strings.TrimSpace(newName) == "" {
-				frame.needFullRedraw = true
-				continue
-			}
-			newName = filepath.Base(strings.TrimSpace(newName))
-			if newName == "." || newName == ".." {
-				lb.errMsgPause("\r\n|01Invalid filename.|07\r\n")
-				frame.needFullRedraw = true
-				continue
-			}
-			// Check for duplicate filename in the current area.
-			duplicate := false
-			for _, f := range lb.allFiles {
-				if strings.EqualFold(f.Filename, newName) && f.ID != rec.ID {
-					duplicate = true
-					break
-				}
-			}
-			if duplicate {
-				lb.errMsgPause("\r\n|01Filename already exists in this area.|07\r\n")
-				frame.needFullRedraw = true
-				continue
-			}
-			oldPath, pathErr := lb.e.FileMgr.GetFilePath(rec.ID)
-			if pathErr != nil {
-				slog.Error("failed to resolve path", "node", lb.nodeNumber, "file", rec.Filename, "error", pathErr)
-				frame.needFullRedraw = true
-				continue
-			}
-			newPath := filepath.Join(filepath.Dir(oldPath), newName)
-			// Guard against clobbering an untracked file already on disk at the
-			// target path (the duplicate check above only consults DB records).
-			// os.SameFile permits a case-only rename of the same file on a
-			// case-insensitive filesystem. A stat error other than "not exist"
-			// (e.g. a permission/IO fault) means we cannot prove the target is
-			// safe to overwrite, so refuse rather than risk a clobber.
-			newInfo, statErr := os.Stat(newPath)
-			switch {
-			case statErr == nil:
-				oldInfo, oldStatErr := os.Stat(oldPath)
-				if oldStatErr != nil || !os.SameFile(oldInfo, newInfo) {
-					slog.Error("rename target already exists on disk", "node", lb.nodeNumber, "path", newPath)
-					lb.errMsgPause("\r\n|01A file with that name already exists.|07\r\n")
-					frame.needFullRedraw = true
-					continue
-				}
-			case !errors.Is(statErr, os.ErrNotExist):
-				slog.Error("cannot stat rename target", "node", lb.nodeNumber, "path", newPath, "error", statErr)
-				lb.errMsgPause("\r\n|01Rename failed.|07\r\n")
-				frame.needFullRedraw = true
-				continue
-			}
-			if renErr := os.Rename(oldPath, newPath); renErr != nil {
-				slog.Error("failed to rename file", "node", lb.nodeNumber, "from", rec.Filename, "to", newName, "error", renErr)
-				lb.errMsgPause("\r\n|01Rename failed.|07\r\n")
-				frame.needFullRedraw = true
-				continue
-			}
-			if updErr := lb.e.FileMgr.UpdateFileRecord(rec.ID, func(r *file.FileRecord) {
-				r.Filename = newName
-			}); updErr != nil {
-				slog.Error("failed to update record", "node", lb.nodeNumber, "file", newName, "error", updErr)
-				if rollbackErr := os.Rename(newPath, oldPath); rollbackErr != nil {
-					slog.Error("rollback rename failed (disk/DB inconsistent)", "node", lb.nodeNumber, "file", newName, "error", rollbackErr)
-				}
-			} else {
-				slog.Info("sysop renamed file in area", "node", lb.nodeNumber, "from", rec.Filename, "to", newName, "area", lb.currentAreaID)
-				lb.allFiles = lb.e.FileMgr.GetFilesForArea(lb.currentAreaID)
-			}
-			frame.needFullRedraw = true
+		exit, result, action, err = lb.dispatchCommand(key, frame)
+		if exit {
+			return result, action, err
 		}
 	}
 }

--- a/internal/menu/file_lightbar.go
+++ b/internal/menu/file_lightbar.go
@@ -223,68 +223,14 @@ func runListFilesLightbar(st *fileListState) (*user.User, string, error) {
 // runListFilesLightbar, which constructs lb and calls this method.
 func (lb *fileLightbar) run() (*user.User, string, error) {
 	// Track previous state for smart refresh.
-	prevSelectedIndex := -1
-	prevTopIndex := -1
-	prevCmdIndex := -1
-	prevPage := -1
-	needFullRedraw := true
+	frame := &lbFrame{prevSelectedIndex: -1, prevTopIndex: -1, prevCmdIndex: -1, prevPage: -1, needFullRedraw: true}
 
 	for {
 		lb.clampSelection()
 
-		if needFullRedraw {
-			if err := lb.renderFull(); err != nil {
-				return nil, "", err
-			}
-			needFullRedraw = false
-		} else if lb.topIndex != prevTopIndex {
-			// Viewport scrolled — full redraw of all regions to prevent overlap.
-			if err := lb.renderTop(); err != nil {
-				return nil, "", err
-			}
-			if err := lb.renderFileArea(); err != nil {
-				return nil, "", err
-			}
-			if err := lb.renderSeparator(); err != nil {
-				return nil, "", err
-			}
-			if err := lb.renderCmdBar(); err != nil {
-				return nil, "", err
-			}
-			if err := lb.renderPageIndicator(); err != nil {
-				return nil, "", err
-			}
-		} else if lb.selectedIndex != prevSelectedIndex {
-			// Same viewport, selection changed — redraw old/new rows; redraw TOP if page changed.
-			curPage, _ := lb.calculatePageInfo()
-			if curPage != prevPage {
-				if err := lb.renderTop(); err != nil {
-					return nil, "", err
-				}
-			}
-			if prevSelectedIndex >= 0 && prevSelectedIndex < len(lb.allFiles) {
-				if row, h := lb.screenRowForFile(prevSelectedIndex); row >= 0 {
-					if err := lb.writeFileRow(row, prevSelectedIndex, false, h); err != nil {
-						return nil, "", err
-					}
-				}
-			}
-			if row, h := lb.screenRowForFile(lb.selectedIndex); row >= 0 {
-				if err := lb.writeFileRow(row, lb.selectedIndex, true, h); err != nil {
-					return nil, "", err
-				}
-			}
+		if err := lb.refreshFrame(frame); err != nil {
+			return nil, "", err
 		}
-		if lb.cmdIndex != prevCmdIndex {
-			if err := lb.renderCmdBar(); err != nil {
-				return nil, "", err
-			}
-		}
-
-		prevSelectedIndex = lb.selectedIndex
-		prevTopIndex = lb.topIndex
-		prevCmdIndex = lb.cmdIndex
-		prevPage, _ = lb.calculatePageInfo()
 
 		keyInt, err := lb.ih.ReadKey()
 		if err != nil {
@@ -367,7 +313,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				copy(lb.cmdEntries, lb.userEntries)
 			}
 			lb.cmdIndex = 0
-			needFullRedraw = true
+			frame.needFullRedraw = true
 			continue
 		}
 
@@ -402,45 +348,12 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			return nil, "", nil
 
 		case "i": // Info: show file detail overlay
-			if len(lb.allFiles) > 0 {
-				sel := lb.allFiles[lb.selectedIndex]
-				descLines := formatDIZLines(sel.Description, dizMaxWidth, dizMaxLines)
-
-				_ = terminalio.WriteProcessedBytes(lb.terminal, []byte(ansi.ClearScreen()), lb.outputMode)
-
-				d1 := fmt.Sprintf("|15Filename  : |07%s\r\n", sel.Filename)
-				d2 := fmt.Sprintf("|15Size      : |07%s\r\n", compactFileSize(sel.Size))
-				_ = lb.writePipe(d1)
-				_ = lb.writePipe(d2)
-
-				for i, dl := range descLines {
-					var dLine string
-					if i == 0 {
-						dLine = fmt.Sprintf("|15Desc      : |07%s\r\n", dl)
-					} else {
-						dLine = fmt.Sprintf("|07            %s\r\n", dl)
-					}
-					_ = lb.writePipe(dLine)
-				}
-				if len(descLines) == 0 {
-					_ = lb.writePipe("|15Desc      : |07(none)\r\n")
-				}
-
-				d3 := fmt.Sprintf("|15Uploaded  : |07%s\r\n", sel.UploadedAt.Format("01/02/2006 15:04"))
-				d4 := fmt.Sprintf("|15Uploader  : |07%s\r\n", sel.UploadedBy)
-				d5 := fmt.Sprintf("|15Downloads : |07%d\r\n", sel.DownloadCount)
-				_ = lb.writePipe(d3)
-				_ = lb.writePipe(d4)
-				_ = lb.writePipe(d5)
-
-				_ = lb.writePipe("\r\n|08Press any key to return...|07")
-				if _, waitErr := lb.ih.ReadKey(); waitErr != nil {
-					if logoffIfDisconnected(waitErr) {
-						return nil, "LOGOFF", io.EOF
-					}
-					return nil, "", waitErr
-				}
-				needFullRedraw = true
+			refresh, exit, result, action, infoErr := lb.showFileInfo()
+			if exit {
+				return result, action, infoErr
+			}
+			if refresh {
+				frame.needFullRedraw = true
 			}
 
 		case "v":
@@ -463,7 +376,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				}
 				// Hide cursor again.
 				lb.endFooterPrompt()
-				needFullRedraw = true
+				frame.needFullRedraw = true
 			}
 
 		case "d":
@@ -471,7 +384,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				msg := "\r\n|07No files marked for download. Use |15Space|07 to mark files.|07\r\n"
 				_ = lb.writePipe(msg)
 				time.Sleep(1 * time.Second)
-				needFullRedraw = true
+				frame.needFullRedraw = true
 				continue
 			}
 
@@ -487,13 +400,13 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				}
 				slog.Error("error getting download confirmation", "node", lb.nodeNumber, "error", promptErr)
 				lb.endFooterPrompt()
-				needFullRedraw = true
+				frame.needFullRedraw = true
 				continue
 			}
 
 			if !proceed {
 				lb.endFooterPrompt()
-				needFullRedraw = true
+				frame.needFullRedraw = true
 				continue
 			}
 
@@ -570,7 +483,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			// Refresh file list.
 			lb.refreshFileList()
 			lb.endFooterPrompt()
-			needFullRedraw = true
+			frame.needFullRedraw = true
 
 		case "u":
 			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
@@ -584,7 +497,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			// Refresh file list after upload.
 			lb.refreshFileList()
 			lb.endFooterPrompt()
-			needFullRedraw = true
+			frame.needFullRedraw = true
 
 		case "e": // Edit description (sysop only)
 			if !lb.isSysop || len(lb.allFiles) == 0 {
@@ -602,7 +515,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 					lb.allFiles = lb.e.FileMgr.GetFilesForArea(lb.currentAreaID)
 				}
 			}
-			needFullRedraw = true
+			frame.needFullRedraw = true
 
 		case "k": // Kill/delete file (sysop only)
 			if !lb.isSysop || len(lb.allFiles) == 0 {
@@ -618,7 +531,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				if logoffIfDisconnected(promptErr) {
 					return nil, "LOGOFF", io.EOF
 				}
-				needFullRedraw = true
+				frame.needFullRedraw = true
 				continue
 			}
 			if proceed {
@@ -637,7 +550,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 					lb.refreshFileList()
 				}
 			}
-			needFullRedraw = true
+			frame.needFullRedraw = true
 
 		case "m": // Move file to another area (sysop only)
 			if !lb.isSysop || len(lb.allFiles) == 0 {
@@ -649,7 +562,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			areaInput, readErr := readLineFromSessionIHAllowAbort(lb.s, lb.terminal)
 			lb.endFooterPrompt()
 			if readErr != nil || strings.TrimSpace(areaInput) == "" {
-				needFullRedraw = true
+				frame.needFullRedraw = true
 				continue
 			}
 			// Resolve area by ID or tag.
@@ -667,7 +580,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			}
 			if targetArea == nil {
 				lb.errMsgPause("\r\n|01Area not found.|07\r\n")
-				needFullRedraw = true
+				frame.needFullRedraw = true
 				continue
 			}
 			confirmPrompt := fmt.Sprintf("Move %s to %s?", rec.Filename, targetArea.Name)
@@ -679,7 +592,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				if logoffIfDisconnected(promptErr) {
 					return nil, "LOGOFF", io.EOF
 				}
-				needFullRedraw = true
+				frame.needFullRedraw = true
 				continue
 			}
 			if proceed {
@@ -690,7 +603,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 					lb.refreshFileList()
 				}
 			}
-			needFullRedraw = true
+			frame.needFullRedraw = true
 
 		case "r": // Rename file on disk (sysop only)
 			if !lb.isSysop || len(lb.allFiles) == 0 {
@@ -702,13 +615,13 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			newName, readErr := readLineFromSessionIHAllowAbort(lb.s, lb.terminal)
 			lb.endFooterPrompt()
 			if readErr != nil || strings.TrimSpace(newName) == "" {
-				needFullRedraw = true
+				frame.needFullRedraw = true
 				continue
 			}
 			newName = filepath.Base(strings.TrimSpace(newName))
 			if newName == "." || newName == ".." {
 				lb.errMsgPause("\r\n|01Invalid filename.|07\r\n")
-				needFullRedraw = true
+				frame.needFullRedraw = true
 				continue
 			}
 			// Check for duplicate filename in the current area.
@@ -721,13 +634,13 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			}
 			if duplicate {
 				lb.errMsgPause("\r\n|01Filename already exists in this area.|07\r\n")
-				needFullRedraw = true
+				frame.needFullRedraw = true
 				continue
 			}
 			oldPath, pathErr := lb.e.FileMgr.GetFilePath(rec.ID)
 			if pathErr != nil {
 				slog.Error("failed to resolve path", "node", lb.nodeNumber, "file", rec.Filename, "error", pathErr)
-				needFullRedraw = true
+				frame.needFullRedraw = true
 				continue
 			}
 			newPath := filepath.Join(filepath.Dir(oldPath), newName)
@@ -744,19 +657,19 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				if oldStatErr != nil || !os.SameFile(oldInfo, newInfo) {
 					slog.Error("rename target already exists on disk", "node", lb.nodeNumber, "path", newPath)
 					lb.errMsgPause("\r\n|01A file with that name already exists.|07\r\n")
-					needFullRedraw = true
+					frame.needFullRedraw = true
 					continue
 				}
 			case !errors.Is(statErr, os.ErrNotExist):
 				slog.Error("cannot stat rename target", "node", lb.nodeNumber, "path", newPath, "error", statErr)
 				lb.errMsgPause("\r\n|01Rename failed.|07\r\n")
-				needFullRedraw = true
+				frame.needFullRedraw = true
 				continue
 			}
 			if renErr := os.Rename(oldPath, newPath); renErr != nil {
 				slog.Error("failed to rename file", "node", lb.nodeNumber, "from", rec.Filename, "to", newName, "error", renErr)
 				lb.errMsgPause("\r\n|01Rename failed.|07\r\n")
-				needFullRedraw = true
+				frame.needFullRedraw = true
 				continue
 			}
 			if updErr := lb.e.FileMgr.UpdateFileRecord(rec.ID, func(r *file.FileRecord) {
@@ -770,7 +683,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				slog.Info("sysop renamed file in area", "node", lb.nodeNumber, "from", rec.Filename, "to", newName, "area", lb.currentAreaID)
 				lb.allFiles = lb.e.FileMgr.GetFilesForArea(lb.currentAreaID)
 			}
-			needFullRedraw = true
+			frame.needFullRedraw = true
 		}
 	}
 }

--- a/internal/menu/file_lightbar.go
+++ b/internal/menu/file_lightbar.go
@@ -71,6 +71,14 @@ type fileLightbar struct {
 	cmdIndex             int
 }
 
+// logoffIfDisconnected reports whether err indicates the session has gone
+// away (EOF) or idled out — the six places in the lightbar loop that read a
+// key or wait on a prompt all map either condition to the same "LOGOFF"
+// result.
+func logoffIfDisconnected(err error) bool {
+	return errors.Is(err, io.EOF) || errors.Is(err, editor.ErrIdleTimeout)
+}
+
 // runListFilesLightbar builds a fileLightbar from st's already-loaded
 // templates, pagination, and area state, then drives the interactive
 // lightbar file browser via run(). It always returns a nil *user.User; the
@@ -280,10 +288,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 
 		keyInt, err := lb.ih.ReadKey()
 		if err != nil {
-			if errors.Is(err, io.EOF) {
-				return nil, "LOGOFF", io.EOF
-			}
-			if errors.Is(err, editor.ErrIdleTimeout) {
+			if logoffIfDisconnected(err) {
 				return nil, "LOGOFF", io.EOF
 			}
 			return nil, "", err
@@ -405,8 +410,8 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 
 				d1 := fmt.Sprintf("|15Filename  : |07%s\r\n", sel.Filename)
 				d2 := fmt.Sprintf("|15Size      : |07%s\r\n", compactFileSize(sel.Size))
-				_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte(d1)), lb.outputMode)
-				_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte(d2)), lb.outputMode)
+				_ = lb.writePipe(d1)
+				_ = lb.writePipe(d2)
 
 				for i, dl := range descLines {
 					var dLine string
@@ -415,22 +420,22 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 					} else {
 						dLine = fmt.Sprintf("|07            %s\r\n", dl)
 					}
-					_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte(dLine)), lb.outputMode)
+					_ = lb.writePipe(dLine)
 				}
 				if len(descLines) == 0 {
-					_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("|15Desc      : |07(none)\r\n")), lb.outputMode)
+					_ = lb.writePipe("|15Desc      : |07(none)\r\n")
 				}
 
 				d3 := fmt.Sprintf("|15Uploaded  : |07%s\r\n", sel.UploadedAt.Format("01/02/2006 15:04"))
 				d4 := fmt.Sprintf("|15Uploader  : |07%s\r\n", sel.UploadedBy)
 				d5 := fmt.Sprintf("|15Downloads : |07%d\r\n", sel.DownloadCount)
-				_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte(d3)), lb.outputMode)
-				_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte(d4)), lb.outputMode)
-				_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte(d5)), lb.outputMode)
+				_ = lb.writePipe(d3)
+				_ = lb.writePipe(d4)
+				_ = lb.writePipe(d5)
 
-				_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|08Press any key to return...|07")), lb.outputMode)
+				_ = lb.writePipe("\r\n|08Press any key to return...|07")
 				if _, waitErr := lb.ih.ReadKey(); waitErr != nil {
-					if errors.Is(waitErr, io.EOF) || errors.Is(waitErr, editor.ErrIdleTimeout) {
+					if logoffIfDisconnected(waitErr) {
 						return nil, "LOGOFF", io.EOF
 					}
 					return nil, "", waitErr
@@ -457,14 +462,14 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 					viewFileByRecord(lb.e, lb.s, lb.terminal, sel, lb.outputMode, tw, th)
 				}
 				// Hide cursor again.
-				_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25l"), lb.outputMode)
+				lb.endFooterPrompt()
 				needFullRedraw = true
 			}
 
 		case "d":
 			if len(lb.currentUser.TaggedFileIDs) == 0 {
 				msg := "\r\n|07No files marked for download. Use |15Space|07 to mark files.|07\r\n"
-				_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte(msg)), lb.outputMode)
+				_ = lb.writePipe(msg)
 				time.Sleep(1 * time.Second)
 				needFullRedraw = true
 				continue
@@ -472,25 +477,22 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 
 			confirmPrompt := fmt.Sprintf("Download %d marked file(s)?", len(lb.currentUser.TaggedFileIDs))
 			// Replace the footer lightbar with the confirm prompt instead of printing over the file list.
-			clearFooter := ansi.MoveCursor(lb.separatorRow, 1) + "\x1b[2K" + ansi.MoveCursor(lb.cmdBarRow, 1) + "\x1b[2K"
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte(clearFooter), lb.outputMode)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte(ansi.MoveCursor(lb.cmdBarRow, 1)), lb.outputMode)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
+			lb.beginFooterPrompt()
 
 			tw, th := getTerminalSize(lb.s)
 			proceed, promptErr := lb.e.PromptYesNo(lb.s, lb.terminal, confirmPrompt, lb.outputMode, lb.nodeNumber, tw, th, false)
 			if promptErr != nil {
-				if errors.Is(promptErr, io.EOF) {
+				if logoffIfDisconnected(promptErr) {
 					return nil, "LOGOFF", io.EOF
 				}
 				slog.Error("error getting download confirmation", "node", lb.nodeNumber, "error", promptErr)
-				_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25l"), lb.outputMode)
+				lb.endFooterPrompt()
 				needFullRedraw = true
 				continue
 			}
 
 			if !proceed {
-				_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25l"), lb.outputMode)
+				lb.endFooterPrompt()
 				needFullRedraw = true
 				continue
 			}
@@ -498,7 +500,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			slog.Info("starting download", "node", lb.nodeNumber, "handle", lb.currentUser.Handle, "count", len(lb.currentUser.TaggedFileIDs))
 			// Clear the screen before the download process begins.
 			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[2J\x1b[H"), lb.outputMode)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("|07Preparing download...\r\n")), lb.outputMode)
+			_ = lb.writePipe("|07Preparing download...\r\n")
 			time.Sleep(500 * time.Millisecond)
 
 			successCount := 0
@@ -532,14 +534,14 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				// Use protocol selection (respects connection type - SSH vs Telnet)
 				proto, protoOK, protoErr := lb.e.selectTransferProtocol(lb.s, lb.terminal, lb.outputMode)
 				if protoErr != nil {
-					if errors.Is(protoErr, io.EOF) {
+					if logoffIfDisconnected(protoErr) {
 						return nil, "LOGOFF", io.EOF
 					}
 					slog.Error("protocol selection error", "node", lb.nodeNumber, "error", protoErr)
-					_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Error: No transfer protocols configured on this system.|07\r\n")), lb.outputMode)
+					_ = lb.writePipe("\r\n|01Error: No transfer protocols configured on this system.|07\r\n")
 					failCount += len(filesToDownload)
 				} else if !protoOK {
-					_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|07Download cancelled.|07\r\n")), lb.outputMode)
+					_ = lb.writePipe("\r\n|07Download cancelled.|07\r\n")
 				} else {
 					sentCount, sendFails := lb.e.runTransferSend(lb.s, lb.terminal, proto, filesToDownload, fileIDsToDownload, lb.outputMode, lb.nodeNumber)
 					successCount = sentCount
@@ -549,7 +551,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				time.Sleep(1 * time.Second)
 			} else {
 				slog.Warn("no valid file paths found for tagged files", "node", lb.nodeNumber)
-				_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Could not find any of the marked files on the server.|07\r\n")), lb.outputMode)
+				_ = lb.writePipe("\r\n|01Could not find any of the marked files on the server.|07\r\n")
 				// failCount already equals the number of missing files (every
 				// tagged ID incremented it in the collection loop above).
 			}
@@ -562,15 +564,12 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			}
 
 			statusMsg := fmt.Sprintf("|07Download finished. Success: %d, Failed: %d.|07\r\n", successCount, failCount)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte(statusMsg)), lb.outputMode)
+			_ = lb.writePipe(statusMsg)
 			time.Sleep(2 * time.Second)
 
 			// Refresh file list.
-			lb.allFiles = lb.e.FileMgr.GetFilesForArea(lb.currentAreaID)
-			if lb.selectedIndex >= len(lb.allFiles) && len(lb.allFiles) > 0 {
-				lb.selectedIndex = len(lb.allFiles) - 1
-			}
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25l"), lb.outputMode)
+			lb.refreshFileList()
+			lb.endFooterPrompt()
 			needFullRedraw = true
 
 		case "u":
@@ -583,11 +582,8 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			// so the local ih is now stale — refresh it.
 			lb.ih = getSessionIH(lb.s)
 			// Refresh file list after upload.
-			lb.allFiles = lb.e.FileMgr.GetFilesForArea(lb.currentAreaID)
-			if lb.selectedIndex >= len(lb.allFiles) && len(lb.allFiles) > 0 {
-				lb.selectedIndex = len(lb.allFiles) - 1
-			}
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25l"), lb.outputMode)
+			lb.refreshFileList()
+			lb.endFooterPrompt()
 			needFullRedraw = true
 
 		case "e": // Edit description (sysop only)
@@ -595,13 +591,10 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				continue
 			}
 			rec := lb.allFiles[lb.selectedIndex]
-			clearFooter := ansi.MoveCursor(lb.separatorRow, 1) + "\x1b[2K" + ansi.MoveCursor(lb.cmdBarRow, 1) + "\x1b[2K"
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte(clearFooter), lb.outputMode)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte(ansi.MoveCursor(lb.cmdBarRow, 1)), lb.outputMode)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("|15New description: |07")), lb.outputMode)
+			lb.beginFooterPrompt()
+			_ = lb.writePipe("|15New description: |07")
 			newDesc, readErr := readLineFromSessionIHAllowAbort(lb.s, lb.terminal)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25l"), lb.outputMode)
+			lb.endFooterPrompt()
 			if readErr == nil && newDesc != "" {
 				if updErr := lb.e.FileMgr.UpdateFileDescription(rec.ID, newDesc); updErr != nil {
 					slog.Error("failed to update description", "node", lb.nodeNumber, "file", rec.Filename, "error", updErr)
@@ -617,15 +610,12 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			}
 			rec := lb.allFiles[lb.selectedIndex]
 			confirmPrompt := fmt.Sprintf("Delete %s from disk?", rec.Filename)
-			clearFooter := ansi.MoveCursor(lb.separatorRow, 1) + "\x1b[2K" + ansi.MoveCursor(lb.cmdBarRow, 1) + "\x1b[2K"
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte(clearFooter), lb.outputMode)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte(ansi.MoveCursor(lb.cmdBarRow, 1)), lb.outputMode)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
+			lb.beginFooterPrompt()
 			tw, th := getTerminalSize(lb.s)
 			proceed, promptErr := lb.e.PromptYesNo(lb.s, lb.terminal, confirmPrompt, lb.outputMode, lb.nodeNumber, tw, th, false)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25l"), lb.outputMode)
+			lb.endFooterPrompt()
 			if promptErr != nil {
-				if errors.Is(promptErr, io.EOF) {
+				if logoffIfDisconnected(promptErr) {
 					return nil, "LOGOFF", io.EOF
 				}
 				needFullRedraw = true
@@ -644,10 +634,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 						}
 					}
 					lb.currentUser.TaggedFileIDs = filtered
-					lb.allFiles = lb.e.FileMgr.GetFilesForArea(lb.currentAreaID)
-					if lb.selectedIndex >= len(lb.allFiles) && len(lb.allFiles) > 0 {
-						lb.selectedIndex = len(lb.allFiles) - 1
-					}
+					lb.refreshFileList()
 				}
 			}
 			needFullRedraw = true
@@ -657,13 +644,10 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				continue
 			}
 			rec := lb.allFiles[lb.selectedIndex]
-			clearFooter := ansi.MoveCursor(lb.separatorRow, 1) + "\x1b[2K" + ansi.MoveCursor(lb.cmdBarRow, 1) + "\x1b[2K"
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte(clearFooter), lb.outputMode)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte(ansi.MoveCursor(lb.cmdBarRow, 1)), lb.outputMode)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("|15Move to area (# or tag): |07")), lb.outputMode)
+			lb.beginFooterPrompt()
+			_ = lb.writePipe("|15Move to area (# or tag): |07")
 			areaInput, readErr := readLineFromSessionIHAllowAbort(lb.s, lb.terminal)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25l"), lb.outputMode)
+			lb.endFooterPrompt()
 			if readErr != nil || strings.TrimSpace(areaInput) == "" {
 				needFullRedraw = true
 				continue
@@ -682,8 +666,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				}
 			}
 			if targetArea == nil {
-				_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Area not found.|07\r\n")), lb.outputMode)
-				time.Sleep(1 * time.Second)
+				lb.errMsgPause("\r\n|01Area not found.|07\r\n")
 				needFullRedraw = true
 				continue
 			}
@@ -691,9 +674,9 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
 			tw, th := getTerminalSize(lb.s)
 			proceed, promptErr := lb.e.PromptYesNo(lb.s, lb.terminal, confirmPrompt, lb.outputMode, lb.nodeNumber, tw, th, false)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25l"), lb.outputMode)
+			lb.endFooterPrompt()
 			if promptErr != nil {
-				if errors.Is(promptErr, io.EOF) {
+				if logoffIfDisconnected(promptErr) {
 					return nil, "LOGOFF", io.EOF
 				}
 				needFullRedraw = true
@@ -704,10 +687,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 					slog.Error("failed to move file to area", "node", lb.nodeNumber, "file", rec.Filename, "area", targetAreaID, "error", mvErr)
 				} else {
 					slog.Info("sysop moved file to area", "node", lb.nodeNumber, "file", rec.Filename, "area", targetAreaID, "tag", targetArea.Tag)
-					lb.allFiles = lb.e.FileMgr.GetFilesForArea(lb.currentAreaID)
-					if lb.selectedIndex >= len(lb.allFiles) && len(lb.allFiles) > 0 {
-						lb.selectedIndex = len(lb.allFiles) - 1
-					}
+					lb.refreshFileList()
 				}
 			}
 			needFullRedraw = true
@@ -717,21 +697,17 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				continue
 			}
 			rec := lb.allFiles[lb.selectedIndex]
-			clearFooter := ansi.MoveCursor(lb.separatorRow, 1) + "\x1b[2K" + ansi.MoveCursor(lb.cmdBarRow, 1) + "\x1b[2K"
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte(clearFooter), lb.outputMode)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte(ansi.MoveCursor(lb.cmdBarRow, 1)), lb.outputMode)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("|15New filename: |07")), lb.outputMode)
+			lb.beginFooterPrompt()
+			_ = lb.writePipe("|15New filename: |07")
 			newName, readErr := readLineFromSessionIHAllowAbort(lb.s, lb.terminal)
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25l"), lb.outputMode)
+			lb.endFooterPrompt()
 			if readErr != nil || strings.TrimSpace(newName) == "" {
 				needFullRedraw = true
 				continue
 			}
 			newName = filepath.Base(strings.TrimSpace(newName))
 			if newName == "." || newName == ".." {
-				_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Invalid filename.|07\r\n")), lb.outputMode)
-				time.Sleep(1 * time.Second)
+				lb.errMsgPause("\r\n|01Invalid filename.|07\r\n")
 				needFullRedraw = true
 				continue
 			}
@@ -744,8 +720,7 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				}
 			}
 			if duplicate {
-				_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Filename already exists in this area.|07\r\n")), lb.outputMode)
-				time.Sleep(1 * time.Second)
+				lb.errMsgPause("\r\n|01Filename already exists in this area.|07\r\n")
 				needFullRedraw = true
 				continue
 			}
@@ -768,22 +743,19 @@ func (lb *fileLightbar) run() (*user.User, string, error) {
 				oldInfo, oldStatErr := os.Stat(oldPath)
 				if oldStatErr != nil || !os.SameFile(oldInfo, newInfo) {
 					slog.Error("rename target already exists on disk", "node", lb.nodeNumber, "path", newPath)
-					_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|01A file with that name already exists.|07\r\n")), lb.outputMode)
-					time.Sleep(1 * time.Second)
+					lb.errMsgPause("\r\n|01A file with that name already exists.|07\r\n")
 					needFullRedraw = true
 					continue
 				}
 			case !errors.Is(statErr, os.ErrNotExist):
 				slog.Error("cannot stat rename target", "node", lb.nodeNumber, "path", newPath, "error", statErr)
-				_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Rename failed.|07\r\n")), lb.outputMode)
-				time.Sleep(1 * time.Second)
+				lb.errMsgPause("\r\n|01Rename failed.|07\r\n")
 				needFullRedraw = true
 				continue
 			}
 			if renErr := os.Rename(oldPath, newPath); renErr != nil {
 				slog.Error("failed to rename file", "node", lb.nodeNumber, "from", rec.Filename, "to", newName, "error", renErr)
-				_ = terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte("\r\n|01Rename failed.|07\r\n")), lb.outputMode)
-				time.Sleep(1 * time.Second)
+				lb.errMsgPause("\r\n|01Rename failed.|07\r\n")
 				needFullRedraw = true
 				continue
 			}

--- a/internal/menu/file_lightbar_actions.go
+++ b/internal/menu/file_lightbar_actions.go
@@ -17,24 +17,31 @@ import (
 
 // fileLightbar user-facing actions: mark toggle, view, download, upload.
 
+// toggleTaggedID returns taggedIDs with fileID removed, if it was already
+// present, or appended, if it wasn't — the pure list-mutation logic behind
+// toggleMark's tag toggle.
+func toggleTaggedID(taggedIDs []uuid.UUID, fileID uuid.UUID) []uuid.UUID {
+	found := false
+	newTaggedIDs := make([]uuid.UUID, 0, len(taggedIDs))
+	for _, taggedID := range taggedIDs {
+		if taggedID == fileID {
+			found = true
+		} else {
+			newTaggedIDs = append(newTaggedIDs, taggedID)
+		}
+	}
+	if !found {
+		newTaggedIDs = append(newTaggedIDs, fileID)
+	}
+	return newTaggedIDs
+}
+
 // toggleMark toggles whether the selected file is tagged for download,
 // saves the change to the user record, and redraws just the toggled row.
 func (lb *fileLightbar) toggleMark() {
 	if len(lb.allFiles) > 0 {
 		fileID := lb.allFiles[lb.selectedIndex].ID
-		found := false
-		newTaggedIDs := make([]uuid.UUID, 0, len(lb.currentUser.TaggedFileIDs))
-		for _, taggedID := range lb.currentUser.TaggedFileIDs {
-			if taggedID == fileID {
-				found = true
-			} else {
-				newTaggedIDs = append(newTaggedIDs, taggedID)
-			}
-		}
-		if !found {
-			newTaggedIDs = append(newTaggedIDs, fileID)
-		}
-		lb.currentUser.TaggedFileIDs = newTaggedIDs
+		lb.currentUser.TaggedFileIDs = toggleTaggedID(lb.currentUser.TaggedFileIDs, fileID)
 		if err := lb.userManager.UpdateUser(lb.currentUser); err != nil {
 			slog.Error("failed to save user after tag toggle", "node", lb.nodeNumber, "error", err)
 		}

--- a/internal/menu/file_lightbar_actions.go
+++ b/internal/menu/file_lightbar_actions.go
@@ -1,6 +1,7 @@
 package menu
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -93,7 +94,7 @@ func (lb *fileLightbar) confirmDownload() (proceed bool, exit bool, action strin
 	tw, th := getTerminalSize(lb.s)
 	proceed, promptErr := lb.e.PromptYesNo(lb.s, lb.terminal, confirmPrompt, lb.outputMode, lb.nodeNumber, tw, th, false)
 	if promptErr != nil {
-		if logoffIfDisconnected(promptErr) {
+		if errors.Is(promptErr, io.EOF) {
 			return false, true, "LOGOFF", io.EOF
 		}
 		slog.Error("error getting download confirmation", "node", lb.nodeNumber, "error", promptErr)
@@ -148,7 +149,7 @@ func (lb *fileLightbar) sendTaggedFiles(filesToDownload []string, fileIDsToDownl
 	// Use protocol selection (respects connection type - SSH vs Telnet)
 	proto, protoOK, protoErr := lb.e.selectTransferProtocol(lb.s, lb.terminal, lb.outputMode)
 	if protoErr != nil {
-		if logoffIfDisconnected(protoErr) {
+		if errors.Is(protoErr, io.EOF) {
 			return 0, failCount, true, "LOGOFF", io.EOF
 		}
 		slog.Error("protocol selection error", "node", lb.nodeNumber, "error", protoErr)

--- a/internal/menu/file_lightbar_actions.go
+++ b/internal/menu/file_lightbar_actions.go
@@ -1,0 +1,237 @@
+package menu
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/file"
+	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+	"github.com/ViSiON-3/vision-3-bbs/internal/ziplab"
+)
+
+// fileLightbar user-facing actions: mark toggle, view, download, upload.
+
+// toggleMark toggles whether the selected file is tagged for download,
+// saves the change to the user record, and redraws just the toggled row.
+func (lb *fileLightbar) toggleMark() {
+	if len(lb.allFiles) > 0 {
+		fileID := lb.allFiles[lb.selectedIndex].ID
+		found := false
+		newTaggedIDs := make([]uuid.UUID, 0, len(lb.currentUser.TaggedFileIDs))
+		for _, taggedID := range lb.currentUser.TaggedFileIDs {
+			if taggedID == fileID {
+				found = true
+			} else {
+				newTaggedIDs = append(newTaggedIDs, taggedID)
+			}
+		}
+		if !found {
+			newTaggedIDs = append(newTaggedIDs, fileID)
+		}
+		lb.currentUser.TaggedFileIDs = newTaggedIDs
+		if err := lb.userManager.UpdateUser(lb.currentUser); err != nil {
+			slog.Error("failed to save user after tag toggle", "node", lb.nodeNumber, "error", err)
+		}
+		// Redraw just the toggled row to show/hide the mark.
+		if row, h := lb.screenRowForFile(lb.selectedIndex); row >= 0 {
+			_ = lb.writeFileRow(row, lb.selectedIndex, true, h)
+		}
+	}
+}
+
+// viewFile displays the selected file — the ziplab viewer for supported
+// archives, or the plain file viewer otherwise — and reports whether run()
+// should do a full redraw afterward. refresh is false only when the file's
+// on-disk path couldn't be resolved (matching the original inline case,
+// which skipped the redraw in that case).
+func (lb *fileLightbar) viewFile() (refresh bool) {
+	if len(lb.allFiles) > 0 {
+		sel := &lb.allFiles[lb.selectedIndex]
+		filePath, pathErr := lb.e.FileMgr.GetFilePath(sel.ID)
+		if pathErr != nil {
+			slog.Error("failed to get path for file", "node", lb.nodeNumber, "id", sel.ID, "error", pathErr)
+			return false
+		}
+		// Show cursor for the viewer.
+		_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
+		if lb.e.FileMgr.IsSupportedArchive(sel.Filename) {
+			ctx, cancel := lb.e.transferContext(lb.s.Context())
+			ziplab.RunZipLabView(ctx, lb.s, lb.terminal, filePath, sel.Filename, lb.outputMode, sessionReadLine(lb.s, lb.terminal), sessionReadKey(lb.s))
+			cancel()
+		} else {
+			tw, th := getTerminalSize(lb.s)
+			viewFileByRecord(lb.e, lb.s, lb.terminal, sel, lb.outputMode, tw, th)
+		}
+		// Hide cursor again.
+		lb.endFooterPrompt()
+		return true
+	}
+	return false
+}
+
+// confirmDownload prompts the user to confirm downloading the currently
+// tagged files. proceed is only meaningful when exit is false: it is true
+// if — and only if — the user confirmed.
+func (lb *fileLightbar) confirmDownload() (proceed bool, exit bool, action string, err error) {
+	confirmPrompt := fmt.Sprintf("Download %d marked file(s)?", len(lb.currentUser.TaggedFileIDs))
+	// Replace the footer lightbar with the confirm prompt instead of printing over the file list.
+	lb.beginFooterPrompt()
+
+	tw, th := getTerminalSize(lb.s)
+	proceed, promptErr := lb.e.PromptYesNo(lb.s, lb.terminal, confirmPrompt, lb.outputMode, lb.nodeNumber, tw, th, false)
+	if promptErr != nil {
+		if logoffIfDisconnected(promptErr) {
+			return false, true, "LOGOFF", io.EOF
+		}
+		slog.Error("error getting download confirmation", "node", lb.nodeNumber, "error", promptErr)
+		lb.endFooterPrompt()
+		return false, false, "", nil
+	}
+
+	if !proceed {
+		lb.endFooterPrompt()
+		return false, false, "", nil
+	}
+
+	return true, false, "", nil
+}
+
+// collectTaggedPaths resolves each tagged file ID to a path on disk via fm,
+// skipping (and counting as a failure) any ID whose record can't be
+// resolved or whose backing file is missing or unreadable. paths and ids
+// are parallel slices: paths[i] is the resolved path for ids[i].
+func collectTaggedPaths(fm *file.FileManager, nodeNumber int, taggedIDs []uuid.UUID) (paths []string, ids []uuid.UUID, failCount int) {
+	paths = make([]string, 0, len(taggedIDs))
+	ids = make([]uuid.UUID, 0, len(taggedIDs))
+	for _, fileID := range taggedIDs {
+		fp, pathErr := fm.GetFilePath(fileID)
+		if pathErr != nil {
+			slog.Error("failed to get path for file ID", "node", nodeNumber, "id", fileID, "error", pathErr)
+			failCount++
+			continue
+		}
+		if _, statErr := os.Stat(fp); os.IsNotExist(statErr) {
+			slog.Error("file path for ID does not exist", "node", nodeNumber, "path", fp, "id", fileID)
+			failCount++
+			continue
+		} else if statErr != nil {
+			slog.Error("error stating file path for ID", "node", nodeNumber, "path", fp, "id", fileID, "error", statErr)
+			failCount++
+			continue
+		}
+		paths = append(paths, fp)
+		ids = append(ids, fileID)
+	}
+	return paths, ids, failCount
+}
+
+// sendTaggedFiles selects a transfer protocol and sends filesToDownload over
+// it, adding to failCount on a protocol-selection failure. exit is set for
+// a mid-selection disconnect (LOGOFF); failCount already reflects the files
+// collectTaggedPaths could not resolve, per the comment preserved below.
+func (lb *fileLightbar) sendTaggedFiles(filesToDownload []string, fileIDsToDownload []uuid.UUID, failCount int) (successCount int, newFailCount int, exit bool, action string, err error) {
+	slog.Info("initiating transfer", "node", lb.nodeNumber, "count", len(filesToDownload))
+
+	// Use protocol selection (respects connection type - SSH vs Telnet)
+	proto, protoOK, protoErr := lb.e.selectTransferProtocol(lb.s, lb.terminal, lb.outputMode)
+	if protoErr != nil {
+		if logoffIfDisconnected(protoErr) {
+			return 0, failCount, true, "LOGOFF", io.EOF
+		}
+		slog.Error("protocol selection error", "node", lb.nodeNumber, "error", protoErr)
+		_ = lb.writePipe("\r\n|01Error: No transfer protocols configured on this system.|07\r\n")
+		failCount += len(filesToDownload)
+	} else if !protoOK {
+		_ = lb.writePipe("\r\n|07Download cancelled.|07\r\n")
+	} else {
+		sentCount, sendFails := lb.e.runTransferSend(lb.s, lb.terminal, proto, filesToDownload, fileIDsToDownload, lb.outputMode, lb.nodeNumber)
+		successCount = sentCount
+		failCount += sendFails
+		lb.ih = getSessionIH(lb.s)
+	}
+	time.Sleep(1 * time.Second)
+	return successCount, failCount, false, "", nil
+}
+
+// downloadFiles drives the "d" command end to end: confirm, collect paths,
+// send, and report the result. It returns the dispatchCommand exit signal.
+func (lb *fileLightbar) downloadFiles(frame *lbFrame) (exit bool, result *user.User, action string, err error) {
+	if len(lb.currentUser.TaggedFileIDs) == 0 {
+		msg := "\r\n|07No files marked for download. Use |15Space|07 to mark files.|07\r\n"
+		_ = lb.writePipe(msg)
+		time.Sleep(1 * time.Second)
+		frame.needFullRedraw = true
+		return false, nil, "", nil
+	}
+
+	proceed, exit, action, err := lb.confirmDownload()
+	if exit {
+		return true, nil, action, err
+	}
+	if !proceed {
+		frame.needFullRedraw = true
+		return false, nil, "", nil
+	}
+
+	slog.Info("starting download", "node", lb.nodeNumber, "handle", lb.currentUser.Handle, "count", len(lb.currentUser.TaggedFileIDs))
+	// Clear the screen before the download process begins.
+	_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[2J\x1b[H"), lb.outputMode)
+	_ = lb.writePipe("|07Preparing download...\r\n")
+	time.Sleep(500 * time.Millisecond)
+
+	filesToDownload, fileIDsToDownload, failCount := collectTaggedPaths(lb.e.FileMgr, lb.nodeNumber, lb.currentUser.TaggedFileIDs)
+
+	successCount := 0
+	if len(filesToDownload) > 0 {
+		var sendExit bool
+		successCount, failCount, sendExit, action, err = lb.sendTaggedFiles(filesToDownload, fileIDsToDownload, failCount)
+		if sendExit {
+			return true, nil, action, err
+		}
+	} else {
+		slog.Warn("no valid file paths found for tagged files", "node", lb.nodeNumber)
+		_ = lb.writePipe("\r\n|01Could not find any of the marked files on the server.|07\r\n")
+		// failCount already equals the number of missing files (every
+		// tagged ID incremented it in collectTaggedPaths above).
+	}
+
+	// Clear tags, update download count, and save.
+	lb.currentUser.TaggedFileIDs = nil
+	lb.currentUser.NumDownloads += successCount
+	if saveErr := lb.userManager.UpdateUser(lb.currentUser); saveErr != nil {
+		slog.Error("failed to save user data after download", "node", lb.nodeNumber, "error", saveErr)
+	}
+
+	statusMsg := fmt.Sprintf("|07Download finished. Success: %d, Failed: %d.|07\r\n", successCount, failCount)
+	_ = lb.writePipe(statusMsg)
+	time.Sleep(2 * time.Second)
+
+	// Refresh file list.
+	lb.refreshFileList()
+	lb.endFooterPrompt()
+	frame.needFullRedraw = true
+	return false, nil, "", nil
+}
+
+// uploadFiles runs the upload prompt/transfer flow for the "u" command and
+// refreshes the file list afterward.
+func (lb *fileLightbar) uploadFiles(frame *lbFrame) {
+	_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
+	uploadErr := lb.e.runUploadFiles(lb.s, lb.terminal, lb.currentUser, lb.userManager, lb.currentAreaID, lb.currentAreaTag, lb.outputMode, lb.nodeNumber, lb.sessionStartTime)
+	if uploadErr != nil {
+		slog.Error("upload error", "node", lb.nodeNumber, "error", uploadErr)
+	}
+	// runUploadFiles calls resetSessionIH/getSessionIH internally,
+	// so the local ih is now stale — refresh it.
+	lb.ih = getSessionIH(lb.s)
+	// Refresh file list after upload.
+	lb.refreshFileList()
+	lb.endFooterPrompt()
+	frame.needFullRedraw = true
+}

--- a/internal/menu/file_lightbar_actions_test.go
+++ b/internal/menu/file_lightbar_actions_test.go
@@ -1,0 +1,89 @@
+package menu
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/file"
+)
+
+// newTestFileManagerWithRecord builds a real *file.FileManager with a single
+// area and, optionally, a file record. AddFileRecord only writes metadata —
+// it never creates the backing file on disk — so a record added this way
+// has a resolvable path via GetFilePath but fails os.Stat, exercising the
+// "missing from disk" branch of collectTaggedPaths exactly like the
+// existing TestFileLightbar_* fixtures do.
+func newTestFileManagerWithRecord(t *testing.T, id uuid.UUID, filename string) *file.FileManager {
+	t.Helper()
+	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	areasJSON := `[{"id":1,"tag":"UTILS","name":"Utilities","path":"utils","acs_list":""}]`
+	if err := os.WriteFile(filepath.Join(cfgDir, "file_areas.json"), []byte(areasJSON), 0644); err != nil {
+		t.Fatalf("write areas: %v", err)
+	}
+	fm, err := file.NewFileManager(dataDir, cfgDir)
+	if err != nil {
+		t.Fatalf("NewFileManager: %v", err)
+	}
+	if filename != "" {
+		if err := fm.AddFileRecord(file.FileRecord{
+			ID: id, AreaID: 1, Filename: filename, Size: 1024, UploadedBy: "sysop",
+		}); err != nil {
+			t.Fatalf("AddFileRecord: %v", err)
+		}
+	}
+	return fm
+}
+
+// TestCollectTaggedPaths_MissingFromDisk pins that a tagged ID whose record
+// exists but whose file was never written to disk is skipped and counted as
+// a failure, not resolved as a downloadable path.
+func TestCollectTaggedPaths_MissingFromDisk(t *testing.T) {
+	id := uuid.New()
+	fm := newTestFileManagerWithRecord(t, id, "ghost.txt")
+
+	paths, ids, failCount := collectTaggedPaths(fm, 1, []uuid.UUID{id})
+
+	if len(paths) != 0 || len(ids) != 0 {
+		t.Errorf("paths/ids = %v/%v, want both empty (file missing from disk)", paths, ids)
+	}
+	if failCount != 1 {
+		t.Errorf("failCount = %d, want 1", failCount)
+	}
+}
+
+// TestCollectTaggedPaths_UnknownID pins that a tagged ID with no matching
+// record at all (GetFilePath itself errors) is also skipped and counted as
+// a failure.
+func TestCollectTaggedPaths_UnknownID(t *testing.T) {
+	fm := newTestFileManagerWithRecord(t, uuid.Nil, "")
+
+	paths, ids, failCount := collectTaggedPaths(fm, 1, []uuid.UUID{uuid.New()})
+
+	if len(paths) != 0 || len(ids) != 0 {
+		t.Errorf("paths/ids = %v/%v, want both empty (unknown ID)", paths, ids)
+	}
+	if failCount != 1 {
+		t.Errorf("failCount = %d, want 1", failCount)
+	}
+}
+
+// TestCollectTaggedPaths_Mixed pins that resolvable and unresolvable IDs in
+// the same batch are partitioned correctly: only failures increment
+// failCount, and paths/ids stay parallel and in order for the rest — even
+// though every ID here ultimately fails (no test file is ever written to
+// disk), collectTaggedPaths must not fail closed on the whole batch just
+// because it saw one bad ID first.
+func TestCollectTaggedPaths_Mixed(t *testing.T) {
+	knownID := uuid.New()
+	unknownID := uuid.New()
+	fm := newTestFileManagerWithRecord(t, knownID, "known.txt")
+
+	_, _, failCount := collectTaggedPaths(fm, 1, []uuid.UUID{unknownID, knownID})
+
+	if failCount != 2 {
+		t.Errorf("failCount = %d, want 2 (unknown ID + missing-from-disk known ID)", failCount)
+	}
+}

--- a/internal/menu/file_lightbar_cmdbar.go
+++ b/internal/menu/file_lightbar_cmdbar.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 )
 
@@ -88,6 +90,22 @@ func buildFileListCmdBar(e *MenuExecutor, currentUser *user.User, cmdBarOptions,
 		hiColorSeq = colorCodeToAnsi(hiBarOptions[0].HighlightColor)
 	}
 	return cmdEntries, sysopEntries, userEntries, hiColorSeq, isSysop
+}
+
+// beginFooterPrompt clears the separator and command-bar rows, moves the
+// cursor to the command-bar row, and shows the cursor — the preamble every
+// sysop footer prompt (edit/kill/move/rename) and the download confirm use
+// before reading input. Pair with endFooterPrompt when the prompt is done.
+func (lb *fileLightbar) beginFooterPrompt() {
+	clearFooter := ansi.MoveCursor(lb.separatorRow, 1) + "\x1b[2K" + ansi.MoveCursor(lb.cmdBarRow, 1) + "\x1b[2K"
+	_ = terminalio.WriteProcessedBytes(lb.terminal, []byte(clearFooter), lb.outputMode)
+	_ = terminalio.WriteProcessedBytes(lb.terminal, []byte(ansi.MoveCursor(lb.cmdBarRow, 1)), lb.outputMode)
+	_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
+}
+
+// endFooterPrompt hides the cursor again after a footer prompt completes.
+func (lb *fileLightbar) endFooterPrompt() {
+	_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25l"), lb.outputMode)
 }
 
 // compactFileSize renders a byte count compactly: bytes (B), kilobytes (k), or

--- a/internal/menu/file_lightbar_frame.go
+++ b/internal/menu/file_lightbar_frame.go
@@ -1,0 +1,78 @@
+package menu
+
+// lbFrame tracks the fileLightbar's smart-refresh state across run() loop
+// iterations — what was last rendered — so refreshFrame can redraw only the
+// regions that changed since then.
+type lbFrame struct {
+	prevSelectedIndex int
+	prevTopIndex      int
+	prevCmdIndex      int
+	prevPage          int
+	needFullRedraw    bool
+}
+
+// refreshFrame redraws whichever screen regions changed since the last call:
+// everything, if f.needFullRedraw is set; the whole footer and file area, if
+// the viewport scrolled; or just the old/new selected rows (plus the top
+// line, if the page changed) when only the selection moved within the same
+// viewport. The command bar is redrawn separately whenever cmdIndex changed.
+// calculatePageInfo is computed once per call and reused for both the
+// page-changed check and the trailing prevPage update — it previously ran
+// twice per keystroke.
+func (lb *fileLightbar) refreshFrame(f *lbFrame) error {
+	curPage, _ := lb.calculatePageInfo()
+
+	if f.needFullRedraw {
+		if err := lb.renderFull(); err != nil {
+			return err
+		}
+		f.needFullRedraw = false
+	} else if lb.topIndex != f.prevTopIndex {
+		// Viewport scrolled — full redraw of all regions to prevent overlap.
+		if err := lb.renderTop(); err != nil {
+			return err
+		}
+		if err := lb.renderFileArea(); err != nil {
+			return err
+		}
+		if err := lb.renderSeparator(); err != nil {
+			return err
+		}
+		if err := lb.renderCmdBar(); err != nil {
+			return err
+		}
+		if err := lb.renderPageIndicator(); err != nil {
+			return err
+		}
+	} else if lb.selectedIndex != f.prevSelectedIndex {
+		// Same viewport, selection changed — redraw old/new rows; redraw TOP if page changed.
+		if curPage != f.prevPage {
+			if err := lb.renderTop(); err != nil {
+				return err
+			}
+		}
+		if f.prevSelectedIndex >= 0 && f.prevSelectedIndex < len(lb.allFiles) {
+			if row, h := lb.screenRowForFile(f.prevSelectedIndex); row >= 0 {
+				if err := lb.writeFileRow(row, f.prevSelectedIndex, false, h); err != nil {
+					return err
+				}
+			}
+		}
+		if row, h := lb.screenRowForFile(lb.selectedIndex); row >= 0 {
+			if err := lb.writeFileRow(row, lb.selectedIndex, true, h); err != nil {
+				return err
+			}
+		}
+	}
+	if lb.cmdIndex != f.prevCmdIndex {
+		if err := lb.renderCmdBar(); err != nil {
+			return err
+		}
+	}
+
+	f.prevSelectedIndex = lb.selectedIndex
+	f.prevTopIndex = lb.topIndex
+	f.prevCmdIndex = lb.cmdIndex
+	f.prevPage = curPage
+	return nil
+}

--- a/internal/menu/file_lightbar_info.go
+++ b/internal/menu/file_lightbar_info.go
@@ -1,0 +1,60 @@
+package menu
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+// showFileInfo displays the "i" info overlay for the selected file and
+// blocks for a keypress to dismiss it. It follows the same signal
+// convention as handleNavKey/action handlers: refresh tells run() to set
+// needFullRedraw; exit tells run() to return (result, action, err)
+// immediately (used for the LOGOFF/error paths out of the blocking
+// ReadKey call).
+func (lb *fileLightbar) showFileInfo() (refresh bool, exit bool, result *user.User, action string, err error) {
+	if len(lb.allFiles) == 0 {
+		return false, false, nil, "", nil
+	}
+	sel := lb.allFiles[lb.selectedIndex]
+	descLines := formatDIZLines(sel.Description, dizMaxWidth, dizMaxLines)
+
+	_ = terminalio.WriteProcessedBytes(lb.terminal, []byte(ansi.ClearScreen()), lb.outputMode)
+
+	d1 := fmt.Sprintf("|15Filename  : |07%s\r\n", sel.Filename)
+	d2 := fmt.Sprintf("|15Size      : |07%s\r\n", compactFileSize(sel.Size))
+	_ = lb.writePipe(d1)
+	_ = lb.writePipe(d2)
+
+	for i, dl := range descLines {
+		var dLine string
+		if i == 0 {
+			dLine = fmt.Sprintf("|15Desc      : |07%s\r\n", dl)
+		} else {
+			dLine = fmt.Sprintf("|07            %s\r\n", dl)
+		}
+		_ = lb.writePipe(dLine)
+	}
+	if len(descLines) == 0 {
+		_ = lb.writePipe("|15Desc      : |07(none)\r\n")
+	}
+
+	d3 := fmt.Sprintf("|15Uploaded  : |07%s\r\n", sel.UploadedAt.Format("01/02/2006 15:04"))
+	d4 := fmt.Sprintf("|15Uploader  : |07%s\r\n", sel.UploadedBy)
+	d5 := fmt.Sprintf("|15Downloads : |07%d\r\n", sel.DownloadCount)
+	_ = lb.writePipe(d3)
+	_ = lb.writePipe(d4)
+	_ = lb.writePipe(d5)
+
+	_ = lb.writePipe("\r\n|08Press any key to return...|07")
+	if _, waitErr := lb.ih.ReadKey(); waitErr != nil {
+		if logoffIfDisconnected(waitErr) {
+			return false, true, nil, "LOGOFF", io.EOF
+		}
+		return false, true, nil, "", waitErr
+	}
+	return true, false, nil, "", nil
+}

--- a/internal/menu/file_lightbar_keys.go
+++ b/internal/menu/file_lightbar_keys.go
@@ -88,6 +88,12 @@ func (lb *fileLightbar) handleNavKey(keyInt int) (key string, dispatch bool, exi
 	case editor.KeyEsc: // Bare Esc
 		return "", false, true, nil, "", nil
 	case editor.KeyEnter: // Enter: execute selected command bar item
+		// FIX: guard against an empty command bar — cmdIndex is otherwise
+		// unconditionally trusted as a valid index into cmdEntries, which
+		// panics if the bar has no entries (e.g. a misconfigured BAR file).
+		if len(lb.cmdEntries) == 0 {
+			return "", false, false, nil, "", nil
+		}
 		return lb.cmdEntries[lb.cmdIndex].hotkey, true, false, nil, "", nil
 	default:
 		if keyInt >= 32 && keyInt < 127 {

--- a/internal/menu/file_lightbar_keys.go
+++ b/internal/menu/file_lightbar_keys.go
@@ -8,15 +8,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
-
-	"github.com/google/uuid"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/editor"
 	"github.com/ViSiON-3/vision-3-bbs/internal/file"
 	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
-	"github.com/ViSiON-3/vision-3-bbs/internal/ziplab"
 )
 
 // fileLightbar key handling: reading input, navigation, the sysop-bar
@@ -136,29 +132,7 @@ func (lb *fileLightbar) toggleSysopBar() {
 func (lb *fileLightbar) dispatchCommand(key string, frame *lbFrame) (exit bool, result *user.User, action string, err error) {
 	switch key {
 	case " ": // Space: toggle mark
-		if len(lb.allFiles) > 0 {
-			fileID := lb.allFiles[lb.selectedIndex].ID
-			found := false
-			newTaggedIDs := make([]uuid.UUID, 0, len(lb.currentUser.TaggedFileIDs))
-			for _, taggedID := range lb.currentUser.TaggedFileIDs {
-				if taggedID == fileID {
-					found = true
-				} else {
-					newTaggedIDs = append(newTaggedIDs, taggedID)
-				}
-			}
-			if !found {
-				newTaggedIDs = append(newTaggedIDs, fileID)
-			}
-			lb.currentUser.TaggedFileIDs = newTaggedIDs
-			if err := lb.userManager.UpdateUser(lb.currentUser); err != nil {
-				slog.Error("failed to save user after tag toggle", "node", lb.nodeNumber, "error", err)
-			}
-			// Redraw just the toggled row to show/hide the mark.
-			if row, h := lb.screenRowForFile(lb.selectedIndex); row >= 0 {
-				_ = lb.writeFileRow(row, lb.selectedIndex, true, h)
-			}
-		}
+		lb.toggleMark()
 
 	case "q":
 		return true, nil, "", nil
@@ -173,147 +147,15 @@ func (lb *fileLightbar) dispatchCommand(key string, frame *lbFrame) (exit bool, 
 		}
 
 	case "v":
-		if len(lb.allFiles) > 0 {
-			sel := &lb.allFiles[lb.selectedIndex]
-			filePath, pathErr := lb.e.FileMgr.GetFilePath(sel.ID)
-			if pathErr != nil {
-				slog.Error("failed to get path for file", "node", lb.nodeNumber, "id", sel.ID, "error", pathErr)
-				return false, nil, "", nil
-			}
-			// Show cursor for the viewer.
-			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
-			if lb.e.FileMgr.IsSupportedArchive(sel.Filename) {
-				ctx, cancel := lb.e.transferContext(lb.s.Context())
-				ziplab.RunZipLabView(ctx, lb.s, lb.terminal, filePath, sel.Filename, lb.outputMode, sessionReadLine(lb.s, lb.terminal), sessionReadKey(lb.s))
-				cancel()
-			} else {
-				tw, th := getTerminalSize(lb.s)
-				viewFileByRecord(lb.e, lb.s, lb.terminal, sel, lb.outputMode, tw, th)
-			}
-			// Hide cursor again.
-			lb.endFooterPrompt()
+		if lb.viewFile() {
 			frame.needFullRedraw = true
 		}
 
 	case "d":
-		if len(lb.currentUser.TaggedFileIDs) == 0 {
-			msg := "\r\n|07No files marked for download. Use |15Space|07 to mark files.|07\r\n"
-			_ = lb.writePipe(msg)
-			time.Sleep(1 * time.Second)
-			frame.needFullRedraw = true
-			return false, nil, "", nil
-		}
-
-		confirmPrompt := fmt.Sprintf("Download %d marked file(s)?", len(lb.currentUser.TaggedFileIDs))
-		// Replace the footer lightbar with the confirm prompt instead of printing over the file list.
-		lb.beginFooterPrompt()
-
-		tw, th := getTerminalSize(lb.s)
-		proceed, promptErr := lb.e.PromptYesNo(lb.s, lb.terminal, confirmPrompt, lb.outputMode, lb.nodeNumber, tw, th, false)
-		if promptErr != nil {
-			if logoffIfDisconnected(promptErr) {
-				return true, nil, "LOGOFF", io.EOF
-			}
-			slog.Error("error getting download confirmation", "node", lb.nodeNumber, "error", promptErr)
-			lb.endFooterPrompt()
-			frame.needFullRedraw = true
-			return false, nil, "", nil
-		}
-
-		if !proceed {
-			lb.endFooterPrompt()
-			frame.needFullRedraw = true
-			return false, nil, "", nil
-		}
-
-		slog.Info("starting download", "node", lb.nodeNumber, "handle", lb.currentUser.Handle, "count", len(lb.currentUser.TaggedFileIDs))
-		// Clear the screen before the download process begins.
-		_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[2J\x1b[H"), lb.outputMode)
-		_ = lb.writePipe("|07Preparing download...\r\n")
-		time.Sleep(500 * time.Millisecond)
-
-		successCount := 0
-		failCount := 0
-		filesToDownload := make([]string, 0, len(lb.currentUser.TaggedFileIDs))
-		fileIDsToDownload := make([]uuid.UUID, 0, len(lb.currentUser.TaggedFileIDs))
-
-		for _, fileID := range lb.currentUser.TaggedFileIDs {
-			fp, pathErr := lb.e.FileMgr.GetFilePath(fileID)
-			if pathErr != nil {
-				slog.Error("failed to get path for file ID", "node", lb.nodeNumber, "id", fileID, "error", pathErr)
-				failCount++
-				continue
-			}
-			if _, statErr := os.Stat(fp); os.IsNotExist(statErr) {
-				slog.Error("file path for ID does not exist", "node", lb.nodeNumber, "path", fp, "id", fileID)
-				failCount++
-				continue
-			} else if statErr != nil {
-				slog.Error("error stating file path for ID", "node", lb.nodeNumber, "path", fp, "id", fileID, "error", statErr)
-				failCount++
-				continue
-			}
-			filesToDownload = append(filesToDownload, fp)
-			fileIDsToDownload = append(fileIDsToDownload, fileID)
-		}
-
-		if len(filesToDownload) > 0 {
-			slog.Info("initiating transfer", "node", lb.nodeNumber, "count", len(filesToDownload))
-
-			// Use protocol selection (respects connection type - SSH vs Telnet)
-			proto, protoOK, protoErr := lb.e.selectTransferProtocol(lb.s, lb.terminal, lb.outputMode)
-			if protoErr != nil {
-				if logoffIfDisconnected(protoErr) {
-					return true, nil, "LOGOFF", io.EOF
-				}
-				slog.Error("protocol selection error", "node", lb.nodeNumber, "error", protoErr)
-				_ = lb.writePipe("\r\n|01Error: No transfer protocols configured on this system.|07\r\n")
-				failCount += len(filesToDownload)
-			} else if !protoOK {
-				_ = lb.writePipe("\r\n|07Download cancelled.|07\r\n")
-			} else {
-				sentCount, sendFails := lb.e.runTransferSend(lb.s, lb.terminal, proto, filesToDownload, fileIDsToDownload, lb.outputMode, lb.nodeNumber)
-				successCount = sentCount
-				failCount += sendFails
-				lb.ih = getSessionIH(lb.s)
-			}
-			time.Sleep(1 * time.Second)
-		} else {
-			slog.Warn("no valid file paths found for tagged files", "node", lb.nodeNumber)
-			_ = lb.writePipe("\r\n|01Could not find any of the marked files on the server.|07\r\n")
-			// failCount already equals the number of missing files (every
-			// tagged ID incremented it in the collection loop above).
-		}
-
-		// Clear tags, update download count, and save.
-		lb.currentUser.TaggedFileIDs = nil
-		lb.currentUser.NumDownloads += successCount
-		if saveErr := lb.userManager.UpdateUser(lb.currentUser); saveErr != nil {
-			slog.Error("failed to save user data after download", "node", lb.nodeNumber, "error", saveErr)
-		}
-
-		statusMsg := fmt.Sprintf("|07Download finished. Success: %d, Failed: %d.|07\r\n", successCount, failCount)
-		_ = lb.writePipe(statusMsg)
-		time.Sleep(2 * time.Second)
-
-		// Refresh file list.
-		lb.refreshFileList()
-		lb.endFooterPrompt()
-		frame.needFullRedraw = true
+		return lb.downloadFiles(frame)
 
 	case "u":
-		_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
-		uploadErr := lb.e.runUploadFiles(lb.s, lb.terminal, lb.currentUser, lb.userManager, lb.currentAreaID, lb.currentAreaTag, lb.outputMode, lb.nodeNumber, lb.sessionStartTime)
-		if uploadErr != nil {
-			slog.Error("upload error", "node", lb.nodeNumber, "error", uploadErr)
-		}
-		// runUploadFiles calls resetSessionIH/getSessionIH internally,
-		// so the local ih is now stale — refresh it.
-		lb.ih = getSessionIH(lb.s)
-		// Refresh file list after upload.
-		lb.refreshFileList()
-		lb.endFooterPrompt()
-		frame.needFullRedraw = true
+		lb.uploadFiles(frame)
 
 	case "e": // Edit description (sysop only)
 		if !lb.isSysop || len(lb.allFiles) == 0 {

--- a/internal/menu/file_lightbar_keys.go
+++ b/internal/menu/file_lightbar_keys.go
@@ -1,0 +1,505 @@
+package menu
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/editor"
+	"github.com/ViSiON-3/vision-3-bbs/internal/file"
+	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+	"github.com/ViSiON-3/vision-3-bbs/internal/ziplab"
+)
+
+// fileLightbar key handling: reading input, navigation, the sysop-bar
+// toggle, and the command dispatch switch.
+
+// readKeyOrLogoff reads the next key from lb.ih, mapping a disconnect or
+// idle timeout to the "LOGOFF" result convention documented on
+// runListFilesLightbar. exit is true whenever run() should return
+// immediately (either a real read error or the LOGOFF mapping); keyInt is
+// only meaningful when exit is false.
+func (lb *fileLightbar) readKeyOrLogoff() (keyInt int, exit bool, action string, err error) {
+	keyInt, readErr := lb.ih.ReadKey()
+	if readErr != nil {
+		if logoffIfDisconnected(readErr) {
+			return 0, true, "LOGOFF", io.EOF
+		}
+		return 0, true, "", readErr
+	}
+	return keyInt, false, "", nil
+}
+
+// handleNavKey processes one key code read by run()'s main loop. It reports
+// whether run() should exit immediately (exit, with result/action/err as the
+// values run() should return — used for bare Esc); otherwise dispatch tells
+// run() whether key was set to a command that the command switch
+// (dispatchCommand) should handle. Pure navigation keys (arrows, paging,
+// Home/End) mutate lb's selection/viewport/cmdIndex fields directly and
+// report dispatch=false so run() simply loops around, matching the
+// `continue` behavior of the original inline switch.
+func (lb *fileLightbar) handleNavKey(keyInt int) (key string, dispatch bool, exit bool, result *user.User, action string, err error) {
+	// Navigation keys — matched directly on integer key codes so that
+	// multi-byte escape sequences (PageUp/PageDown etc.) are handled
+	// atomically by the InputHandler and can never be split by the
+	// 100 ms inter-byte ESC timeout, which previously caused bare ESC
+	// to be returned and the lightbar to exit unexpectedly.
+	switch keyInt {
+	case editor.KeyArrowUp: // Up
+		lb.selectedIndex--
+		return "", false, false, nil, "", nil
+	case editor.KeyArrowDown: // Down
+		lb.selectedIndex++
+		return "", false, false, nil, "", nil
+	case editor.KeyArrowRight: // Right — command bar
+		lb.cmdIndex++
+		if lb.cmdIndex >= len(lb.cmdEntries) {
+			lb.cmdIndex = 0
+		}
+		return "", false, false, nil, "", nil
+	case editor.KeyArrowLeft: // Left — command bar
+		lb.cmdIndex--
+		if lb.cmdIndex < 0 {
+			lb.cmdIndex = len(lb.cmdEntries) - 1
+		}
+		return "", false, false, nil, "", nil
+	case editor.KeyPageUp, editor.KeyCtrlR: // Page Up
+		newTop := lb.topIndexForPrevPage()
+		lb.topIndex = newTop
+		lb.selectedIndex = newTop
+		return "", false, false, nil, "", nil
+	case editor.KeyPageDown: // Page Down
+		count := lb.filesVisibleFrom(lb.topIndex)
+		nextTop := lb.topIndex + count
+		if nextTop >= len(lb.allFiles) {
+			if len(lb.allFiles) > 0 {
+				lb.selectedIndex = len(lb.allFiles) - 1
+			}
+		} else {
+			lb.topIndex = nextTop
+			lb.selectedIndex = nextTop
+		}
+		return "", false, false, nil, "", nil
+	case editor.KeyHome: // Home
+		lb.selectedIndex = 0
+		return "", false, false, nil, "", nil
+	case editor.KeyEnd: // End
+		if len(lb.allFiles) > 0 {
+			lb.selectedIndex = len(lb.allFiles) - 1
+		}
+		return "", false, false, nil, "", nil
+	case editor.KeyEsc: // Bare Esc
+		return "", false, true, nil, "", nil
+	case editor.KeyEnter: // Enter: execute selected command bar item
+		return lb.cmdEntries[lb.cmdIndex].hotkey, true, false, nil, "", nil
+	default:
+		if keyInt >= 32 && keyInt < 127 {
+			return strings.ToLower(string(rune(keyInt))), true, false, nil, "", nil
+		}
+		return "", false, false, nil, "", nil // Ignore non-printable, non-navigation keys
+	}
+}
+
+// toggleSysopBar flips whether the sysop-only command bar entries are
+// shown, swapping cmdEntries between the sysop and user sets and resetting
+// cmdIndex to the first entry.
+func (lb *fileLightbar) toggleSysopBar() {
+	lb.showSysopBar = !lb.showSysopBar
+	if lb.showSysopBar {
+		lb.cmdEntries = make([]cmdEntry, len(lb.sysopEntries))
+		copy(lb.cmdEntries, lb.sysopEntries)
+	} else {
+		lb.cmdEntries = make([]cmdEntry, len(lb.userEntries))
+		copy(lb.cmdEntries, lb.userEntries)
+	}
+	lb.cmdIndex = 0
+}
+
+// dispatchCommand executes the hotkey or Enter-selected command bar item in
+// key: mark toggle, quit, info overlay, view, download, upload, and the
+// sysop-only edit/kill/move/rename commands. It follows the (exit, result,
+// action, err) signal convention documented on handleNavKey: false/nil/""/nil
+// means "handled, run() should loop around". Every bare `continue` in the
+// original inline switch becomes `return false, nil, "", nil` here, because
+// the switch was the last statement in run()'s for loop — continuing was
+// already equivalent to falling out of the switch. continue/break statements
+// inside a case's own nested for/switch are untouched: they still target
+// that inner loop, not run()'s.
+func (lb *fileLightbar) dispatchCommand(key string, frame *lbFrame) (exit bool, result *user.User, action string, err error) {
+	switch key {
+	case " ": // Space: toggle mark
+		if len(lb.allFiles) > 0 {
+			fileID := lb.allFiles[lb.selectedIndex].ID
+			found := false
+			newTaggedIDs := make([]uuid.UUID, 0, len(lb.currentUser.TaggedFileIDs))
+			for _, taggedID := range lb.currentUser.TaggedFileIDs {
+				if taggedID == fileID {
+					found = true
+				} else {
+					newTaggedIDs = append(newTaggedIDs, taggedID)
+				}
+			}
+			if !found {
+				newTaggedIDs = append(newTaggedIDs, fileID)
+			}
+			lb.currentUser.TaggedFileIDs = newTaggedIDs
+			if err := lb.userManager.UpdateUser(lb.currentUser); err != nil {
+				slog.Error("failed to save user after tag toggle", "node", lb.nodeNumber, "error", err)
+			}
+			// Redraw just the toggled row to show/hide the mark.
+			if row, h := lb.screenRowForFile(lb.selectedIndex); row >= 0 {
+				_ = lb.writeFileRow(row, lb.selectedIndex, true, h)
+			}
+		}
+
+	case "q":
+		return true, nil, "", nil
+
+	case "i": // Info: show file detail overlay
+		refresh, infoExit, infoResult, infoAction, infoErr := lb.showFileInfo()
+		if infoExit {
+			return true, infoResult, infoAction, infoErr
+		}
+		if refresh {
+			frame.needFullRedraw = true
+		}
+
+	case "v":
+		if len(lb.allFiles) > 0 {
+			sel := &lb.allFiles[lb.selectedIndex]
+			filePath, pathErr := lb.e.FileMgr.GetFilePath(sel.ID)
+			if pathErr != nil {
+				slog.Error("failed to get path for file", "node", lb.nodeNumber, "id", sel.ID, "error", pathErr)
+				return false, nil, "", nil
+			}
+			// Show cursor for the viewer.
+			_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
+			if lb.e.FileMgr.IsSupportedArchive(sel.Filename) {
+				ctx, cancel := lb.e.transferContext(lb.s.Context())
+				ziplab.RunZipLabView(ctx, lb.s, lb.terminal, filePath, sel.Filename, lb.outputMode, sessionReadLine(lb.s, lb.terminal), sessionReadKey(lb.s))
+				cancel()
+			} else {
+				tw, th := getTerminalSize(lb.s)
+				viewFileByRecord(lb.e, lb.s, lb.terminal, sel, lb.outputMode, tw, th)
+			}
+			// Hide cursor again.
+			lb.endFooterPrompt()
+			frame.needFullRedraw = true
+		}
+
+	case "d":
+		if len(lb.currentUser.TaggedFileIDs) == 0 {
+			msg := "\r\n|07No files marked for download. Use |15Space|07 to mark files.|07\r\n"
+			_ = lb.writePipe(msg)
+			time.Sleep(1 * time.Second)
+			frame.needFullRedraw = true
+			return false, nil, "", nil
+		}
+
+		confirmPrompt := fmt.Sprintf("Download %d marked file(s)?", len(lb.currentUser.TaggedFileIDs))
+		// Replace the footer lightbar with the confirm prompt instead of printing over the file list.
+		lb.beginFooterPrompt()
+
+		tw, th := getTerminalSize(lb.s)
+		proceed, promptErr := lb.e.PromptYesNo(lb.s, lb.terminal, confirmPrompt, lb.outputMode, lb.nodeNumber, tw, th, false)
+		if promptErr != nil {
+			if logoffIfDisconnected(promptErr) {
+				return true, nil, "LOGOFF", io.EOF
+			}
+			slog.Error("error getting download confirmation", "node", lb.nodeNumber, "error", promptErr)
+			lb.endFooterPrompt()
+			frame.needFullRedraw = true
+			return false, nil, "", nil
+		}
+
+		if !proceed {
+			lb.endFooterPrompt()
+			frame.needFullRedraw = true
+			return false, nil, "", nil
+		}
+
+		slog.Info("starting download", "node", lb.nodeNumber, "handle", lb.currentUser.Handle, "count", len(lb.currentUser.TaggedFileIDs))
+		// Clear the screen before the download process begins.
+		_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[2J\x1b[H"), lb.outputMode)
+		_ = lb.writePipe("|07Preparing download...\r\n")
+		time.Sleep(500 * time.Millisecond)
+
+		successCount := 0
+		failCount := 0
+		filesToDownload := make([]string, 0, len(lb.currentUser.TaggedFileIDs))
+		fileIDsToDownload := make([]uuid.UUID, 0, len(lb.currentUser.TaggedFileIDs))
+
+		for _, fileID := range lb.currentUser.TaggedFileIDs {
+			fp, pathErr := lb.e.FileMgr.GetFilePath(fileID)
+			if pathErr != nil {
+				slog.Error("failed to get path for file ID", "node", lb.nodeNumber, "id", fileID, "error", pathErr)
+				failCount++
+				continue
+			}
+			if _, statErr := os.Stat(fp); os.IsNotExist(statErr) {
+				slog.Error("file path for ID does not exist", "node", lb.nodeNumber, "path", fp, "id", fileID)
+				failCount++
+				continue
+			} else if statErr != nil {
+				slog.Error("error stating file path for ID", "node", lb.nodeNumber, "path", fp, "id", fileID, "error", statErr)
+				failCount++
+				continue
+			}
+			filesToDownload = append(filesToDownload, fp)
+			fileIDsToDownload = append(fileIDsToDownload, fileID)
+		}
+
+		if len(filesToDownload) > 0 {
+			slog.Info("initiating transfer", "node", lb.nodeNumber, "count", len(filesToDownload))
+
+			// Use protocol selection (respects connection type - SSH vs Telnet)
+			proto, protoOK, protoErr := lb.e.selectTransferProtocol(lb.s, lb.terminal, lb.outputMode)
+			if protoErr != nil {
+				if logoffIfDisconnected(protoErr) {
+					return true, nil, "LOGOFF", io.EOF
+				}
+				slog.Error("protocol selection error", "node", lb.nodeNumber, "error", protoErr)
+				_ = lb.writePipe("\r\n|01Error: No transfer protocols configured on this system.|07\r\n")
+				failCount += len(filesToDownload)
+			} else if !protoOK {
+				_ = lb.writePipe("\r\n|07Download cancelled.|07\r\n")
+			} else {
+				sentCount, sendFails := lb.e.runTransferSend(lb.s, lb.terminal, proto, filesToDownload, fileIDsToDownload, lb.outputMode, lb.nodeNumber)
+				successCount = sentCount
+				failCount += sendFails
+				lb.ih = getSessionIH(lb.s)
+			}
+			time.Sleep(1 * time.Second)
+		} else {
+			slog.Warn("no valid file paths found for tagged files", "node", lb.nodeNumber)
+			_ = lb.writePipe("\r\n|01Could not find any of the marked files on the server.|07\r\n")
+			// failCount already equals the number of missing files (every
+			// tagged ID incremented it in the collection loop above).
+		}
+
+		// Clear tags, update download count, and save.
+		lb.currentUser.TaggedFileIDs = nil
+		lb.currentUser.NumDownloads += successCount
+		if saveErr := lb.userManager.UpdateUser(lb.currentUser); saveErr != nil {
+			slog.Error("failed to save user data after download", "node", lb.nodeNumber, "error", saveErr)
+		}
+
+		statusMsg := fmt.Sprintf("|07Download finished. Success: %d, Failed: %d.|07\r\n", successCount, failCount)
+		_ = lb.writePipe(statusMsg)
+		time.Sleep(2 * time.Second)
+
+		// Refresh file list.
+		lb.refreshFileList()
+		lb.endFooterPrompt()
+		frame.needFullRedraw = true
+
+	case "u":
+		_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
+		uploadErr := lb.e.runUploadFiles(lb.s, lb.terminal, lb.currentUser, lb.userManager, lb.currentAreaID, lb.currentAreaTag, lb.outputMode, lb.nodeNumber, lb.sessionStartTime)
+		if uploadErr != nil {
+			slog.Error("upload error", "node", lb.nodeNumber, "error", uploadErr)
+		}
+		// runUploadFiles calls resetSessionIH/getSessionIH internally,
+		// so the local ih is now stale — refresh it.
+		lb.ih = getSessionIH(lb.s)
+		// Refresh file list after upload.
+		lb.refreshFileList()
+		lb.endFooterPrompt()
+		frame.needFullRedraw = true
+
+	case "e": // Edit description (sysop only)
+		if !lb.isSysop || len(lb.allFiles) == 0 {
+			return false, nil, "", nil
+		}
+		rec := lb.allFiles[lb.selectedIndex]
+		lb.beginFooterPrompt()
+		_ = lb.writePipe("|15New description: |07")
+		newDesc, readErr := readLineFromSessionIHAllowAbort(lb.s, lb.terminal)
+		lb.endFooterPrompt()
+		if readErr == nil && newDesc != "" {
+			if updErr := lb.e.FileMgr.UpdateFileDescription(rec.ID, newDesc); updErr != nil {
+				slog.Error("failed to update description", "node", lb.nodeNumber, "file", rec.Filename, "error", updErr)
+			} else {
+				lb.allFiles = lb.e.FileMgr.GetFilesForArea(lb.currentAreaID)
+			}
+		}
+		frame.needFullRedraw = true
+
+	case "k": // Kill/delete file (sysop only)
+		if !lb.isSysop || len(lb.allFiles) == 0 {
+			return false, nil, "", nil
+		}
+		rec := lb.allFiles[lb.selectedIndex]
+		confirmPrompt := fmt.Sprintf("Delete %s from disk?", rec.Filename)
+		lb.beginFooterPrompt()
+		tw, th := getTerminalSize(lb.s)
+		proceed, promptErr := lb.e.PromptYesNo(lb.s, lb.terminal, confirmPrompt, lb.outputMode, lb.nodeNumber, tw, th, false)
+		lb.endFooterPrompt()
+		if promptErr != nil {
+			if logoffIfDisconnected(promptErr) {
+				return true, nil, "LOGOFF", io.EOF
+			}
+			frame.needFullRedraw = true
+			return false, nil, "", nil
+		}
+		if proceed {
+			if delErr := lb.e.FileMgr.DeleteFileRecord(rec.ID, true); delErr != nil {
+				slog.Error("failed to delete file", "node", lb.nodeNumber, "file", rec.Filename, "error", delErr)
+			} else {
+				slog.Info("sysop deleted file from area", "node", lb.nodeNumber, "file", rec.Filename, "area", lb.currentAreaID)
+				// Remove from user's tag list so stale IDs don't reach batch download.
+				filtered := lb.currentUser.TaggedFileIDs[:0]
+				for _, tid := range lb.currentUser.TaggedFileIDs {
+					if tid != rec.ID {
+						filtered = append(filtered, tid)
+					}
+				}
+				lb.currentUser.TaggedFileIDs = filtered
+				lb.refreshFileList()
+			}
+		}
+		frame.needFullRedraw = true
+
+	case "m": // Move file to another area (sysop only)
+		if !lb.isSysop || len(lb.allFiles) == 0 {
+			return false, nil, "", nil
+		}
+		rec := lb.allFiles[lb.selectedIndex]
+		lb.beginFooterPrompt()
+		_ = lb.writePipe("|15Move to area (# or tag): |07")
+		areaInput, readErr := readLineFromSessionIHAllowAbort(lb.s, lb.terminal)
+		lb.endFooterPrompt()
+		if readErr != nil || strings.TrimSpace(areaInput) == "" {
+			frame.needFullRedraw = true
+			return false, nil, "", nil
+		}
+		// Resolve area by ID or tag.
+		var targetAreaID int
+		var targetArea *file.FileArea
+		if n, parseErr := fmt.Sscanf(strings.TrimSpace(areaInput), "%d", &targetAreaID); n == 1 && parseErr == nil {
+			if a, ok := lb.e.FileMgr.GetAreaByID(targetAreaID); ok {
+				targetArea = a
+			}
+		} else {
+			if a, ok := lb.e.FileMgr.GetAreaByTag(strings.TrimSpace(areaInput)); ok {
+				targetArea = a
+				targetAreaID = a.ID
+			}
+		}
+		if targetArea == nil {
+			lb.errMsgPause("\r\n|01Area not found.|07\r\n")
+			frame.needFullRedraw = true
+			return false, nil, "", nil
+		}
+		confirmPrompt := fmt.Sprintf("Move %s to %s?", rec.Filename, targetArea.Name)
+		_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
+		tw, th := getTerminalSize(lb.s)
+		proceed, promptErr := lb.e.PromptYesNo(lb.s, lb.terminal, confirmPrompt, lb.outputMode, lb.nodeNumber, tw, th, false)
+		lb.endFooterPrompt()
+		if promptErr != nil {
+			if logoffIfDisconnected(promptErr) {
+				return true, nil, "LOGOFF", io.EOF
+			}
+			frame.needFullRedraw = true
+			return false, nil, "", nil
+		}
+		if proceed {
+			if mvErr := lb.e.FileMgr.MoveFileRecord(rec.ID, targetAreaID); mvErr != nil {
+				slog.Error("failed to move file to area", "node", lb.nodeNumber, "file", rec.Filename, "area", targetAreaID, "error", mvErr)
+			} else {
+				slog.Info("sysop moved file to area", "node", lb.nodeNumber, "file", rec.Filename, "area", targetAreaID, "tag", targetArea.Tag)
+				lb.refreshFileList()
+			}
+		}
+		frame.needFullRedraw = true
+
+	case "r": // Rename file on disk (sysop only)
+		if !lb.isSysop || len(lb.allFiles) == 0 {
+			return false, nil, "", nil
+		}
+		rec := lb.allFiles[lb.selectedIndex]
+		lb.beginFooterPrompt()
+		_ = lb.writePipe("|15New filename: |07")
+		newName, readErr := readLineFromSessionIHAllowAbort(lb.s, lb.terminal)
+		lb.endFooterPrompt()
+		if readErr != nil || strings.TrimSpace(newName) == "" {
+			frame.needFullRedraw = true
+			return false, nil, "", nil
+		}
+		newName = filepath.Base(strings.TrimSpace(newName))
+		if newName == "." || newName == ".." {
+			lb.errMsgPause("\r\n|01Invalid filename.|07\r\n")
+			frame.needFullRedraw = true
+			return false, nil, "", nil
+		}
+		// Check for duplicate filename in the current area.
+		duplicate := false
+		for _, f := range lb.allFiles {
+			if strings.EqualFold(f.Filename, newName) && f.ID != rec.ID {
+				duplicate = true
+				break
+			}
+		}
+		if duplicate {
+			lb.errMsgPause("\r\n|01Filename already exists in this area.|07\r\n")
+			frame.needFullRedraw = true
+			return false, nil, "", nil
+		}
+		oldPath, pathErr := lb.e.FileMgr.GetFilePath(rec.ID)
+		if pathErr != nil {
+			slog.Error("failed to resolve path", "node", lb.nodeNumber, "file", rec.Filename, "error", pathErr)
+			frame.needFullRedraw = true
+			return false, nil, "", nil
+		}
+		newPath := filepath.Join(filepath.Dir(oldPath), newName)
+		// Guard against clobbering an untracked file already on disk at the
+		// target path (the duplicate check above only consults DB records).
+		// os.SameFile permits a case-only rename of the same file on a
+		// case-insensitive filesystem. A stat error other than "not exist"
+		// (e.g. a permission/IO fault) means we cannot prove the target is
+		// safe to overwrite, so refuse rather than risk a clobber.
+		newInfo, statErr := os.Stat(newPath)
+		switch {
+		case statErr == nil:
+			oldInfo, oldStatErr := os.Stat(oldPath)
+			if oldStatErr != nil || !os.SameFile(oldInfo, newInfo) {
+				slog.Error("rename target already exists on disk", "node", lb.nodeNumber, "path", newPath)
+				lb.errMsgPause("\r\n|01A file with that name already exists.|07\r\n")
+				frame.needFullRedraw = true
+				return false, nil, "", nil
+			}
+		case !errors.Is(statErr, os.ErrNotExist):
+			slog.Error("cannot stat rename target", "node", lb.nodeNumber, "path", newPath, "error", statErr)
+			lb.errMsgPause("\r\n|01Rename failed.|07\r\n")
+			frame.needFullRedraw = true
+			return false, nil, "", nil
+		}
+		if renErr := os.Rename(oldPath, newPath); renErr != nil {
+			slog.Error("failed to rename file", "node", lb.nodeNumber, "from", rec.Filename, "to", newName, "error", renErr)
+			lb.errMsgPause("\r\n|01Rename failed.|07\r\n")
+			frame.needFullRedraw = true
+			return false, nil, "", nil
+		}
+		if updErr := lb.e.FileMgr.UpdateFileRecord(rec.ID, func(r *file.FileRecord) {
+			r.Filename = newName
+		}); updErr != nil {
+			slog.Error("failed to update record", "node", lb.nodeNumber, "file", newName, "error", updErr)
+			if rollbackErr := os.Rename(newPath, oldPath); rollbackErr != nil {
+				slog.Error("rollback rename failed (disk/DB inconsistent)", "node", lb.nodeNumber, "file", newName, "error", rollbackErr)
+			}
+		} else {
+			slog.Info("sysop renamed file in area", "node", lb.nodeNumber, "from", rec.Filename, "to", newName, "area", lb.currentAreaID)
+			lb.allFiles = lb.e.FileMgr.GetFilesForArea(lb.currentAreaID)
+		}
+		frame.needFullRedraw = true
+	}
+	return false, nil, "", nil
+}

--- a/internal/menu/file_lightbar_keys.go
+++ b/internal/menu/file_lightbar_keys.go
@@ -1,17 +1,10 @@
 package menu
 
 import (
-	"errors"
-	"fmt"
 	"io"
-	"log/slog"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/editor"
-	"github.com/ViSiON-3/vision-3-bbs/internal/file"
-	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 )
 
@@ -161,187 +154,25 @@ func (lb *fileLightbar) dispatchCommand(key string, frame *lbFrame) (exit bool, 
 		if !lb.isSysop || len(lb.allFiles) == 0 {
 			return false, nil, "", nil
 		}
-		rec := lb.allFiles[lb.selectedIndex]
-		lb.beginFooterPrompt()
-		_ = lb.writePipe("|15New description: |07")
-		newDesc, readErr := readLineFromSessionIHAllowAbort(lb.s, lb.terminal)
-		lb.endFooterPrompt()
-		if readErr == nil && newDesc != "" {
-			if updErr := lb.e.FileMgr.UpdateFileDescription(rec.ID, newDesc); updErr != nil {
-				slog.Error("failed to update description", "node", lb.nodeNumber, "file", rec.Filename, "error", updErr)
-			} else {
-				lb.allFiles = lb.e.FileMgr.GetFilesForArea(lb.currentAreaID)
-			}
-		}
-		frame.needFullRedraw = true
+		lb.editDescription(frame)
 
 	case "k": // Kill/delete file (sysop only)
 		if !lb.isSysop || len(lb.allFiles) == 0 {
 			return false, nil, "", nil
 		}
-		rec := lb.allFiles[lb.selectedIndex]
-		confirmPrompt := fmt.Sprintf("Delete %s from disk?", rec.Filename)
-		lb.beginFooterPrompt()
-		tw, th := getTerminalSize(lb.s)
-		proceed, promptErr := lb.e.PromptYesNo(lb.s, lb.terminal, confirmPrompt, lb.outputMode, lb.nodeNumber, tw, th, false)
-		lb.endFooterPrompt()
-		if promptErr != nil {
-			if logoffIfDisconnected(promptErr) {
-				return true, nil, "LOGOFF", io.EOF
-			}
-			frame.needFullRedraw = true
-			return false, nil, "", nil
-		}
-		if proceed {
-			if delErr := lb.e.FileMgr.DeleteFileRecord(rec.ID, true); delErr != nil {
-				slog.Error("failed to delete file", "node", lb.nodeNumber, "file", rec.Filename, "error", delErr)
-			} else {
-				slog.Info("sysop deleted file from area", "node", lb.nodeNumber, "file", rec.Filename, "area", lb.currentAreaID)
-				// Remove from user's tag list so stale IDs don't reach batch download.
-				filtered := lb.currentUser.TaggedFileIDs[:0]
-				for _, tid := range lb.currentUser.TaggedFileIDs {
-					if tid != rec.ID {
-						filtered = append(filtered, tid)
-					}
-				}
-				lb.currentUser.TaggedFileIDs = filtered
-				lb.refreshFileList()
-			}
-		}
-		frame.needFullRedraw = true
+		return lb.killFile(frame)
 
 	case "m": // Move file to another area (sysop only)
 		if !lb.isSysop || len(lb.allFiles) == 0 {
 			return false, nil, "", nil
 		}
-		rec := lb.allFiles[lb.selectedIndex]
-		lb.beginFooterPrompt()
-		_ = lb.writePipe("|15Move to area (# or tag): |07")
-		areaInput, readErr := readLineFromSessionIHAllowAbort(lb.s, lb.terminal)
-		lb.endFooterPrompt()
-		if readErr != nil || strings.TrimSpace(areaInput) == "" {
-			frame.needFullRedraw = true
-			return false, nil, "", nil
-		}
-		// Resolve area by ID or tag.
-		var targetAreaID int
-		var targetArea *file.FileArea
-		if n, parseErr := fmt.Sscanf(strings.TrimSpace(areaInput), "%d", &targetAreaID); n == 1 && parseErr == nil {
-			if a, ok := lb.e.FileMgr.GetAreaByID(targetAreaID); ok {
-				targetArea = a
-			}
-		} else {
-			if a, ok := lb.e.FileMgr.GetAreaByTag(strings.TrimSpace(areaInput)); ok {
-				targetArea = a
-				targetAreaID = a.ID
-			}
-		}
-		if targetArea == nil {
-			lb.errMsgPause("\r\n|01Area not found.|07\r\n")
-			frame.needFullRedraw = true
-			return false, nil, "", nil
-		}
-		confirmPrompt := fmt.Sprintf("Move %s to %s?", rec.Filename, targetArea.Name)
-		_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
-		tw, th := getTerminalSize(lb.s)
-		proceed, promptErr := lb.e.PromptYesNo(lb.s, lb.terminal, confirmPrompt, lb.outputMode, lb.nodeNumber, tw, th, false)
-		lb.endFooterPrompt()
-		if promptErr != nil {
-			if logoffIfDisconnected(promptErr) {
-				return true, nil, "LOGOFF", io.EOF
-			}
-			frame.needFullRedraw = true
-			return false, nil, "", nil
-		}
-		if proceed {
-			if mvErr := lb.e.FileMgr.MoveFileRecord(rec.ID, targetAreaID); mvErr != nil {
-				slog.Error("failed to move file to area", "node", lb.nodeNumber, "file", rec.Filename, "area", targetAreaID, "error", mvErr)
-			} else {
-				slog.Info("sysop moved file to area", "node", lb.nodeNumber, "file", rec.Filename, "area", targetAreaID, "tag", targetArea.Tag)
-				lb.refreshFileList()
-			}
-		}
-		frame.needFullRedraw = true
+		return lb.moveFile(frame)
 
 	case "r": // Rename file on disk (sysop only)
 		if !lb.isSysop || len(lb.allFiles) == 0 {
 			return false, nil, "", nil
 		}
-		rec := lb.allFiles[lb.selectedIndex]
-		lb.beginFooterPrompt()
-		_ = lb.writePipe("|15New filename: |07")
-		newName, readErr := readLineFromSessionIHAllowAbort(lb.s, lb.terminal)
-		lb.endFooterPrompt()
-		if readErr != nil || strings.TrimSpace(newName) == "" {
-			frame.needFullRedraw = true
-			return false, nil, "", nil
-		}
-		newName = filepath.Base(strings.TrimSpace(newName))
-		if newName == "." || newName == ".." {
-			lb.errMsgPause("\r\n|01Invalid filename.|07\r\n")
-			frame.needFullRedraw = true
-			return false, nil, "", nil
-		}
-		// Check for duplicate filename in the current area.
-		duplicate := false
-		for _, f := range lb.allFiles {
-			if strings.EqualFold(f.Filename, newName) && f.ID != rec.ID {
-				duplicate = true
-				break
-			}
-		}
-		if duplicate {
-			lb.errMsgPause("\r\n|01Filename already exists in this area.|07\r\n")
-			frame.needFullRedraw = true
-			return false, nil, "", nil
-		}
-		oldPath, pathErr := lb.e.FileMgr.GetFilePath(rec.ID)
-		if pathErr != nil {
-			slog.Error("failed to resolve path", "node", lb.nodeNumber, "file", rec.Filename, "error", pathErr)
-			frame.needFullRedraw = true
-			return false, nil, "", nil
-		}
-		newPath := filepath.Join(filepath.Dir(oldPath), newName)
-		// Guard against clobbering an untracked file already on disk at the
-		// target path (the duplicate check above only consults DB records).
-		// os.SameFile permits a case-only rename of the same file on a
-		// case-insensitive filesystem. A stat error other than "not exist"
-		// (e.g. a permission/IO fault) means we cannot prove the target is
-		// safe to overwrite, so refuse rather than risk a clobber.
-		newInfo, statErr := os.Stat(newPath)
-		switch {
-		case statErr == nil:
-			oldInfo, oldStatErr := os.Stat(oldPath)
-			if oldStatErr != nil || !os.SameFile(oldInfo, newInfo) {
-				slog.Error("rename target already exists on disk", "node", lb.nodeNumber, "path", newPath)
-				lb.errMsgPause("\r\n|01A file with that name already exists.|07\r\n")
-				frame.needFullRedraw = true
-				return false, nil, "", nil
-			}
-		case !errors.Is(statErr, os.ErrNotExist):
-			slog.Error("cannot stat rename target", "node", lb.nodeNumber, "path", newPath, "error", statErr)
-			lb.errMsgPause("\r\n|01Rename failed.|07\r\n")
-			frame.needFullRedraw = true
-			return false, nil, "", nil
-		}
-		if renErr := os.Rename(oldPath, newPath); renErr != nil {
-			slog.Error("failed to rename file", "node", lb.nodeNumber, "from", rec.Filename, "to", newName, "error", renErr)
-			lb.errMsgPause("\r\n|01Rename failed.|07\r\n")
-			frame.needFullRedraw = true
-			return false, nil, "", nil
-		}
-		if updErr := lb.e.FileMgr.UpdateFileRecord(rec.ID, func(r *file.FileRecord) {
-			r.Filename = newName
-		}); updErr != nil {
-			slog.Error("failed to update record", "node", lb.nodeNumber, "file", newName, "error", updErr)
-			if rollbackErr := os.Rename(newPath, oldPath); rollbackErr != nil {
-				slog.Error("rollback rename failed (disk/DB inconsistent)", "node", lb.nodeNumber, "file", newName, "error", rollbackErr)
-			}
-		} else {
-			slog.Info("sysop renamed file in area", "node", lb.nodeNumber, "from", rec.Filename, "to", newName, "area", lb.currentAreaID)
-			lb.allFiles = lb.e.FileMgr.GetFilesForArea(lb.currentAreaID)
-		}
-		frame.needFullRedraw = true
+		return lb.renameFile(frame)
 	}
 	return false, nil, "", nil
 }

--- a/internal/menu/file_lightbar_keys_test.go
+++ b/internal/menu/file_lightbar_keys_test.go
@@ -1,0 +1,46 @@
+package menu
+
+import (
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/editor"
+)
+
+// TestHandleNavKey_EnterOnEmptyCmdBarDoesNotPanic pins the bounds-guard fix:
+// pressing Enter used to index lb.cmdEntries[lb.cmdIndex] unconditionally,
+// which panics if the command bar has no entries (e.g. a misconfigured BAR
+// file leaves cmdEntries empty). handleNavKey must instead report "not
+// dispatched" so run() just loops around.
+func TestHandleNavKey_EnterOnEmptyCmdBarDoesNotPanic(t *testing.T) {
+	lb := &fileLightbar{cmdEntries: nil, cmdIndex: 0}
+
+	key, dispatch, exit, result, action, err := lb.handleNavKey(editor.KeyEnter)
+
+	if dispatch {
+		t.Errorf("dispatch = true, want false (nothing to dispatch on an empty command bar)")
+	}
+	if exit || result != nil || action != "" || err != nil {
+		t.Errorf("(exit, result, action, err) = (%v, %v, %q, %v), want (false, nil, \"\", nil)", exit, result, action, err)
+	}
+	if key != "" {
+		t.Errorf("key = %q, want empty", key)
+	}
+}
+
+// TestHandleNavKey_EnterOnNonEmptyCmdBarStillWorks pins that the guard only
+// affects the empty case: Enter still selects the entry at cmdIndex.
+func TestHandleNavKey_EnterOnNonEmptyCmdBarStillWorks(t *testing.T) {
+	lb := &fileLightbar{
+		cmdEntries: []cmdEntry{{label: "Mark", hotkey: " "}, {label: "Quit", hotkey: "q"}},
+		cmdIndex:   1,
+	}
+
+	key, dispatch, exit, _, _, _ := lb.handleNavKey(editor.KeyEnter)
+
+	if !dispatch || exit {
+		t.Errorf("(dispatch, exit) = (%v, %v), want (true, false)", dispatch, exit)
+	}
+	if key != "q" {
+		t.Errorf("key = %q, want %q", key, "q")
+	}
+}

--- a/internal/menu/file_lightbar_layout.go
+++ b/internal/menu/file_lightbar_layout.go
@@ -1,10 +1,98 @@
 package menu
 
 import (
+	"regexp"
+	"strings"
+
+	"github.com/gliderlabs/ssh"
 	"github.com/google/uuid"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 )
 
 // fileLightbar geometry, paging, and selection helpers.
+
+// resolveTermSize returns the terminal height and width for s, falling back
+// to the default 80x24 when no PTY window size is reported.
+func resolveTermSize(s ssh.Session) (termHeight, termWidth int) {
+	termHeight = 24
+	termWidth = 80
+	if ptyReq, _, ok := s.Pty(); ok && ptyReq.Window.Height > 0 {
+		termHeight = ptyReq.Window.Height
+		if ptyReq.Window.Width > 0 {
+			termWidth = ptyReq.Window.Width
+		}
+	}
+	return termHeight, termWidth
+}
+
+// computeVerticalLayout derives the lightbar's fixed vertical geometry from
+// the terminal height and the top/bot templates: how many lines the top
+// template's header renders, how many lines the (already placeholder- and
+// pipe-code-expanded) BOT template occupies, how many rows are reserved for
+// the separator/command bar/BOT, how many rows remain for the file list, and
+// the absolute rows where the file area, separator, and command bar begin.
+func computeVerticalLayout(termHeight int, topTemplateBytes []byte, processedBotTemplate []byte, totalFiles int, fconfpath string) (headerLines int, botContent string, botLineCount int, reservedBottom int, visibleRows int, fileAreaStartRow int, cmdBarRow int, separatorRow int) {
+	// Count header lines from top template (line count is invariant to page/file counts).
+	processedTopSample := ansi.ReplacePipeCodes(processFileListPlaceholders(topTemplateBytes, 1, 1, totalFiles, fconfpath))
+	headerLines = strings.Count(string(processedTopSample), "\n")
+	if headerLines < 1 {
+		headerLines = 1
+	}
+
+	// Reserve rows for the separator, command bar, and optional BOT template.
+	// Derive botLineCount from the expanded string (after placeholder + pipe-code
+	// processing) so it matches what renderPageIndicator actually renders.
+	botContent = strings.TrimRight(string(processedBotTemplate), "\r\n")
+	botLineCount = 0
+	if len(botContent) > 0 {
+		expandedBotSample := string(ansi.ReplacePipeCodes(processFileListPlaceholders([]byte(botContent), 1, 1, totalFiles, fconfpath)))
+		expandedBotSample = strings.ReplaceAll(expandedBotSample, "^PAGE", "1")
+		expandedBotSample = strings.ReplaceAll(expandedBotSample, "^TOTALPAGES", "1")
+		botLineCount = len(strings.Split(expandedBotSample, "\n"))
+	}
+	reservedBottom = 2 // separator + command bar
+	if botLineCount > 0 {
+		reservedBottom = 2 + botLineCount // separator + command bar + BOT lines
+	}
+	visibleRows = termHeight - headerLines - reservedBottom - 1
+	if visibleRows < 3 {
+		visibleRows = 3
+	}
+
+	// fileAreaStartRow is the absolute terminal row where file entries begin.
+	fileAreaStartRow = headerLines + 2
+
+	// Layout: separator row, then command bar, then optional BOT.
+	cmdBarRow = max(1, termHeight-botLineCount)
+	separatorRow = max(1, cmdBarRow-1)
+
+	return headerLines, botContent, botLineCount, reservedBottom, visibleRows, fileAreaStartRow, cmdBarRow, separatorRow
+}
+
+// computeDescMetrics precomputes the fixed-width description-column geometry
+// shared by fileEntryHeight and buildFileEntry: every mid-template
+// placeholder except ^DESC is fixed width, so the prefix length (and
+// therefore how much room is left for the description) is constant across
+// all file entries.
+func computeDescMetrics(processedMidTemplate string, termWidth int) (ansiRe *regexp.Regexp, descPrefixLen int, descColWidth int, descIndentStr string) {
+	// stripAnsi removes all ANSI escape sequences from a string.
+	ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+	sample := strings.ReplaceAll(processedMidTemplate, "^MARK", " ")
+	sample = strings.ReplaceAll(sample, "^NUM", "  1")
+	sample = strings.ReplaceAll(sample, "^NAME", "            ")
+	sample = strings.ReplaceAll(sample, "^DATE", "01/01/00")
+	sample = strings.ReplaceAll(sample, "^SIZE", "     ")
+	sample = strings.ReplaceAll(sample, "^DESC", "")
+	descPrefixLen = len(ansiRe.ReplaceAllString(string(ansi.ReplacePipeCodes([]byte(sample))), ""))
+	descColWidth = termWidth - descPrefixLen - 1
+	if descColWidth < 20 {
+		descColWidth = 20
+	}
+	descIndentStr = strings.Repeat(" ", descPrefixLen)
+	return ansiRe, descPrefixLen, descColWidth, descIndentStr
+}
 func (lb *fileLightbar) isFileTagged(fileID uuid.UUID) bool {
 	for _, taggedID := range lb.currentUser.TaggedFileIDs {
 		if taggedID == fileID {

--- a/internal/menu/file_lightbar_layout.go
+++ b/internal/menu/file_lightbar_layout.go
@@ -150,6 +150,16 @@ func (lb *fileLightbar) clampSelection() {
 	}
 }
 
+// refreshFileList refetches allFiles for the current area and clamps
+// selectedIndex back onto the list if the file that was selected no longer
+// exists (e.g. after a download, upload, kill, or move changed the count).
+func (lb *fileLightbar) refreshFileList() {
+	lb.allFiles = lb.e.FileMgr.GetFilesForArea(lb.currentAreaID)
+	if lb.selectedIndex >= len(lb.allFiles) && len(lb.allFiles) > 0 {
+		lb.selectedIndex = len(lb.allFiles) - 1
+	}
+}
+
 func (lb *fileLightbar) screenRowForFile(fileIdx int) (startRow int, height int) {
 	if fileIdx < lb.topIndex {
 		return -1, 0

--- a/internal/menu/file_lightbar_layout_test.go
+++ b/internal/menu/file_lightbar_layout_test.go
@@ -1,0 +1,123 @@
+package menu
+
+import (
+	"regexp"
+	"testing"
+)
+
+// TestComputeVerticalLayout_NoBotTemplate pins the geometry when there is no
+// BOT template: 2 rows are reserved (separator + command bar), and the file
+// area starts right after the header.
+func TestComputeVerticalLayout_NoBotTemplate(t *testing.T) {
+	headerLines, botContent, botLineCount, reservedBottom, visibleRows, fileAreaStartRow, cmdBarRow, separatorRow :=
+		computeVerticalLayout(24, []byte("Header line 1\r\nHeader line 2\r\n"), []byte{}, 5, "")
+
+	if headerLines != 2 {
+		t.Errorf("headerLines = %d, want 2", headerLines)
+	}
+	if botContent != "" {
+		t.Errorf("botContent = %q, want empty", botContent)
+	}
+	if botLineCount != 0 {
+		t.Errorf("botLineCount = %d, want 0", botLineCount)
+	}
+	if reservedBottom != 2 {
+		t.Errorf("reservedBottom = %d, want 2", reservedBottom)
+	}
+	// visibleRows = termHeight - headerLines - reservedBottom - 1 = 24 - 2 - 2 - 1 = 19
+	if visibleRows != 19 {
+		t.Errorf("visibleRows = %d, want 19", visibleRows)
+	}
+	if fileAreaStartRow != 4 {
+		t.Errorf("fileAreaStartRow = %d, want 4", fileAreaStartRow)
+	}
+	if cmdBarRow != 24 {
+		t.Errorf("cmdBarRow = %d, want 24", cmdBarRow)
+	}
+	if separatorRow != 23 {
+		t.Errorf("separatorRow = %d, want 23", separatorRow)
+	}
+}
+
+// TestComputeVerticalLayout_WithBotTemplate pins that a non-empty BOT
+// template reserves extra rows for its own line count, and that ^PAGE/
+// ^TOTALPAGES placeholders are expanded before measuring it.
+func TestComputeVerticalLayout_WithBotTemplate(t *testing.T) {
+	headerLines, botContent, botLineCount, reservedBottom, visibleRows, fileAreaStartRow, cmdBarRow, separatorRow :=
+		computeVerticalLayout(24, []byte("Header\r\n"), []byte("Page ^PAGE of ^TOTALPAGES\r\n"), 5, "")
+
+	if headerLines != 1 {
+		t.Errorf("headerLines = %d, want 1", headerLines)
+	}
+	if botContent != "Page ^PAGE of ^TOTALPAGES" {
+		t.Errorf("botContent = %q, want %q", botContent, "Page ^PAGE of ^TOTALPAGES")
+	}
+	if botLineCount != 1 {
+		t.Errorf("botLineCount = %d, want 1", botLineCount)
+	}
+	// reservedBottom = 2 (separator + cmdbar) + 1 (bot line) = 3
+	if reservedBottom != 3 {
+		t.Errorf("reservedBottom = %d, want 3", reservedBottom)
+	}
+	// visibleRows = 24 - 1 - 3 - 1 = 19
+	if visibleRows != 19 {
+		t.Errorf("visibleRows = %d, want 19", visibleRows)
+	}
+	if fileAreaStartRow != 3 {
+		t.Errorf("fileAreaStartRow = %d, want 3", fileAreaStartRow)
+	}
+	// cmdBarRow = max(1, termHeight-botLineCount) = max(1, 24-1) = 23
+	if cmdBarRow != 23 {
+		t.Errorf("cmdBarRow = %d, want 23", cmdBarRow)
+	}
+	if separatorRow != 22 {
+		t.Errorf("separatorRow = %d, want 22", separatorRow)
+	}
+}
+
+// TestComputeVerticalLayout_ClampsVisibleRows pins the floor: visibleRows
+// never drops below 3 even on a tiny terminal.
+func TestComputeVerticalLayout_ClampsVisibleRows(t *testing.T) {
+	_, _, _, _, visibleRows, _, _, _ := computeVerticalLayout(5, []byte("Header\r\n"), []byte{}, 1, "")
+	if visibleRows != 3 {
+		t.Errorf("visibleRows = %d, want clamped to 3", visibleRows)
+	}
+}
+
+// TestComputeDescMetrics pins the fixed-width description column geometry
+// derived from a mid template: descPrefixLen is the ansi/pipe-stripped
+// length of the template with ^DESC blanked out, descColWidth is what's left
+// of termWidth for the description, and descIndentStr pads continuation
+// lines to align under the description column.
+func TestComputeDescMetrics(t *testing.T) {
+	ansiRe, descPrefixLen, descColWidth, descIndentStr := computeDescMetrics("^MARK^NUM ^NAME ^DATE ^SIZE ^DESC", 80)
+
+	if ansiRe == nil {
+		t.Fatal("ansiRe is nil")
+	}
+	if _, ok := interface{}(ansiRe).(*regexp.Regexp); !ok {
+		t.Fatal("ansiRe is not a *regexp.Regexp")
+	}
+	// Prefix (with ^DESC blanked): " " + "  1" + " " + "            " + " " + "01/01/00" + " " + "     " + " "
+	// = 1+3+1+12+1+8+1+5+1 = 33
+	wantPrefixLen := 33
+	if descPrefixLen != wantPrefixLen {
+		t.Errorf("descPrefixLen = %d, want %d", descPrefixLen, wantPrefixLen)
+	}
+	wantColWidth := 80 - wantPrefixLen - 1
+	if descColWidth != wantColWidth {
+		t.Errorf("descColWidth = %d, want %d", descColWidth, wantColWidth)
+	}
+	if len(descIndentStr) != descPrefixLen {
+		t.Errorf("descIndentStr length = %d, want %d", len(descIndentStr), descPrefixLen)
+	}
+}
+
+// TestComputeDescMetrics_ClampsNarrowTerminal pins the 20-column floor for
+// descColWidth on a terminal too narrow for the fixed-width prefix.
+func TestComputeDescMetrics_ClampsNarrowTerminal(t *testing.T) {
+	_, _, descColWidth, _ := computeDescMetrics("^MARK^NUM ^NAME ^DATE ^SIZE ^DESC", 10)
+	if descColWidth != 20 {
+		t.Errorf("descColWidth = %d, want clamped to 20", descColWidth)
+	}
+}

--- a/internal/menu/file_lightbar_render.go
+++ b/internal/menu/file_lightbar_render.go
@@ -2,11 +2,13 @@ package menu
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 )
 
 // fileLightbar rendering: file rows, separator, command bar, page indicator.
@@ -251,6 +253,133 @@ func (lb *fileLightbar) renderTop() error {
 	curPage, calcTotalPages := lb.calculatePageInfo()
 	processed := ansi.ReplacePipeCodes(processFileListPlaceholders(lb.topTemplateBytes, curPage, calcTotalPages, len(lb.allFiles), lb.fconfpath))
 	return terminalio.WriteProcessedBytes(lb.terminal, processed, lb.outputMode)
+}
+
+// lbFrame tracks the fileLightbar's smart-refresh state across run() loop
+// iterations — what was last rendered — so refreshFrame can redraw only the
+// regions that changed since then.
+type lbFrame struct {
+	prevSelectedIndex int
+	prevTopIndex      int
+	prevCmdIndex      int
+	prevPage          int
+	needFullRedraw    bool
+}
+
+// refreshFrame redraws whichever screen regions changed since the last call:
+// everything, if f.needFullRedraw is set; the whole footer and file area, if
+// the viewport scrolled; or just the old/new selected rows (plus the top
+// line, if the page changed) when only the selection moved within the same
+// viewport. The command bar is redrawn separately whenever cmdIndex changed.
+// calculatePageInfo is computed once per call and reused for both the
+// page-changed check and the trailing prevPage update — it previously ran
+// twice per keystroke.
+func (lb *fileLightbar) refreshFrame(f *lbFrame) error {
+	curPage, _ := lb.calculatePageInfo()
+
+	if f.needFullRedraw {
+		if err := lb.renderFull(); err != nil {
+			return err
+		}
+		f.needFullRedraw = false
+	} else if lb.topIndex != f.prevTopIndex {
+		// Viewport scrolled — full redraw of all regions to prevent overlap.
+		if err := lb.renderTop(); err != nil {
+			return err
+		}
+		if err := lb.renderFileArea(); err != nil {
+			return err
+		}
+		if err := lb.renderSeparator(); err != nil {
+			return err
+		}
+		if err := lb.renderCmdBar(); err != nil {
+			return err
+		}
+		if err := lb.renderPageIndicator(); err != nil {
+			return err
+		}
+	} else if lb.selectedIndex != f.prevSelectedIndex {
+		// Same viewport, selection changed — redraw old/new rows; redraw TOP if page changed.
+		if curPage != f.prevPage {
+			if err := lb.renderTop(); err != nil {
+				return err
+			}
+		}
+		if f.prevSelectedIndex >= 0 && f.prevSelectedIndex < len(lb.allFiles) {
+			if row, h := lb.screenRowForFile(f.prevSelectedIndex); row >= 0 {
+				if err := lb.writeFileRow(row, f.prevSelectedIndex, false, h); err != nil {
+					return err
+				}
+			}
+		}
+		if row, h := lb.screenRowForFile(lb.selectedIndex); row >= 0 {
+			if err := lb.writeFileRow(row, lb.selectedIndex, true, h); err != nil {
+				return err
+			}
+		}
+	}
+	if lb.cmdIndex != f.prevCmdIndex {
+		if err := lb.renderCmdBar(); err != nil {
+			return err
+		}
+	}
+
+	f.prevSelectedIndex = lb.selectedIndex
+	f.prevTopIndex = lb.topIndex
+	f.prevCmdIndex = lb.cmdIndex
+	f.prevPage = curPage
+	return nil
+}
+
+// showFileInfo displays the "i" info overlay for the selected file and
+// blocks for a keypress to dismiss it. It follows the same signal
+// convention as handleNavKey/action handlers: refresh tells run() to set
+// needFullRedraw; exit tells run() to return (result, action, err)
+// immediately (used for the LOGOFF/error paths out of the blocking
+// ReadKey call).
+func (lb *fileLightbar) showFileInfo() (refresh bool, exit bool, result *user.User, action string, err error) {
+	if len(lb.allFiles) == 0 {
+		return false, false, nil, "", nil
+	}
+	sel := lb.allFiles[lb.selectedIndex]
+	descLines := formatDIZLines(sel.Description, dizMaxWidth, dizMaxLines)
+
+	_ = terminalio.WriteProcessedBytes(lb.terminal, []byte(ansi.ClearScreen()), lb.outputMode)
+
+	d1 := fmt.Sprintf("|15Filename  : |07%s\r\n", sel.Filename)
+	d2 := fmt.Sprintf("|15Size      : |07%s\r\n", compactFileSize(sel.Size))
+	_ = lb.writePipe(d1)
+	_ = lb.writePipe(d2)
+
+	for i, dl := range descLines {
+		var dLine string
+		if i == 0 {
+			dLine = fmt.Sprintf("|15Desc      : |07%s\r\n", dl)
+		} else {
+			dLine = fmt.Sprintf("|07            %s\r\n", dl)
+		}
+		_ = lb.writePipe(dLine)
+	}
+	if len(descLines) == 0 {
+		_ = lb.writePipe("|15Desc      : |07(none)\r\n")
+	}
+
+	d3 := fmt.Sprintf("|15Uploaded  : |07%s\r\n", sel.UploadedAt.Format("01/02/2006 15:04"))
+	d4 := fmt.Sprintf("|15Uploader  : |07%s\r\n", sel.UploadedBy)
+	d5 := fmt.Sprintf("|15Downloads : |07%d\r\n", sel.DownloadCount)
+	_ = lb.writePipe(d3)
+	_ = lb.writePipe(d4)
+	_ = lb.writePipe(d5)
+
+	_ = lb.writePipe("\r\n|08Press any key to return...|07")
+	if _, waitErr := lb.ih.ReadKey(); waitErr != nil {
+		if logoffIfDisconnected(waitErr) {
+			return false, true, nil, "LOGOFF", io.EOF
+		}
+		return false, true, nil, "", waitErr
+	}
+	return true, false, nil, "", nil
 }
 
 func (lb *fileLightbar) renderFull() error {

--- a/internal/menu/file_lightbar_render.go
+++ b/internal/menu/file_lightbar_render.go
@@ -2,13 +2,11 @@ package menu
 
 import (
 	"fmt"
-	"io"
 	"strings"
 	"time"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
-	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 )
 
 // fileLightbar rendering: file rows, separator, command bar, page indicator.
@@ -253,133 +251,6 @@ func (lb *fileLightbar) renderTop() error {
 	curPage, calcTotalPages := lb.calculatePageInfo()
 	processed := ansi.ReplacePipeCodes(processFileListPlaceholders(lb.topTemplateBytes, curPage, calcTotalPages, len(lb.allFiles), lb.fconfpath))
 	return terminalio.WriteProcessedBytes(lb.terminal, processed, lb.outputMode)
-}
-
-// lbFrame tracks the fileLightbar's smart-refresh state across run() loop
-// iterations — what was last rendered — so refreshFrame can redraw only the
-// regions that changed since then.
-type lbFrame struct {
-	prevSelectedIndex int
-	prevTopIndex      int
-	prevCmdIndex      int
-	prevPage          int
-	needFullRedraw    bool
-}
-
-// refreshFrame redraws whichever screen regions changed since the last call:
-// everything, if f.needFullRedraw is set; the whole footer and file area, if
-// the viewport scrolled; or just the old/new selected rows (plus the top
-// line, if the page changed) when only the selection moved within the same
-// viewport. The command bar is redrawn separately whenever cmdIndex changed.
-// calculatePageInfo is computed once per call and reused for both the
-// page-changed check and the trailing prevPage update — it previously ran
-// twice per keystroke.
-func (lb *fileLightbar) refreshFrame(f *lbFrame) error {
-	curPage, _ := lb.calculatePageInfo()
-
-	if f.needFullRedraw {
-		if err := lb.renderFull(); err != nil {
-			return err
-		}
-		f.needFullRedraw = false
-	} else if lb.topIndex != f.prevTopIndex {
-		// Viewport scrolled — full redraw of all regions to prevent overlap.
-		if err := lb.renderTop(); err != nil {
-			return err
-		}
-		if err := lb.renderFileArea(); err != nil {
-			return err
-		}
-		if err := lb.renderSeparator(); err != nil {
-			return err
-		}
-		if err := lb.renderCmdBar(); err != nil {
-			return err
-		}
-		if err := lb.renderPageIndicator(); err != nil {
-			return err
-		}
-	} else if lb.selectedIndex != f.prevSelectedIndex {
-		// Same viewport, selection changed — redraw old/new rows; redraw TOP if page changed.
-		if curPage != f.prevPage {
-			if err := lb.renderTop(); err != nil {
-				return err
-			}
-		}
-		if f.prevSelectedIndex >= 0 && f.prevSelectedIndex < len(lb.allFiles) {
-			if row, h := lb.screenRowForFile(f.prevSelectedIndex); row >= 0 {
-				if err := lb.writeFileRow(row, f.prevSelectedIndex, false, h); err != nil {
-					return err
-				}
-			}
-		}
-		if row, h := lb.screenRowForFile(lb.selectedIndex); row >= 0 {
-			if err := lb.writeFileRow(row, lb.selectedIndex, true, h); err != nil {
-				return err
-			}
-		}
-	}
-	if lb.cmdIndex != f.prevCmdIndex {
-		if err := lb.renderCmdBar(); err != nil {
-			return err
-		}
-	}
-
-	f.prevSelectedIndex = lb.selectedIndex
-	f.prevTopIndex = lb.topIndex
-	f.prevCmdIndex = lb.cmdIndex
-	f.prevPage = curPage
-	return nil
-}
-
-// showFileInfo displays the "i" info overlay for the selected file and
-// blocks for a keypress to dismiss it. It follows the same signal
-// convention as handleNavKey/action handlers: refresh tells run() to set
-// needFullRedraw; exit tells run() to return (result, action, err)
-// immediately (used for the LOGOFF/error paths out of the blocking
-// ReadKey call).
-func (lb *fileLightbar) showFileInfo() (refresh bool, exit bool, result *user.User, action string, err error) {
-	if len(lb.allFiles) == 0 {
-		return false, false, nil, "", nil
-	}
-	sel := lb.allFiles[lb.selectedIndex]
-	descLines := formatDIZLines(sel.Description, dizMaxWidth, dizMaxLines)
-
-	_ = terminalio.WriteProcessedBytes(lb.terminal, []byte(ansi.ClearScreen()), lb.outputMode)
-
-	d1 := fmt.Sprintf("|15Filename  : |07%s\r\n", sel.Filename)
-	d2 := fmt.Sprintf("|15Size      : |07%s\r\n", compactFileSize(sel.Size))
-	_ = lb.writePipe(d1)
-	_ = lb.writePipe(d2)
-
-	for i, dl := range descLines {
-		var dLine string
-		if i == 0 {
-			dLine = fmt.Sprintf("|15Desc      : |07%s\r\n", dl)
-		} else {
-			dLine = fmt.Sprintf("|07            %s\r\n", dl)
-		}
-		_ = lb.writePipe(dLine)
-	}
-	if len(descLines) == 0 {
-		_ = lb.writePipe("|15Desc      : |07(none)\r\n")
-	}
-
-	d3 := fmt.Sprintf("|15Uploaded  : |07%s\r\n", sel.UploadedAt.Format("01/02/2006 15:04"))
-	d4 := fmt.Sprintf("|15Uploader  : |07%s\r\n", sel.UploadedBy)
-	d5 := fmt.Sprintf("|15Downloads : |07%d\r\n", sel.DownloadCount)
-	_ = lb.writePipe(d3)
-	_ = lb.writePipe(d4)
-	_ = lb.writePipe(d5)
-
-	_ = lb.writePipe("\r\n|08Press any key to return...|07")
-	if _, waitErr := lb.ih.ReadKey(); waitErr != nil {
-		if logoffIfDisconnected(waitErr) {
-			return false, true, nil, "LOGOFF", io.EOF
-		}
-		return false, true, nil, "", waitErr
-	}
-	return true, false, nil, "", nil
 }
 
 func (lb *fileLightbar) renderFull() error {

--- a/internal/menu/file_lightbar_render.go
+++ b/internal/menu/file_lightbar_render.go
@@ -20,14 +20,15 @@ func (lb *fileLightbar) writePipe(s string) error {
 	return terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte(s)), lb.outputMode)
 }
 
-// errMsgPause writes msg, pauses briefly so the user can read it, and expects
-// the caller to set needFullRedraw = true and continue the run() loop
-// afterward (that part can't be hoisted since needFullRedraw is local to
-// run()).
+// errMsgPause writes msg and pauses briefly so the user can read it. The
+// message clobbers part of the screen, so callers are expected to set
+// frame.needFullRedraw = true afterward; that part stays at the call site
+// because the frame is owned by the run() loop.
 func (lb *fileLightbar) errMsgPause(msg string) {
 	_ = lb.writePipe(msg)
 	time.Sleep(1 * time.Second)
 }
+
 func (lb *fileLightbar) buildFileEntry(idx int, highlighted bool, maxLines int) []string {
 	if idx < 0 || idx >= len(lb.allFiles) {
 		return nil

--- a/internal/menu/file_lightbar_render.go
+++ b/internal/menu/file_lightbar_render.go
@@ -3,12 +3,31 @@ package menu
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
 )
 
 // fileLightbar rendering: file rows, separator, command bar, page indicator.
+
+// writePipe writes s to the terminal after pipe-code ANSI translation. This is
+// the lightbar's most common output call (~25 sites in the former monolithic
+// run() method), hoisted verbatim to cut the repeated
+// terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte(s)), lb.outputMode)
+// boilerplate.
+func (lb *fileLightbar) writePipe(s string) error {
+	return terminalio.WriteProcessedBytes(lb.terminal, ansi.ReplacePipeCodes([]byte(s)), lb.outputMode)
+}
+
+// errMsgPause writes msg, pauses briefly so the user can read it, and expects
+// the caller to set needFullRedraw = true and continue the run() loop
+// afterward (that part can't be hoisted since needFullRedraw is local to
+// run()).
+func (lb *fileLightbar) errMsgPause(msg string) {
+	_ = lb.writePipe(msg)
+	time.Sleep(1 * time.Second)
+}
 func (lb *fileLightbar) buildFileEntry(idx int, highlighted bool, maxLines int) []string {
 	if idx < 0 || idx >= len(lb.allFiles) {
 		return nil

--- a/internal/menu/file_lightbar_sysop.go
+++ b/internal/menu/file_lightbar_sysop.go
@@ -1,0 +1,249 @@
+package menu
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/file"
+	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+// fileLightbar sysop-only commands: edit description, kill, move, rename —
+// plus the pure decision helpers they share.
+
+// resolveTargetArea resolves a user-typed "move to area" input to a target
+// area: numeric input is looked up by area ID, anything else by area tag.
+// targetArea is nil if nothing matched.
+func resolveTargetArea(fm *file.FileManager, input string) (targetAreaID int, targetArea *file.FileArea) {
+	trimmed := strings.TrimSpace(input)
+	if n, parseErr := fmt.Sscanf(trimmed, "%d", &targetAreaID); n == 1 && parseErr == nil {
+		if a, ok := fm.GetAreaByID(targetAreaID); ok {
+			targetArea = a
+		}
+	} else {
+		if a, ok := fm.GetAreaByTag(trimmed); ok {
+			targetArea = a
+			targetAreaID = a.ID
+		}
+	}
+	return targetAreaID, targetArea
+}
+
+// validateNewName cleans a user-provided rename target (basename only,
+// trimmed) and checks it against the reserved "." / ".." names and the
+// other files already in existingFiles (matched case-insensitively, since
+// the filesystem this runs on may itself be case-insensitive). errMsg is
+// empty when cleaned is safe to use as a new filename.
+func validateNewName(newName string, existingFiles []file.FileRecord, currentID uuid.UUID) (cleaned string, errMsg string) {
+	cleaned = filepath.Base(strings.TrimSpace(newName))
+	if cleaned == "." || cleaned == ".." {
+		return cleaned, "\r\n|01Invalid filename.|07\r\n"
+	}
+	for _, f := range existingFiles {
+		if strings.EqualFold(f.Filename, cleaned) && f.ID != currentID {
+			return cleaned, "\r\n|01Filename already exists in this area.|07\r\n"
+		}
+	}
+	return cleaned, ""
+}
+
+// renameConflict classifies why safeRenameOnDisk refused to rename, so the
+// caller can log and message the user exactly as the original inline case
+// did for each distinct failure.
+type renameConflict int
+
+const (
+	renameOK renameConflict = iota
+	renameTargetExists
+	renameStatFailed
+	renameFailed
+)
+
+// safeRenameOnDisk renames oldPath to newPath, refusing to clobber an
+// untracked file already on disk at the target path (the duplicate check in
+// validateNewName only consults DB records). os.SameFile permits a
+// case-only rename of the same file on a case-insensitive filesystem. A
+// stat error other than "not exist" means we cannot prove the target is
+// safe to overwrite, so it also refuses. renErr is the underlying error the
+// caller should log alongside its own node/file context; it is nil on
+// renameOK and renameTargetExists (which isn't itself an error).
+func safeRenameOnDisk(oldPath, newPath string) (conflict renameConflict, renErr error) {
+	newInfo, statErr := os.Stat(newPath)
+	switch {
+	case statErr == nil:
+		oldInfo, oldStatErr := os.Stat(oldPath)
+		if oldStatErr != nil || !os.SameFile(oldInfo, newInfo) {
+			return renameTargetExists, nil
+		}
+	case !errors.Is(statErr, os.ErrNotExist):
+		return renameStatFailed, statErr
+	}
+	if err := os.Rename(oldPath, newPath); err != nil {
+		return renameFailed, err
+	}
+	return renameOK, nil
+}
+
+// editDescription runs the "e" sysop command: prompt for a new description
+// and save it. There's no disconnect-mid-prompt LOGOFF path here (an abort
+// or read error just means "don't save"), so this is a plain void method.
+func (lb *fileLightbar) editDescription(frame *lbFrame) {
+	rec := lb.allFiles[lb.selectedIndex]
+	lb.beginFooterPrompt()
+	_ = lb.writePipe("|15New description: |07")
+	newDesc, readErr := readLineFromSessionIHAllowAbort(lb.s, lb.terminal)
+	lb.endFooterPrompt()
+	if readErr == nil && newDesc != "" {
+		if updErr := lb.e.FileMgr.UpdateFileDescription(rec.ID, newDesc); updErr != nil {
+			slog.Error("failed to update description", "node", lb.nodeNumber, "file", rec.Filename, "error", updErr)
+		} else {
+			lb.allFiles = lb.e.FileMgr.GetFilesForArea(lb.currentAreaID)
+		}
+	}
+	frame.needFullRedraw = true
+}
+
+// killFile runs the "k" sysop command: confirm and delete the selected file
+// from disk, dropping any stale tag reference to it.
+func (lb *fileLightbar) killFile(frame *lbFrame) (exit bool, result *user.User, action string, err error) {
+	rec := lb.allFiles[lb.selectedIndex]
+	confirmPrompt := fmt.Sprintf("Delete %s from disk?", rec.Filename)
+	lb.beginFooterPrompt()
+	tw, th := getTerminalSize(lb.s)
+	proceed, promptErr := lb.e.PromptYesNo(lb.s, lb.terminal, confirmPrompt, lb.outputMode, lb.nodeNumber, tw, th, false)
+	lb.endFooterPrompt()
+	if promptErr != nil {
+		if logoffIfDisconnected(promptErr) {
+			return true, nil, "LOGOFF", io.EOF
+		}
+		frame.needFullRedraw = true
+		return false, nil, "", nil
+	}
+	if proceed {
+		if delErr := lb.e.FileMgr.DeleteFileRecord(rec.ID, true); delErr != nil {
+			slog.Error("failed to delete file", "node", lb.nodeNumber, "file", rec.Filename, "error", delErr)
+		} else {
+			slog.Info("sysop deleted file from area", "node", lb.nodeNumber, "file", rec.Filename, "area", lb.currentAreaID)
+			// Remove from user's tag list so stale IDs don't reach batch download.
+			filtered := lb.currentUser.TaggedFileIDs[:0]
+			for _, tid := range lb.currentUser.TaggedFileIDs {
+				if tid != rec.ID {
+					filtered = append(filtered, tid)
+				}
+			}
+			lb.currentUser.TaggedFileIDs = filtered
+			lb.refreshFileList()
+		}
+	}
+	frame.needFullRedraw = true
+	return false, nil, "", nil
+}
+
+// moveFile runs the "m" sysop command: prompt for a target area (by ID or
+// tag), confirm, and move the selected file's record there.
+func (lb *fileLightbar) moveFile(frame *lbFrame) (exit bool, result *user.User, action string, err error) {
+	rec := lb.allFiles[lb.selectedIndex]
+	lb.beginFooterPrompt()
+	_ = lb.writePipe("|15Move to area (# or tag): |07")
+	areaInput, readErr := readLineFromSessionIHAllowAbort(lb.s, lb.terminal)
+	lb.endFooterPrompt()
+	if readErr != nil || strings.TrimSpace(areaInput) == "" {
+		frame.needFullRedraw = true
+		return false, nil, "", nil
+	}
+	// Resolve area by ID or tag.
+	targetAreaID, targetArea := resolveTargetArea(lb.e.FileMgr, areaInput)
+	if targetArea == nil {
+		lb.errMsgPause("\r\n|01Area not found.|07\r\n")
+		frame.needFullRedraw = true
+		return false, nil, "", nil
+	}
+	confirmPrompt := fmt.Sprintf("Move %s to %s?", rec.Filename, targetArea.Name)
+	_ = terminalio.WriteProcessedBytes(lb.terminal, []byte("\x1b[?25h"), lb.outputMode)
+	tw, th := getTerminalSize(lb.s)
+	proceed, promptErr := lb.e.PromptYesNo(lb.s, lb.terminal, confirmPrompt, lb.outputMode, lb.nodeNumber, tw, th, false)
+	lb.endFooterPrompt()
+	if promptErr != nil {
+		if logoffIfDisconnected(promptErr) {
+			return true, nil, "LOGOFF", io.EOF
+		}
+		frame.needFullRedraw = true
+		return false, nil, "", nil
+	}
+	if proceed {
+		if mvErr := lb.e.FileMgr.MoveFileRecord(rec.ID, targetAreaID); mvErr != nil {
+			slog.Error("failed to move file to area", "node", lb.nodeNumber, "file", rec.Filename, "area", targetAreaID, "error", mvErr)
+		} else {
+			slog.Info("sysop moved file to area", "node", lb.nodeNumber, "file", rec.Filename, "area", targetAreaID, "tag", targetArea.Tag)
+			lb.refreshFileList()
+		}
+	}
+	frame.needFullRedraw = true
+	return false, nil, "", nil
+}
+
+// renameFile runs the "r" sysop command: prompt for a new filename,
+// validate and rename it on disk, and update the file record.
+func (lb *fileLightbar) renameFile(frame *lbFrame) (exit bool, result *user.User, action string, err error) {
+	rec := lb.allFiles[lb.selectedIndex]
+	lb.beginFooterPrompt()
+	_ = lb.writePipe("|15New filename: |07")
+	newNameInput, readErr := readLineFromSessionIHAllowAbort(lb.s, lb.terminal)
+	lb.endFooterPrompt()
+	if readErr != nil || strings.TrimSpace(newNameInput) == "" {
+		frame.needFullRedraw = true
+		return false, nil, "", nil
+	}
+	newName, validateErrMsg := validateNewName(newNameInput, lb.allFiles, rec.ID)
+	if validateErrMsg != "" {
+		lb.errMsgPause(validateErrMsg)
+		frame.needFullRedraw = true
+		return false, nil, "", nil
+	}
+	oldPath, pathErr := lb.e.FileMgr.GetFilePath(rec.ID)
+	if pathErr != nil {
+		slog.Error("failed to resolve path", "node", lb.nodeNumber, "file", rec.Filename, "error", pathErr)
+		frame.needFullRedraw = true
+		return false, nil, "", nil
+	}
+	newPath := filepath.Join(filepath.Dir(oldPath), newName)
+	conflict, renErr := safeRenameOnDisk(oldPath, newPath)
+	switch conflict {
+	case renameTargetExists:
+		slog.Error("rename target already exists on disk", "node", lb.nodeNumber, "path", newPath)
+		lb.errMsgPause("\r\n|01A file with that name already exists.|07\r\n")
+		frame.needFullRedraw = true
+		return false, nil, "", nil
+	case renameStatFailed:
+		slog.Error("cannot stat rename target", "node", lb.nodeNumber, "path", newPath, "error", renErr)
+		lb.errMsgPause("\r\n|01Rename failed.|07\r\n")
+		frame.needFullRedraw = true
+		return false, nil, "", nil
+	case renameFailed:
+		slog.Error("failed to rename file", "node", lb.nodeNumber, "from", rec.Filename, "to", newName, "error", renErr)
+		lb.errMsgPause("\r\n|01Rename failed.|07\r\n")
+		frame.needFullRedraw = true
+		return false, nil, "", nil
+	}
+	if updErr := lb.e.FileMgr.UpdateFileRecord(rec.ID, func(r *file.FileRecord) {
+		r.Filename = newName
+	}); updErr != nil {
+		slog.Error("failed to update record", "node", lb.nodeNumber, "file", newName, "error", updErr)
+		if rollbackErr := os.Rename(newPath, oldPath); rollbackErr != nil {
+			slog.Error("rollback rename failed (disk/DB inconsistent)", "node", lb.nodeNumber, "file", newName, "error", rollbackErr)
+		}
+	} else {
+		slog.Info("sysop renamed file in area", "node", lb.nodeNumber, "from", rec.Filename, "to", newName, "area", lb.currentAreaID)
+		lb.allFiles = lb.e.FileMgr.GetFilesForArea(lb.currentAreaID)
+	}
+	frame.needFullRedraw = true
+	return false, nil, "", nil
+}

--- a/internal/menu/file_lightbar_sysop.go
+++ b/internal/menu/file_lightbar_sysop.go
@@ -121,7 +121,7 @@ func (lb *fileLightbar) killFile(frame *lbFrame) (exit bool, result *user.User, 
 	proceed, promptErr := lb.e.PromptYesNo(lb.s, lb.terminal, confirmPrompt, lb.outputMode, lb.nodeNumber, tw, th, false)
 	lb.endFooterPrompt()
 	if promptErr != nil {
-		if logoffIfDisconnected(promptErr) {
+		if errors.Is(promptErr, io.EOF) {
 			return true, nil, "LOGOFF", io.EOF
 		}
 		frame.needFullRedraw = true
@@ -172,7 +172,7 @@ func (lb *fileLightbar) moveFile(frame *lbFrame) (exit bool, result *user.User, 
 	proceed, promptErr := lb.e.PromptYesNo(lb.s, lb.terminal, confirmPrompt, lb.outputMode, lb.nodeNumber, tw, th, false)
 	lb.endFooterPrompt()
 	if promptErr != nil {
-		if logoffIfDisconnected(promptErr) {
+		if errors.Is(promptErr, io.EOF) {
 			return true, nil, "LOGOFF", io.EOF
 		}
 		frame.needFullRedraw = true

--- a/internal/menu/file_lightbar_sysop_test.go
+++ b/internal/menu/file_lightbar_sysop_test.go
@@ -1,0 +1,193 @@
+package menu
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/file"
+)
+
+// newTestFileManagerTwoAreas builds a real *file.FileManager with two areas
+// (ID 1 "UTILS" and ID 2 "GAMES") for resolveTargetArea to look up.
+func newTestFileManagerTwoAreas(t *testing.T) *file.FileManager {
+	t.Helper()
+	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	areasJSON := `[
+		{"id":1,"tag":"UTILS","name":"Utilities","path":"utils","acs_list":""},
+		{"id":2,"tag":"GAMES","name":"Games","path":"games","acs_list":""}
+	]`
+	if err := os.WriteFile(filepath.Join(cfgDir, "file_areas.json"), []byte(areasJSON), 0644); err != nil {
+		t.Fatalf("write areas: %v", err)
+	}
+	fm, err := file.NewFileManager(dataDir, cfgDir)
+	if err != nil {
+		t.Fatalf("NewFileManager: %v", err)
+	}
+	return fm
+}
+
+func TestResolveTargetArea_ByID(t *testing.T) {
+	fm := newTestFileManagerTwoAreas(t)
+
+	id, area := resolveTargetArea(fm, "2")
+
+	if area == nil {
+		t.Fatal("expected area to be found by ID")
+	}
+	if id != 2 || area.Tag != "GAMES" {
+		t.Errorf("resolveTargetArea(\"2\") = (%d, %+v), want (2, GAMES)", id, area)
+	}
+}
+
+func TestResolveTargetArea_ByTag(t *testing.T) {
+	fm := newTestFileManagerTwoAreas(t)
+
+	id, area := resolveTargetArea(fm, "utils")
+
+	if area == nil {
+		t.Fatal("expected area to be found by tag")
+	}
+	if id != 1 || area.Tag != "UTILS" {
+		t.Errorf("resolveTargetArea(\"utils\") = (%d, %+v), want (1, UTILS)", id, area)
+	}
+}
+
+func TestResolveTargetArea_NotFound(t *testing.T) {
+	fm := newTestFileManagerTwoAreas(t)
+
+	_, area := resolveTargetArea(fm, "NOPE")
+	if area != nil {
+		t.Errorf("resolveTargetArea(\"NOPE\") = %+v, want nil", area)
+	}
+
+	_, area = resolveTargetArea(fm, "99")
+	if area != nil {
+		t.Errorf("resolveTargetArea(\"99\") = %+v, want nil", area)
+	}
+}
+
+func TestValidateNewName(t *testing.T) {
+	id1, id2 := uuid.New(), uuid.New()
+	existing := []file.FileRecord{
+		{ID: id1, Filename: "existing.zip"},
+	}
+
+	tests := []struct {
+		name       string
+		input      string
+		currentID  uuid.UUID
+		wantClean  string
+		wantErrMsg bool
+	}{
+		{"valid new name", "renamed.zip", id2, "renamed.zip", false},
+		{"trims whitespace and path", "  ../../etc/renamed.zip  ", id2, "renamed.zip", false},
+		{"rejects dot", ".", id2, ".", true},
+		{"rejects dotdot", "..", id2, "..", true},
+		{"rejects duplicate of another file", "existing.zip", id2, "existing.zip", true},
+		{"allows renaming a file to its own current name", "existing.zip", id1, "existing.zip", false},
+		{"case-insensitive duplicate check", "EXISTING.ZIP", id2, "EXISTING.ZIP", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleaned, errMsg := validateNewName(tt.input, existing, tt.currentID)
+			if cleaned != tt.wantClean {
+				t.Errorf("cleaned = %q, want %q", cleaned, tt.wantClean)
+			}
+			if (errMsg != "") != tt.wantErrMsg {
+				t.Errorf("errMsg = %q, want non-empty=%v", errMsg, tt.wantErrMsg)
+			}
+		})
+	}
+}
+
+func TestSafeRenameOnDisk_Success(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "old.txt")
+	newPath := filepath.Join(dir, "new.txt")
+	if err := os.WriteFile(oldPath, []byte("hi"), 0644); err != nil {
+		t.Fatalf("write oldPath: %v", err)
+	}
+
+	conflict, err := safeRenameOnDisk(oldPath, newPath)
+
+	if conflict != renameOK || err != nil {
+		t.Fatalf("safeRenameOnDisk = (%v, %v), want (renameOK, nil)", conflict, err)
+	}
+	if _, statErr := os.Stat(newPath); statErr != nil {
+		t.Errorf("expected file at newPath after rename: %v", statErr)
+	}
+}
+
+func TestSafeRenameOnDisk_TargetExists(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "old.txt")
+	newPath := filepath.Join(dir, "new.txt")
+	if err := os.WriteFile(oldPath, []byte("hi"), 0644); err != nil {
+		t.Fatalf("write oldPath: %v", err)
+	}
+	if err := os.WriteFile(newPath, []byte("already here"), 0644); err != nil {
+		t.Fatalf("write newPath: %v", err)
+	}
+
+	conflict, err := safeRenameOnDisk(oldPath, newPath)
+
+	if conflict != renameTargetExists {
+		t.Errorf("conflict = %v, want renameTargetExists", conflict)
+	}
+	if err != nil {
+		t.Errorf("err = %v, want nil (renameTargetExists isn't itself an error)", err)
+	}
+	// Original file must be untouched.
+	if _, statErr := os.Stat(oldPath); statErr != nil {
+		t.Errorf("oldPath should still exist after a refused rename: %v", statErr)
+	}
+}
+
+func TestSafeRenameOnDisk_SameFileCaseOnlyRenameSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "same.txt")
+	if err := os.WriteFile(oldPath, []byte("hi"), 0644); err != nil {
+		t.Fatalf("write oldPath: %v", err)
+	}
+	// os.Stat(oldPath) via a different-cased path resolves to the same file
+	// on a case-insensitive filesystem, exercising the os.SameFile branch.
+	newPath := filepath.Join(dir, "SAME.txt")
+
+	conflict, err := safeRenameOnDisk(oldPath, newPath)
+
+	// On a case-sensitive filesystem SAME.txt won't exist yet, so this is a
+	// plain successful rename; on a case-insensitive one it's the SameFile
+	// path. Either way it must not be reported as a conflict.
+	if conflict == renameTargetExists {
+		t.Errorf("conflict = %v, want not renameTargetExists", conflict)
+	}
+	if conflict != renameOK {
+		t.Errorf("conflict = %v, err = %v, want renameOK", conflict, err)
+	}
+}
+
+func TestToggleTaggedID(t *testing.T) {
+	a, b, c := uuid.New(), uuid.New(), uuid.New()
+
+	// Adding to an empty list.
+	got := toggleTaggedID(nil, a)
+	if len(got) != 1 || got[0] != a {
+		t.Errorf("toggle onto empty list = %v, want [%v]", got, a)
+	}
+
+	// Adding a second, distinct ID.
+	got = toggleTaggedID([]uuid.UUID{a}, b)
+	if len(got) != 2 || got[0] != a || got[1] != b {
+		t.Errorf("toggle add = %v, want [%v %v]", got, a, b)
+	}
+
+	// Removing an already-tagged ID preserves the order of the rest.
+	got = toggleTaggedID([]uuid.UUID{a, b, c}, b)
+	if len(got) != 2 || got[0] != a || got[1] != c {
+		t.Errorf("toggle remove = %v, want [%v %v]", got, a, c)
+	}
+}


### PR DESCRIPTION
## Summary

`file_lightbar.go` was the largest remaining file in `internal/menu` at 846 lines — a 44-field struct, a 171-line constructor, and a **588-line `run()` method**. It's now **198 lines**, with `run()` reduced to a ~36-line loop that reads as its actual shape: clamp → refresh frame → read key → navigate → dispatch.

## Result

Most code moved into the sibling files that already owned these concerns, rather than into new ones.

| File | Lines | Role |
| --- | --- | --- |
| `file_lightbar.go` | 198 | struct, constructor, slim `run()` |
| `file_lightbar_render.go` | 273 | screen output (pre-existing + `writePipe`/`errMsgPause`) |
| `file_lightbar_layout.go` | 271 | geometry/arithmetic, no I/O |
| `file_lightbar_sysop.go` | 249 | edit-desc, kill, move, rename (new) |
| `file_lightbar_actions.go` | 245 | mark, view, download, upload (new) |
| `file_lightbar_keys.go` | 184 | nav keys, sysop-bar toggle, dispatch skeleton (new) |
| `file_lightbar_cmdbar.go` | 121 | command bar + footer-prompt pair |
| `file_lightbar_placeholders.go` | 114 | template placeholders (untouched) |
| `file_lightbar_frame.go` | 78 | smart-refresh orchestration (new) |
| `file_lightbar_info.go` | 60 | file-info overlay (new) |

Five repeated idioms were hoisted along the way (`writePipe` ×18, the footer-prompt preamble ×5, `errMsgPause` ×5, `refreshFileList` ×5, `logoffIfDisconnected` ×2), and ~30 lines of orphaned doc comments were removed — leftovers from an earlier extraction whose bodies already lived in the siblings.

## Tests

About 430 of `run()`'s 588 lines had no coverage. The split shook out genuinely pure helpers, which are now unit-tested: `computeVerticalLayout`, `computeDescMetrics`, `collectTaggedPaths`, `resolveTargetArea`, `validateNewName`, `safeRenameOnDisk`, `toggleTaggedID`, and the nav-key bounds guard.

The 9 pre-existing `TestFileLightbar_*` tests assert on **captured terminal output**, which makes them the real proof each extraction was mechanical. They are byte-for-byte unmodified and pass after every commit.

## Behavior

Two intentional changes, both isolated in their own commits:

- **`0914e03`** — guards `KeyEnter` against an empty command bar. Indexing `cmdEntries[cmdIndex]` was unguarded, so a `.BAR` config yielding no entries would panic the session. Pre-existing crash bug.
- **`calculatePageInfo` caching** — it ran twice per keystroke, O(n) each. Same values, computed once.

One change was caught in review and reverted (**`54a8e15`**): hoisting the disconnect check had uniformly applied EOF-*and*-idle-timeout logic to four confirm-prompt sites that originally checked EOF only, which would have force-logged-off a user who idled out at a "download these files?" or "kill this file?" prompt. Those sites are back to the original check, verified line-by-line including the surrounding recoverable-error paths.

Deliberately preserved rather than "fixed": the redundant double cmdBar render after the `*` sysop toggle, and the stale `filesPerPage`/`totalFiles`/`totalPages` after an `allFiles` refresh. Both are pre-existing and out of scope here.

## Verification

- `go test ./...` exit 0; `go test -race -count=1 ./internal/menu/` exit 0
- `gofmt -l` empty; `go vet` clean; `staticcheck` exit 0, zero findings
- No production exported-symbol changes (only new test functions)
- Server binary builds and boots pre-flight cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added file lightbar actions: toggle marks, view files (including ZIP archives), download marked files with confirmation, and upload files.
  * Added an info overlay for the currently selected file, plus sysop tools for edit/kill/move/rename.
* **Usability**
  * Improved lightbar navigation, terminal sizing/layout, and selective redraw behavior.
  * Standardized disconnected/idle-timeout handling and enhanced footer prompt rendering (cursor/rows).
  * Clamped selection when the current file is no longer available.
* **Bug Fixes**
  * Prevented issues when pressing Enter with an empty command bar.
* **Tests**
  * Added unit and integration-style tests for layout/metrics, tagged-path collection, and sysop helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->