### PR TITLE
fix: cut FTN fields and editor columns on rune boundaries

### DIFF
--- a/internal/ftn/packet.go
+++ b/internal/ftn/packet.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"golang.org/x/text/encoding/charmap"
 	"golang.org/x/text/transform"
@@ -336,11 +337,26 @@ func writePackedMessage(w io.Writer, msg *PackedMessage) error {
 	return nil
 }
 
+// truncateField clamps s to max BYTES, which is what FTS-0001 specifies for the
+// null-terminated To/From/Subject fields — but it cuts on a rune boundary, so a
+// multi-byte character is dropped whole rather than leaving a partial UTF-8
+// sequence on the wire for every other system to parse.
 func truncateField(s string, max int) string {
-	if len(s) > max {
-		return s[:max]
+	if len(s) <= max {
+		return s
 	}
-	return s
+	end := 0
+	for i, r := range s {
+		size := utf8.RuneLen(r)
+		if size < 0 {
+			size = 1 // invalid rune: it occupies a single byte here
+		}
+		if i+size > max {
+			break
+		}
+		end = i + size
+	}
+	return s[:end]
 }
 
 // ParsedBody holds the components of a parsed FTN message body.

--- a/internal/ftn/packet.go
+++ b/internal/ftn/packet.go
@@ -346,15 +346,16 @@ func truncateField(s string, max int) string {
 		return s
 	}
 	end := 0
-	for i, r := range s {
-		size := utf8.RuneLen(r)
-		if size < 0 {
-			size = 1 // invalid rune: it occupies a single byte here
-		}
-		if i+size > max {
+	for end < len(s) {
+		// DecodeRuneInString gives the byte size at this offset, which is 1 for a
+		// stray invalid byte. utf8.RuneLen would report 3 for those, since range
+		// surfaces them as RuneError, and the cut would land inside the next
+		// character.
+		_, size := utf8.DecodeRuneInString(s[end:])
+		if end+size > max {
 			break
 		}
-		end = i + size
+		end += size
 	}
 	return s[:end]
 }

--- a/internal/ftn/packet_truncate_test.go
+++ b/internal/ftn/packet_truncate_test.go
@@ -1,0 +1,51 @@
+package ftn
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// FTS-0001 packed-message fields are null-terminated byte strings with byte
+// limits (36 for To/From, 72 for Subject), so truncation must respect the byte
+// budget — but it must not cut a multi-byte character in half, which would put
+// an invalid UTF-8 sequence on the wire for every other system to parse.
+func TestTruncateFieldCutsOnRuneBoundaryWithinByteBudget(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		max  int
+	}{
+		{"ascii under budget", "Hello", 36},
+		{"ascii over budget", "abcdefghijklmnopqrstuvwxyz0123456789extra", 36},
+		{"accented over budget", "Réponse à propos des accents dans les sujets FTN", 36},
+		{"cjk over budget", "日本語のメッセージの件名がとても長い場合", 36},
+		// Constructed so the byte budget lands INSIDE a multi-byte rune: 35
+		// ASCII bytes then a 2-byte "é" occupying bytes 35-36, so a byte cut at
+		// 36 keeps only the lead byte.
+		{"budget splits a 2-byte rune", strings.Repeat("a", 35) + "é" + "tail", 36},
+		// Same for a 3-byte rune straddling the limit.
+		{"budget splits a 3-byte rune", strings.Repeat("a", 34) + "日" + "tail", 36},
+		{"subject budget", "Re: " + "société normande " + "encore plus long que soixante-douze octets", 72},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateField(tt.s, tt.max)
+
+			if len(got) > tt.max {
+				t.Errorf("len = %d bytes, want <= %d (FTS-0001 field limit)", len(got), tt.max)
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("truncateField produced invalid UTF-8: %q", got)
+			}
+			// Must keep as much as the byte budget allows: adding the next rune
+			// back would have to overflow.
+			if len(got) < len(tt.s) {
+				next, size := utf8.DecodeRuneInString(tt.s[len(got):])
+				if next != utf8.RuneError && len(got)+size <= tt.max {
+					t.Errorf("truncated to %d bytes but another %d-byte rune would fit in %d", len(got), size, tt.max)
+				}
+			}
+		})
+	}
+}

--- a/internal/ftn/packet_truncate_test.go
+++ b/internal/ftn/packet_truncate_test.go
@@ -49,3 +49,23 @@ func TestTruncateFieldCutsOnRuneBoundaryWithinByteBudget(t *testing.T) {
 		})
 	}
 }
