### PR TITLE
fix(user): roll back the cache when UpdateUser's save fails

### DIFF
--- a/internal/user/manager.go
+++ b/internal/user/manager.go
@@ -416,7 +416,7 @@ func (um *UserMgr) UpdateUser(u *User) error {
 	um.users[lowerHandle] = &userCopy
 	if err := um.saveUsersLocked(); err != nil {
 		// Restore the previous entry so the cache never serves a value that
-		// failed to reach disk, matching AddUser and RenameUser.
+		// failed to reach disk, matching AddUser and UpdateUserByID.
 		um.users[lowerHandle] = previous
 		return err
 	}

--- a/internal/user/manager.go
+++ b/internal/user/manager.go
@@ -412,8 +412,15 @@ func (um *UserMgr) UpdateUser(u *User) error {
 	}
 	// Create a defensive copy to prevent external mutations from bypassing locks
 	userCopy := *u
+	previous := um.users[lowerHandle]
 	um.users[lowerHandle] = &userCopy
-	return um.saveUsersLocked()
+	if err := um.saveUsersLocked(); err != nil {
+		// Restore the previous entry so the cache never serves a value that
+		// failed to reach disk, matching AddUser and RenameUser.
+		um.users[lowerHandle] = previous
+		return err
+	}
+	return nil
 }
 
 // LogAdminActivity logs an administrative action to the activity log file

--- a/internal/user/manager_update_rollback_test.go
+++ b/internal/user/manager_update_rollback_test.go
@@ -1,0 +1,50 @@
+package user
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// UpdateUser writes the user into the in-memory map before persisting. If the
+// save fails it must restore the previous entry, the way AddUser and RenameUser
+// do — otherwise the in-process cache serves data that never reached disk, for
+// the rest of the process's life.
+func TestUpdateUserRollsBackCacheWhenSaveFails(t *testing.T) {
+	dir := t.TempDir()
+	um, err := NewUserManager(dir)
+	if err != nil {
+		t.Fatalf("NewUserManager: %v", err)
+	}
+	if _, err := um.AddUser("password", "Tester", "Real Name", "Loc"); err != nil {
+		t.Fatalf("AddUser: %v", err)
+	}
+
+	// Make the store unwritable so the save inside UpdateUser fails. Chmod the
+	// file, not the directory: the owner can still rewrite an existing file
+	// regardless of the directory's mode.
+	usersPath := filepath.Join(dir, "users.json")
+	if err := os.Chmod(usersPath, 0o400); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(usersPath, 0o600) })
+
+	before, ok := um.GetUser("Tester")
+	if !ok {
+		t.Fatal("seeded user not found")
+	}
+
+	modified := *before
+	modified.RealName = "Should Not Stick"
+	if err := um.UpdateUser(&modified); err == nil {
+		t.Fatal("UpdateUser returned nil error; expected the read-only store to fail the save")
+	}
+
+	after, ok := um.GetUser("Tester")
+	if !ok {
+		t.Fatal("user missing from cache after failed update")
+	}
+	if after.RealName != before.RealName {
+		t.Errorf("cache holds unsaved value %q; want rollback to %q", after.RealName, before.RealName)
+	}
+}

--- a/internal/user/manager_update_rollback_test.go
+++ b/internal/user/manager_update_rollback_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 // UpdateUser writes the user into the in-memory map before persisting. If the
-// save fails it must restore the previous entry, the way AddUser and RenameUser
-// do — otherwise the in-process cache serves data that never reached disk, for
-// the rest of the process's life.
+// save fails it must restore the previous entry, the way AddUser and
+// UpdateUserByID do — otherwise the in-process cache serves data that never
+// reached disk, for the rest of the process's life.
 func TestUpdateUserRollsBackCacheWhenSaveFails(t *testing.T) {
 	dir := t.TempDir()
 	um, err := NewUserManager(dir)
@@ -20,14 +20,15 @@ func TestUpdateUserRollsBackCacheWhenSaveFails(t *testing.T) {
 		t.Fatalf("AddUser: %v", err)
 	}
 
-	// Make the store unwritable so the save inside UpdateUser fails. Chmod the
-	// file, not the directory: the owner can still rewrite an existing file
-	// regardless of the directory's mode.
-	usersPath := filepath.Join(dir, "users.json")
-	if err := os.Chmod(usersPath, 0o400); err != nil {
-		t.Fatalf("chmod: %v", err)
+	// Point the store at an existing directory: os.WriteFile can never write
+	// bytes into a directory inode, so the save fails deterministically on every
+	// platform and regardless of privileges. (chmod would not — the owner can
+	// still rewrite a read-only file, and root ignores the mode entirely.)
+	blocker := filepath.Join(dir, "blocked")
+	if err := os.MkdirAll(blocker, 0o750); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
 	}
-	t.Cleanup(func() { _ = os.Chmod(usersPath, 0o600) })
+	um.path = blocker
 
 	before, ok := um.GetUser("Tester")
 	if !ok {
@@ -37,7 +38,7 @@ func TestUpdateUserRollsBackCacheWhenSaveFails(t *testing.T) {
 	modified := *before
 	modified.RealName = "Should Not Stick"
 	if err := um.UpdateUser(&modified); err == nil {
-		t.Fatal("UpdateUser returned nil error; expected the read-only store to fail the save")
+		t.Fatal("UpdateUser returned nil error; expected the unwritable store to fail the save")
 	}
 
 	after, ok := um.GetUser("Tester")


### PR DESCRIPTION
## Problem

`UpdateUser` wrote its defensive copy into the in-memory map *before* persisting, then returned the save error without undoing it:

```go
userCopy := *u
um.users[lowerHandle] = &userCopy
return um.saveUsersLocked()   // on error, the map keeps the new value
```

So on a failed save the in-process cache serves a value that never reached disk — and since nothing reloads the map, it keeps serving it for the rest of the process's life. Every `GetUser` in that session sees phantom data, and a later successful save from any other code path writes it out for real.

`AddUser` and `UpdateUserByID` already handle this: `AddUser` does `delete(um.users, lowerHandle)` plus `nextUserID--`, and `UpdateUserByID` keeps an `originalEntry` explicitly commented "save for rollback". `UpdateUser` was the lone outlier — the same shape as the `NewUserMgrForTest` key bug in #144, where six sites lowercased the map key and one didn't.

## Found via

Fixing the menu-layer equivalent in #146 (eight config handlers that didn't roll back `currentUser` on save failure). Writing tests for that surfaced this one layer down: the menu fix is still correct, but rolling back the session's user object doesn't help if the manager's cache stays wrong.

## Test

`TestUpdateUserRollsBackCacheWhenSaveFails` forces a genuine save failure and asserts the cache still holds the original value. It fails against the pre-fix code with:

```
cache holds unsaved value "Should Not Stick"; want rollback to "Real Name"
```

The failure is forced by pointing `um.path` at an existing **directory**: `os.WriteFile` can never write bytes into a directory inode, so this is deterministic on every platform and regardless of privileges. An earlier revision used `chmod(0400)`, which is *not* reliable — root ignores the mode, and on some platforms the owner can rewrite a read-only file — so it would have needed a Windows/root skip and lost coverage there.

## Verification

`go test ./...` exit 0; `gofmt` and `go vet` clean. RED re-confirmed against the pre-fix code after switching seams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User updates now roll back safely if saving fails, keeping in-memory cached user details consistent with successfully persisted data.

* **Tests**
  * Added coverage to verify that when an update cannot be saved, the original cached user information remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->