### PR TITLE
fix(menu): stop writing characters CP437 cannot render

### DIFF
--- a/internal/menu/executor_admin_users.go
+++ b/internal/menu/executor_admin_users.go
@@ -190,8 +190,11 @@ func sortedUsersByID(users []*user.User) []*user.User {
 }
 
 // adminTruncate trims surrounding whitespace, then clamps input to max
-// columns, appending "..." when it cuts. The ellipsis is ASCII deliberately:
-// U+2026 has no CP437 mapping, so it reached CP437 terminals as a stray '?'.
+// columns, appending "..." when it cuts — except when max is 3 or less, where
+// there is no room for the ellipsis and the value is hard-cut instead.
+//
+// The ellipsis is ASCII deliberately: U+2026 has no CP437 mapping, so it
+// reached CP437 terminals as a stray '?'.
 func adminTruncate(input string, max int) string {
 	return ansi.TruncateRunes(strings.TrimSpace(input), max, "...")
 }

--- a/internal/menu/executor_admin_users.go
+++ b/internal/menu/executor_admin_users.go
@@ -190,9 +190,10 @@ func sortedUsersByID(users []*user.User) []*user.User {
 }
 
 // adminTruncate trims surrounding whitespace, then clamps input to max
-// columns, appending "…" when it cuts.
+// columns, appending "..." when it cuts. The ellipsis is ASCII deliberately:
+// U+2026 has no CP437 mapping, so it reached CP437 terminals as a stray '?'.
 func adminTruncate(input string, max int) string {
-	return ansi.TruncateRunes(strings.TrimSpace(input), max, "…")
+	return ansi.TruncateRunes(strings.TrimSpace(input), max, "...")
 }
 
 func adminTime(t time.Time) string {

--- a/internal/menu/executor_admin_users_ellipsis_test.go
+++ b/internal/menu/executor_admin_users_ellipsis_test.go
@@ -1,0 +1,31 @@
+package menu
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
+)
+
+// adminTruncate's ellipsis reaches the terminal through WriteProcessedBytes,
+// which maps every rune to a CP437 byte in CP437 mode and substitutes '?' for
+// anything CP437 lacks. U+2026 ("…") is not in CP437, so a truncated admin
+// field must not rely on it — a stray '?' reads as corrupted data.
+func TestAdminTruncateEllipsisSurvivesCP437(t *testing.T) {
+	truncated := adminTruncate(strings.Repeat("A", 40), 10)
+
+	var buf bytes.Buffer
+	if err := terminalio.WriteProcessedBytes(&buf, []byte(truncated), ansi.OutputModeCP437); err != nil {
+		t.Fatalf("WriteProcessedBytes: %v", err)
+	}
+	got := buf.String()
+
+	if strings.Contains(got, "?") {
+		t.Errorf("CP437 render of %q contains '?': %q — the ellipsis has no CP437 mapping", truncated, got)
+	}
+	if len(got) != 10 {
+		t.Errorf("CP437 render = %d bytes (%q), want 10 columns", len(got), got)
+	}
+}

--- a/internal/menu/executor_admin_users_test.go
+++ b/internal/menu/executor_admin_users_test.go
@@ -2,10 +2,11 @@ package menu
 
 import "testing"
 
