### PR TITLE
refactor: consolidate text-width helpers onto shared primitives

### DIFF
--- a/internal/ansi/width.go
+++ b/internal/ansi/width.go
@@ -1,0 +1,66 @@
+package ansi
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// TruncateRunes clamps s to maxRunes columns, appending ellipsis when it cuts.
+// Counted and cut in runes so multi-byte text is never split. When maxRunes is
+// not larger than the ellipsis itself, the value is hard-cut with no ellipsis.
+//
+// This is a bare rune-counting primitive: unlike TruncateVisible, it does not
+// understand ANSI escape sequences or pipe color codes. Use it for plain text
+// (labels, names, free-form user input); use TruncateVisible for strings that
+// may carry ANSI escapes.
+func TruncateRunes(s string, maxRunes int, ellipsis string) string {
+	if maxRunes < 0 {
+		maxRunes = 0
+	}
+	if utf8.RuneCountInString(s) <= maxRunes {
+		return s
+	}
+	runes := []rune(s)
+	e := utf8.RuneCountInString(ellipsis)
+	if maxRunes <= e {
+		return string(runes[:maxRunes])
+	}
+	return string(runes[:maxRunes-e]) + ellipsis
+}
+
+// PadRight pads s with spaces on the right to width columns, counted in
+// runes. It never truncates: if s is already at or beyond width, it is
+// returned unchanged. Compose with TruncateRunes when the caller needs a hard
+// column budget.
+func PadRight(s string, width int) string {
+	n := utf8.RuneCountInString(s)
+	if n >= width {
+		return s
+	}
+	return s + strings.Repeat(" ", width-n)
+}
+
+// PadLeft pads s with spaces on the left to width columns, counted in runes.
+// It never truncates: if s is already at or beyond width, it is returned
+// unchanged. Compose with TruncateRunes when the caller needs a hard column
+// budget.
+func PadLeft(s string, width int) string {
+	n := utf8.RuneCountInString(s)
+	if n >= width {
+		return s
+	}
+	return strings.Repeat(" ", width-n) + s
+}
+
+// Center centers s within width columns, counted in runes. It never
+// truncates: if s is already at or beyond width, it is returned unchanged.
+// Compose with TruncateRunes when the caller needs a hard column budget. When
+// the padding is odd, the extra space goes on the right.
+func Center(s string, width int) string {
+	n := utf8.RuneCountInString(s)
+	if n >= width {
+		return s
+	}
+	pad := (width - n) / 2
+	return strings.Repeat(" ", pad) + s + strings.Repeat(" ", width-pad-n)
+}