+
+// Invalid UTF-8 can reach these fields (a peer's packet is just bytes). Each
+// stray byte occupies exactly one byte of the budget: range decodes it as
+// RuneError, whose utf8.RuneLen is 3, so sizing by RuneLen would truncate at a
+// third of the real limit.
+func TestTruncateFieldCountsInvalidBytesAsOneByte(t *testing.T) {
+	// One stray byte, then a 3-byte rune. The stray byte occupies ONE byte, so a
+	// 3-byte budget must keep just it — sizing the stray byte as 3 (utf8.RuneLen
+	// of RuneError) makes the cut land inside the following rune instead.
+	s := "\xff" + "\u65e5" + "tail"
+
+	got := truncateField(s, 3)
+
+	// Not asserting ValidString here: the input itself carries a stray byte, so a
+	// faithful prefix cannot be valid UTF-8. What matters is that the cut lands on
+	// a decode boundary rather than inside the following character.
+	if len(got) != 1 {
+		t.Errorf("len = %d bytes (%q), want 1 (the stray byte alone fits in 3)", len(got), got)
+	}
+}

--- a/internal/menueditor/fields.go
+++ b/internal/menueditor/fields.go
@@ -170,17 +170,19 @@ func cmdFields() []fieldDef {
 
 // padRight pads a string to width with spaces, truncating if longer.
 func padRight(s string, width int) string {
-	if len(s) >= width {
-		return s[:width]
+	runes := []rune(s)
+	if len(runes) >= width {
+		return string(runes[:width])
 	}
-	return s + strings.Repeat(" ", width-len(s))
+	return s + strings.Repeat(" ", width-len(runes))
 }
 
 // centerText centers a string within a given width.
 func centerText(s string, width int) string {
-	if len(s) >= width {
-		return s[:width]
+	runes := []rune(s)
+	if len(runes) >= width {
+		return string(runes[:width])
 	}
-	pad := (width - len(s)) / 2
-	return strings.Repeat(" ", pad) + s + strings.Repeat(" ", width-pad-len(s))
+	pad := (width - len(runes)) / 2
+	return strings.Repeat(" ", pad) + s + strings.Repeat(" ", width-pad-len(runes))
 }

--- a/internal/menueditor/fields_pad_test.go
+++ b/internal/menueditor/fields_pad_test.go
@@ -1,0 +1,38 @@
+package menueditor
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+// padRight and centerText lay out the menu editor's lists. Menu names, ACS
+// strings and descriptions are edited in this TUI without the BBS prompts'
+// ASCII gate, so they must be measured and cut in characters.
+func TestPadAndCenterUseColumnsNotBytes(t *testing.T) {
+	tests := []struct {
+		name  string
+		s     string
+		width int
+	}{
+		{"ascii short", "abc", 10},
+		{"ascii long", "abcdefghijklmn", 10},
+		{"accented long", "café société normande", 10},
+		{"cjk long", "日本語のメッセージ", 10},
+	}
+	for _, tt := range tests {
+		for _, fn := range []struct {
+			name string
+			f    func(string, int) string
+		}{{"padRight", padRight}, {"centerText", centerText}} {
+			t.Run(fn.name+"/"+tt.name, func(t *testing.T) {
+				got := fn.f(tt.s, tt.width)
+				if !utf8.ValidString(got) {
+					t.Fatalf("%s(%q, %d) produced invalid UTF-8: %q", fn.name, tt.s, tt.width, got)
+				}
+				if n := utf8.RuneCountInString(got); n < tt.width {
+					t.Errorf("%s(%q, %d) = %d columns, want at least %d (%q)", fn.name, tt.s, tt.width, n, tt.width, got)
+				}
+			})
+		}
+	}
+}

--- a/internal/usereditor/fields.go
+++ b/internal/usereditor/fields.go
@@ -307,16 +307,18 @@ func infoformStatus(dataDir string, userID int) string {
 
 // padRight pads a string to width with spaces, truncating if longer.
 func padRight(s string, width int) string {
-	if len(s) >= width {
-		return s[:width]
+	runes := []rune(s)
+	if len(runes) >= width {
+		return string(runes[:width])
 	}
-	return s + strings.Repeat(" ", width-len(s))
+	return s + strings.Repeat(" ", width-len(runes))
 }
 
 // padLeft pads a string on the left to width.
 func padLeft(s string, width int) string {
-	if len(s) >= width {
-		return s[:width]
+	runes := []rune(s)
+	if len(runes) >= width {
+		return string(runes[:width])
 	}
-	return strings.Repeat(" ", width-len(s)) + s
+	return strings.Repeat(" ", width-len(runes)) + s
 }

--- a/internal/usereditor/fields_pad_test.go
+++ b/internal/usereditor/fields_pad_test.go
@@ -1,0 +1,41 @@
+package usereditor
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+// padRight and padLeft lay out the user editor's columns. The fields they
+// render — handle, real name, group location, private note — are edited in this
+// TUI without the BBS prompts' ASCII gate, so they can hold multi-byte text and
+// must be measured and cut in characters.
+func TestPadHelpersUseColumnsNotBytes(t *testing.T) {
+	tests := []struct {
+		name  string
+		s     string
+		width int
+	}{
+		{"ascii short", "abc", 10},
+		{"ascii exact", "abcdefghij", 10},
+		{"ascii long", "abcdefghijklmn", 10},
+		{"accented short", "café", 10},
+		{"accented long", "café société normande", 10},
+		{"cjk long", "日本語のメッセージ", 10},
+	}
+	for _, tt := range tests {
+		for _, fn := range []struct {
+			name string
+			f    func(string, int) string
+		}{{"padRight", padRight}, {"padLeft", padLeft}} {
+			t.Run(fn.name+"/"+tt.name, func(t *testing.T) {
+				got := fn.f(tt.s, tt.width)
+				if !utf8.ValidString(got) {
+					t.Fatalf("%s(%q, %d) produced invalid UTF-8: %q", fn.name, tt.s, tt.width, got)
+				}
+				if n := utf8.RuneCountInString(got); n != tt.width {
+					t.Errorf("%s(%q, %d) = %d columns, want %d (%q)", fn.name, tt.s, tt.width, n, tt.width, got)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The two byte-vs-rune sites outside `internal/menu` that the audit behind #148 found. Both TDD, with recorded RED evidence.

## `internal/ftn/packet.go` — invalid UTF-8 on the wire

`truncateField` clamps the null-terminated To/From/Subject fields on the packet **write** path. This is the one place in the audit where **byte counting is correct**: FTS-0001 specifies those limits in bytes (36/36/72), and switching to rune counting would emit oversized fields and corrupt packets worse than the original bug.

The actual defect is *where* it cut — anywhere, including inside a multi-byte character:

```
truncateField("aaa…a" + "é" + "tail", 36) → "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\xc3"
```

That partial sequence goes onto the wire for every other system to parse. It now drops the straddling character whole while staying inside the byte budget.

Reaching it needs an over-long non-ASCII subject — a reply to imported echomail is the realistic path, since the reply builder prepends `"Re: "` to a subject that FTN import decoded from CP437 to UTF-8.

A second defect in that fix, caught in review: sizing characters with `utf8.RuneLen(r)` from a `range` loop charges a stray invalid byte 3 bytes, because `range` surfaces it as `RuneError` whose `RuneLen` is 3 — so the cut could still land inside the *next* character, and the `size < 0` guard was dead code. It now takes the real size from `utf8.DecodeRuneInString`. Packets arrive from peers as raw bytes, so invalid UTF-8 here isn't hypothetical.

## `internal/usereditor`, `internal/menueditor` — column layout

`padRight`, `padLeft` and `centerText` measured *and truncated* by bytes, so a multi-byte value both under-filled its column and could be cut mid-character. These TUIs write handle, real name, group location, private note and menu fields **without** the BBS prompts' ASCII gate (`key >= 32 && key < 127`), so the values genuinely can be multi-byte.

`configeditor`, `stringeditor` and `wfcui` had already been converted; these two were the stragglers.

**Correction to an earlier version of this description:** I wrote that these now "match configeditor's implementation exactly". That is not true of `centerText` — `menueditor`'s truncates an over-long string to `width`, while `configeditor`'s returns it unchanged. Each helper keeps the overflow behaviour it already had, since changing that would be a layout change rather than a bug fix. The two implementations still differ, and reconciling them deliberately is worth a follow-up.

## Verification

- `go test ./...` exit 0; `go test -race -count=1` on all three packages exit 0
- `gofmt -l` empty; `go vet` clean