-// adminTruncate trims surrounding whitespace before measuring, then appends a
-// ASCII "..." ellipsis when it cuts. These cases pin its current
-// behaviour, which the migration onto ansi.TruncateRunes had to preserve
-// exactly — and still must.
+// adminTruncate trims surrounding whitespace before measuring, then appends an
+// ASCII "..." ellipsis when it cuts (hard-cutting instead when max is 3 or
+// less). These cases pin that behaviour. The expectations changed once, when
+// the ellipsis moved from U+2026 to ASCII because CP437 cannot render U+2026;
+// they should not change again without an equally deliberate reason.
 func TestAdminTruncate(t *testing.T) {
 	tests := []struct {
 		name string
@@ -19,7 +20,13 @@ func TestAdminTruncate(t *testing.T) {
 		{"shorter than max", "abc", 10, "abc"},
 		{"exactly max", "Hello", 5, "Hello"},
 		{"longer gets ellipsis", "Hello World", 8, "Hello..."},
+		// The ellipsis is 3 runes, so anything up to and including 3 has no room
+		// for it and hard-cuts instead. This boundary moved when the ellipsis
+		// changed from the 1-rune U+2026 to ASCII "...".
 		{"maxLen exactly 1 hard-cuts", "Hello", 1, "H"},
+		{"maxLen 2 hard-cuts", "Hello", 2, "He"},
+		{"maxLen 3 hard-cuts", "Hello", 3, "Hel"},
+		{"maxLen 4 has room for the ellipsis", "Hello", 4, "H..."},
 		{"maxLen 0 with non-empty trimmed value", "Hello", 0, ""},
 		{"leading and trailing whitespace trimmed first", "  Hello  ", 10, "Hello"},
 		{"trimmed then truncated", "  Hello World  ", 8, "Hello..."},

--- a/internal/menu/executor_admin_users_test.go
+++ b/internal/menu/executor_admin_users_test.go
@@ -3,7 +3,7 @@ package menu
 import "testing"
 
 // adminTruncate trims surrounding whitespace before measuring, then appends a
-// single-rune "…" ellipsis when it cuts. These cases pin its current
+// ASCII "..." ellipsis when it cuts. These cases pin its current
 // behaviour, which the migration onto ansi.TruncateRunes had to preserve
 // exactly — and still must.
 func TestAdminTruncate(t *testing.T) {
@@ -18,14 +18,14 @@ func TestAdminTruncate(t *testing.T) {
 		{"max 0", "hello", 0, ""},
 		{"shorter than max", "abc", 10, "abc"},
 		{"exactly max", "Hello", 5, "Hello"},
-		{"longer gets ellipsis", "Hello World", 8, "Hello W…"},
+		{"longer gets ellipsis", "Hello World", 8, "Hello..."},
 		{"maxLen exactly 1 hard-cuts", "Hello", 1, "H"},
 		{"maxLen 0 with non-empty trimmed value", "Hello", 0, ""},
 		{"leading and trailing whitespace trimmed first", "  Hello  ", 10, "Hello"},
-		{"trimmed then truncated", "  Hello World  ", 8, "Hello W…"},
+		{"trimmed then truncated", "  Hello World  ", 8, "Hello..."},
 		{"multi-byte fits by runes", "héllo", 5, "héllo"},
-		{"multi-byte truncation on rune boundary", "héllo wörld", 8, "héllo w…"},
-		{"cjk truncation on rune boundary", "日本語のメッセージ", 5, "日本語の…"},
+		{"multi-byte truncation on rune boundary", "héllo wörld", 8, "héllo..."},
+		{"cjk truncation on rune boundary", "日本語のメッセージ", 5, "日本..."},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/menu/executor_files_transfer.go
+++ b/internal/menu/executor_files_transfer.go
@@ -89,7 +89,7 @@ func (e *MenuExecutor) selectTransferProtocol(s ssh.Session, terminal *term.Term
 		if found {
 			return p, true, nil
 		}
-		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(fmt.Sprintf("\r\n|01Unknown protocol %q — please choose from the list above.|07\r\n", strings.ToUpper(input)))), outputMode)
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(fmt.Sprintf("\r\n|01Unknown protocol %q - please choose from the list above.|07\r\n", strings.ToUpper(input)))), outputMode)
 	}
 }
 

