### PR TITLE
fix(user): deleted-user SSH key bypass and five further findings

### DIFF
--- a/internal/user/manager_auth.go
+++ b/internal/user/manager_auth.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"bytes"
 	"log/slog"
 	"strings"
 	"time"
@@ -67,12 +68,18 @@ func (um *UserMgr) FindByAuthorizedKey(marshaled []byte) (*User, bool) {
 	um.mu.RLock()
 	defer um.mu.RUnlock()
 	for _, u := range um.users { // um.users is map[string]*User
+		// A soft-deleted account must not authenticate. The SSH-key path is the
+		// one login route that never re-checks this: callers only verify access
+		// level, so without this guard a removed user keeps their key access.
+		if u.DeletedUser {
+			continue
+		}
 		for _, line := range u.PublicKeys {
 			pub, _, _, _, err := ssh.ParseAuthorizedKey([]byte(line))
 			if err != nil {
 				continue
 			}
-			if string(pub.Marshal()) == string(marshaled) {
+			if bytes.Equal(pub.Marshal(), marshaled) {
 				return u, true
 			}
 		}

--- a/internal/user/manager_auth.go
+++ b/internal/user/manager_auth.go
@@ -80,7 +80,12 @@ func (um *UserMgr) FindByAuthorizedKey(marshaled []byte) (*User, bool) {
 				continue
 			}
 			if bytes.Equal(pub.Marshal(), marshaled) {
-				return u, true
+				// Return a copy, as GetUser/GetUserByID/Authenticate do. Handing
+				// back the map's own pointer lets the caller read it after the
+				// lock is released, while Authenticate mutates LastLogin and
+				// TimesCalled on that same struct in place -- a live data race.
+				userCopy := *u
+				return &userCopy, true
 			}
 		}
 	}

--- a/internal/user/manager_auth_deleted_test.go
+++ b/internal/user/manager_auth_deleted_test.go
@@ -50,3 +50,25 @@ func TestFindByAuthorizedKeyFindsActiveUsers(t *testing.T) {
 		t.Errorf("found %q, want Active", got.Handle)
 	}
 }
+
+// FindByAuthorizedKey must return a copy, like the rest of the UserMgr API.
+// Handing back the map's own pointer would let a caller observe another
+// session's in-place LastLogin/TimesCalled updates from Authenticate.
+func TestFindByAuthorizedKeyReturnsCopy(t *testing.T) {
+	const keyLine = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJx0eUyJ1cVfhVJZ2m8mZmXaJXVMRxHi/8oRSPCbf5oM tester"
+	pub, _, _, _, err := ssh.ParseAuthorizedKey([]byte(keyLine))
+	if err != nil {
+		t.Fatalf("ParseAuthorizedKey: %v", err)
+	}
+	seeded := &User{ID: 1, Handle: "Active", PublicKeys: []string{keyLine}, TimesCalled: 5}
+	um := NewUserMgrForTest(seeded)
+
+	got, ok := um.FindByAuthorizedKey(pub.Marshal())
+	if !ok {
+		t.Fatal("user not found by key")
+	}
+	got.TimesCalled = 999
+	if seeded.TimesCalled != 5 {
+		t.Errorf("mutating the returned user changed the stored one (TimesCalled=%d); a copy was not returned", seeded.TimesCalled)
+	}
+}

