### PR TITLE
fix(configeditor): truncate centred titles so the box holds its shape

### DIFF
--- a/internal/configeditor/fields.go
+++ b/internal/configeditor/fields.go
@@ -61,5 +61,9 @@ func padLeft(s string, width int) string {
 
 // centerText centers a string within a given width using visual (rune) width.
 func centerText(s string, width int) string {
-	return ansi.Center(s, width)
+	// Truncate before centring so the box holds its shape: an over-long title
+	// is cut to the column budget rather than pushing the border out. Matches
+	// menueditor and usereditor. Editable values are not affected — the
+	// textinput fields scroll horizontally while editing.
+	return ansi.Center(ansi.TruncateRunes(s, width, ""), width)
 }

--- a/internal/configeditor/fields_center_test.go
+++ b/internal/configeditor/fields_center_test.go
@@ -14,21 +14,26 @@ func TestCenterTextHoldsTheBoxWidth(t *testing.T) {
 		name  string
 		s     string
 		width int
+		want  string
 	}{
-		{"shorter than width", "Title", 20},
-		{"exactly width", "12345678901234567890", 20},
-		{"longer than width", "A Very Long Category Title That Overflows", 20},
-		{"multi-byte longer than width", "Zone Réseau — Configuration Générale Étendue", 20},
-		{"cjk longer than width", "日本語のメッセージエリア設定画面", 20},
+		{"shorter is centred", "Title", 20, "       Title        "},
+		{"exactly width is untouched", "12345678901234567890", 20, "12345678901234567890"},
+		{"longer is truncated", "A Very Long Category Title That Overflows", 20, "A Very Long Category"},
+		{"multi-byte truncated on a rune boundary", "Zone Réseau — Configuration Générale Étendue", 20, "Zone Réseau — Config"},
+		{"cjk shorter is centred", "日本語のメッセージエリア設定画面", 20, "  日本語のメッセージエリア設定画面  "},
+		{"cjk longer is truncated", "日本語のメッセージエリア設定画面をとても長くしたもの", 20, "日本語のメッセージエリア設定画面をとても"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := centerText(tt.s, tt.width)
+			if got != tt.want {
+				t.Errorf("centerText(%q, %d) = %q, want %q", tt.s, tt.width, got, tt.want)
+			}
 			if !utf8.ValidString(got) {
-				t.Fatalf("centerText(%q, %d) produced invalid UTF-8: %q", tt.s, tt.width, got)
+				t.Errorf("centerText(%q, %d) produced invalid UTF-8: %q", tt.s, tt.width, got)
 			}
 			if n := utf8.RuneCountInString(got); n != tt.width {
-				t.Errorf("centerText(%q, %d) = %d columns, want exactly %d (%q)", tt.s, tt.width, n, tt.width, got)
+				t.Errorf("centerText(%q, %d) = %d columns, want exactly %d", tt.s, tt.width, n, tt.width)
 			}
 		})
 	}

--- a/internal/configeditor/fields_center_test.go
+++ b/internal/configeditor/fields_center_test.go
@@ -1,0 +1,35 @@
+package configeditor
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+// centerText lays out box headers and help bars whose content is dynamic —
+// category titles, record names, hub-area counts. The box must hold its shape:
+// an over-long value is truncated to the column budget rather than pushing the
+// border out. This matches menueditor and usereditor.
+func TestCenterTextHoldsTheBoxWidth(t *testing.T) {
+	tests := []struct {
+		name  string
+		s     string
+		width int
+	}{
+		{"shorter than width", "Title", 20},
+		{"exactly width", "12345678901234567890", 20},
+		{"longer than width", "A Very Long Category Title That Overflows", 20},
+		{"multi-byte longer than width", "Zone Réseau — Configuration Générale Étendue", 20},
+		{"cjk longer than width", "日本語のメッセージエリア設定画面", 20},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := centerText(tt.s, tt.width)
+			if !utf8.ValidString(got) {
+				t.Fatalf("centerText(%q, %d) produced invalid UTF-8: %q", tt.s, tt.width, got)
+			}
+			if n := utf8.RuneCountInString(got); n != tt.width {
+				t.Errorf("centerText(%q, %d) = %d columns, want exactly %d (%q)", tt.s, tt.width, n, tt.width, got)
+			}
+		})
+	}
+}

--- a/internal/configeditor/fields_test.go
+++ b/internal/configeditor/fields_test.go
@@ -39,7 +39,10 @@ func TestCenterText(t *testing.T) {
 	if got := centerText("hi", 5); got != " hi  " {
 		t.Errorf("centerText odd = %q, want %q", got, " hi  ")
 	}
-	if got := centerText("toolong", 3); got != "toolong" {
-		t.Errorf("centerText overflow = %q, want toolong", got)
+	// An over-long value is truncated so the box holds its shape. This
+	// expectation changed deliberately: centerText used to return the value
+	// unchanged and let it push the border out.
+	if got := centerText("toolong", 3); got != "too" {
+		t.Errorf("centerText overflow = %q, want %q", got, "too")
 	}
 }


### PR DESCRIPTION
## Summary

Closes the last follow-up from the width-primitive consolidation (#150): `configeditor`'s `centerText` returned an over-long value unchanged, while `menueditor`'s and `usereditor`'s truncated it. Resolved in favour of **the box holding its shape**.

All three implementations are now identical.

## Why it mattered

The callers are not all static labels. `centerText` renders category titles, record names, hub-area counts and help bars — values derived from config and from remote V3Net hub data. An over-long one pushed the border out:

```
centerText("A Very Long Category Title That Overflows", 20) → 41 columns in a 20-column box
```

## Editing is unaffected

Truncation applies to *display*. All three TUIs set `textinput.Width`, so bubbles scrolls the value horizontally while a field is being edited — the full value is always reachable, exactly as a normal editor behaves. No change was needed there; I checked rather than assumed.

## One expectation changed deliberately

`TestCenterText` asserted `centerText("toolong", 3) == "toolong"` — it pinned the overflow behaviour. That expectation is now `"too"`, updated because the behaviour changed on purpose, not to make the change pass. The test comment records that.

New `TestCenterTextHoldsTheBoxWidth` covers the boundary properly: shorter, exact, over-long, multi-byte and CJK, asserting the result is always exactly the column budget and always valid UTF-8.

## Verification

- `go test ./...` exit 0; `go test -race -count=1 ./internal/configeditor/` exit 0
- `gofmt -l` empty; `go vet` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented long centered text from expanding configuration interface borders and columns.
  * Added support for consistent truncation of multi-byte and CJK text while preserving valid character encoding.
* **Tests**
  * Added coverage confirming centered text remains within its specified width across short, exact-length, and oversized content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->