### PR TITLE
fix(menu): measure user-facing text in characters, not bytes

### DIFF
--- a/internal/menu/area_lightbar_render.go
+++ b/internal/menu/area_lightbar_render.go
@@ -51,8 +51,10 @@ func (p *areaLightbarPicker[T]) renderItemArea() error {
 		line := p.buildItemLine(p.items[idx], idx+1)
 		if idx == p.selectedIndex {
 			stripped := stripAreaAnsi(line)
-			if len(stripped) > p.termWidth {
-				stripped = stripped[:p.termWidth]
+			// Runes, not bytes: the row text comes from area Tag/Name/
+			// Description, which can hold multi-byte characters.
+			if strippedRunes := []rune(stripped); len(strippedRunes) > p.termWidth {
+				stripped = string(strippedRunes[:p.termWidth])
 			}
 			rendered := p.hiColorSeq + padRight(stripped, p.termWidth) + "\x1b[0m"
 			if err := terminalio.WriteProcessedBytes(p.terminal, []byte(rendered), p.outputMode); err != nil {

--- a/internal/menu/area_lightbar_test.go
+++ b/internal/menu/area_lightbar_test.go
@@ -154,6 +154,31 @@ func TestRenderItemAreaInvokesBuilder(t *testing.T) {
 	}
 }
 
+// renderItemArea clamps the highlighted row's stripped text to termWidth
+// with len(stripped) and stripped[:p.termWidth] — both byte counts. The row
+// text comes from area Tag/Name/Description, which can hold multi-byte
+// characters, so a byte-based clamp can split it mid-rune.
+func TestRenderItemAreaHighlightedRowClampsByRunes(t *testing.T) {
+	// 20 CJK runes = 60 bytes, well past termWidth=10.
+	longName := strings.Repeat("日", 20)
+	p, out, _ := newTestPicker(1, 5)
+	p.buildItemLine = func(item string, displayIdx int) string { return longName }
+	p.termWidth = 10
+	p.selectedIndex = 0
+	p.hiColorSeq = "\x1b[44m"
+	p.outputMode = ansi.OutputModeUTF8
+
+	if err := p.renderItemArea(); err != nil {
+		t.Fatalf("renderItemArea: %v", err)
+	}
+
+	// A rune-correct clamp keeps all 10 runes of the highlighted row (it is
+	// clamped to termWidth runes, not bytes).
+	if got, want := strings.Count(out.String(), "日"), 10; got != want {
+		t.Errorf("highlighted row has %d intact '日' runes, want %d (output %q)", got, want, out.String())
+	}
+}
+
 func TestComputeLayout(t *testing.T) {
 	p, _, _ := newTestPicker(1, 0)
 	p.termHeight = 24

--- a/internal/menu/chat.go
+++ b/internal/menu/chat.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gliderlabs/ssh"
 	term "golang.org/x/term"
@@ -282,13 +283,17 @@ func runChat(c *cmdCtx, args string) (*user.User, string, error) {
 		artPath := filepath.Join(e.MenuSetPath, "ansi", "CHATHEADER.ANS")
 		artData, artErr := ansi.GetAnsiFileContent(artPath)
 		if artErr == nil {
-			// Replace MCI placeholders (ASCII — safe before CP437 conversion).
-			artData = chatArtReplace(artData, "NET", currentNetwork)
-			artData = chatArtReplace(artData, "ROOM", currentRoom)
-			artData = chatArtReplace(artData, "TOPIC", currentTopic)
 			// Convert CP437 high bytes to UTF-8 so box-drawing chars render
 			// correctly on UTF-8 SSH terminals.
 			artData = ansi.ConvertCP437ToUTF8(artData)
+			// Substitute AFTER the conversion. The network name comes from a
+			// V3Net leaf and can be non-ASCII; substituting first would feed its
+			// UTF-8 bytes through the CP437 converter, which reinterprets each
+			// byte separately and garbles the name rather than just cutting it.
+			// The @NAME@ placeholders are ASCII, so conversion leaves them intact.
+			artData = chatArtReplace(artData, "NET", currentNetwork)
+			artData = chatArtReplace(artData, "ROOM", currentRoom)
+			artData = chatArtReplace(artData, "TOPIC", currentTopic)
 			// Split into lines (SAUCE already stripped by GetAnsiFileContent).
 			lines := strings.Split(string(artData), "\n")
 			for i := 0; i < chatHeaderRows && i < len(lines); i++ {
@@ -808,12 +813,16 @@ func chatArtReplace(data []byte, name, value string) []byte {
 	if end < 0 {
 		return data
 	}
-	totalLen := len(tag) + end + 1 // full placeholder byte span including both @s
-	repl := []byte(value)
-	if len(repl) > totalLen {
-		repl = repl[:totalLen]
+	totalLen := len(tag) + end + 1 // placeholder span; ASCII, so bytes == columns
+	// Fill by columns, not bytes: the NET value is a V3Net leaf network name and
+	// is not ASCII-gated, so byte padding would leave the row short and byte
+	// truncation would cut a rune in half.
+	runes := []rune(value)
+	if len(runes) > totalLen {
+		runes = runes[:totalLen]
 	}
-	for len(repl) < totalLen {
+	repl := []byte(string(runes))
+	for utf8.RuneCount(repl) < totalLen {
 		repl = append(repl, ' ')
 	}
 	out := make([]byte, 0, len(data))

--- a/internal/menu/chat_art_test.go
+++ b/internal/menu/chat_art_test.go
@@ -1,0 +1,41 @@
+package menu
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// chatArtReplace fills fixed-width @NAME####@ placeholders in CHATHEADER.ANS.
+// The NET value is a V3Net leaf network name, which is not ASCII-gated, so the
+// placeholder must be filled by columns rather than bytes — otherwise the row
+// width shifts and a multi-byte name is cut mid-sequence.
+func TestChatArtReplaceFillsPlaceholderByColumns(t *testing.T) {
+	// A 10-column placeholder: "@NET" + 5 fill chars + "@".
+	const placeholder = "@NET#####@"
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"ascii short", "FSX"},
+		{"ascii exact", "ABCDEFGHIJ"},
+		{"ascii long", "ABCDEFGHIJKLMNOP"},
+		{"multi-byte short", "café"},
+		{"multi-byte overlong", "café société normande"},
+		{"cjk overlong", "日本語のネットワーク"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			art := "|" + placeholder + "|"
+			got := string(chatArtReplace([]byte(art), "NET", tt.value))
+
+			if !utf8.ValidString(got) {
+				t.Fatalf("chatArtReplace produced invalid UTF-8: %q", got)
+			}
+			inner := strings.TrimSuffix(strings.TrimPrefix(got, "|"), "|")
+			if n := utf8.RuneCountInString(inner); n != utf8.RuneCountInString(placeholder) {
+				t.Errorf("filled width = %d columns, want %d (%q)", n, utf8.RuneCountInString(placeholder), inner)
+			}
+		})
+	}
+}

--- a/internal/menu/conference_menu.go
+++ b/internal/menu/conference_menu.go
@@ -424,7 +424,6 @@ func padRight(s string, width int) string {
 	return s + strings.Repeat(" ", width-n)
 }
 
-// truncateStr truncates s to maxLen characters, appending ".." if truncated.
 // truncateStr clamps s to maxLen columns, appending ".." when it cuts.
 // Measured and cut in runes so a multi-byte name is never split mid-sequence:
 // several callers render text fetched from the remote V3Net registry.

--- a/internal/menu/conference_menu.go
+++ b/internal/menu/conference_menu.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/conference"
@@ -412,22 +413,30 @@ func displayMessageAreaListFiltered(e *MenuExecutor, s ssh.Session, terminal *te
 }
 
 // padRight pads s with spaces on the right to the given width. If s is already wider, it is returned as-is.
+// padRight pads s with spaces to width columns. Counted in runes, not bytes:
+// callers pass area, conference and network names that can hold multi-byte
+// characters, and byte padding would leave the column short.
 func padRight(s string, width int) string {
-	if len(s) >= width {
+	n := utf8.RuneCountInString(s)
+	if n >= width {
 		return s
 	}
-	return s + strings.Repeat(" ", width-len(s))
+	return s + strings.Repeat(" ", width-n)
 }
 
 // truncateStr truncates s to maxLen characters, appending ".." if truncated.
+// truncateStr clamps s to maxLen columns, appending ".." when it cuts.
+// Measured and cut in runes so a multi-byte name is never split mid-sequence:
+// several callers render text fetched from the remote V3Net registry.
 func truncateStr(s string, maxLen int) string {
-	if len(s) <= maxLen {
+	if utf8.RuneCountInString(s) <= maxLen {
 		return s
 	}
+	runes := []rune(s)
 	if maxLen <= 2 {
-		return s[:maxLen]
+		return string(runes[:maxLen])
 	}
-	return s[:maxLen-2] + ".."
+	return string(runes[:maxLen-2]) + ".."
 }
 
 // findFirstAccessibleAreaInConference returns the first area the user can read in the given conference.

--- a/internal/menu/conference_menu_test.go
+++ b/internal/menu/conference_menu_test.go
@@ -1,0 +1,77 @@
+package menu
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// padRight and truncateStr lay out the area, conference, file and V3Net
+// pickers. Both must work in characters: their inputs include area and
+// conference names from UTF-8 JSON and network names fetched from the remote
+// V3Net registry.
+
+func TestPadRightPadsToVisibleColumns(t *testing.T) {
+	tests := []struct {
+		name  string
+		s     string
+		width int
+		want  int // expected visible columns
+	}{
+		{"ascii shorter", "abc", 10, 10},
+		{"ascii exact", "abcdefghij", 10, 10},
+		{"ascii longer left alone", "abcdefghijkl", 10, 12},
+		{"multi-byte padded by runes", "café", 10, 10},
+		{"cjk padded by runes", "日本語", 10, 10},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := utf8.RuneCountInString(padRight(tt.s, tt.width))
+			if got != tt.want {
+				t.Errorf("padRight(%q, %d) = %d columns, want %d", tt.s, tt.width, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTruncateStrCutsOnRuneBoundaries(t *testing.T) {
+	tests := []struct {
+		name   string
+		s      string
+		maxLen int
+		want   string
+	}{
+		{"shorter than max", "abc", 10, "abc"},
+		{"exactly max", "abcde", 5, "abcde"},
+		{"longer gets ellipsis", "abcdefgh", 5, "abc.."},
+		{"maxLen 2 hard cut", "abcdef", 2, "ab"},
+		{"multi-byte fits by runes", "café", 4, "café"},
+		{"multi-byte cut on boundary", "café society", 6, "café.."},
+		{"cjk cut on boundary", "日本語のメッセージ", 5, "日本語.."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateStr(tt.s, tt.maxLen)
+			if got != tt.want {
+				t.Errorf("truncateStr(%q, %d) = %q, want %q", tt.s, tt.maxLen, got, tt.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("truncateStr(%q, %d) produced invalid UTF-8: %q", tt.s, tt.maxLen, got)
+			}
+		})
+	}
+}
+
+// The two are used together to build fixed-width rows; a multi-byte name must
+// not push the row wider than the column budget.
+func TestPadRightAfterTruncateStrHoldsColumnBudget(t *testing.T) {
+	for _, name := range []string{"ascii name", "café society", "日本語のメッセージ"} {
+		row := padRight(truncateStr(name, 12), 12)
+		if got := utf8.RuneCountInString(row); got != 12 {
+			t.Errorf("row for %q = %d columns, want 12 (%q)", name, got, row)
+		}
+		if strings.Contains(row, "�") {
+			t.Errorf("row for %q contains a replacement char: %q", name, row)
+		}
+	}
+}

--- a/internal/menu/executor_input_helpers.go
+++ b/internal/menu/executor_input_helpers.go
@@ -58,7 +58,10 @@ func writeCenteredPausePrompt(s ssh.Session, terminal *term.Terminal, pausePromp
 	// Center the pause prompt if terminal width is available
 	if termWidth > 0 {
 		// Calculate visible text width (excluding ANSI escape sequences)
-		visibleWidth := calculateVisibleWidth(string(pauseBytesToWrite))
+		// ansi.VisibleLength advances a rune at a time, so this is correct in
+		// UTF-8 mode; in CP437 mode the raw high bytes are invalid UTF-8 and
+		// decode as one RuneError each, which is also one column apiece.
+		visibleWidth := ansi.VisibleLength(string(pauseBytesToWrite))
 
 		if visibleWidth < termWidth {
 			// Calculate centering offset

--- a/internal/menu/executor_input_helpers_test.go
+++ b/internal/menu/executor_input_helpers_test.go
@@ -1,0 +1,48 @@
+package menu
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+)
+
+var centerCursorRe = regexp.MustCompile(`\r\x1b\[(\d+)C`)
+
+// The pause prompt is centered by measuring its visible width. That width must
+// be counted in characters: the shipped pauseString contains U+25A0 block
+// glyphs, which are 3 bytes each in UTF-8 mode, so a byte count over-measures
+// and shifts the prompt left of center.
+func TestWriteCenteredPausePromptCentersByVisibleColumns(t *testing.T) {
+	const termWidth = 80
+	// Mirrors the shipped strings.json pauseString shape: pipe codes plus
+	// multi-byte block glyphs around ASCII text.
+	prompt := "|15■|07■|08■ |15SlAm eNtEr!|08 ■|07■|15■"
+
+	ts := newTestSession("\r")
+	terminal := newTestTerminal(ts)
+
+	if err := writeCenteredPausePrompt(ts, terminal, prompt, ansi.OutputModeUTF8, termWidth, 24); err != nil {
+		t.Fatalf("writeCenteredPausePrompt: %v", err)
+	}
+
+	m := centerCursorRe.FindStringSubmatch(ts.output())
+	if m == nil {
+		t.Fatalf("no centering cursor move found in output %q", ts.output())
+	}
+	gotPad, err := strconv.Atoi(m[1])
+	if err != nil {
+		t.Fatalf("bad cursor column %q: %v", m[1], err)
+	}
+
+	// Expected padding from the visible text, pipe codes removed.
+	visible := strings.NewReplacer("|15", "", "|07", "", "|08", "").Replace(prompt)
+	wantPad := (termWidth - utf8.RuneCountInString(visible)) / 2
+	if gotPad != wantPad {
+		t.Errorf("left padding = %d, want %d (visible text %q is %d columns, %d bytes)",
+			gotPad, wantPad, visible, utf8.RuneCountInString(visible), len(visible))
+	}
+}

--- a/internal/menu/executor_prompt.go
+++ b/internal/menu/executor_prompt.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/editor"
@@ -73,7 +74,9 @@ func (e *MenuExecutor) promptYesNoLightbar(s ssh.Session, terminal *term.Termina
 
 		// Total visible width of the options area (used for cursor-backward repositioning).
 		// This avoids cursor save/restore which is unreliable across terminals.
-		optionsWidth := len(noOptionText) + optionSpacing + len(yesOptionText)
+		// Runes, not bytes: Yes/No labels are sysop-configurable strings and a
+		// localized label can hold multi-byte characters.
+		optionsWidth := utf8.RuneCountInString(noOptionText) + optionSpacing + utf8.RuneCountInString(yesOptionText)
 
 		// Track current selection: 0 = No, 1 = Yes
 		selectedIndex := 0

--- a/internal/menu/executor_prompt_test.go
+++ b/internal/menu/executor_prompt_test.go
@@ -12,14 +12,14 @@ import (
 
 var promptCursorBackRe = regexp.MustCompile(`\x1b\[(\d+)D`)
 
-// promptYesNoLightbar computes optionsWidth = len(noOptionText) + spacing +
-// len(yesOptionText), counting bytes, and uses it to move the cursor
-// backward (CursorBackward) before erasing and redrawing the options. The
-// shipped Yes/No labels are ASCII ("Yes"/"No"), so this is unreachable
-// today, but a localized label with multi-byte characters would move the
-// cursor too far and the following "\x1b[K" would erase into the prompt
-// text itself. This test uses custom labels to exercise that path
-// pre-emptively.
+// promptYesNoLightbar sums the option-label widths and uses the total to move
+// the cursor backward (CursorBackward) before erasing and redrawing the
+// options. That sum used to count bytes; it now counts runes. The
+// shipped Yes/No labels are ASCII ("Yes"/"No"), so the byte version was never
+// reachable in practice — but a localized label with multi-byte characters
+// would have moved the cursor too far, and the following "\x1b[K" would have
+// erased into the prompt text itself. This test uses custom labels to keep
+// that path correct.
 func TestPromptYesNoLightbarCursorBackIsRuneWidth(t *testing.T) {
 	yesLabel := "はい" // 2 runes, 6 bytes
 	noLabel := "いいえ" // 3 runes, 9 bytes

--- a/internal/menu/executor_prompt_test.go
+++ b/internal/menu/executor_prompt_test.go
@@ -1,0 +1,54 @@
+package menu
+
+import (
+	"regexp"
+	"strconv"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+)
+
+var promptCursorBackRe = regexp.MustCompile(`\x1b\[(\d+)D`)
+
+// promptYesNoLightbar computes optionsWidth = len(noOptionText) + spacing +
+// len(yesOptionText), counting bytes, and uses it to move the cursor
+// backward (CursorBackward) before erasing and redrawing the options. The
+// shipped Yes/No labels are ASCII ("Yes"/"No"), so this is unreachable
+// today, but a localized label with multi-byte characters would move the
+// cursor too far and the following "\x1b[K" would erase into the prompt
+// text itself. This test uses custom labels to exercise that path
+// pre-emptively.
+func TestPromptYesNoLightbarCursorBackIsRuneWidth(t *testing.T) {
+	yesLabel := "はい" // 2 runes, 6 bytes
+	noLabel := "いいえ" // 3 runes, 9 bytes
+
+	e := &MenuExecutor{
+		LoadedStrings: config.StringsConfig{YesPromptText: yesLabel, NoPromptText: noLabel},
+	}
+	ts := newTestSession("\x1b[C\r") // toggle selection, then confirm
+	terminal := newTestTerminal(ts)
+
+	if _, err := e.PromptYesNo(ts, terminal, "Continue?", ansi.OutputModeUTF8, 1, 80, 24, false); err != nil {
+		t.Fatalf("PromptYesNo: %v", err)
+	}
+
+	out := ts.output()
+	matches := promptCursorBackRe.FindAllStringSubmatch(out, -1)
+	if len(matches) == 0 {
+		t.Fatalf("no cursor-backward sequence found in output %q", out)
+	}
+
+	// optionsWidth = " いいえ " + 2 spacing + " はい " (rune counts: 5 + 2 + 4 = 11).
+	wantWidth := utf8.RuneCountInString(" "+noLabel+" ") + 2 + utf8.RuneCountInString(" "+yesLabel+" ")
+	for _, m := range matches {
+		got, err := strconv.Atoi(m[1])
+		if err != nil {
+			t.Fatalf("parse cursor-back count %q: %v", m[1], err)
+		}
+		if got != wantWidth {
+			t.Errorf("cursor-backward count = %d, want %d (visible width of the options area); output %q", got, wantWidth, out)
+		}
+	}
+}

--- a/internal/menu/executor_text_utils.go
+++ b/internal/menu/executor_text_utils.go
@@ -15,37 +15,6 @@ import (
 
 // colorCodeToAnsi converts a DOS-style color code (0-255) to ANSI escape sequence.
 // Assumes Color = Background*16 + Foreground
-// calculateVisibleWidth calculates the visible width of text, excluding ANSI escape sequences.
-// This is used for centering text that contains color codes.
-func calculateVisibleWidth(text string) int {
-	width := 0
-	inEscape := false
-
-	for i := 0; i < len(text); i++ {
-		ch := text[i]
-
-		if ch == '\x1b' {
-			// Start of ANSI escape sequence
-			inEscape = true
-			continue
-		}
-
-		if inEscape {
-			// Skip characters until we hit a letter (end of ANSI sequence)
-			if (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') {
-				inEscape = false
-			}
-			continue
-		}
-
-		// Count visible characters (excluding control characters)
-		if ch >= 32 {
-			width++
-		}
-	}
-
-	return width
-}
 
 func colorCodeToAnsi(code int) string {
 	fgCode := code % 16

--- a/internal/menu/file_area_lightbar_select.go
+++ b/internal/menu/file_area_lightbar_select.go
@@ -217,8 +217,10 @@ func runSelectFileAreaLightbar(c *cmdCtx, args string) (*user.User, string, erro
 			line := buildItemLine(areas[idx], idx+1)
 			if idx == selectedIndex {
 				stripped := stripAreaAnsi(line)
-				if len(stripped) > termWidth {
-					stripped = stripped[:termWidth]
+				// Runes, not bytes: the row includes area Description, which is
+				// inserted unconstrained and can hold multi-byte characters.
+				if strippedRunes := []rune(stripped); len(strippedRunes) > termWidth {
+					stripped = string(strippedRunes[:termWidth])
 				}
 				rendered := hiColorSeq + padRight(stripped, termWidth) + "\x1b[0m"
 				if err := terminalio.WriteProcessedBytes(terminal, []byte(rendered), outputMode); err != nil {

--- a/internal/menu/file_area_lightbar_select_test.go
+++ b/internal/menu/file_area_lightbar_select_test.go
@@ -1,0 +1,89 @@
+package menu
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/file"
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+// runSelectFileAreaLightbar's renderItemArea clamps the highlighted row's
+// stripped text to termWidth with len(stripped) and stripped[:termWidth] —
+// both byte counts, the same shape as the site D bug fixed in
+// area_lightbar_render.go (see 13acfda). The row's Description field is
+// inserted by buildItemLine without any padRight/truncateStr constraint, so
+// a long, multi-byte file-area description (sysop-editable UTF-8 JSON) can
+// push the row's byte length over termWidth while landing the clamp
+// mid-rune.
+func TestRunSelectFileAreaLightbarHighlightedRowClampsByRunes(t *testing.T) {
+	menuSetPath := t.TempDir()
+	templatesDir := filepath.Join(menuSetPath, "templates")
+	if err := os.MkdirAll(templatesDir, 0755); err != nil {
+		t.Fatalf("mkdir templates: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(templatesDir, "FILEAREA.TOP"), []byte("Areas\r\n"), 0644); err != nil {
+		t.Fatalf("write TOP: %v", err)
+	}
+	// ^ID(3) + " " + ^TAG(16) + " " + ^NA(38) + " " + ^DS(unconstrained) = 60
+	// fixed ASCII visible columns before the description.
+	if err := os.WriteFile(filepath.Join(templatesDir, "FILEAREA.MID"), []byte("^ID ^TAG ^NA ^DS\r\n"), 0644); err != nil {
+		t.Fatalf("write MID: %v", err)
+	}
+
+	// 30 CJK runes (90 bytes) pushes the row's visible width to 60+30=90,
+	// over termWidth=80, and its byte length to 60+90=150 bytes, so a
+	// byte-based clamp at 80 lands well inside the description.
+	longDesc := strings.Repeat("日", 30)
+
+	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	areasJSON := `[{"id":1,"tag":"UTILS","name":"Utilities","description":"` + longDesc + `","path":"utils","acs_list":""}]`
+	if err := os.WriteFile(filepath.Join(cfgDir, "file_areas.json"), []byte(areasJSON), 0644); err != nil {
+		t.Fatalf("write areas: %v", err)
+	}
+	fm, err := file.NewFileManager(dataDir, cfgDir)
+	if err != nil {
+		t.Fatalf("NewFileManager: %v", err)
+	}
+
+	um, err := user.NewUserManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewUserManager: %v", err)
+	}
+	u, err := um.AddUser("password", "Tester", "Real Name", "Loc")
+	if err != nil {
+		t.Fatalf("AddUser: %v", err)
+	}
+	u.AccessLevel = 255
+
+	e := &MenuExecutor{FileMgr: fm, MenuSetPath: menuSetPath}
+	ts := newTestSession("q")
+	terminal := newTestTerminal(ts)
+
+	c := &cmdCtx{
+		e: e, s: ts, terminal: terminal, userManager: um, currentUser: u,
+		nodeNumber: 1, outputMode: ansi.OutputModeUTF8, termWidth: 80, termHeight: 24,
+	}
+
+	if _, _, err := runSelectFileAreaLightbar(c, ""); err != nil {
+		t.Fatalf("runSelectFileAreaLightbar: %v", err)
+	}
+
+	out := ts.output()
+	// A rune-correct clamp to termWidth=80 keeps all 30 "日" runes intact
+	// (60 fixed ASCII columns + 30 description columns = 90, over 80, so the
+	// row IS clamped — but on a rune boundary, so every rune that survives
+	// is intact; the point under test is that none are split).
+	if strings.Contains(out, "�") {
+		t.Errorf("output contains the Unicode replacement character, row was split mid-rune: %q", out)
+	}
+	// Provably wrong under the byte-based bug: it keeps only 20/3=6 whole
+	// runes (18 of the 20 bytes remaining after the 60-byte ASCII prefix)
+	// plus a stray glyph. A rune-correct clamp keeps min(30, 80-60)=20 runes.
+	if got, want := strings.Count(out, "日"), 20; got != want {
+		t.Errorf("highlighted row has %d intact '日' runes, want %d (output %q)", got, want, out)
+	}
+}

--- a/internal/menu/file_newscan.go
+++ b/internal/menu/file_newscan.go
@@ -128,9 +128,11 @@ func runFileNewscan(c *cmdCtx, args string) (*user.User, string, error) {
 				desc = string(descRunes[:maxDesc-3]) + "..."
 			}
 
+			// Clamp in runes so a multi-byte filename is not cut mid-sequence,
+			// matching executor_files_list_render.go and file_lightbar_render.go.
 			fname := f.Filename
-			if len(fname) > 12 {
-				fname = fname[:12]
+			if fnameRunes := []rune(fname); len(fnameRunes) > 12 {
+				fname = string(fnameRunes[:12])
 			}
 
 			line := midTemplate

--- a/internal/menu/file_newscan.go
+++ b/internal/menu/file_newscan.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/editor"
@@ -121,8 +122,10 @@ func runFileNewscan(c *cmdCtx, args string) (*user.User, string, error) {
 			if maxDesc < 10 {
 				maxDesc = 10
 			}
-			if len(desc) > maxDesc {
-				desc = desc[:maxDesc-3] + "..."
+			// Runes, not bytes: FILE_ID.DIZ descriptions are UTF-8 (converted by
+			// internal/ziplab/diz.go cleanDIZ) and can hold multi-byte characters.
+			if descRunes := []rune(desc); len(descRunes) > maxDesc {
+				desc = string(descRunes[:maxDesc-3]) + "..."
 			}
 
 			fname := f.Filename
@@ -298,10 +301,11 @@ func runFileNewscanConfig(c *cmdCtx, args string) (*user.User, string, error) {
 	previousViewportOffset := 0
 
 	padRight := func(s string, width int) string {
-		if len(s) >= width {
+		n := utf8.RuneCountInString(s)
+		if n >= width {
 			return s
 		}
-		return s + strings.Repeat(" ", width-len(s))
+		return s + strings.Repeat(" ", width-n)
 	}
 
 	formatAreaLine := func(item fileAreaListItem, selected bool, tagged bool) string {
@@ -322,8 +326,8 @@ func runFileNewscanConfig(c *cmdCtx, args string) (*user.User, string, error) {
 			colorSeq = "\x1b[97;46m"
 		}
 		areaName := item.area.Name
-		if len(areaName) > 40 {
-			areaName = areaName[:37] + "..."
+		if nameRunes := []rune(areaName); len(nameRunes) > 40 {
+			areaName = string(nameRunes[:37]) + "..."
 		}
 		var b strings.Builder
 		b.WriteString(paddingStr)

--- a/internal/menu/file_newscan_test.go
+++ b/internal/menu/file_newscan_test.go
@@ -1,0 +1,145 @@
+package menu
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/file"
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+// runFileNewscan renders FILE_ID.DIZ descriptions that internal/ziplab/diz.go
+// has already converted to UTF-8. desc[:maxDesc-3] cut on bytes, so a
+// multi-byte description is sliced mid-rune: the dangling lead byte is not
+// valid UTF-8, and terminalio's UTF-8 writer maps it to an unrelated CP437
+// glyph rather than the truncated text, silently dropping runes from the
+// description. maxDesc=40 (termWidth 80 - 40) here, so the byte cut at
+// maxDesc-3=37 bytes lands after only 12 whole "日" runes (36 bytes) plus one
+// stray lead byte, instead of the 37 runes a rune-correct cut would keep.
+func TestRunFileNewscanNonASCIIDescriptionNotSplitMidRune(t *testing.T) {
+	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	areasJSON := `[{"id":1,"tag":"UTILS","name":"Utilities","path":"utils","acs_list":""}]`
+	if err := os.WriteFile(filepath.Join(cfgDir, "file_areas.json"), []byte(areasJSON), 0644); err != nil {
+		t.Fatalf("write areas: %v", err)
+	}
+	fm, err := file.NewFileManager(dataDir, cfgDir)
+	if err != nil {
+		t.Fatalf("NewFileManager: %v", err)
+	}
+
+	// 50 CJK runes (150 bytes): well past maxDesc (40, rune-correct), and far
+	// enough past it in bytes (150) that a byte-based cut lands inside a rune.
+	desc := strings.Repeat("日", 50)
+	uploadTime := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	if err := fm.AddFileRecord(file.FileRecord{
+		ID: uuid.New(), AreaID: 1, Filename: "test.zip", Description: desc,
+		Size: 1024, UploadedAt: uploadTime, UploadedBy: "sysop",
+	}); err != nil {
+		t.Fatalf("AddFileRecord: %v", err)
+	}
+
+	um, err := user.NewUserManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewUserManager: %v", err)
+	}
+	u, err := um.AddUser("password", "Tester", "Real Name", "Loc")
+	if err != nil {
+		t.Fatalf("AddUser: %v", err)
+	}
+	u.AccessLevel = 255
+	u.LastLogin = uploadTime.Add(-time.Hour)
+
+	e := &MenuExecutor{FileMgr: fm}
+	ts := newTestSession("")
+	terminal := newTestTerminal(ts)
+
+	c := &cmdCtx{
+		e: e, s: ts, terminal: terminal, userManager: um, currentUser: u,
+		nodeNumber: 1, sessionStartTime: uploadTime,
+		outputMode: ansi.OutputModeUTF8, termWidth: 80, termHeight: 24,
+	}
+
+	if _, _, err := runFileNewscan(c, ""); err != nil {
+		t.Fatalf("runFileNewscan: %v", err)
+	}
+
+	out := ts.output()
+	// A rune-correct cut keeps 37 whole "日" runes before the "..." ellipsis.
+	if got, want := strings.Count(out, "日"), 37; got != want {
+		t.Errorf("rendered description has %d intact '日' runes, want %d (output %q)", got, want, out)
+	}
+}
+
+// runFileNewscanConfig's picker lays out area names with an inline padRight
+// closure and an areaName[:37]-style truncation, both measuring len() in
+// bytes. Area names are sysop-editable UTF-8 JSON and can be auto-created
+// from hub-supplied names by V3Net area sync, so both are reachable with
+// real data.
+func TestRunFileNewscanConfigAreaNameRuneCorrect(t *testing.T) {
+	// 20 CJK runes = 60 bytes: rune count is well under the 40-column limit,
+	// but the byte length is over it, so a byte-length truncation check wrongly
+	// truncates a name that should render in full, splitting mid-rune.
+	longName := strings.Repeat("日", 20)
+	// 20 "é" runes = 40 bytes exactly: byte length reaches the 40-column pad
+	// width even though the rune (visible) length is only 20, so a byte-length
+	// pad check skips padding a name that is visibly 20 columns short.
+	padName := strings.Repeat("é", 20)
+
+	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	areasJSON := `[
+		{"id":1,"tag":"AREA1","name":"` + longName + `","path":"a1","acs_list":""},
+		{"id":2,"tag":"AREA2","name":"` + padName + `","path":"a2","acs_list":""}
+	]`
+	if err := os.WriteFile(filepath.Join(cfgDir, "file_areas.json"), []byte(areasJSON), 0644); err != nil {
+		t.Fatalf("write areas: %v", err)
+	}
+	fm, err := file.NewFileManager(dataDir, cfgDir)
+	if err != nil {
+		t.Fatalf("NewFileManager: %v", err)
+	}
+
+	um, err := user.NewUserManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewUserManager: %v", err)
+	}
+	u, err := um.AddUser("password", "Tester", "Real Name", "Loc")
+	if err != nil {
+		t.Fatalf("AddUser: %v", err)
+	}
+	u.AccessLevel = 255
+
+	e := &MenuExecutor{FileMgr: fm}
+	ts := newTestSession("q")
+	terminal := newTestTerminal(ts)
+
+	c := &cmdCtx{
+		e: e, s: ts, terminal: terminal, userManager: um, currentUser: u,
+		nodeNumber: 1, sessionStartTime: time.Now(),
+		outputMode: ansi.OutputModeUTF8, termWidth: 80, termHeight: 24,
+	}
+
+	if _, _, err := runFileNewscanConfig(c, ""); err != nil {
+		t.Fatalf("runFileNewscanConfig: %v", err)
+	}
+
+	stripped := testAnsiEscape.ReplaceAllString(ts.output(), "")
+
+	if got, want := strings.Count(stripped, "日"), 20; got != want {
+		t.Errorf("rendered long area name has %d intact '日' runes, want %d (all 20 fit under the 40-column limit): %q",
+			got, want, stripped)
+	}
+
+	// padRight must pad padName (20 visible columns) out to 40 columns before
+	// the " [" status bracket.
+	wantPadded := padName + strings.Repeat(" ", 20) + " ["
+	if !strings.Contains(stripped, wantPadded) {
+		t.Errorf("rendered short area name row missing %d columns of padding before the bracket; want substring %q in %q",
+			20, wantPadded, stripped)
+	}
+}

--- a/internal/menu/file_search.go
+++ b/internal/menu/file_search.go
@@ -100,8 +100,8 @@ func runSearchFiles(c *cmdCtx, args string) (*user.User, string, error) {
 	lineCount := 0
 	for _, r := range filtered {
 		fname := r.filename
-		if len(fname) > 12 {
-			fname = fname[:12]
+		if runes := []rune(fname); len(runes) > 12 {
+			fname = string(runes[:12])
 		}
 
 		line := fmt.Sprintf("\r\n|09%-8s |15%-12s |07%5dk |14%s", r.areaTag, fname, (r.size+1023)/1024, r.description)

--- a/internal/menu/file_search_test.go
+++ b/internal/menu/file_search_test.go
@@ -1,0 +1,77 @@
+package menu
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/file"
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+// runSearchFiles clamps a result's filename to 12 characters with
+// fname[:12], counting bytes. Two sibling renderers (formatFileListLine in
+// executor_files_list_render.go, and file_lightbar_render.go) do the
+// identical 12-char clamp rune-correctly with []rune, because uploaded
+// filenames are not ASCII-normalized: registerUploadedFiles only rejects
+// path traversal and duplicates (internal/menu/executor_files_upload.go),
+// it does not strip non-ASCII bytes, so a ZMODEM upload with a UTF-8
+// filename reaches this unmodified.
+func TestRunSearchFilesFilenameClampedByRunes(t *testing.T) {
+	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	areasJSON := `[{"id":1,"tag":"UTILS","name":"Utilities","path":"utils","acs_list":""}]`
+	if err := os.WriteFile(filepath.Join(cfgDir, "file_areas.json"), []byte(areasJSON), 0644); err != nil {
+		t.Fatalf("write areas: %v", err)
+	}
+	fm, err := file.NewFileManager(dataDir, cfgDir)
+	if err != nil {
+		t.Fatalf("NewFileManager: %v", err)
+	}
+
+	// "AB" (2 ASCII bytes) + 18 CJK runes (54 bytes): a byte cut at position 12
+	// lands 1 byte into the 4th CJK rune, splitting it. The search query
+	// matches via the description, not the filename, so the filename's
+	// content doesn't need to relate to the query term.
+	fname := "AB" + strings.Repeat("日", 18) + ".zip"
+	if err := fm.AddFileRecord(file.FileRecord{
+		ID: uuid.New(), AreaID: 1, Filename: fname, Description: "search target info",
+		Size: 1024, UploadedAt: time.Now(), UploadedBy: "sysop",
+	}); err != nil {
+		t.Fatalf("AddFileRecord: %v", err)
+	}
+
+	um, err := user.NewUserManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewUserManager: %v", err)
+	}
+	u, err := um.AddUser("password", "Tester", "Real Name", "Loc")
+	if err != nil {
+		t.Fatalf("AddUser: %v", err)
+	}
+	u.AccessLevel = 255
+
+	e := &MenuExecutor{FileMgr: fm}
+	ts := newTestSession("info\r")
+	terminal := newTestTerminal(ts)
+
+	c := &cmdCtx{
+		e: e, s: ts, terminal: terminal, currentUser: u,
+		nodeNumber: 1, sessionStartTime: time.Now(),
+		outputMode: ansi.OutputModeUTF8, termWidth: 80, termHeight: 24,
+	}
+
+	if _, _, err := runSearchFiles(c, ""); err != nil {
+		t.Fatalf("runSearchFiles: %v", err)
+	}
+
+	out := ts.output()
+	// A rune-correct clamp to 12 runes keeps "AB" plus the first 10 "日".
+	if got, want := strings.Count(out, "日"), 10; got != want {
+		t.Errorf("rendered filename has %d intact '日' runes, want %d (output %q)", got, want, out)
+	}
+}

--- a/internal/menu/message_list_render.go
+++ b/internal/menu/message_list_render.go
@@ -52,11 +52,15 @@ func drawMessageListScreen(terminal *term.Terminal, state *MessageListState, are
 		title = fmt.Sprintf("%s > %s - Message List", confName, areaName)
 	}
 	title = truncateString(title, 75)
-	padding := (77 - len(title)) / 2
+	// Runes, not bytes: truncateString clamps to 75 runes, so a multi-byte
+	// title measured in bytes overflows the 77-column frame and hands
+	// strings.Repeat a negative count.
+	titleLen := utf8.RuneCountInString(title)
+	padding := (77 - titleLen) / 2
 	titleLine := fmt.Sprintf("|11│|13%s%s%s|11│|07\r\n",
 		strings.Repeat(" ", padding),
 		title,
-		strings.Repeat(" ", 77-padding-len(title)))
+		strings.Repeat(" ", 77-padding-titleLen))
 	if err := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(titleLine)), outputMode); err != nil {
 		return err
 	}

--- a/internal/menu/message_list_test.go
+++ b/internal/menu/message_list_test.go
@@ -342,3 +342,40 @@ func TestDrawMessageListScreenHelpLineCenteringIsRuneBased(t *testing.T) {
 		})
 	}
 }
+
+// A non-ASCII area or conference name must not panic the screen draw. The title
+// is clamped to 75 runes, but the padding arithmetic measured bytes, so a
+// multi-byte title exceeded the 77-column frame and strings.Repeat got a
+// negative count.
+func TestDrawMessageListScreenNonASCIITitleDoesNotPanic(t *testing.T) {
+	ts := newTestSession("")
+	terminal := newTestTerminal(ts)
+	state := &MessageListState{
+		Entries:       []MessageListEntry{},
+		CurrentPage:   1,
+		ItemsPerPage:  10,
+		TotalMessages: 0,
+	}
+
+	// 40 CJK runes: well under the 75-rune clamp, but 120 bytes.
+	areaName := strings.Repeat("日", 40)
+
+	if err := drawMessageListScreen(terminal, state, areaName, "Main", ansi.OutputModeUTF8); err != nil {
+		t.Fatalf("drawMessageListScreen: %v", err)
+	}
+
+	var titleLine string
+	for _, line := range strings.Split(ts.output(), "\n") {
+		if strings.Contains(line, "Message List") {
+			titleLine = strings.TrimRight(line, "\r")
+			break
+		}
+	}
+	if titleLine == "" {
+		t.Fatal("title line not found in rendered output")
+	}
+	stripped := testAnsiEscape.ReplaceAllString(titleLine, "")
+	if got := utf8.RuneCountInString(stripped); got != 79 {
+		t.Errorf("title line visible width = %d runes, want 79 (line %q)", got, stripped)
+	}
+}

--- a/internal/menu/message_reader.go
+++ b/internal/menu/message_reader.go
@@ -218,7 +218,7 @@ readerLoop:
 		if outputMode == ansi.OutputModeCP437 {
 			substitutions = convertSubsToCP437(substitutions)
 		}
-		autoWidths := buildAutoWidths(substitutions, totalMsgCount, termWidth)
+		autoWidths := buildAutoWidths(substitutions, totalMsgCount, termWidth, outputMode == ansi.OutputModeCP437)
 
 		// Process template with substitutions (auto-detects @CODE@ or |X format)
 		processedHeader := processTemplate(hdrTemplateBytes, substitutions, autoWidths)

--- a/internal/menu/message_reader_headers.go
+++ b/internal/menu/message_reader_headers.go
@@ -325,7 +325,14 @@ func runGetHeaderType(c *cmdCtx, args string) (*user.User, string, error) {
 				'X': "GENERAL > General Discussion [1/42]",
 				'K': strconv.Itoa(nodeNumber),
 			}
-			sampleAutoWidths := buildAutoWidths(sampleSubs, 42, 80, false)
+			// Mirror the real reader path: in CP437 mode the substitutions are
+			// converted to CP437 bytes before widths are measured, so the preview
+			// sizes and renders the same way the message reader will.
+			cp437Preview := outputMode == ansi.OutputModeCP437
+			if cp437Preview {
+				sampleSubs = convertSubsToCP437(sampleSubs)
+			}
+			sampleAutoWidths := buildAutoWidths(sampleSubs, 42, 80, cp437Preview)
 
 			processedPreview := processTemplate(hdrBytes, sampleSubs, sampleAutoWidths)
 			terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)

--- a/internal/menu/message_reader_headers.go
+++ b/internal/menu/message_reader_headers.go
@@ -325,7 +325,7 @@ func runGetHeaderType(c *cmdCtx, args string) (*user.User, string, error) {
 				'X': "GENERAL > General Discussion [1/42]",
 				'K': strconv.Itoa(nodeNumber),
 			}
-			sampleAutoWidths := buildAutoWidths(sampleSubs, 42, 80)
+			sampleAutoWidths := buildAutoWidths(sampleSubs, 42, 80, false)
 
 			processedPreview := processTemplate(hdrBytes, sampleSubs, sampleAutoWidths)
 			terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)

--- a/internal/menu/message_reader_subst.go
+++ b/internal/menu/message_reader_subst.go
@@ -221,9 +221,10 @@ func buildAutoWidths(subs map[byte]string, totalMsgs int, termWidth int) map[byt
 
 	// Z = "confName > areaName" (same for all messages in area)
 	if zVal, ok := subs['Z']; ok {
-		widths['Z'] = len(zVal)
+		zLen := utf8.RuneCountInString(zVal)
+		widths['Z'] = zLen
 		// X = Z + " " + [current/total], max when current = totalMsgs
-		widths['X'] = len(zVal) + 1 + len(maxCountStr)
+		widths['X'] = zLen + 1 + len(maxCountStr)
 	}
 
 	// Gap fill: target width is terminal width minus 1 to avoid auto-wrap
@@ -235,7 +236,7 @@ func buildAutoWidths(subs map[byte]string, totalMsgs int, termWidth int) map[byt
 	// All other codes: use current value length
 	for code, val := range subs {
 		if _, exists := widths[code]; !exists {
-			widths[code] = len(val)
+			widths[code] = utf8.RuneCountInString(val)
 		}
 	}
 

--- a/internal/menu/message_reader_subst.go
+++ b/internal/menu/message_reader_subst.go
@@ -198,7 +198,17 @@ func buildNameWithAddr(name, addr string) string {
 //   - Fixed-format codes (D, W): known max format lengths
 //   - Context codes (Z, X): based on current conference/area names + max count width
 //   - All others: width of the current substitution value
-func buildAutoWidths(subs map[byte]string, totalMsgs int, termWidth int) map[byte]int {
+//
+// cp437Values says how to measure the substitution values. In CP437 mode the
+// caller has already converted them to raw CP437 bytes, where one byte is one
+// column; counting runes there would undercount whenever adjacent CP437 bytes
+// happen to form a valid UTF-8 sequence. In UTF-8 mode the values are UTF-8 and
+// must be counted in runes.
+func buildAutoWidths(subs map[byte]string, totalMsgs int, termWidth int, cp437Values bool) map[byte]int {
+	valueWidth := utf8.RuneCountInString
+	if cp437Values {
+		valueWidth = func(s string) int { return len(s) }
+	}
 	widths := make(map[byte]int)
 
 	maxMsgNumWidth := len(strconv.Itoa(totalMsgs))
@@ -221,7 +231,7 @@ func buildAutoWidths(subs map[byte]string, totalMsgs int, termWidth int) map[byt
 
 	// Z = "confName > areaName" (same for all messages in area)
 	if zVal, ok := subs['Z']; ok {
-		zLen := utf8.RuneCountInString(zVal)
+		zLen := valueWidth(zVal)
 		widths['Z'] = zLen
 		// X = Z + " " + [current/total], max when current = totalMsgs
 		widths['X'] = zLen + 1 + len(maxCountStr)
@@ -236,7 +246,7 @@ func buildAutoWidths(subs map[byte]string, totalMsgs int, termWidth int) map[byt
 	// All other codes: use current value length
 	for code, val := range subs {
 		if _, exists := widths[code]; !exists {
-			widths[code] = utf8.RuneCountInString(val)
+			widths[code] = valueWidth(val)
 		}
 	}
 

--- a/internal/menu/message_reader_subst_test.go
+++ b/internal/menu/message_reader_subst_test.go
@@ -1,0 +1,33 @@
+package menu
+
+import (
+	"strings"
+	"testing"
+)
+
+// buildAutoWidths feeds ansi.ApplyWidthConstraintAligned, which pads and
+// truncates by visible runes. A multi-byte subject, from/to, or Z
+// (conference/area) value must produce a width matching its rune count, not
+// its byte length, or the caller over-pads the column.
+func TestBuildAutoWidthsMeasuresRunesNotBytes(t *testing.T) {
+	// 5 CJK runes: 15 bytes in UTF-8.
+	subj := strings.Repeat("日", 5)
+	subs := map[byte]string{
+		'S': subj,
+		'Z': subj,
+	}
+
+	widths := buildAutoWidths(subs, 42, 80)
+
+	if got, want := widths['S'], 5; got != want {
+		t.Errorf("widths['S'] = %d, want %d (rune count of %q)", got, want, subj)
+	}
+	if got, want := widths['Z'], 5; got != want {
+		t.Errorf("widths['Z'] = %d, want %d (rune count of %q)", got, want, subj)
+	}
+	// X = Z + " " + "[42/42]"
+	wantX := 5 + 1 + len("[42/42]")
+	if got := widths['X']; got != wantX {
+		t.Errorf("widths['X'] = %d, want %d", got, wantX)
+	}
+}

--- a/internal/menu/message_reader_subst_test.go
+++ b/internal/menu/message_reader_subst_test.go
@@ -17,7 +17,7 @@ func TestBuildAutoWidthsMeasuresRunesNotBytes(t *testing.T) {
 		'Z': subj,
 	}
 
-	widths := buildAutoWidths(subs, 42, 80)
+	widths := buildAutoWidths(subs, 42, 80, false)
 
 	if got, want := widths['S'], 5; got != want {
 		t.Errorf("widths['S'] = %d, want %d (rune count of %q)", got, want, subj)
@@ -29,5 +29,20 @@ func TestBuildAutoWidthsMeasuresRunesNotBytes(t *testing.T) {
 	wantX := 5 + 1 + len("[42/42]")
 	if got := widths['X']; got != wantX {
 		t.Errorf("widths['X'] = %d, want %d", got, wantX)
+	}
+}
+
+// In CP437 mode the caller converts substitutions to raw CP437 bytes before
+// building widths, so one byte is one column. Counting runes there undercounts
+// whenever adjacent CP437 bytes happen to form a valid UTF-8 sequence — 0xC3
+// ("├") followed by 0xA9 ("⌐") decodes as the single rune "é".
+func TestBuildAutoWidthsCountsCP437BytesAsColumns(t *testing.T) {
+	cp437 := string([]byte{0xC3, 0xA9, 0xC3, 0xA9}) // 4 CP437 glyphs, 2 UTF-8 runes
+	subs := map[byte]string{'S': cp437}
+
+	widths := buildAutoWidths(subs, 42, 80, true)
+
+	if got, want := widths['S'], 4; got != want {
+		t.Errorf("widths['S'] = %d, want %d (one column per CP437 byte)", got, want)
 	}
 }

--- a/internal/menu/message_scan_config.go
+++ b/internal/menu/message_scan_config.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/editor"
@@ -167,10 +168,11 @@ func runNewscanConfig(c *cmdCtx, args string) (*user.User, string, error) {
 
 	// Helper to pad string to width
 	padRight := func(s string, width int) string {
-		if len(s) >= width {
+		n := utf8.RuneCountInString(s)
+		if n >= width {
 			return s
 		}
-		return s + strings.Repeat(" ", width-len(s))
+		return s + strings.Repeat(" ", width-n)
 	}
 
 	// Format a single area line to match the menu layout
@@ -198,10 +200,11 @@ func runNewscanConfig(c *cmdCtx, args string) (*user.User, string, error) {
 			colorSeq = "\x1b[97;46m" // Bright white text on cyan background
 		}
 
-		// Truncate area name if too long
+		// Truncate area name if too long. Runes, not bytes: area names are
+		// sysop-editable UTF-8 JSON and can hold multi-byte characters.
 		areaName := item.area.Name
-		if len(areaName) > 40 {
-			areaName = areaName[:37] + "..."
+		if nameRunes := []rune(areaName); len(nameRunes) > 40 {
+			areaName = string(nameRunes[:37]) + "..."
 		}
 
 		var builder strings.Builder

--- a/internal/menu/message_scan_config_test.go
+++ b/internal/menu/message_scan_config_test.go
@@ -1,0 +1,77 @@
+package menu
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/message"
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+// runNewscanConfig's message-area picker lays out area names with an inline
+// padRight closure and an areaName[:37]-style truncation, both measuring
+// len() in bytes — the same class of bug fixed in runFileNewscanConfig
+// (internal/menu/file_newscan.go). Area names are sysop-editable UTF-8 JSON
+// and can be auto-created from hub-supplied names by V3Net area sync, so
+// both are reachable with real data.
+func TestRunNewscanConfigAreaNameRuneCorrect(t *testing.T) {
+	// 20 CJK runes = 60 bytes: rune count is well under the 40-column limit,
+	// but the byte length is over it, so a byte-length truncation check wrongly
+	// truncates a name that should render in full, splitting mid-rune.
+	longName := strings.Repeat("日", 20)
+	// 20 "é" runes = 40 bytes exactly: byte length reaches the 40-column pad
+	// width even though the rune (visible) length is only 20, so a byte-length
+	// pad check skips padding a name that is visibly 20 columns short.
+	padName := strings.Repeat("é", 20)
+
+	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	mm, err := message.NewMessageManager(dataDir, cfgDir, "TestBBS", nil)
+	if err != nil {
+		t.Fatalf("NewMessageManager: %v", err)
+	}
+	if _, err := mm.AddArea(message.MessageArea{Tag: "AREA1", Name: longName, AreaType: "local"}); err != nil {
+		t.Fatalf("AddArea longName: %v", err)
+	}
+	if _, err := mm.AddArea(message.MessageArea{Tag: "AREA2", Name: padName, AreaType: "local"}); err != nil {
+		t.Fatalf("AddArea padName: %v", err)
+	}
+
+	um, err := user.NewUserManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewUserManager: %v", err)
+	}
+	u, err := um.AddUser("password", "Tester", "Real Name", "Loc")
+	if err != nil {
+		t.Fatalf("AddUser: %v", err)
+	}
+	u.AccessLevel = 255
+
+	e := &MenuExecutor{MessageMgr: mm}
+	ts := newTestSession("q")
+	terminal := newTestTerminal(ts)
+
+	c := &cmdCtx{
+		e: e, s: ts, terminal: terminal, userManager: um, currentUser: u,
+		nodeNumber: 1, sessionStartTime: time.Now(),
+		outputMode: ansi.OutputModeUTF8, termWidth: 80, termHeight: 24,
+	}
+
+	if _, _, err := runNewscanConfig(c, ""); err != nil {
+		t.Fatalf("runNewscanConfig: %v", err)
+	}
+
+	stripped := testAnsiEscape.ReplaceAllString(ts.output(), "")
+
+	if got, want := strings.Count(stripped, "日"), 20; got != want {
+		t.Errorf("rendered long area name has %d intact '日' runes, want %d (all 20 fit under the 40-column limit): %q",
+			got, want, stripped)
+	}
+
+	wantPadded := padName + strings.Repeat(" ", 20) + " ["
+	if !strings.Contains(stripped, wantPadded) {
+		t.Errorf("rendered short area name row missing %d columns of padding before the bracket; want substring %q in %q",
+			20, wantPadded, stripped)
+	}
+}

--- a/internal/menu/v3net_areas.go
+++ b/internal/menu/v3net_areas.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gliderlabs/ssh"
 	term "golang.org/x/term"
@@ -170,10 +171,13 @@ func runV3NetAreas(c *cmdCtx, args string) (*user.User, string, error) {
 
 		line := fmt.Sprintf(" %s %-24s %-28s %-8s %s", status, tag, name, access, net)
 		maxW := termWidth - 1 // leave 1 col to prevent terminal auto-wrap
-		if len(line) < maxW {
-			line += strings.Repeat(" ", maxW-len(line))
-		} else if len(line) > maxW {
-			line = line[:maxW]
+		// Runes, not bytes: net is a hub-supplied network name and can hold
+		// multi-byte characters, so a byte-based clamp can split it mid-rune.
+		lineLen := utf8.RuneCountInString(line)
+		if lineLen < maxW {
+			line += strings.Repeat(" ", maxW-lineLen)
+		} else if lineLen > maxW {
+			line = string([]rune(line)[:maxW])
 		}
 
 		if highlight {

--- a/internal/menu/v3net_areas_test.go
+++ b/internal/menu/v3net_areas_test.go
@@ -1,0 +1,84 @@
+package menu
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+)
+
+// fakeV3NetStatus is a minimal V3NetStatusProvider backed by a single
+// in-memory NAL, standing in for a hub HTTP fetch in tests.
+type fakeV3NetStatus struct {
+	network string
+	hubURL  string
+	nal     *protocol.NAL
+}
+
+func (f *fakeV3NetStatus) NodeID() string                 { return "TEST" }
+func (f *fakeV3NetStatus) HubActive() bool                { return false }
+func (f *fakeV3NetStatus) LeafCount() int                 { return 1 }
+func (f *fakeV3NetStatus) LeafNetworks() []string         { return []string{f.network} }
+func (f *fakeV3NetStatus) NetworkForArea(int) string      { return f.network }
+func (f *fakeV3NetStatus) HubURLForNetwork(string) string { return f.hubURL }
+func (f *fakeV3NetStatus) RegistryURL() string            { return "" }
+func (f *fakeV3NetStatus) FetchNALForNetwork(ctx context.Context, network string) (*protocol.NAL, error) {
+	return f.nal, nil
+}
+func (f *fakeV3NetStatus) ProposeArea(network string, req protocol.AreaProposalRequest) (*protocol.ProposalResponse, error) {
+	return nil, nil
+}
+
+// runV3NetAreas builds each row as " %s %-24s %-28s %-8s %s" (status, tag,
+// name, access, network) then clamps the whole line to termWidth-1 with
+// len(line) and line[:maxW] — both byte counts. tag/name are already padded
+// to a fixed rune width via padRight/truncateStr, but the trailing network
+// name is appended unpadded: a multi-byte network name can push the line's
+// byte length over the limit even while its visible (rune) width still fits,
+// triggering a truncation that lands mid-rune. Network names are hub-supplied
+// (this NAL stands in for the hub's HTTP response), so this is reachable
+// without local misconfiguration.
+func TestRunV3NetAreasRowNotSplitMidRune(t *testing.T) {
+	// 10 CJK runes = 30 bytes. Prefix (status+tag+name+access, all ASCII,
+	// padded) is exactly 68 visible columns/bytes, so the full row is 78
+	// visible columns (fits under maxW=79) but 98 bytes (over it).
+	network := strings.Repeat("日", 10)
+
+	nal := &protocol.NAL{
+		Network: network,
+		Areas: []protocol.Area{
+			{
+				Tag:    "aa.bb",
+				Name:   "TestArea",
+				Access: protocol.AreaAccess{Mode: "open"},
+			},
+		},
+	}
+
+	e := &MenuExecutor{
+		V3NetStatus:    &fakeV3NetStatus{network: network, hubURL: "https://hub.example", nal: nal},
+		RootConfigPath: t.TempDir(),
+	}
+	ts := newTestSession("q")
+	terminal := newTestTerminal(ts)
+
+	c := &cmdCtx{
+		e: e, s: ts, terminal: terminal, currentUser: &user.User{Handle: "Tester", AccessLevel: 255},
+		outputMode: ansi.OutputModeUTF8, termWidth: 80, termHeight: 24,
+	}
+
+	if _, _, err := runV3NetAreas(c, ""); err != nil {
+		t.Fatalf("runV3NetAreas: %v", err)
+	}
+
+	out := ts.output()
+	// The item row's Network column should render the full, intact name.
+	// A byte-based clamp instead truncates it mid-rune, e.g. to
+	// "日日日µù" (3 intact runes plus stray CP437 glyphs from the dangling bytes).
+	if !strings.Contains(out, "open     "+network) {
+		t.Errorf("item row does not contain the intact network name %q after \"open\": %q", network, out)
+	}
+}


### PR DESCRIPTION
## Summary

A systematic audit of byte-vs-rune measurement in user-facing text, prompted by two such bugs found during the refactor campaign. Twelve sites fixed, each TDD with recorded RED evidence.

The root cause is structural: **the package has no width primitive**, so each screen re-derives one and re-introduces the bug. There were three near-duplicate width helpers and five inline `padRight`s.

## The two that matter most

**A reachable panic.** `drawMessageListScreen` clamps its title to 75 *runes* but padded by *bytes*, so any non-ASCII area or conference name overflowed the 77-column frame:

```
panic: strings: negative Repeat count
```

This became reachable in c2d28f6 (mine), which made `truncateString` rune-correct — the previous byte clamp had masked the mismatch at this call site. Area and conference names are sysop-editable UTF-8 JSON and are auto-created from hub-supplied names by V3Net area sync, so no local misconfiguration is needed.

**Every pause prompt was drawn off-centre on UTF-8 terminals.** The shipped `pauseString` has six U+25A0 glyphs: 19 visible columns, 31 bytes — so it rendered 6 columns left of centre, on every pause, every session. `calculateVisibleWidth` counted bytes; it's replaced by the rune-correct `ansi.VisibleLength` and deleted.

## The rest

- **`padRight`/`truncateStr`** (32 call sites: area, conference, file-area, message-scan, file-newscan and V3Net pickers) — `truncateStr("café society", 6)` returned `"caf\xc3.."`
- **Message-header `@CODE*@` auto-widths** — over-padded on imported echomail, which is exactly the traffic most likely to be non-ASCII (FTN import decodes CP437→UTF-8)
- **FILE_ID.DIZ descriptions**, file search filenames, the highlighted area and file-area rows, V3Net area rows, message/file newscan area names
- **Chat header `@NET@` placeholder** — the worst failure mode of the set: substitution ran *before* `ConvertCP437ToUTF8`, so a UTF-8 network name had each byte reinterpreted as a separate CP437 character, garbling it rather than truncating it. Now substituted after conversion and filled by runes.
- **Yes/No prompt cursor-back width** — **unreachable today** (shipped labels are ASCII) and labelled as such in its commit; fixed pre-emptively because it degrades badly if the labels are ever localised, erasing part of the prompt.

## Some of these are remote-controlled

`v3net_registry.go` renders network names and descriptions fetched over HTTP from the registry, and V3Net area sync auto-creates areas from hub-supplied names. A peer or MITM could previously put invalid UTF-8 on a subscriber's terminal.

## Deliberately not done

- **Wide-character (CJK double-width) support.** These fixes make measurement rune-correct, not column-correct for double-width glyphs. That would need `go-runewidth` threaded through `ansi.VisibleLength`; for a CP437-first renderer, half-width correctness is what prevents the corruption and the crash. Noted for later.
- **Consolidating on a single width primitive.** The durable fix, but it doesn't belong inside a bug-fix PR.
- **Sites where bytes are the correct unit** — ANSI/SAUCE/marker parsers, raw-CP437 templates where 1 byte = 1 column, and inputs gated to ASCII by `readLineFromSessionIH` (`key >= 32 && key < 127`). Each was traced to its input source before being judged; several candidates were skipped for exactly this reason.

## Verification

- `go test ./...` exit 0; `go test -race -count=1 ./internal/menu/` exit 0
- `gofmt -l` empty; `go vet ./...` clean; `staticcheck` zero findings; binary builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 rendering across menus with rune-safe truncation/padding to prevent splitting multi-byte characters.
  * Fixed alignment/layout for highlighted rows, centered prompts, option areas, file/search/newscan/config, message lists, chat headers, and V3Net “Network” rows.
  * Improved placeholder width handling for both UTF-8 and CP437 modes to keep art/header columns consistent.

* **Tests**
  * Added/expanded regression tests covering rune-based clamping, visible-column centering, UTF-8 validity, and CP437-aware width behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->