--- a/internal/user/manager_auth_deleted_test.go
+++ b/internal/user/manager_auth_deleted_test.go
@@ -1,0 +1,52 @@
+package user
+
+import (
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// A soft-deleted account must not be able to authenticate by SSH key.
+// FindByAuthorizedKey is the lookup behind key-based login, and the caller
+// (cmd/vision3) only rechecks access level, not DeletedUser — so if this
+// returns a deleted user, a removed account keeps working.
+func TestFindByAuthorizedKeySkipsDeletedUsers(t *testing.T) {
+	// A syntactically valid authorized_keys line.
+	const keyLine = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJx0eUyJ1cVfhVJZ2m8mZmXaJXVMRxHi/8oRSPCbf5oM tester"
+	pub, _, _, _, err := ssh.ParseAuthorizedKey([]byte(keyLine))
+	if err != nil {
+		t.Fatalf("ParseAuthorizedKey: %v", err)
+	}
+	marshaled := pub.Marshal()
+
+	um := NewUserMgrForTest(&User{
+		ID:          1,
+		Handle:      "Ghost",
+		PublicKeys:  []string{keyLine},
+		DeletedUser: true,
+	})
+
+	if got, ok := um.FindByAuthorizedKey(marshaled); ok {
+		t.Errorf("deleted user %q was returned for key lookup; a removed account can still log in", got.Handle)
+	}
+}
+
+// An active account with the same shape must still be found, so the guard
+// cannot be satisfied by rejecting everything.
+func TestFindByAuthorizedKeyFindsActiveUsers(t *testing.T) {
+	const keyLine = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJx0eUyJ1cVfhVJZ2m8mZmXaJXVMRxHi/8oRSPCbf5oM tester"
+	pub, _, _, _, err := ssh.ParseAuthorizedKey([]byte(keyLine))
+	if err != nil {
+		t.Fatalf("ParseAuthorizedKey: %v", err)
+	}
+
+	um := NewUserMgrForTest(&User{ID: 1, Handle: "Active", PublicKeys: []string{keyLine}})
+
+	got, ok := um.FindByAuthorizedKey(pub.Marshal())
+	if !ok {
+		t.Fatal("active user not found by key")
+	}
+	if got.Handle != "Active" {
+		t.Errorf("found %q, want Active", got.Handle)
+	}
+}

--- a/internal/user/manager_calls.go
+++ b/internal/user/manager_calls.go
@@ -89,7 +89,7 @@ func (um *UserMgr) saveCallHistoryLocked() error {
 	}
 
 	filePath := filepath.Join(um.dataPath, callHistoryFile) // Use stored dataPath
-	if err := os.WriteFile(filePath, data, 0644); err != nil {
+	if err := os.WriteFile(filePath, data, 0600); err != nil {
 		return fmt.Errorf("failed to write %s: %w", callHistoryFile, err)
 	}
 
@@ -110,7 +110,7 @@ func (um *UserMgr) saveNextCallNumberLocked() error {
 	}
 
 	filePath := filepath.Join(um.dataPath, callNumberFile)
-	if err := os.WriteFile(filePath, data, 0644); err != nil {
+	if err := os.WriteFile(filePath, data, 0600); err != nil {
 		return fmt.Errorf("failed to write %s: %w", callNumberFile, err)
 	}
 	return nil

--- a/internal/user/manager_persist.go
+++ b/internal/user/manager_persist.go
@@ -35,7 +35,10 @@ func (um *UserMgr) saveUsersLocked() error { // Receiver uses renamed type
 		return fmt.Errorf("failed to create directory %s: %w", dir, err)
 	}
 
-	// WriteFile ensures atomic write (usually via temp file)
+	// NOTE: os.WriteFile truncates and rewrites in place. It is NOT atomic --
+	// a crash mid-write can leave a truncated users.json. Callers rely on this
+	// being the single writer under um.mu; making it crash-safe would need a
+	// write-to-temp-then-rename.
 	if err = os.WriteFile(um.path, data, 0600); err != nil {
 		return fmt.Errorf("failed to write users file %s: %w", um.path, err) // Include path in error
 	}
@@ -66,7 +69,10 @@ func (um *UserMgr) LogAdminActivity(logEntry AdminActivityLog) error {
 
 	// Add new entry
 	logEntry.ID = len(logs) + 1
-	logEntry.Timestamp = time.Now()
+	// UTC to match AdminActivityLogEntry in admin_log.go, which stamps
+	// time.Now().UTC(). Mixing zones in one log file silently misorders entries
+	// across a DST boundary for anyone reconstructing an incident.
+	logEntry.Timestamp = time.Now().UTC()
 	logs = append(logs, logEntry)
 
 	// Keep only recent entries (prevent file from growing indefinitely)

--- a/internal/user/manager_users.go
+++ b/internal/user/manager_users.go
@@ -132,18 +132,31 @@ func (um *UserMgr) AddUser(password, handle, realName, groupLocation string) (*U
 	}
 	lowerHandle := strings.ToLower(handle)
 
-	um.mu.Lock()
-	defer um.mu.Unlock()
-
-	// Check if handle already exists
-	if _, exists := um.users[lowerHandle]; exists {
+	// Reject a duplicate handle before doing the expensive work, so the common
+	// error path is unchanged and costs nothing.
+	um.mu.RLock()
+	_, exists := um.users[lowerHandle]
+	um.mu.RUnlock()
+	if exists {
 		return nil, ErrHandleExists
 	}
 
-	// Hash the password
+	// Hash OUTSIDE the lock. bcrypt is deliberately slow, and it depends only on
+	// password -- holding um.mu across it blocks every read and write on the
+	// manager for the duration of each registration. Authenticate already
+	// releases the lock before bcrypt for exactly this reason.
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		return nil, fmt.Errorf("failed to hash password: %w", err)
+	}
+
+	um.mu.Lock()
+	defer um.mu.Unlock()
+
+	// Re-check under the write lock: another registration may have taken the
+	// handle while we were hashing.
+	if _, exists := um.users[lowerHandle]; exists {
+		return nil, ErrHandleExists
 	}
 
 	// Create new user


### PR DESCRIPTION
## Summary

Six pre-existing issues in `internal/user`, all surfaced by the #156 split — the code didn't change, it just became readable enough that the review bots could see it. Kept out of that PR deliberately, since its safety argument was being byte-identical.

## The one that matters: deleted users could still log in by SSH key

`FindByAuthorizedKey` had no `DeletedUser` check. That path is the **one login route that never re-checks it** — `cmd/vision3` only verifies access level afterwards — so a soft-deleted account kept working indefinitely as long as it had a key on file. A sysop deleting a user would reasonably believe access was revoked.

Test fails against the old code:

```
deleted user "Ghost" was returned for key lookup; a removed account can still log in
```

A companion test asserts an active user with the same shape is still found, so the guard can't be satisfied by rejecting everything.

## bcrypt held the write lock

`AddUser` called `bcrypt.GenerateFromPassword` inside `um.mu`, so every registration blocked **all** reads and writes on the user manager for the hash duration — logins included. `Authenticate` in the same package already releases the lock before bcrypt, with the comment "bcrypt is CPU-intensive", so the correct pattern was established and this call site diverged from it.

Hashing now happens outside the lock. The cheap duplicate-handle rejection still runs first under a read lock, so the common error path and its ordering are unchanged, and the handle is **re-checked under the write lock** in case another registration claimed it while hashing.

## Three smaller, one cosmetic

- Call history and call number were written `0644` while `users.json` and the admin log beside them use `0600`. Call records carry user IDs and timestamps.
- `LogAdminActivity` stamped local time while `AdminActivityLogEntry` uses UTC — one log file with two zones, which misorders entries across a DST boundary for anyone reconstructing an incident.
- The `saveUsersLocked` comment claimed `os.WriteFile` is "atomic (usually via temp file)". It truncates and rewrites in place. Claiming durability the code doesn't provide is worse than saying nothing on a persistence path, so the comment now states the real behaviour and what it would take to fix.
- `FindByAuthorizedKey` compares keys with `bytes.Equal` rather than string conversions.

## One review finding declined

Copilot flagged a possible nil-dereference panic in `Authenticate` on the re-fetch after unlocking. There isn't one — the code already guards with `if user == nil { um.mu.Unlock(); return nil, false }`, so a user renamed or removed in that window produces a clean auth failure. Checked before acting rather than "fixing" a non-bug.

## Verification

- `go test ./...` exit 0; `go test -race -count=1 ./internal/user/` exit 0
- `gofmt -l` empty; `go vet` clean; binary builds
- The package's existing 70+ tests pass unchanged