### PR TITLE
fix(user): key NewUserMgrForTest by lowercased handle

### DIFF
--- a/internal/user/manager.go
+++ b/internal/user/manager.go
@@ -806,12 +806,13 @@ func (um *UserMgr) FindByAuthorizedKey(marshaled []byte) (*User, bool) {
 }
 
 // NewUserMgrForTest builds a UserMgr seeded with the given users, keyed by
-// handle. Exported so tests in other packages (e.g. cmd/vision3) can seed a
-// manager without touching the JSON load path.
+// lowercased handle to match the JSON load path and the lookup methods.
+// Exported so tests in other packages (e.g. cmd/vision3) can seed a manager
+// without touching the JSON load path.
 func NewUserMgrForTest(users ...*User) *UserMgr {
 	m := &UserMgr{users: make(map[string]*User, len(users))}
 	for _, u := range users {
-		m.users[u.Handle] = u
+		m.users[strings.ToLower(u.Handle)] = u
 	}
 	return m
 }

--- a/internal/user/manager_testhelper_test.go
+++ b/internal/user/manager_testhelper_test.go
@@ -1,0 +1,37 @@
+package user
+
+import "testing"
+
+// NewUserMgrForTest must key its map the same way the JSON load path and every
+// mutating method do — by lowercased handle — or GetUser (which lowercases the
+// lookup) silently misses users seeded with any uppercase letter.
+func TestNewUserMgrForTestMixedCaseHandleIsFindable(t *testing.T) {
+	um := NewUserMgrForTest(&User{Handle: "SysOp", AccessLevel: 255})
+
+	for _, lookup := range []string{"SysOp", "sysop", "SYSOP"} {
+		got, ok := um.GetUser(lookup)
+		if !ok {
+			t.Fatalf("GetUser(%q) = not found, want the seeded user", lookup)
+		}
+		if got.Handle != "SysOp" {
+			t.Errorf("GetUser(%q).Handle = %q, want %q", lookup, got.Handle, "SysOp")
+		}
+		if got.AccessLevel != 255 {
+			t.Errorf("GetUser(%q).AccessLevel = %d, want 255", lookup, got.AccessLevel)
+		}
+	}
+}
+
+// Lowercase handles worked before the key was normalized; keep them covered so
+// the fix can't regress the existing callers.
+func TestNewUserMgrForTestLowercaseHandleStillFindable(t *testing.T) {
+	um := NewUserMgrForTest(&User{Handle: "boss", AccessLevel: 250})
+
+	got, ok := um.GetUser("boss")
+	if !ok {
+		t.Fatal("GetUser(\"boss\") = not found, want the seeded user")
+	}
+	if got.AccessLevel != 250 {
+		t.Errorf("AccessLevel = %d, want 250", got.AccessLevel)
+	}
+}


### PR DESCRIPTION
## Problem

`NewUserMgrForTest` seeded its map with the raw `Handle`:

```go
m.users[u.Handle] = u
```

but `GetUser` — like `UpdateUser`, `DeleteUser`, and the JSON load path — looks up by lowercased handle:

```go
user, exists := um.users[strings.ToLower(handle)]
```

So any user seeded through the helper with an uppercase letter in their handle was unreachable. The failure mode is a **silent miss** rather than an error, so a test using a realistic handle like `SysOp` fails in a way that points nowhere near the helper.

Every other write to the `users` map in `manager.go` already lowercases the key (lines 108, 170, 388, 415, 579, 774). This was the lone outlier.

## Fix

One line, plus tests. Found while writing coverage for `internal/menu` in #143, which worked around it by using the real `NewUserManager`+`AddUser` path.

## Tests

`TestNewUserMgrForTestMixedCaseHandleIsFindable` reproduces the bug — it fails before the change with `GetUser("SysOp") = not found` — and checks the seeded user is retrievable by `SysOp`, `sysop`, and `SYSOP`. A companion test pins the lowercase case that already worked, so the fix can't regress the existing callers.

## Compatibility

The three existing callers (`cmd/vision3/wfc_admin_test.go`) all use lowercase handles, so they passed by accident and are unaffected. Verified: `go test ./cmd/vision3/` and the full `go test ./...` both pass; `gofmt` and `go vet` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved case-insensitive user lookup behavior for handles with mixed capitalization.
  - Preserved the original handle and access level when users are retrieved.

- **Tests**
  - Added coverage for mixed-case and lowercase handle lookups to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->