--- a/internal/ansi/width_test.go
+++ b/internal/ansi/width_test.go
@@ -1,0 +1,107 @@
+package ansi
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncateRunes(t *testing.T) {
+	tests := []struct {
+		name     string
+		s        string
+		maxRunes int
+		ellipsis string
+		want     string
+	}{
+		{"empty input", "", 10, "...", ""},
+		{"max 0", "hello", 0, "...", ""},
+		{"negative max", "hello", -1, "...", ""},
+		{"shorter than max", "abc", 10, "...", "abc"},
+		{"exactly max", "Hello", 5, "...", "Hello"},
+		{"overflow with 3-rune ellipsis", "Hello World", 8, "...", "Hello..."},
+		{"overflow with 2-rune ellipsis", "abcdefgh", 5, "..", "abc.."},
+		{"overflow with 1-rune ellipsis", "Hello World", 8, "…", "Hello W…"},
+		{"overflow with empty ellipsis hard-cuts", "Hello World", 5, "", "Hello"},
+		{"maxRunes equal to ellipsis length hard-cuts", "Hello", 3, "...", "Hel"},
+		{"maxRunes below ellipsis length hard-cuts", "Hello", 1, "...", "H"},
+		{"maxRunes 0 with empty ellipsis", "Hello", 0, "", ""},
+		{"multi-rune ellipsis longer than 3", "Hello World", 10, ">>>>>", "Hello>>>>>"},
+		{"multi-byte fits by runes", "héllo", 5, "...", "héllo"},
+		{"multi-byte truncation on rune boundary", "héllo wörld", 8, "...", "héllo..."},
+		{"cjk truncation on rune boundary", "日本語のメッセージ", 5, "...", "日本..."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TruncateRunes(tt.s, tt.maxRunes, tt.ellipsis)
+			if got != tt.want {
+				t.Errorf("TruncateRunes(%q, %d, %q) = %q, want %q", tt.s, tt.maxRunes, tt.ellipsis, got, tt.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("TruncateRunes(%q, %d, %q) produced invalid UTF-8: %q", tt.s, tt.maxRunes, tt.ellipsis, got)
+			}
+		})
+	}
+}
+
+func TestPadRight(t *testing.T) {
+	tests := []struct {
+		name  string
+		s     string
+		width int
+		want  string
+	}{
+		{"pads short string", "ab", 5, "ab   "},
+		{"exact width no-op", "abcde", 5, "abcde"},
+		{"longer than width never truncates", "abcdefgh", 5, "abcdefgh"},
+		{"multi-byte counted in runes", "café", 6, "café  "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PadRight(tt.s, tt.width); got != tt.want {
+				t.Errorf("PadRight(%q, %d) = %q, want %q", tt.s, tt.width, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPadLeft(t *testing.T) {
+	tests := []struct {
+		name  string
+		s     string
+		width int
+		want  string
+	}{
+		{"pads short string", "ab", 5, "   ab"},
+		{"exact width no-op", "abcde", 5, "abcde"},
+		{"longer than width never truncates", "abcdefgh", 5, "abcdefgh"},
+		{"multi-byte counted in runes", "café", 6, "  café"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PadLeft(tt.s, tt.width); got != tt.want {
+				t.Errorf("PadLeft(%q, %d) = %q, want %q", tt.s, tt.width, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCenter(t *testing.T) {
+	tests := []struct {
+		name  string
+		s     string
+		width int
+		want  string
+	}{
+		{"even padding", "hi", 6, "  hi  "},
+		{"odd remainder goes right", "hi", 5, " hi  "},
+		{"exact width no-op", "Hello", 5, "Hello"},
+		{"longer than width never truncates", "toolong", 3, "toolong"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Center(tt.s, tt.width); got != tt.want {
+				t.Errorf("Center(%q, %d) = %q, want %q", tt.s, tt.width, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/configeditor/fields.go
+++ b/internal/configeditor/fields.go
@@ -3,6 +3,8 @@ package configeditor
 import (
 	"strings"
 	"unicode/utf8"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 )
 
 // fieldType defines the edit behavior for a field.
@@ -49,28 +51,15 @@ func maskValue(s string) string {
 
 // padRight pads a string to width with spaces, truncating if longer.
 func padRight(s string, width int) string {
-	runes := []rune(s)
-	if len(runes) >= width {
-		return string(runes[:width])
-	}
-	return s + strings.Repeat(" ", width-len(runes))
+	return ansi.PadRight(ansi.TruncateRunes(s, width, ""), width)
 }
 
 // padLeft pads a string on the left to width.
 func padLeft(s string, width int) string {
-	runes := []rune(s)
-	if len(runes) >= width {
-		return string(runes[:width])
-	}
-	return strings.Repeat(" ", width-len(runes)) + s
+	return ansi.PadLeft(ansi.TruncateRunes(s, width, ""), width)
 }
 
 // centerText centers a string within a given width using visual (rune) width.
 func centerText(s string, width int) string {
-	vis := utf8.RuneCountInString(s)
-	if vis >= width {
-		return s
-	}
-	pad := (width - vis) / 2
-	return strings.Repeat(" ", pad) + s + strings.Repeat(" ", width-pad-vis)
+	return ansi.Center(s, width)
 }

--- a/internal/menu/conference_menu.go
+++ b/internal/menu/conference_menu.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/conference"
@@ -412,30 +411,19 @@ func displayMessageAreaListFiltered(e *MenuExecutor, s ssh.Session, terminal *te
 	return displayedAreas, terminalio.WriteProcessedBytes(terminal, outputBuffer.Bytes(), outputMode)
 }
 
-// padRight pads s with spaces on the right to the given width. If s is already wider, it is returned as-is.
-// padRight pads s with spaces to width columns. Counted in runes, not bytes:
-// callers pass area, conference and network names that can hold multi-byte
-// characters, and byte padding would leave the column short.
+// padRight pads s with spaces to width columns. If s is already wider, it is
+// returned as-is. Counted in runes, not bytes: callers pass area, conference
+// and network names that can hold multi-byte characters, and byte padding
+// would leave the column short.
 func padRight(s string, width int) string {
-	n := utf8.RuneCountInString(s)
-	if n >= width {
-		return s
-	}
-	return s + strings.Repeat(" ", width-n)
+	return ansi.PadRight(s, width)
 }
 
 // truncateStr clamps s to maxLen columns, appending ".." when it cuts.
 // Measured and cut in runes so a multi-byte name is never split mid-sequence:
 // several callers render text fetched from the remote V3Net registry.
 func truncateStr(s string, maxLen int) string {
-	if utf8.RuneCountInString(s) <= maxLen {
-		return s
-	}
-	runes := []rune(s)
-	if maxLen <= 2 {
-		return string(runes[:maxLen])
-	}
-	return string(runes[:maxLen-2]) + ".."
+	return ansi.TruncateRunes(s, maxLen, "..")
 }
 
 // findFirstAccessibleAreaInConference returns the first area the user can read in the given conference.

--- a/internal/menu/conference_menu_test.go
+++ b/internal/menu/conference_menu_test.go
@@ -41,10 +41,13 @@ func TestTruncateStrCutsOnRuneBoundaries(t *testing.T) {
 		maxLen int
 		want   string
 	}{
+		{"empty input", "", 10, ""},
+		{"maxLen 0", "abcdef", 0, ""},
 		{"shorter than max", "abc", 10, "abc"},
 		{"exactly max", "abcde", 5, "abcde"},
 		{"longer gets ellipsis", "abcdefgh", 5, "abc.."},
 		{"maxLen 2 hard cut", "abcdef", 2, "ab"},
+		{"maxLen 1 hard cut", "abcdef", 1, "a"},
 		{"multi-byte fits by runes", "café", 4, "café"},
 		{"multi-byte cut on boundary", "café society", 6, "café.."},
 		{"cjk cut on boundary", "日本語のメッセージ", 5, "日本語.."},

--- a/internal/menu/executor_admin_users.go
+++ b/internal/menu/executor_admin_users.go
@@ -189,15 +189,10 @@ func sortedUsersByID(users []*user.User) []*user.User {
 	return filtered
 }
 
+// adminTruncate trims surrounding whitespace, then clamps input to max
+// columns, appending "…" when it cuts.
 func adminTruncate(input string, max int) string {
-	runes := []rune(strings.TrimSpace(input))
-	if len(runes) <= max {
-		return string(runes)
-	}
-	if max <= 1 {
-		return string(runes[:max])
-	}
-	return string(runes[:max-1]) + "…"
+	return ansi.TruncateRunes(strings.TrimSpace(input), max, "…")
 }
 
 func adminTime(t time.Time) string {

--- a/internal/menu/executor_admin_users_test.go
+++ b/internal/menu/executor_admin_users_test.go
@@ -1,0 +1,36 @@
+package menu
+
+import "testing"
+
+// adminTruncate trims surrounding whitespace before measuring, then appends a
+// single-rune "…" ellipsis when it cuts. These cases pin its current
+// behaviour before it is migrated to delegate to ansi.TruncateRunes.
+func TestAdminTruncate(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		max  int
+		want string
+	}{
+		{"empty input", "", 10, ""},
+		{"whitespace only collapses to empty", "   ", 10, ""},
+		{"max 0", "hello", 0, ""},
+		{"shorter than max", "abc", 10, "abc"},
+		{"exactly max", "Hello", 5, "Hello"},
+		{"longer gets ellipsis", "Hello World", 8, "Hello W…"},
+		{"maxLen exactly 1 hard-cuts", "Hello", 1, "H"},
+		{"maxLen 0 with non-empty trimmed value", "Hello", 0, ""},
+		{"leading and trailing whitespace trimmed first", "  Hello  ", 10, "Hello"},
+		{"trimmed then truncated", "  Hello World  ", 8, "Hello W…"},
+		{"multi-byte fits by runes", "héllo", 5, "héllo"},
+		{"multi-byte truncation on rune boundary", "héllo wörld", 8, "héllo w…"},
+		{"cjk truncation on rune boundary", "日本語のメッセージ", 5, "日本語の…"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := adminTruncate(tt.s, tt.max); got != tt.want {
+				t.Errorf("adminTruncate(%q, %d) = %q, want %q", tt.s, tt.max, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/menu/executor_admin_users_test.go
+++ b/internal/menu/executor_admin_users_test.go
@@ -4,7 +4,8 @@ import "testing"
 
 // adminTruncate trims surrounding whitespace before measuring, then appends a
 // single-rune "…" ellipsis when it cuts. These cases pin its current
-// behaviour before it is migrated to delegate to ansi.TruncateRunes.
+// behaviour, which the migration onto ansi.TruncateRunes had to preserve
+// exactly — and still must.
 func TestAdminTruncate(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/menu/executor_oneliners_text.go
+++ b/internal/menu/executor_oneliners_text.go
@@ -3,21 +3,18 @@ package menu
 import (
 	"strings"
 	"unicode/utf8"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 )
 
+// truncateRunes trims surrounding whitespace, then clamps value to max
+// columns, appending "..." when it cuts.
 func truncateRunes(value string, max int) string {
 	value = strings.TrimSpace(value)
 	if max <= 0 || value == "" {
 		return ""
 	}
-	if utf8.RuneCountInString(value) <= max {
-		return value
-	}
-	runes := []rune(value)
-	if max <= 3 {
-		return string(runes[:max])
-	}
-	return string(runes[:max-3]) + "..."
+	return ansi.TruncateRunes(value, max, "...")
 }
 
 func isPipeCodeStartChar(b byte) bool {

--- a/internal/menu/executor_oneliners_text_test.go
+++ b/internal/menu/executor_oneliners_text_test.go
@@ -4,7 +4,8 @@ import "testing"
 
 // truncateRunes (oneliners) trims surrounding whitespace before measuring,
 // then appends a 3-rune "..." ellipsis when it cuts. These cases pin its
-// current behaviour before it is migrated to delegate to ansi.TruncateRunes.
+// behaviour, which the migration onto ansi.TruncateRunes had to preserve
+// exactly — and still must.
 func TestOnelinerTruncateRunes(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/menu/executor_oneliners_text_test.go
+++ b/internal/menu/executor_oneliners_text_test.go
@@ -1,0 +1,37 @@
+package menu
+
+import "testing"
+
+// truncateRunes (oneliners) trims surrounding whitespace before measuring,
+// then appends a 3-rune "..." ellipsis when it cuts. These cases pin its
+// current behaviour before it is migrated to delegate to ansi.TruncateRunes.
+func TestOnelinerTruncateRunes(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		max  int
+		want string
+	}{
+		{"empty input", "", 10, ""},
+		{"whitespace only collapses to empty", "   ", 10, ""},
+		{"max 0", "hello", 0, ""},
+		{"negative max", "hello", -1, ""},
+		{"shorter than max", "abc", 10, "abc"},
+		{"exactly max", "Hello", 5, "Hello"},
+		{"longer gets ellipsis", "Hello World", 8, "Hello..."},
+		{"maxLen exactly 3 hard-cuts", "Hello", 3, "Hel"},
+		{"maxLen 1 hard-cut", "Hello", 1, "H"},
+		{"leading and trailing whitespace trimmed first", "  Hello  ", 10, "Hello"},
+		{"trimmed then truncated", "  Hello World  ", 8, "Hello..."},
+		{"multi-byte fits by runes", "héllo", 5, "héllo"},
+		{"multi-byte truncation on rune boundary", "héllo wörld", 8, "héllo..."},
+		{"cjk truncation on rune boundary", "日本語のメッセージ", 5, "日本..."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := truncateRunes(tt.s, tt.max); got != tt.want {
+				t.Errorf("truncateRunes(%q, %d) = %q, want %q", tt.s, tt.max, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/menu/message_list_state.go
+++ b/internal/menu/message_list_state.go
@@ -3,8 +3,8 @@ package menu
 import (
 	"fmt"
 	"log/slog"
-	"unicode/utf8"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/message"
 )
 
@@ -29,19 +29,12 @@ type MessageListState struct {
 	LastRead      int
 }
 
-// truncateString truncates a string to maxLen, adding "..." if truncated
+// truncateString truncates a string to maxLen, adding "..." if truncated.
+// Measured and cut in runes, not bytes: subjects and handles can hold
+// multi-byte characters, and a byte-offset slice would emit a partial UTF-8
+// sequence and render as garbage.
 func truncateString(s string, maxLen int) string {
-	// Measured and cut in runes, not bytes: subjects and handles can hold
-	// multi-byte characters, and a byte-offset slice would emit a partial UTF-8
-	// sequence and render as garbage.
-	if utf8.RuneCountInString(s) <= maxLen {
-		return s
-	}
-	runes := []rune(s)
-	if maxLen <= 3 {
-		return string(runes[:maxLen])
-	}
-	return string(runes[:maxLen-3]) + "..."
+	return ansi.TruncateRunes(s, maxLen, "...")
 }
 
 // formatStatusChar returns the status character for a message entry

--- a/internal/menu/message_list_test.go
+++ b/internal/menu/message_list_test.go
@@ -53,6 +53,7 @@ func TestTruncateString(t *testing.T) {
 		maxLen int
 		want   string
 	}{
+		{"empty input", "", 10, ""},
 		{"shorter than max", "abc", 10, "abc"},
 		{"exactly max", "Hello", 5, "Hello"},
 		{"longer, ellipsis applied", "Hello World", 8, "Hello..."},

--- a/internal/menueditor/fields.go
+++ b/internal/menueditor/fields.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/stringeditor"
 )
 
@@ -170,19 +171,10 @@ func cmdFields() []fieldDef {
 
 // padRight pads a string to width with spaces, truncating if longer.
 func padRight(s string, width int) string {
-	runes := []rune(s)
-	if len(runes) >= width {
-		return string(runes[:width])
-	}
-	return s + strings.Repeat(" ", width-len(runes))
+	return ansi.PadRight(ansi.TruncateRunes(s, width, ""), width)
 }
 
 // centerText centers a string within a given width.
 func centerText(s string, width int) string {
-	runes := []rune(s)
-	if len(runes) >= width {
-		return string(runes[:width])
-	}
-	pad := (width - len(runes)) / 2
-	return strings.Repeat(" ", pad) + s + strings.Repeat(" ", width-pad-len(runes))
+	return ansi.Center(ansi.TruncateRunes(s, width, ""), width)
 }

--- a/internal/usereditor/fields.go
+++ b/internal/usereditor/fields.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 )
 
@@ -307,18 +308,10 @@ func infoformStatus(dataDir string, userID int) string {
 
 // padRight pads a string to width with spaces, truncating if longer.
 func padRight(s string, width int) string {
-	runes := []rune(s)
-	if len(runes) >= width {
-		return string(runes[:width])
-	}
-	return s + strings.Repeat(" ", width-len(runes))
+	return ansi.PadRight(ansi.TruncateRunes(s, width, ""), width)
 }
 
 // padLeft pads a string on the left to width.
 func padLeft(s string, width int) string {
-	runes := []rune(s)
-	if len(runes) >= width {
-		return string(runes[:width])
-	}
-	return strings.Repeat(" ", width-len(runes)) + s
+	return ansi.PadLeft(ansi.TruncateRunes(s, width, ""), width)
 }

--- a/internal/usereditor/pubkey_dialog.go
+++ b/internal/usereditor/pubkey_dialog.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 )
@@ -57,11 +58,7 @@ func (m *Model) keyDialogDelete(ref string) error {
 // truncateRunes truncates s to at most n runes, returning a string of at most n
 // runes (never splitting a multi-byte UTF-8 sequence).
 func truncateRunes(s string, n int) string {
-	r := []rune(s)
-	if len(r) <= n {
-		return s
-	}
-	return string(r[:n])
+	return ansi.TruncateRunes(s, n, "")
 }
 
 // overlayKeyListDialog renders the WFC Keys list overlay over background.

--- a/internal/usereditor/pubkey_dialog_test.go
+++ b/internal/usereditor/pubkey_dialog_test.go
@@ -15,8 +15,8 @@ import (
 
 // truncateRunes (pubkey dialog) has no ellipsis and no TrimSpace: it is a
 // plain rune-aware hard cut, used for the key-list comment column and error
-// text. These cases pin its current behaviour before it is migrated to
-// delegate to ansi.TruncateRunes.
+// text. These cases pin its behaviour, which the migration onto
+// ansi.TruncateRunes had to preserve exactly — and still must.
 func TestPubkeyDialogTruncateRunes(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/usereditor/pubkey_dialog_test.go
+++ b/internal/usereditor/pubkey_dialog_test.go
@@ -13,6 +13,38 @@ import (
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 )
 
+// truncateRunes (pubkey dialog) has no ellipsis and no TrimSpace: it is a
+// plain rune-aware hard cut, used for the key-list comment column and error
+// text. These cases pin its current behaviour before it is migrated to
+// delegate to ansi.TruncateRunes.
+func TestPubkeyDialogTruncateRunes(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		n    int
+		want string
+	}{
+		{"empty input", "", 10, ""},
+		{"n 0 non-empty input", "hello", 0, ""},
+		{"n 0 empty input", "", 0, ""},
+		{"shorter than n", "abc", 10, "abc"},
+		{"exactly n", "Hello", 5, "Hello"},
+		{"longer hard-cuts, no ellipsis", "Hello World", 5, "Hello"},
+		{"n 1", "Hello", 1, "H"},
+		{"leading/trailing whitespace preserved (no trim)", "  Hello  ", 5, "  Hel"},
+		{"multi-byte fits by runes", "héllo", 5, "héllo"},
+		{"multi-byte hard-cut on rune boundary", "héllo wörld", 6, "héllo "},
+		{"cjk hard-cut on rune boundary", "日本語のメッセージ", 4, "日本語の"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := truncateRunes(tt.s, tt.n); got != tt.want {
+				t.Errorf("truncateRunes(%q, %d) = %q, want %q", tt.s, tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
 // makeTestKey returns a valid OpenSSH ed25519 authorized_keys line for testing.
 func makeTestKey(t *testing.T, comment string) string {
 	t.Helper()

--- a/internal/usereditor/view.go
+++ b/internal/usereditor/view.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 	"strings"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -335,12 +336,12 @@ func (m Model) cursorToDisplayRow(cursor int) int {
 }
 
 // centerText centers a string within a given width.
+//
+// This is rune-based, not byte-based: every caller today passes an ASCII
+// literal, so this was unreachable in practice, but a byte-offset slice on
+// multi-byte input would emit a partial UTF-8 sequence and render as garbage.
 func centerText(s string, width int) string {
-	if len(s) >= width {
-		return s[:width]
-	}
-	pad := (width - len(s)) / 2
-	return strings.Repeat(" ", pad) + s + strings.Repeat(" ", width-pad-len(s))
+	return ansi.Center(ansi.TruncateRunes(s, width, ""), width)
 }
 
 // centerInBox centers text inside the box area between borders.

--- a/internal/usereditor/view_test.go
+++ b/internal/usereditor/view_test.go
@@ -1,6 +1,9 @@
 package usereditor
 
-import "testing"
+import (
+	"testing"
+	"unicode/utf8"
+)
 
 // centerText (view.go) is currently byte-based (len(s) >= width, s[:width]).
 // Every caller today passes ASCII literals, so byte and rune counting agree —
@@ -27,5 +30,19 @@ func TestViewCenterText(t *testing.T) {
 				t.Errorf("centerText(%q, %d) = %q, want %q", tt.s, tt.width, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestViewCenterTextMultiByteIsRuneSafe is new coverage added alongside the
+// migration to ansi.Center/ansi.TruncateRunes: it was unreachable under the
+// old byte-based implementation (no caller passes multi-byte input today),
+// but the fix must not corrupt UTF-8 if that ever changes.
+func TestViewCenterTextMultiByteIsRuneSafe(t *testing.T) {
+	got := centerText("héllo wörld", 8)
+	if !utf8.ValidString(got) {
+		t.Fatalf("centerText produced invalid UTF-8: %q", got)
+	}
+	if want := "héllo wö"; got != want {
+		t.Errorf("centerText(%q, 8) = %q, want %q", "héllo wörld", got, want)
 	}
 }

--- a/internal/usereditor/view_test.go
+++ b/internal/usereditor/view_test.go
@@ -1,0 +1,31 @@
+package usereditor
+
+import "testing"
+
+// centerText (view.go) is currently byte-based (len(s) >= width, s[:width]).
+// Every caller today passes ASCII literals, so byte and rune counting agree —
+// these cases pin that observable behaviour before the helper is migrated to
+// delegate to ansi.Center/ansi.TruncateRunes as a genuine (if today
+// unreachable) correctness fix.
+func TestViewCenterText(t *testing.T) {
+	tests := []struct {
+		name  string
+		s     string
+		width int
+		want  string
+	}{
+		{"empty input", "", 10, "          "},
+		{"shorter than width, even padding", "hi", 6, "  hi  "},
+		{"shorter than width, odd remainder goes right", "hi", 5, " hi  "},
+		{"exactly width", "Hello", 5, "Hello"},
+		{"longer than width hard-cuts", "toolong", 3, "too"},
+		{"width 0 with empty input", "", 0, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := centerText(tt.s, tt.width); got != tt.want {
+				t.Errorf("centerText(%q, %d) = %q, want %q", tt.s, tt.width, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/usereditor/view_test.go
+++ b/internal/usereditor/view_test.go
@@ -5,11 +5,11 @@ import (
 	"unicode/utf8"
 )
 
-// centerText (view.go) is currently byte-based (len(s) >= width, s[:width]).
-// Every caller today passes ASCII literals, so byte and rune counting agree —
-// these cases pin that observable behaviour before the helper is migrated to
-// delegate to ansi.Center/ansi.TruncateRunes as a genuine (if today
-// unreachable) correctness fix.
+// centerText (view.go) was byte-based (len(s) >= width, s[:width]) and now
+// delegates to ansi.Center/ansi.TruncateRunes. Every caller passes ASCII
+// literals, so byte and rune counting agree and these cases pin the observable
+// layout either way; the conversion was a genuine correctness fix for input
+// that cannot reach it today.
 func TestViewCenterText(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary

Removes the root cause behind the 17 byte-vs-rune bugs fixed in #148 and #149: the repo had **six truncation helpers, four pad helpers and three `centerText`s**, each re-deriving the same logic, so every new screen re-invented one and had an even chance of measuring bytes.

They now delegate to shared primitives in `internal/ansi`:

```go
func TruncateRunes(s string, maxRunes int, ellipsis string) string
func PadRight(s string, width int) string
func PadLeft(s string, width int) string
func Center(s string, width int) string
```

## This is de-duplication, not unification

The variants differ deliberately, and those differences are user-visible column budgets:

| Helper | Ellipsis | Trims? |
| --- | --- | --- |
| `menu.truncateStr` | `..` | no |
| `menu.truncateString` | `...` | no |
| `menu.truncateRunes` | `...` | yes |
| `menu.adminTruncate` | `…` (1 rune, 3 bytes) | yes |
| `usereditor.truncateRunes` | none | no |

Each keeps its own convention and becomes a thin wrapper passing its ellipsis to the primitive. Unifying them would shift column budgets across many screens — a deliberate follow-up, not a rider on this change.

One rule generalizes all five:

```
if RuneCount(s) <= maxRunes          -> s
e := RuneCount(ellipsis)
if maxRunes <= e                     -> hard cut, no ellipsis
else                                 -> runes[:maxRunes-e] + ellipsis
```

Verified by hand against each variant before writing it — including `adminTruncate`'s `…`, which is one rune but three bytes, so the boundary had to be rune-based to match its old `max <= 1`.

## Proof that nothing changed

Characterization tests were written **first, in their own commit** (`10cac58`), pinning each helper's current output across no-truncation, exact-boundary, overflow, every hard-cut branch, empty input, whitespace-only, and multi-byte cases.

The migration commit (`aff8751`) touches **only production files** — no test was modified to make the migration pass. That's the evidence the output is identical.

## One behavioural divergence, documented rather than buried

For a **negative** `maxLen`/`width`, the old hand-rolled helpers panicked on the slice bound; the primitives clamp to 0 and return gracefully. Every current call site passes a positive literal or a pre-clamped value, so this is unreachable today, and graceful is the better behaviour — but it is a genuine difference and worth stating.

## Also fixed

`internal/usereditor/view.go`'s `centerText` was still byte-based — my #149 fix covered `fields.go` in the same package and missed this one. Every caller passes ASCII, so it's unreachable today; converted anyway, with the commit saying so plainly.

## Out of scope, deliberately

Unifying the ellipsis conventions; reconciling `configeditor`'s non-truncating `centerText` with `menueditor`'s truncating one; wide-character/CJK double-width support (would need `go-runewidth` threaded through `ansi.VisibleLength`); and `ansi.TruncateVisible`/`VisibleLength`, which were already correct and ANSI-aware.

## Verification

- `go test ./...` exit 0; `go test -race -count=1` across ansi, menu, usereditor, menueditor, configeditor exit 0
- `gofmt -l` empty; `go vet ./...` clean; `staticcheck` zero findings; binary builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unicode-safe text truncation, padding, and centering across menus and editors, avoiding cutting multi-byte characters incorrectly.
  * Standardized truncation/ellipsis behavior and edge-case handling for empty, whitespace-only, narrow, and zero-width values.
* **Tests**
  * Expanded unit and coverage for empty inputs, exact-fit vs truncation, hard-cut behavior, ellipsis variations, whitespace preservation, and UTF-8/rune boundary correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->