--- a/internal/menu/nuv.go
+++ b/internal/menu/nuv.go
@@ -125,7 +125,7 @@ func nuvDisplayStats(e *MenuExecutor, terminal *term.Terminal, c *NUVCandidate, 
 	yes := nuvYesCount(c)
 	no := len(c.Votes) - yes
 	terminalio.WriteProcessedBytes(terminal, []byte("\x1b[2J\x1b[H"), outputMode)
-	wv(terminal, fmt.Sprintf("\r\n|15New User Voting — Candidate #%d\r\n|08%s\r\n", idx, strings.Repeat("\xc4", 50)), outputMode)
+	wv(terminal, fmt.Sprintf("\r\n|15New User Voting - Candidate #%d\r\n|08%s\r\n", idx, strings.Repeat("\xc4", 50)), outputMode)
 
 	// V2: NUV_Voting_On = '|08U|07s|15er |08N|07a|15me|09: |15|NA'
 	nameStr := e.LoadedStrings.WhosBeingVotedOn
@@ -478,7 +478,7 @@ func nuvVoteOn(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 			}
 			nuvMu.Unlock()
 			if removed {
-				wv(terminal, "|10Threshold reached — candidate processed.\r\n", outputMode)
+				wv(terminal, "|10Threshold reached - candidate processed.\r\n", outputMode)
 				return true
 			}
 			wv(terminal, votePrompt, outputMode)

--- a/internal/menu/nuv_scan.go
+++ b/internal/menu/nuv_scan.go
@@ -160,7 +160,7 @@ func runNUVList(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	terminalio.WriteProcessedBytes(terminal, []byte("\x1b[2J\x1b[H"), outputMode)
-	wv(terminal, fmt.Sprintf("|15New User Voting Queue — %d Candidate(s)\r\n", len(nd.Candidates)), outputMode)
+	wv(terminal, fmt.Sprintf("|15New User Voting Queue - %d Candidate(s)\r\n", len(nd.Candidates)), outputMode)
 	wv(terminal, fmt.Sprintf("|08%s\r\n", strings.Repeat("\xc4", 60)), outputMode)
 
 	if len(nd.Candidates) == 0 {
@@ -284,7 +284,7 @@ func runNUVList(c *cmdCtx, args string) (*user.User, string, error) {
 			return currentUser, "", nil
 		}
 		terminalio.WriteProcessedBytes(terminal, []byte("\x1b[2J\x1b[H"), outputMode)
-		wv(terminal, fmt.Sprintf("|15New User Voting Queue — %d Candidate(s)\r\n", len(nd.Candidates)), outputMode)
+		wv(terminal, fmt.Sprintf("|15New User Voting Queue - %d Candidate(s)\r\n", len(nd.Candidates)), outputMode)
 		wv(terminal, fmt.Sprintf("|08%s\r\n", strings.Repeat("\xc4", 60)), outputMode)
 		if len(nd.Candidates) == 0 {
 			wv(terminal, "|07No candidates pending.\r\n", outputMode)

--- a/internal/menu/qwk_handler.go
+++ b/internal/menu/qwk_handler.go
@@ -261,7 +261,7 @@ func runQWKUpload(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	if importRes.Duplicate > 0 {
-		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|07This packet was already uploaded — nothing posted.|07\r\n")), outputMode)
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|07This packet was already uploaded - nothing posted.|07\r\n")), outputMode)
 		time.Sleep(2 * time.Second)
 		return currentUser, "", nil
 	}

--- a/internal/menu/sponsor_menu.go
+++ b/internal/menu/sponsor_menu.go
@@ -453,7 +453,7 @@ func runSponsorEditArea(c *cmdCtx, args string) (*user.User, string, error) {
 		switch key {
 		case int('t'), int('T'):
 			if currentUser.AccessLevel < cfg.CoSysOpLevel {
-				msg := "|01Tag — sysop/co-sysop only.|07"
+				msg := "|01Tag - sysop/co-sysop only.|07"
 				_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 				time.Sleep(1 * time.Second)
 				break
@@ -512,7 +512,7 @@ func runSponsorEditArea(c *cmdCtx, args string) (*user.User, string, error) {
 			case newHandle != "":
 				if userManager != nil {
 					if _, exists := userManager.GetUser(newHandle); !exists {
-						msg := fmt.Sprintf("|01User '%s' not found — sponsor unchanged.|07", newHandle)
+						msg := fmt.Sprintf("|01User '%s' not found - sponsor unchanged.|07", newHandle)
 						_ = terminalio.WriteProcessedBytes(terminal,
 							ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 						time.Sleep(1 * time.Second)
@@ -537,7 +537,7 @@ func runSponsorEditArea(c *cmdCtx, args string) (*user.User, string, error) {
 				if _, scanErr := fmt.Sscanf(raw, "%d", &n); scanErr == nil && n >= 0 {
 					edited.MaxMessages = n
 				} else {
-					msg := "|01Invalid number — unchanged.|07"
+					msg := "|01Invalid number - unchanged.|07"
 					_ = terminalio.WriteProcessedBytes(terminal,
 						ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 					time.Sleep(1 * time.Second)
@@ -557,7 +557,7 @@ func runSponsorEditArea(c *cmdCtx, args string) (*user.User, string, error) {
 				if _, scanErr := fmt.Sscanf(raw, "%d", &n); scanErr == nil && n >= 0 {
 					edited.MaxAge = n
 				} else {
-					msg := "|01Invalid number — unchanged.|07"
+					msg := "|01Invalid number - unchanged.|07"
 					_ = terminalio.WriteProcessedBytes(terminal,
 						ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 					time.Sleep(1 * time.Second)
@@ -645,7 +645,7 @@ func runSponsorEditArea(c *cmdCtx, args string) (*user.User, string, error) {
 				if _, scanErr := fmt.Sscanf(raw, "%d", &n); scanErr == nil && n >= 0 {
 					edited.ConferenceID = n
 				} else {
-					msg := "|01Invalid number — unchanged.|07"
+					msg := "|01Invalid number - unchanged.|07"
 					_ = terminalio.WriteProcessedBytes(terminal,
 						ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 					time.Sleep(1 * time.Second)
@@ -658,7 +658,7 @@ func runSponsorEditArea(c *cmdCtx, args string) (*user.User, string, error) {
 
 		case int('b'), int('B'):
 			if currentUser.AccessLevel < cfg.CoSysOpLevel {
-				msg := "|01Base Path — sysop/co-sysop only.|07"
+				msg := "|01Base Path - sysop/co-sysop only.|07"
 				_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 				time.Sleep(1 * time.Second)
 				break
@@ -673,7 +673,7 @@ func runSponsorEditArea(c *cmdCtx, args string) (*user.User, string, error) {
 
 		case int('y'), int('Y'):
 			if currentUser.AccessLevel < cfg.CoSysOpLevel {
-				msg := "|01Area Type — sysop/co-sysop only.|07"
+				msg := "|01Area Type - sysop/co-sysop only.|07"
 				_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 				time.Sleep(1 * time.Second)
 				break
@@ -688,7 +688,7 @@ func runSponsorEditArea(c *cmdCtx, args string) (*user.User, string, error) {
 
 		case int('e'), int('E'):
 			if currentUser.AccessLevel < cfg.CoSysOpLevel {
-				msg := "|01Echo Tag — sysop/co-sysop only.|07"
+				msg := "|01Echo Tag - sysop/co-sysop only.|07"
 				_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 				time.Sleep(1 * time.Second)
 				break
@@ -703,7 +703,7 @@ func runSponsorEditArea(c *cmdCtx, args string) (*user.User, string, error) {
 
 		case int('o'), int('O'):
 			if currentUser.AccessLevel < cfg.CoSysOpLevel {
-				msg := "|01Origin Address — sysop/co-sysop only.|07"
+				msg := "|01Origin Address - sysop/co-sysop only.|07"
 				_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 				time.Sleep(1 * time.Second)
 				break
@@ -718,7 +718,7 @@ func runSponsorEditArea(c *cmdCtx, args string) (*user.User, string, error) {
 
 		case int('k'), int('K'):
 			if currentUser.AccessLevel < cfg.CoSysOpLevel {
-				msg := "|01Network — sysop/co-sysop only.|07"
+				msg := "|01Network - sysop/co-sysop only.|07"
 				_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 				time.Sleep(1 * time.Second)
 				break
@@ -833,7 +833,7 @@ func runSponsorEditArea(c *cmdCtx, args string) (*user.User, string, error) {
 			}
 			if updateErr := e.MessageMgr.UpdateAreaByID(edited.ID, edited); updateErr != nil {
 				slog.Error("failed to update area", "node", nodeNumber, "error", updateErr)
-				msg := "|01Error updating area — changes may be lost.|07\r\n"
+				msg := "|01Error updating area - changes may be lost.|07\r\n"
 				_ = terminalio.WriteProcessedBytes(terminal,
 					ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 				time.Sleep(2 * time.Second)
@@ -841,7 +841,7 @@ func runSponsorEditArea(c *cmdCtx, args string) (*user.User, string, error) {
 			}
 			if saveErr := e.MessageMgr.SaveAreas(); saveErr != nil {
 				slog.Error("failed to save areas", "node", nodeNumber, "error", saveErr)
-				msg := "|01Error saving area — changes may be lost.|07\r\n"
+				msg := "|01Error saving area - changes may be lost.|07\r\n"
 				_ = terminalio.WriteProcessedBytes(terminal,
 					ansi.ReplacePipeCodes([]byte(msg)), outputMode)
 				time.Sleep(2 * time.Second)


### PR DESCRIPTION
## Summary

`terminalio.WriteStringCP437` maps every rune to a CP437 byte and substitutes `'?'` for anything the codepage lacks. So any character without a mapping reaches CP437 terminals — the BBS's native audience — as a stray question mark that reads as corrupted data.

Found while looking at what I'd filed as a cosmetic follow-up ("unify the ellipsis conventions"). It wasn't cosmetic: one of the three conventions was broken.

## `…` in truncated admin fields

`adminTruncate` appended U+2026, which CP437 has no mapping for. Proven with a regression test before fixing:

```
CP437 render of "AAAAAAAAA…" contains '?': "AAAAAAAAA?"
```

Every truncated handle, real name and note in the sysop user editor showed that. It now uses ASCII `"..."`, which also aligns it with `truncateString` and `truncateRunes`.

The characterization expectations from #150 were updated deliberately — this **does** change displayed output, from a broken glyph to a correct one, which is the point.

## `—` in 18 message strings

An audit for siblings found 18 more, all U+2014, all on paths that reach `WriteProcessedBytes`. Two are screen titles:

```
New User Voting ? Candidate #3
New User Voting Queue ? 4 Candidate(s)
```

The rest are error and status messages in the sponsor menu (12), QWK handler, and transfer-protocol picker: `Invalid number ? unchanged.`, `Tag ? sysop/co-sysop only.`

Replaced with ASCII `-`. **Only strings written to the terminal were changed** — em dashes in `slog` calls and comments were left alone, since those never pass through the CP437 encoder. That's 18 of the 27 occurrences in those files; I classified each line rather than blanket-replacing.

## Scope

The audit also cleared, with reasons: em dashes in log/stderr/CLI paths, `internal/transfer/protocol.go`'s error text (consumers write hard-coded ASCII and only log the error), v3net protocol validation messages (server-side), and the Bubble Tea sysop TUIs, which render to the local console rather than through `terminalio`.

## Noted, not fixed

`ansi.UnicodeToCP437` is missing `╛` (U+255B) and `►` (U+25BA) even though CP437 has them at 0xBE and 0x10. Only TUI code uses them today, so nothing renders wrong — but it's a real gap if that art ever moves to a remote path.

## Verification

- `go test ./...` exit 0; `go test -race -count=1 ./internal/menu/` exit 0
- `gofmt -l` empty; `go vet` clean; `staticcheck` zero findings; binary builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal text truncation to use ASCII dots (`...`) so truncated output renders consistently on CP437 terminals.
  * Updated various menu/status/validation messages to replace typographic em dashes with plain hyphens (`-`) for more consistent display.
* **Tests**
  * Added CP437-specific coverage to ensure truncation ellipsis rendering does not introduce unsupported replacement characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->