### PR TITLE
feat(menu): accept extended characters at text prompts

### DIFF
--- a/cmd/vision3/main.go
+++ b/cmd/vision3/main.go
@@ -765,6 +765,7 @@ func sessionHandler(s ssh.Session) {
 		activeSessionsMutex.Lock()
 		delete(activeSessions, s) // Remove using session as key
 		activeSessionsMutex.Unlock()
+		menu.ClearSessionOutputMode(s)
 		if sessionRegistry != nil {
 			sessionRegistry.Unregister(int(nodeID))
 		}
@@ -899,6 +900,14 @@ func sessionHandler(s ssh.Session) {
 			effectiveMode = ansi.OutputModeUTF8
 		}
 	}
+
+	// Record the output mode for this session so extended (byte >= 128)
+	// keystrokes are decoded the same way output is encoded: CP437 bytes
+	// decode via a single-byte table, UTF-8 bytes accumulate across reads.
+	// See menu.SetSessionOutputMode / readLineFromSessionIH. Re-applied below
+	// if the post-auth encoding prompt or a saved user preference changes
+	// effectiveMode.
+	menu.SetSessionOutputMode(s, effectiveMode)
 
 	// --- Create Terminal ---
 	slog.Info("creating terminal for session", "node", nodeID)
@@ -1413,6 +1422,11 @@ func sessionHandler(s ssh.Session) {
 			slog.Info("using saved encoding preference", "node", nodeID, "encoding", "utf8")
 		}
 	}
+
+	// effectiveMode may have just changed (encoding prompt above, or a saved
+	// user preference) — re-record it so post-auth input decodes extended
+	// characters with the mode actually in effect for the rest of the session.
+	menu.SetSessionOutputMode(s, effectiveMode)
 
 	// Run the configurable login sequence (login.json) directly after authentication.
 	// This replaces the old FASTLOGN menu routing — FASTLOGIN is now an optional login.json item.

--- a/internal/menu/executor_input_helpers.go
+++ b/internal/menu/executor_input_helpers.go
@@ -106,11 +106,18 @@ func styledInput(terminal *term.Terminal, session ssh.Session, outputMode ansi.O
 
 	shadeChar := "\u2591"
 
-	// maxLen is a column budget, not a byte count: input holds UTF-8 (ASCII,
-	// or an extended character decoded via decodeExtendedKey below), so a
-	// multi-byte rune occupies one column but several bytes. defaultValue is
-	// clamped with ansi.TruncateRunes (rune-based) rather than a raw byte
-	// slice, which would otherwise cut a multi-byte value mid-rune.
+	// maxLen is counted in runes, not bytes: input holds UTF-8 (ASCII, or an
+	// extended character decoded via decodeExtendedKey below), so a multi-byte
+	// rune is one unit of the budget but several bytes. defaultValue is clamped
+	// with ansi.TruncateRunes rather than a raw byte slice, which would cut a
+	// multi-byte value mid-rune.
+	//
+	// Runes are treated as one terminal column each. That holds for CP437 and
+	// for the Latin-1 range this BBS actually sees; it is NOT true of
+	// double-width glyphs such as CJK, which would render two columns wide and
+	// skew the box and cursor maths. Wide-character support is deliberately out
+	// of scope repo-wide (it would need go-runewidth threaded through
+	// ansi.VisibleLength), so a CJK value here draws a box that is too narrow.
 	input := make([]byte, 0, maxLen)
 	if defaultValue != "" {
 		input = append(input, []byte(ansi.TruncateRunes(defaultValue, maxLen, ""))...)

--- a/internal/menu/executor_input_helpers.go
+++ b/internal/menu/executor_input_helpers.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/editor"
@@ -105,12 +106,14 @@ func styledInput(terminal *term.Terminal, session ssh.Session, outputMode ansi.O
 
 	shadeChar := "\u2591"
 
+	// maxLen is a column budget, not a byte count: input holds UTF-8 (ASCII,
+	// or an extended character decoded via decodeExtendedKey below), so a
+	// multi-byte rune occupies one column but several bytes. defaultValue is
+	// clamped with ansi.TruncateRunes (rune-based) rather than a raw byte
+	// slice, which would otherwise cut a multi-byte value mid-rune.
 	input := make([]byte, 0, maxLen)
 	if defaultValue != "" {
-		input = append(input, []byte(defaultValue)...)
-		if len(input) > maxLen {
-			input = input[:maxLen]
-		}
+		input = append(input, []byte(ansi.TruncateRunes(defaultValue, maxLen, ""))...)
 	}
 	cursorStyleSet := false
 	savedCursor := false
@@ -125,12 +128,12 @@ func styledInput(terminal *term.Terminal, session ssh.Session, outputMode ansi.O
 		if len(input) > 0 {
 			display.Write(input)
 		}
-		cursorPos := len(input)
+		cursorCols := utf8.RuneCount(input)
 		remainingLen := 0
-		if len(input) < maxLen {
+		if cursorCols < maxLen {
 			display.WriteString(cursorStyle)
 			display.WriteString(shadeChar)
-			remainingLen = maxLen - len(input) - 1
+			remainingLen = maxLen - cursorCols - 1
 		}
 		if remainingLen > 0 {
 			display.WriteString(remainingStyle)
@@ -139,8 +142,8 @@ func styledInput(terminal *term.Terminal, session ssh.Session, outputMode ansi.O
 		display.WriteString(resetColor)
 
 		moveToCursor := ""
-		if cursorPos < maxLen {
-			moveToCursor = fmt.Sprintf("\x1b[%dD", maxLen-cursorPos)
+		if cursorCols < maxLen {
+			moveToCursor = fmt.Sprintf("\x1b[%dD", maxLen-cursorCols)
 		}
 		terminalio.WriteStringCP437(terminal, []byte(display.String()+moveToCursor), outputMode)
 	}
@@ -164,6 +167,7 @@ func styledInput(terminal *term.Terminal, session ssh.Session, outputMode ansi.O
 	// caused the "double key press" bug when the lightbar's goroutine was also active.
 	ih := getSessionIH(session)
 	readBuf := make([]byte, 1)
+	var utf8Pending []byte
 
 	for {
 		n, err := ih.Read(readBuf)
@@ -187,8 +191,14 @@ func styledInput(terminal *term.Terminal, session ssh.Session, outputMode ansi.O
 			return strings.TrimSpace(result), nil
 
 		case 8, 127: // Backspace or Delete
-			if len(input) > 0 {
-				input = input[:len(input)-1]
+			// A byte in progress toward a multi-byte UTF-8 character was never
+			// appended to input or rendered, so just discard it. Otherwise
+			// remove the whole last RUNE (see backspaceRune) -- not one byte,
+			// which would cut a multi-byte character in half.
+			if len(utf8Pending) > 0 {
+				utf8Pending = nil
+			} else if len(input) > 0 {
+				input = backspaceRune(input)
 				renderBox(true)
 			}
 
@@ -201,10 +211,33 @@ func styledInput(terminal *term.Terminal, session ssh.Session, outputMode ansi.O
 			return "", io.EOF
 
 		default:
-			// Printable ASCII character
-			if ch >= 32 && ch < 127 && len(input) < maxLen {
-				input = append(input, ch)
-				renderBox(true)
+			if ch >= 32 && ch < 127 {
+				// Printable ASCII character
+				if utf8.RuneCount(input) < maxLen {
+					input = append(input, ch)
+					renderBox(true)
+				}
+			} else if ch >= 128 {
+				// Extended character (CP437 byte, or one byte of a multi-byte
+				// UTF-8 sequence). decodeExtendedKey only appends once a full
+				// character is known; the echo it returns is not needed here
+				// since renderBox already re-writes the whole visible box
+				// through terminalio.WriteStringCP437, which re-encodes per
+				// outputMode.
+				if utf8.RuneCount(input) < maxLen {
+					var newInput []byte
+					newInput, _, utf8Pending = decodeExtendedKey(input, outputMode, ch, utf8Pending)
+					if len(newInput) != len(input) {
+						input = newInput
+						renderBox(true)
+					}
+				} else {
+					// At the column limit: still track pending UTF-8 bytes so
+					// the next byte of an in-flight sequence isn't
+					// misinterpreted as the start of a new one, but don't
+					// grow input past maxLen.
+					_, _, utf8Pending = decodeExtendedKey(nil, outputMode, ch, utf8Pending)
+				}
 			}
 		}
 	}

--- a/internal/menu/executor_input_helpers.go
+++ b/internal/menu/executor_input_helpers.go
@@ -217,6 +217,12 @@ func styledInput(terminal *term.Terminal, session ssh.Session, outputMode ansi.O
 					input = append(input, ch)
 					renderBox(true)
 				}
+				// A completed ASCII keystroke means any partial multi-byte
+				// sequence still buffered belongs to a different, abandoned
+				// character (e.g. a stray lead byte with no valid
+				// continuation) and must not be left around to absorb the
+				// bytes of the NEXT legitimate character.
+				utf8Pending = nil
 			} else if ch >= 128 {
 				// Extended character (CP437 byte, or one byte of a multi-byte
 				// UTF-8 sequence). decodeExtendedKey only appends once a full
@@ -238,6 +244,11 @@ func styledInput(terminal *term.Terminal, session ssh.Session, outputMode ansi.O
 					// grow input past maxLen.
 					_, _, utf8Pending = decodeExtendedKey(nil, outputMode, ch, utf8Pending)
 				}
+			} else {
+				// Any other ignored byte (e.g. an untranslated control
+				// code): same reasoning as the ASCII branch above -- don't
+				// leave a partial sequence around to absorb what comes next.
+				utf8Pending = nil
 			}
 		}
 	}

--- a/internal/menu/executor_input_helpers_test.go
+++ b/internal/menu/executor_input_helpers_test.go
@@ -1,6 +1,7 @@
 package menu
 
 import (
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -44,5 +45,74 @@ func TestWriteCenteredPausePromptCentersByVisibleColumns(t *testing.T) {
 	if gotPad != wantPad {
 		t.Errorf("left padding = %d, want %d (visible text %q is %d columns, %d bytes)",
 			gotPad, wantPad, visible, utf8.RuneCountInString(visible), len(visible))
+	}
+}
+
+// --- styledInput: rune-correct column math for extended characters ---
+
+// TestStyledInput_CP437ByteRendersOneColumn types a single CP437 extended
+// byte (0x82, 'é') and checks that the cursor reposition after it treats the
+// typed character as ONE column, not two bytes. A byte-based measurement
+// (len(input) where input holds the 2-byte UTF-8 encoding of 'é') would emit
+// "\x1b[3D" instead of the correct "\x1b[4D", mis-drawing the box.
+func TestStyledInput_CP437ByteRendersOneColumn(t *testing.T) {
+	const maxLen = 5
+	ts := newTestSession("\x82\r")
+	SetSessionOutputMode(ts, ansi.OutputModeCP437)
+	terminal := newTestTerminal(ts)
+
+	result, err := styledInput(terminal, ts, ansi.OutputModeCP437, maxLen, "")
+	if err != nil {
+		t.Fatalf("styledInput: %v", err)
+	}
+	if result != "é" {
+		t.Errorf("result = %q, want %q", result, "é")
+	}
+
+	out := ts.output()
+	wantMove := fmt.Sprintf("\x1b[%dD", maxLen-1) // maxLen(5) - cursorCols(1)
+	if !strings.Contains(out, wantMove) {
+		t.Errorf("output = %q, want cursor reposition %q (column-based, not byte-based)", out, wantMove)
+	}
+	if !strings.Contains(out, "\x82") {
+		t.Errorf("output = %q, want raw byte 0x82 echoed back via the rendered box", out)
+	}
+}
+
+// TestStyledInput_DefaultValueClampCountsRunesNotBytes is the maxLen-as-bytes
+// hazard called out in the design brief: "éééé" is 4 runes but 8 bytes. A
+// byte-based clamp (input[:maxLen]) on maxLen=3 would slice mid-rune and
+// corrupt the UTF-8. It must clamp to 3 RUNES instead.
+func TestStyledInput_DefaultValueClampCountsRunesNotBytes(t *testing.T) {
+	const maxLen = 3
+	ts := newTestSession("\r") // accept the (clamped) default unmodified
+	terminal := newTestTerminal(ts)
+
+	result, err := styledInput(terminal, ts, ansi.OutputModeUTF8, maxLen, "éééé")
+	if err != nil {
+		t.Fatalf("styledInput: %v", err)
+	}
+	if !utf8.ValidString(result) {
+		t.Fatalf("result is not valid UTF-8: %q", result)
+	}
+	if result != "ééé" {
+		t.Errorf("result = %q, want %q (clamp must count runes, not bytes)", result, "ééé")
+	}
+}
+
+// TestStyledInput_DefaultValueWithinMaxLenIsUnchanged guards the common case
+// where a multi-byte default value already fits within maxLen columns: it
+// must survive the clamp untouched.
+func TestStyledInput_DefaultValueWithinMaxLenIsUnchanged(t *testing.T) {
+	const maxLen = 3
+	ts := newTestSession("\r")
+	terminal := newTestTerminal(ts)
+
+	result, err := styledInput(terminal, ts, ansi.OutputModeUTF8, maxLen, "éé")
+	if err != nil {
+		t.Fatalf("styledInput: %v", err)
+	}
+	if result != "éé" {
+		t.Errorf("result = %q, want unmodified default %q", result, "éé")
 	}
 }

--- a/internal/menu/executor_input_helpers_test.go
+++ b/internal/menu/executor_input_helpers_test.go
@@ -79,6 +79,29 @@ func TestStyledInput_CP437ByteRendersOneColumn(t *testing.T) {
 	}
 }
 
+// TestStyledInput_StrayLeadByteDoesNotEatNextChar mirrors the reader-side
+// regression: styledInput's read loop has the identical utf8Pending
+// structure, and the same bug applied here -- an ASCII keystroke between a
+// stray lead byte and a legitimate multi-byte character must not leave the
+// stale pending buffer around to swallow it.
+func TestStyledInput_StrayLeadByteDoesNotEatNextChar(t *testing.T) {
+	const maxLen = 5
+	ts := newTestSession("\xc9A\xc3\xa9\r")
+	SetSessionOutputMode(ts, ansi.OutputModeUTF8)
+	terminal := newTestTerminal(ts)
+
+	result, err := styledInput(terminal, ts, ansi.OutputModeUTF8, maxLen, "")
+	if err != nil {
+		t.Fatalf("styledInput: %v", err)
+	}
+	if !utf8.ValidString(result) {
+		t.Fatalf("result is not valid UTF-8: %q", result)
+	}
+	if result != "Aé" {
+		t.Errorf("result = %q, want %q (stray lead byte must not swallow the next legitimate character)", result, "Aé")
+	}
+}
+
 // TestStyledInput_DefaultValueClampCountsRunesNotBytes is the maxLen-as-bytes
 // hazard called out in the design brief: "éééé" is 4 runes but 8 bytes. A
 // byte-based clamp (input[:maxLen]) on maxLen=3 would slice mid-rune and

--- a/internal/menu/executor_session.go
+++ b/internal/menu/executor_session.go
@@ -261,16 +261,31 @@ func readLineFromSessionIHImpl(s ssh.Session, terminal *term.Terminal, allowAbor
 				_, _ = terminal.Write([]byte("\r\n"))
 				return "", errInputAborted
 			}
+			// Ignored (ESC has no other meaning here): drop any partial
+			// UTF-8 sequence rather than let it survive to swallow whatever
+			// comes next.
+			utf8Pending = nil
 		default:
 			if key >= 32 && key < 127 {
 				line = append(line, byte(key))
 				_, _ = terminal.Write([]byte{byte(key)})
+				// A completed ASCII keystroke means any partial multi-byte
+				// sequence still buffered belongs to a different, abandoned
+				// character (e.g. a stray lead byte with no valid
+				// continuation) and must not be left around to absorb the
+				// bytes of the NEXT legitimate character.
+				utf8Pending = nil
 			} else if key >= 128 && key <= 255 {
 				var echo []byte
 				line, echo, utf8Pending = decodeExtendedKey(line, mode, byte(key), utf8Pending)
 				if len(echo) > 0 {
 					_, _ = terminal.Write(echo)
 				}
+			} else {
+				// Any other ignored key (e.g. an untranslated control code
+				// or synthetic key we don't act on here): same reasoning as
+				// the ASCII branch above.
+				utf8Pending = nil
 			}
 		}
 	}

--- a/internal/menu/executor_session.go
+++ b/internal/menu/executor_session.go
@@ -109,8 +109,15 @@ func decodeExtendedKey(line []byte, mode ansi.OutputMode, b byte, utf8Pending []
 			// Malformed sequence: drop it rather than store or echo garbage.
 			return line, nil, nil
 		}
+		// Any bytes beyond the decoded rune are dropped rather than carried
+		// forward: a leftover cannot be a valid lead byte, so keeping it would
+		// swallow the next character. Unreachable today — accumulation stops as
+		// soon as FullRune is true, and the only way to reach four bytes is a
+		// 4-byte lead, which decodes as either size 4 or RuneError size 1 —
+		// but the contract is "drop the malformed remainder", so say so here
+		// rather than leaving it to be re-derived.
 		seq := append([]byte(nil), utf8Pending[:size]...)
-		return append(line, seq...), seq, utf8Pending[size:]
+		return append(line, seq...), seq, nil
 	}
 
 	r := ansi.Cp437ToUnicode[b]

--- a/internal/menu/executor_session.go
+++ b/internal/menu/executor_session.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/editor"
@@ -36,6 +37,102 @@ func applySessionIdleTimeout(s ssh.Session, d time.Duration) {
 // clearSessionIdleTimeout drops the remembered timeout when a session ends.
 func clearSessionIdleTimeout(s ssh.Session) {
 	sessionIdleTimeouts.Delete(s)
+}
+
+// sessionOutputModes remembers the negotiated ansi.OutputMode for each
+// ssh.Session. readLineFromSessionIH and readLineFromSessionIHAllowAbort need
+// this to decode keystroke bytes >= 128 correctly: CP437 terminals send one
+// raw byte per glyph, while UTF-8 terminals send a multi-byte sequence one
+// byte per ReadKey call. This mirrors sessionInputHandlers/sessionIdleTimeouts
+// above rather than threading a parameter through readLineFromSessionIH,
+// which has well over a hundred call sites.
+var sessionOutputModes sync.Map
+
+// SetSessionOutputMode records the output mode for s. Call this once the
+// mode is finalized for the session (see cmd/vision3/main.go, alongside the
+// other per-session setup) so later input reads decode extended characters
+// with the same encoding the terminal is using for output.
+func SetSessionOutputMode(s ssh.Session, mode ansi.OutputMode) {
+	sessionOutputModes.Store(s, mode)
+}
+
+// sessionOutputMode returns the recorded output mode for s, defaulting to
+// ansi.OutputModeCP437 when unset. CP437 is the safe default: most users of
+// this BBS are on CP437 terminals, and a CP437 byte is never mistaken for
+// part of a UTF-8 continuation sequence (so getting this wrong for a UTF-8
+// session degrades gracefully — see decodeExtendedKey below — while getting
+// it wrong for a CP437 session the other way around does not).
+func sessionOutputMode(s ssh.Session) ansi.OutputMode {
+	if v, ok := sessionOutputModes.Load(s); ok {
+		return v.(ansi.OutputMode)
+	}
+	return ansi.OutputModeCP437
+}
+
+// ClearSessionOutputMode drops the remembered output mode when a session
+// ends, mirroring clearSessionIdleTimeout above so sessionOutputModes does
+// not accumulate an entry per connection for the life of the process.
+func ClearSessionOutputMode(s ssh.Session) {
+	sessionOutputModes.Delete(s)
+}
+
+// decodeExtendedKey processes one keystroke byte b (128-255) according to
+// mode, returning the line with the decoded character appended (if any), the
+// raw bytes to echo back to the terminal (if any), and the updated
+// utf8Pending accumulator for the next call.
+//
+// CP437 mode is a single-byte table lookup: b maps through
+// ansi.Cp437ToUnicode to exactly one rune, which is appended to line as
+// UTF-8 (so callers only ever store valid UTF-8) while the RAW byte b is
+// echoed unchanged -- a CP437 terminal draws directly from the byte value,
+// so echoing anything else would not round-trip. A byte with no mapping
+// (Cp437ToUnicode[b] == 0) is dropped: it is not stored, matching how the
+// reader already drops any other keystroke it won't accept, and it avoids
+// ever writing invalid/unintended data into users.json.
+//
+// UTF-8 mode receives one byte of a multi-byte sequence per call (that is
+// how bytes >= 128 arrive from ReadKey on a real connection), so b is
+// accumulated into utf8Pending until utf8.FullRune reports a complete
+// sequence (or 4 bytes -- utf8.UTFMax, the longest possible UTF-8 encoding --
+// have accumulated without one, which guards against a malformed sequence
+// that would otherwise never complete and silently swallow all subsequent
+// input). Once complete, the sequence is appended to line and echoed
+// verbatim; a malformed sequence is dropped without being stored or echoed.
+func decodeExtendedKey(line []byte, mode ansi.OutputMode, b byte, utf8Pending []byte) (newLine []byte, echo []byte, pending []byte) {
+	if mode == ansi.OutputModeUTF8 {
+		utf8Pending = append(utf8Pending, b)
+		if !utf8.FullRune(utf8Pending) && len(utf8Pending) < utf8.UTFMax {
+			return line, nil, utf8Pending
+		}
+		r, size := utf8.DecodeRune(utf8Pending)
+		if r == utf8.RuneError && size <= 1 {
+			// Malformed sequence: drop it rather than store or echo garbage.
+			return line, nil, nil
+		}
+		seq := append([]byte(nil), utf8Pending[:size]...)
+		return append(line, seq...), seq, utf8Pending[size:]
+	}
+
+	r := ansi.Cp437ToUnicode[b]
+	if r == 0 {
+		return line, nil, utf8Pending
+	}
+	var buf [utf8.UTFMax]byte
+	n := utf8.EncodeRune(buf[:], r)
+	return append(line, buf[:n]...), []byte{b}, utf8Pending
+}
+
+// backspaceRune removes the last RUNE (not byte) from line. line always holds
+// valid UTF-8 (ASCII, or a CP437/UTF-8 extended character decoded via
+// decodeExtendedKey above), so a byte-based backspace would cut a multi-byte
+// character in half. The caller still echoes "\b \b" exactly once, matching
+// the single terminal column every stored character occupies.
+func backspaceRune(line []byte) []byte {
+	if len(line) == 0 {
+		return line
+	}
+	_, size := utf8.DecodeLastRune(line)
+	return line[:len(line)-size]
 }
 
 // getSessionIH returns (creating if necessary) the session-scoped InputHandler
@@ -116,38 +213,31 @@ func (e *MenuExecutor) holdScreen(s ssh.Session, terminal *term.Terminal, output
 // readLineFromSessionIH reads a simple command line from the shared session
 // InputHandler so menu input never races with other session readers.
 func readLineFromSessionIH(s ssh.Session, terminal *term.Terminal) (string, error) {
-	ih := getSessionIH(s)
-	line := make([]byte, 0, 64)
-
-	for {
-		key, err := ih.ReadKey()
-		if err != nil {
-			return "", err
-		}
-
-		switch key {
-		case editor.KeyEnter:
-			_, _ = terminal.Write([]byte("\r\n"))
-			return string(line), nil
-		case editor.KeyBackspace:
-			if len(line) > 0 {
-				line = line[:len(line)-1]
-				_, _ = terminal.Write([]byte("\b \b"))
-			}
-		default:
-			if key >= 32 && key < 127 {
-				line = append(line, byte(key))
-				_, _ = terminal.Write([]byte{byte(key)})
-			}
-		}
-	}
+	return readLineFromSessionIHImpl(s, terminal, false)
 }
 
 // readLineFromSessionIHAllowAbort reads a simple command line like
 // readLineFromSessionIH, but returns errInputAborted when ESC is pressed.
 func readLineFromSessionIHAllowAbort(s ssh.Session, terminal *term.Terminal) (string, error) {
+	return readLineFromSessionIHImpl(s, terminal, true)
+}
+
+// readLineFromSessionIHImpl is the shared implementation behind
+// readLineFromSessionIH and readLineFromSessionIHAllowAbort; the two differ
+// only in whether ESC aborts the read.
+//
+// Extended keystrokes (byte >= 128) are decoded per the session's output
+// mode via decodeExtendedKey: a CP437 byte is a complete character on its
+// own, while a UTF-8 byte may be one of several making up a single rune and
+// is accumulated in utf8Pending across loop iterations until decodeExtendedKey
+// reports it complete. Backspace deletes one whole rune (see backspaceRune)
+// rather than one byte, and clears any in-progress utf8Pending sequence
+// without touching line or echoing, since nothing was displayed for it yet.
+func readLineFromSessionIHImpl(s ssh.Session, terminal *term.Terminal, allowAbort bool) (string, error) {
 	ih := getSessionIH(s)
+	mode := sessionOutputMode(s)
 	line := make([]byte, 0, 64)
+	var utf8Pending []byte
 
 	for {
 		key, err := ih.ReadKey()
@@ -160,17 +250,27 @@ func readLineFromSessionIHAllowAbort(s ssh.Session, terminal *term.Terminal) (st
 			_, _ = terminal.Write([]byte("\r\n"))
 			return string(line), nil
 		case editor.KeyBackspace:
-			if len(line) > 0 {
-				line = line[:len(line)-1]
+			if len(utf8Pending) > 0 {
+				utf8Pending = nil
+			} else if len(line) > 0 {
+				line = backspaceRune(line)
 				_, _ = terminal.Write([]byte("\b \b"))
 			}
 		case editor.KeyEsc:
-			_, _ = terminal.Write([]byte("\r\n"))
-			return "", errInputAborted
+			if allowAbort {
+				_, _ = terminal.Write([]byte("\r\n"))
+				return "", errInputAborted
+			}
 		default:
 			if key >= 32 && key < 127 {
 				line = append(line, byte(key))
 				_, _ = terminal.Write([]byte{byte(key)})
+			} else if key >= 128 && key <= 255 {
+				var echo []byte
+				line, echo, utf8Pending = decodeExtendedKey(line, mode, byte(key), utf8Pending)
+				if len(echo) > 0 {
+					_, _ = terminal.Write(echo)
+				}
 			}
 		}
 	}

--- a/internal/menu/executor_session.go
+++ b/internal/menu/executor_session.go
@@ -97,29 +97,32 @@ func ClearSessionOutputMode(s ssh.Session) {
 // have accumulated without one, which guards against a malformed sequence
 // that would otherwise never complete and silently swallow all subsequent
 // input). Once complete, the sequence is appended to line and echoed
-// verbatim; a malformed sequence is dropped without being stored or echoed.
+// verbatim.
+//
+// A malformed sequence is not stored or echoed, and the decoder resynchronises
+// by discarding one byte at a time rather than the whole accumulator: a stray
+// lead byte is often immediately followed by a real character's lead byte, and
+// dropping the buffer wholesale would swallow that character too.
 func decodeExtendedKey(line []byte, mode ansi.OutputMode, b byte, utf8Pending []byte) (newLine []byte, echo []byte, pending []byte) {
 	if mode == ansi.OutputModeUTF8 {
 		utf8Pending = append(utf8Pending, b)
-		if !utf8.FullRune(utf8Pending) && len(utf8Pending) < utf8.UTFMax {
-			return line, nil, utf8Pending
+		for len(utf8Pending) > 0 {
+			if !utf8.FullRune(utf8Pending) && len(utf8Pending) < utf8.UTFMax {
+				return line, nil, utf8Pending
+			}
+			r, size := utf8.DecodeRune(utf8Pending)
+			if r == utf8.RuneError && size <= 1 {
+				// Malformed: drop one byte and retry, so a stray lead byte does
+				// not take the following character down with it. Discarding the
+				// whole buffer would swallow a valid lead byte sitting behind it.
+				utf8Pending = utf8Pending[1:]
+				continue
+			}
+			seq := append([]byte(nil), utf8Pending[:size]...)
+			return append(line, seq...), seq, nil
 		}
-		r, size := utf8.DecodeRune(utf8Pending)
-		if r == utf8.RuneError && size <= 1 {
-			// Malformed sequence: drop it rather than store or echo garbage.
-			return line, nil, nil
-		}
-		// Any bytes beyond the decoded rune are dropped rather than carried
-		// forward: a leftover cannot be a valid lead byte, so keeping it would
-		// swallow the next character. Unreachable today — accumulation stops as
-		// soon as FullRune is true, and the only way to reach four bytes is a
-		// 4-byte lead, which decodes as either size 4 or RuneError size 1 —
-		// but the contract is "drop the malformed remainder", so say so here
-		// rather than leaving it to be re-derived.
-		seq := append([]byte(nil), utf8Pending[:size]...)
-		return append(line, seq...), seq, nil
+		return line, nil, nil
 	}
-
 	r := ansi.Cp437ToUnicode[b]
 	if r == 0 {
 		return line, nil, utf8Pending

--- a/internal/menu/executor_session_test.go
+++ b/internal/menu/executor_session_test.go
@@ -152,3 +152,58 @@ func TestReadLineFromSessionIH_ASCIIUnchanged(t *testing.T) {
 		t.Errorf("line = %q, want %q", line, "hel")
 	}
 }
+
+// TestReadLineFromSessionIH_StrayLeadByteDoesNotEatNextChar reproduces the
+// bug found in review: utf8Pending was only cleared by the extended-byte
+// branch and by Backspace. A stray valid-looking lead byte (0xC9 here, which
+// wants one continuation byte) left pending by itself; the ASCII branch for
+// 'A' appended and echoed 'A' but never touched utf8Pending, so the next
+// extended byte (0xC3, the lead byte of a legitimate "é") was appended to
+// the STALE pending buffer instead of starting fresh. 0xC9+0xC3 is not a
+// valid sequence, so it was dropped as malformed -- silently eating the
+// leading byte of "é" -- and the trailing continuation byte 0xA9 was then
+// dropped too as an orphaned continuation byte with no lead. Net effect:
+// "é" vanished with no echo and no error, and the stored line was "A", not
+// "Aé". Reachable whenever a UTF-8-mode session's client sends a high byte
+// with no valid continuation, e.g. auto-detection misreading a raw-CP437
+// client as modern.
+func TestReadLineFromSessionIH_StrayLeadByteDoesNotEatNextChar(t *testing.T) {
+	ts := newTestSession("\xc9A\xc3\xa9\r")
+	SetSessionOutputMode(ts, ansi.OutputModeUTF8)
+	terminal := newTestTerminal(ts)
+
+	line, err := readLineFromSessionIH(ts, terminal)
+	if err != nil {
+		t.Fatalf("readLineFromSessionIH: %v", err)
+	}
+	if !utf8.ValidString(line) {
+		t.Fatalf("line is not valid UTF-8: %q", line)
+	}
+	if line != "Aé" {
+		t.Errorf("line = %q, want %q (stray lead byte must not swallow the next legitimate character)", line, "Aé")
+	}
+}
+
+// TestReadLineFromSessionIH_BackspaceInterruptsPendingUTF8Sequence verifies
+// the case right next to the bug above: Backspace arriving while a partial
+// multi-byte sequence is buffered (nothing appended to line or echoed yet)
+// must discard only the pending bytes -- not touch line, not echo "\b \b" --
+// and normal typing afterward must resume cleanly.
+func TestReadLineFromSessionIH_BackspaceInterruptsPendingUTF8Sequence(t *testing.T) {
+	// 0xC3 is a valid lead byte awaiting one continuation byte; Backspace
+	// arrives before that continuation byte, then 'x', then Enter.
+	ts := newTestSession("\xc3\x08x\r")
+	SetSessionOutputMode(ts, ansi.OutputModeUTF8)
+	terminal := newTestTerminal(ts)
+
+	line, err := readLineFromSessionIH(ts, terminal)
+	if err != nil {
+		t.Fatalf("readLineFromSessionIH: %v", err)
+	}
+	if line != "x" {
+		t.Errorf("line = %q, want %q (backspace on a pending sequence must not affect line)", line, "x")
+	}
+	if n := strings.Count(ts.output(), "\b \b"); n != 0 {
+		t.Errorf("output contains %d \\b \\b sequences, want 0 (nothing was displayed for the pending byte yet)", n)
+	}
+}

--- a/internal/menu/executor_session_test.go
+++ b/internal/menu/executor_session_test.go
@@ -207,3 +207,22 @@ func TestReadLineFromSessionIH_BackspaceInterruptsPendingUTF8Sequence(t *testing
 		t.Errorf("output contains %d \\b \\b sequences, want 0 (nothing was displayed for the pending byte yet)", n)
 	}
 }
+
+// A stray lead byte must not take a following valid character down with it.
+// Dropping the whole pending buffer on a malformed decode discards the next
+// lead byte too; the decoder has to resynchronise by dropping one byte and
+// retrying, the way any UTF-8 decoder does.
+func TestReadLineFromSessionIH_ResyncsAfterStrayLeadByte(t *testing.T) {
+	ts := newTestSession("\xc3" + "日" + "\r") // stray 2-byte lead, then a valid "日"
+	terminal := newTestTerminal(ts)
+	SetSessionOutputMode(ts, ansi.OutputModeUTF8)
+	t.Cleanup(func() { ClearSessionOutputMode(ts) })
+
+	got, err := readLineFromSessionIH(ts, terminal)
+	if err != nil {
+		t.Fatalf("readLineFromSessionIH: %v", err)
+	}
+	if got != "日" {
+		t.Errorf("line = %q, want %q — the stray lead byte swallowed the next character", got, "日")
+	}
+}

--- a/internal/menu/executor_session_test.go
+++ b/internal/menu/executor_session_test.go
@@ -1,0 +1,154 @@
+package menu
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+)
+
+// --- session output mode plumbing ---
+
+// TestSessionOutputModeDefaultsToCP437 verifies the safe default for a
+// session that never called SetSessionOutputMode: CP437, because most users
+// are on CP437 terminals and a CP437 byte is never mistaken for part of a
+// UTF-8 continuation sequence.
+func TestSessionOutputModeDefaultsToCP437(t *testing.T) {
+	ts := newTestSession("")
+	if got := sessionOutputMode(ts); got != ansi.OutputModeCP437 {
+		t.Errorf("sessionOutputMode() default = %v, want OutputModeCP437", got)
+	}
+}
+
+func TestSetSessionOutputModeOverridesDefault(t *testing.T) {
+	ts := newTestSession("")
+	SetSessionOutputMode(ts, ansi.OutputModeUTF8)
+	if got := sessionOutputMode(ts); got != ansi.OutputModeUTF8 {
+		t.Errorf("sessionOutputMode() = %v, want OutputModeUTF8", got)
+	}
+}
+
+// --- readLineFromSessionIH: CP437 round trip (the acceptance test) ---
+
+// TestReadLineFromSessionIH_CP437RoundTrips is the acceptance test for the
+// whole feature: a CP437 user types the raw byte 0x82 (code page 437's
+// 'é'). It must be STORED as the UTF-8 encoding of 'é' (so users.json and
+// friends only ever hold valid UTF-8) and ECHOED back as the same raw byte
+// 0x82 -- not re-encoded -- because a CP437 terminal only understands its
+// own single-byte glyph table.
+func TestReadLineFromSessionIH_CP437RoundTrips(t *testing.T) {
+	ts := newTestSession("caf\x82\r")
+	SetSessionOutputMode(ts, ansi.OutputModeCP437)
+	terminal := newTestTerminal(ts)
+
+	line, err := readLineFromSessionIH(ts, terminal)
+	if err != nil {
+		t.Fatalf("readLineFromSessionIH: %v", err)
+	}
+	if line != "café" {
+		t.Errorf("line = %q, want %q", line, "café")
+	}
+	if !strings.Contains(ts.output(), "caf\x82") {
+		t.Errorf("output = %q, want raw byte 0x82 echoed back unchanged", ts.output())
+	}
+}
+
+// TestReadLineFromSessionIHAllowAbort_CP437RoundTrips guards the sibling
+// reader against the same bug; the two functions share almost identical
+// loops and must not drift.
+func TestReadLineFromSessionIHAllowAbort_CP437RoundTrips(t *testing.T) {
+	ts := newTestSession("caf\x82\r")
+	SetSessionOutputMode(ts, ansi.OutputModeCP437)
+	terminal := newTestTerminal(ts)
+
+	line, err := readLineFromSessionIHAllowAbort(ts, terminal)
+	if err != nil {
+		t.Fatalf("readLineFromSessionIHAllowAbort: %v", err)
+	}
+	if line != "café" {
+		t.Errorf("line = %q, want %q", line, "café")
+	}
+}
+
+// TestDecodeExtendedKey_CP437UnmappedByteDropped exercises the drop path for
+// a CP437 byte whose Cp437ToUnicode entry is 0 directly against the decode
+// helper: it must not be stored (which would put invalid/unintended data
+// into users.json) and must not be echoed, matching how the reader silently
+// drops anything else it won't accept.
+func TestDecodeExtendedKey_CP437UnmappedByteDropped(t *testing.T) {
+	line, echo, pending := decodeExtendedKey(nil, ansi.OutputModeCP437, 0, nil)
+	if len(line) != 0 {
+		t.Errorf("line = %q, want empty (unmapped byte must not be stored)", line)
+	}
+	if len(echo) != 0 {
+		t.Errorf("echo = %v, want nil (unmapped byte must not be echoed)", echo)
+	}
+	if len(pending) != 0 {
+		t.Errorf("pending = %v, want nil", pending)
+	}
+}
+
+// TestReadLineFromSessionIH_UTF8ModeAccumulatesMultiByteRune drives the three
+// bytes of "日" (U+65E5, encoded E6 97 A5) through one at a time -- exactly
+// how they arrive over a real connection, one byte per ReadKey call -- and
+// expects them assembled into a single stored rune.
+func TestReadLineFromSessionIH_UTF8ModeAccumulatesMultiByteRune(t *testing.T) {
+	ts := newTestSession("\xe6\x97\xa5\r")
+	SetSessionOutputMode(ts, ansi.OutputModeUTF8)
+	terminal := newTestTerminal(ts)
+
+	line, err := readLineFromSessionIH(ts, terminal)
+	if err != nil {
+		t.Fatalf("readLineFromSessionIH: %v", err)
+	}
+	if line != "日" {
+		t.Errorf("line = %q (%d bytes), want \"日\"", line, len(line))
+	}
+	if n := utf8.RuneCountInString(line); n != 1 {
+		t.Errorf("line has %d runes, want 1", n)
+	}
+	if !strings.Contains(ts.output(), "\xe6\x97\xa5") {
+		t.Errorf("output = %q, want the complete UTF-8 sequence echoed back", ts.output())
+	}
+}
+
+// TestReadLineFromSessionIH_BackspaceRemovesWholeMultiByteChar is the
+// backspace hazard test called out in the design brief: before this fix,
+// backspace deleted exactly one BYTE (line = line[:len(line)-1]), which would
+// cut a multi-byte character in half instead of removing it whole.
+func TestReadLineFromSessionIH_BackspaceRemovesWholeMultiByteChar(t *testing.T) {
+	// Type 'é' (CP437 0x82), backspace, then 'x', then Enter.
+	ts := newTestSession("\x82\x08x\r")
+	SetSessionOutputMode(ts, ansi.OutputModeCP437)
+	terminal := newTestTerminal(ts)
+
+	line, err := readLineFromSessionIH(ts, terminal)
+	if err != nil {
+		t.Fatalf("readLineFromSessionIH: %v", err)
+	}
+	if line != "x" {
+		t.Errorf("line = %q, want %q (backspace must remove the whole rune, not one byte)", line, "x")
+	}
+	if !utf8.ValidString(line) {
+		t.Fatalf("line is not valid UTF-8: %q", line)
+	}
+	if n := strings.Count(ts.output(), "\b \b"); n != 1 {
+		t.Errorf("output contains %d \\b \\b sequences, want exactly 1 (one column erased)", n)
+	}
+}
+
+// TestReadLineFromSessionIH_ASCIIUnchanged is a regression guard: ASCII
+// input, the overwhelmingly common case, must behave exactly as before.
+func TestReadLineFromSessionIH_ASCIIUnchanged(t *testing.T) {
+	ts := newTestSession("hello\x08\x08\r")
+	terminal := newTestTerminal(ts)
+
+	line, err := readLineFromSessionIH(ts, terminal)
+	if err != nil {
+		t.Fatalf("readLineFromSessionIH: %v", err)
+	}
+	if line != "hel" {
+		t.Errorf("line = %q, want %q", line, "hel")
+	}
+}


### PR DESCRIPTION
## Summary

Users could not type an accented character into any single-line prompt. Both line readers and `styledInput` gated keystrokes with `key >= 32 && key < 127`, and since every byte of every extended character is ≥ 128, they were silently discarded: **`café` stored as `caf`**, a pure-CJK entry stored as `""`. No error, nothing logged — a sysop had no way to diagnose it.

This affects real name, private note, custom prompt, handle, location, search terms — every prompt in the BBS.

## Design: CP437-first, decode on input

Most users are on CP437 terminals, so that's the case optimised for. Internal storage stays UTF-8, because everything downstream already is — `users.json`, the message store, and FTN import, which decodes CP437→UTF-8. `terminalio.WriteStringCP437` re-encodes on the way out. So the fix decodes at the input boundary rather than introducing a second internal representation.

**Round-trip, verified end-to-end:** a CP437 user types `0x82` → stored as UTF-8 `é` → echoed back as raw `0x82` → redisplayed later as `0x82`. Traced through `ansi.Cp437ToUnicode` on the way in and `ansi.UnicodeToCP437` on the way out.

In UTF-8 mode, bytes arrive one per `ReadKey` and are accumulated into a complete sequence before being appended or echoed.

## No parameter threading

`readLineFromSessionIH` has **111 call sites**. Rather than thread the mode through all of them, it rides the existing per-session `sync.Map` pattern already used for input handlers and idle timeouts — registered where `effectiveMode` is finalised, cleared on teardown. Zero signature changes.

It defaults to CP437 when unset, which is both the common case and the safe one: a CP437 byte can never be mistaken for part of a UTF-8 sequence.

## Two hazards this had to handle

**Backspace deleted one byte**, which would have cut a multi-byte character in half. It now deletes a whole rune and echoes one column, as before.

**Interrupted UTF-8 state.** Caught in review: `utf8Pending` was only cleared by the extended-byte branch and Backspace, so a stray lead byte survived and ate the *next* legitimate character — `0xC9 'A' 0xC3 0xA9` stored `"A"`, silently losing a correctly-typed `é`. Reachable whenever auto-detection misreads a raw-CP437 client as modern, which is exactly why the post-auth encoding-override prompt exists. Now cleared on every branch that accepts or ignores a key; the reviewer verified exhaustiveness by tracing both switches rather than just the reported case.

## Why this is safe now and wasn't before

Relaxing this filter would previously have turned every byte-based truncation downstream into a live corruption bug. That's why it waited: #148–#152 made widths and truncation rune-correct throughout and consolidated them onto shared primitives. The ordering was deliberate.

## Scope

The full-screen message editor's `IsPrintable` is deliberately untouched — it also touches buffer, word-wrap and screen rendering, a much larger surface. Message *bodies* remain ASCII-only for now.

## Verification

- `go test ./...` exit 0; `go test -race -count=1 ./internal/menu/` exit 0
- `gofmt -l` empty; `go vet ./...` clean; `staticcheck` zero findings; binary builds
- New tests cover the CP437 round-trip, UTF-8 accumulation, rune-aware backspace, backspace interrupting a pending sequence, the stray-lead-byte bug, and an ASCII regression guard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH/telnet input decoding and echoing for CP437 and UTF-8 (including extended key handling).
  * Cursor movement and maximum input length now use rune/column counts to prevent mid-rune truncation.
  * Backspace deletes whole characters and properly clears partially received UTF-8 sequences.
  * Stray/malformed UTF-8 bytes no longer corrupt or consume subsequent valid input.
  * Session output-mode is applied consistently for the remainder of the session and reset when it ends.
* **Tests**
  * Added regression tests covering rune-based truncation, CP437 column width, and UTF-8 resynchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->