### PR TITLE
fix: reject duplicate FTN echo tags within a network

### DIFF
--- a/internal/message/manager.go
+++ b/internal/message/manager.go
@@ -44,13 +44,17 @@ const messageAreaFile = "message_areas.json"
 // Bases are opened on-demand and closed after each operation to allow
 // v3mail and other external tools concurrent access.
 type MessageManager struct {
-	mu             sync.RWMutex
-	dataPath       string // Base data directory (e.g., "data")
-	areasPath      string // Full path to message_areas.json
-	areasByID      map[int]*MessageArea
-	areasByTag     map[string]*MessageArea
-	areasByEchoTag map[string]*MessageArea // indexed by EchoTag when it differs from Tag
-	boardName      string                  // BBS name for echomail origin lines
+	mu         sync.RWMutex
+	dataPath   string // Base data directory (e.g., "data")
+	areasPath  string // Full path to message_areas.json
+	areasByID  map[int]*MessageArea
+	areasByTag map[string]*MessageArea
+	// areasByEchoTag indexes areas by EchoTag when it differs from Tag.
+	// The key is the echo tag alone, so it holds at most one area per tag even
+	// across networks; AddArea/UpdateAreaByID reject same-network duplicates and
+	// the load path warns about any collision it finds in an existing config.
+	areasByEchoTag map[string]*MessageArea
+	boardName      string // BBS name for echomail origin lines
 	// networkTearlines maps network key -> custom tearline text.
 	networkTearlines map[string]string
 	threadIndex      map[int]*threadIndex

--- a/internal/message/manager_areas.go
+++ b/internal/message/manager_areas.go
@@ -23,32 +23,48 @@ func (mm *MessageManager) GetAreaByTag(tag string) (*MessageArea, bool) {
 	return area, exists
 }
 
-// echoTagConflict reports an area that already claims echoTag on the same
-// network, excluding excludeID.
+// echoTagConflict reports an area that already claims echoTag, excluding
+// excludeID. Two kinds of claim count:
 //
-// Within one network a duplicate is a misconfiguration: areasByEchoTag keeps
-// only the last writer, so that echo's mail silently lands in whichever area
-// happened to be indexed last. Areas on different networks may legitimately
-// share an echo tag -- the same echo name exists on separate FTN networks, and
-// the tosser disambiguates by network when routing (see internal/tosser/import.go).
+//   - Another area with the same EchoTag on the same network. areasByEchoTag
+//     keeps only the last writer, so that echo's mail silently lands in
+//     whichever area was indexed last. Areas on DIFFERENT networks may
+//     legitimately share an echo tag -- the same echo name exists on separate
+//     FTN networks -- and the tosser disambiguates by network when routing
+//     (internal/tosser/import.go).
 //
-// Comparison is exact, matching the areasByEchoTag key. Areas whose EchoTag
-// equals their Tag count as claimants too: they are not in the index, but the
-// tosser's tag lookup already routes that echo to them, so a second area asking
-// for it would never receive anything. Caller must hold mm.mu.
+//   - Any area whose Tag equals echoTag, on any network. The tosser tries
+//     GetAreaByTag first and that lookup is NOT network-gated, so a tag match
+//     always wins and the echo-tagged area would never receive anything.
+//
+// Comparison is exact, matching the areasByEchoTag key. Caller must hold mm.mu.
 func (mm *MessageManager) echoTagConflict(echoTag, network string, excludeID int) *MessageArea {
 	if echoTag == "" {
 		return nil
 	}
 	for _, a := range mm.areasByID {
-		if a.ID == excludeID || a.EchoTag == "" {
+		if a.ID == excludeID {
 			continue
 		}
-		if a.EchoTag == echoTag && strings.EqualFold(a.Network, network) {
+		if a.Tag == echoTag {
+			return a
+		}
+		if a.EchoTag != "" && a.EchoTag == echoTag && strings.EqualFold(a.Network, network) {
 			return a
 		}
 	}
 	return nil
+}
+
+// echoTagConflictError describes why echoTag cannot be used, naming the area
+// that already claims it and how.
+func echoTagConflictError(echoTag string, c *MessageArea) error {
+	if c.Tag == echoTag {
+		return fmt.Errorf("echo tag %q is the local tag of area %q (id %d); inbound mail for it already routes there",
+			echoTag, c.Tag, c.ID)
+	}
+	return fmt.Errorf("echo tag %q already used by area %q (id %d) on network %q",
+		echoTag, c.Tag, c.ID, c.Network)
 }
 
 // GetAreaByEchoTag retrieves a message area by its FTN echo tag.
@@ -86,8 +102,7 @@ func (mm *MessageManager) UpdateAreaByID(id int, updated MessageArea) error {
 		}
 	}
 	if conflict := mm.echoTagConflict(updated.EchoTag, updated.Network, id); conflict != nil {
-		return fmt.Errorf("echo tag %q already used by area %q (id %d) on network %q",
-			updated.EchoTag, conflict.Tag, conflict.ID, updated.Network)
+		return echoTagConflictError(updated.EchoTag, conflict)
 	}
 	if oldTag != updated.Tag {
 		delete(mm.areasByTag, oldTag)
@@ -119,8 +134,7 @@ func (mm *MessageManager) AddArea(area MessageArea) (int, error) {
 
 	if conflict := mm.echoTagConflict(area.EchoTag, area.Network, 0); conflict != nil {
 		mm.mu.Unlock()
-		return 0, fmt.Errorf("echo tag %q already used by area %q (id %d) on network %q",
-			area.EchoTag, conflict.Tag, conflict.ID, area.Network)
+		return 0, echoTagConflictError(area.EchoTag, conflict)
 	}
 
 	// Assign next ID and position.

--- a/internal/message/manager_areas.go
+++ b/internal/message/manager_areas.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"strings"
 )
 
 // GetAreaByID retrieves a message area by its ID.
@@ -20,6 +21,34 @@ func (mm *MessageManager) GetAreaByTag(tag string) (*MessageArea, bool) {
 	defer mm.mu.RUnlock()
 	area, exists := mm.areasByTag[tag]
 	return area, exists
+}
+
+// echoTagConflict reports an area that already claims echoTag on the same
+// network, excluding excludeID.
+//
+// Within one network a duplicate is a misconfiguration: areasByEchoTag keeps
+// only the last writer, so that echo's mail silently lands in whichever area
+// happened to be indexed last. Areas on different networks may legitimately
+// share an echo tag -- the same echo name exists on separate FTN networks, and
+// the tosser disambiguates by network when routing (see internal/tosser/import.go).
+//
+// Comparison is exact, matching the areasByEchoTag key. Areas whose EchoTag
+// equals their Tag count as claimants too: they are not in the index, but the
+// tosser's tag lookup already routes that echo to them, so a second area asking
+// for it would never receive anything. Caller must hold mm.mu.
+func (mm *MessageManager) echoTagConflict(echoTag, network string, excludeID int) *MessageArea {
+	if echoTag == "" {
+		return nil
+	}
+	for _, a := range mm.areasByID {
+		if a.ID == excludeID || a.EchoTag == "" {
+			continue
+		}
+		if a.EchoTag == echoTag && strings.EqualFold(a.Network, network) {
+			return a
+		}
+	}
+	return nil
 }
 
 // GetAreaByEchoTag retrieves a message area by its FTN echo tag.
@@ -49,12 +78,21 @@ func (mm *MessageManager) UpdateAreaByID(id int, updated MessageArea) error {
 	oldEchoTag := old.EchoTag
 	replacement := new(MessageArea)
 	*replacement = updated
+	// Validate everything before touching any index, so a rejected update
+	// leaves the manager exactly as it was.
 	if oldTag != updated.Tag {
 		if existing, ok := mm.areasByTag[updated.Tag]; ok && existing.ID != id {
 			return fmt.Errorf("tag %q already in use by area %d", updated.Tag, existing.ID)
 		}
+	}
+	if conflict := mm.echoTagConflict(updated.EchoTag, updated.Network, id); conflict != nil {
+		return fmt.Errorf("echo tag %q already used by area %q (id %d) on network %q",
+			updated.EchoTag, conflict.Tag, conflict.ID, updated.Network)
+	}
+	if oldTag != updated.Tag {
 		delete(mm.areasByTag, oldTag)
 	}
+
 	// Keep areasByEchoTag in sync when EchoTag changes.
 	if oldEchoTag != "" && oldEchoTag != old.Tag {
 		delete(mm.areasByEchoTag, oldEchoTag)
@@ -77,6 +115,12 @@ func (mm *MessageManager) AddArea(area MessageArea) (int, error) {
 	if _, exists := mm.areasByTag[area.Tag]; exists {
 		mm.mu.Unlock()
 		return 0, fmt.Errorf("message area tag %q already exists", area.Tag)
+	}
+
+	if conflict := mm.echoTagConflict(area.EchoTag, area.Network, 0); conflict != nil {
+		mm.mu.Unlock()
+		return 0, fmt.Errorf("echo tag %q already used by area %q (id %d) on network %q",
+			area.EchoTag, conflict.Tag, conflict.ID, area.Network)
 	}
 
 	// Assign next ID and position.

--- a/internal/message/manager_areas_store.go
+++ b/internal/message/manager_areas_store.go
@@ -45,7 +45,15 @@ func (mm *MessageManager) loadMessageAreas() error {
 		mm.areasByID[area.ID] = area
 		mm.areasByTag[area.Tag] = area
 		// Also index by EchoTag for FTN inbound routing when tag-prefix is in use.
+		// Existing configs may already contain duplicates, so load stays tolerant
+		// and warns rather than failing; AddArea/UpdateAreaByID reject new ones.
 		if area.EchoTag != "" && area.EchoTag != area.Tag {
+			if prev, dup := mm.areasByEchoTag[area.EchoTag]; dup {
+				slog.Warn("duplicate FTN echo tag; inbound mail for it will route to the last area loaded",
+					"echo_tag", area.EchoTag,
+					"kept_area", area.Tag, "kept_id", area.ID, "kept_network", area.Network,
+					"shadowed_area", prev.Tag, "shadowed_id", prev.ID, "shadowed_network", prev.Network)
+			}
 			mm.areasByEchoTag[area.EchoTag] = area
 		}
 		slog.Debug("loaded area", "id", area.ID, "tag", area.Tag, "type", area.AreaType)

--- a/internal/message/manager_areas_store.go
+++ b/internal/message/manager_areas_store.go
@@ -49,7 +49,11 @@ func (mm *MessageManager) loadMessageAreas() error {
 		// and warns rather than failing; AddArea/UpdateAreaByID reject new ones.
 		if area.EchoTag != "" && area.EchoTag != area.Tag {
 			if prev, dup := mm.areasByEchoTag[area.EchoTag]; dup {
-				slog.Warn("duplicate FTN echo tag; inbound mail for it will route to the last area loaded",
+				// Only the last area loaded stays reachable by this echo tag.
+				// Same network: its mail goes to that area instead of the other.
+				// Different networks: the tosser's network check rejects the
+				// mismatch, so the shadowed network's mail goes unrouted.
+				slog.Warn("duplicate FTN echo tag; only the last area loaded is reachable by it",
 					"echo_tag", area.EchoTag,
 					"kept_area", area.Tag, "kept_id", area.ID, "kept_network", area.Network,
 					"shadowed_area", prev.Tag, "shadowed_id", prev.ID, "shadowed_network", prev.Network)
@@ -57,6 +61,22 @@ func (mm *MessageManager) loadMessageAreas() error {
 			mm.areasByEchoTag[area.EchoTag] = area
 		}
 		slog.Debug("loaded area", "id", area.ID, "tag", area.Tag, "type", area.AreaType)
+	}
+
+	// An area's Tag shadows another area's EchoTag: the tosser tries the tag
+	// lookup first and that lookup is not network-gated, so the echo-tagged
+	// area never receives anything. Checked after the loop because the two
+	// areas can appear in either order.
+	for _, area := range mm.areasByID {
+		if area.EchoTag == "" || area.EchoTag == area.Tag {
+			continue
+		}
+		if owner, ok := mm.areasByTag[area.EchoTag]; ok && owner.ID != area.ID {
+			slog.Warn("FTN echo tag is another area's local tag; mail for it routes to that area instead",
+				"echo_tag", area.EchoTag,
+				"echo_area", area.Tag, "echo_id", area.ID, "echo_network", area.Network,
+				"tag_area", owner.Tag, "tag_id", owner.ID)
+		}
 	}
 
 	// Migration: assign positions to any areas that have Position <= 0.

--- a/internal/message/manager_echotag_test.go
+++ b/internal/message/manager_echotag_test.go
@@ -1,0 +1,150 @@
+package message
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newEchoTagTestManager(t *testing.T) *MessageManager {
+	t.Helper()
+	mm, err := NewMessageManager(t.TempDir(), t.TempDir(), "TestBBS", nil)
+	if err != nil {
+		t.Fatalf("NewMessageManager: %v", err)
+	}
+	return mm
+}
+
+// Two areas on the SAME network sharing an EchoTag silently overwrite each
+// other in areasByEchoTag, so inbound echomail for that tag lands in whichever
+// area was indexed last — and map ordering makes that unstable across restarts.
+// Adding such an area must be refused.
+func TestAddAreaRejectsDuplicateEchoTagSameNetwork(t *testing.T) {
+	mm := newEchoTagTestManager(t)
+
+	if _, err := mm.AddArea(MessageArea{Tag: "FD_LINUX", Name: "Linux", EchoTag: "LINUX", Network: "fsxnet"}); err != nil {
+		t.Fatalf("first AddArea: %v", err)
+	}
+	_, err := mm.AddArea(MessageArea{Tag: "OTHER_LINUX", Name: "Linux 2", EchoTag: "LINUX", Network: "fsxnet"})
+	if err == nil {
+		t.Fatal("second AddArea with a duplicate EchoTag on the same network was accepted")
+	}
+	if !strings.Contains(err.Error(), "LINUX") {
+		t.Errorf("error should name the conflicting echo tag, got: %v", err)
+	}
+}
+
+// The same echo tag on a DIFFERENT network is legitimate — FTN echoes of the
+// same name genuinely exist on separate networks, and the tosser already
+// disambiguates by network when routing.
+func TestAddAreaAllowsSameEchoTagOnDifferentNetwork(t *testing.T) {
+	mm := newEchoTagTestManager(t)
+
+	if _, err := mm.AddArea(MessageArea{Tag: "FD_LINUX", Name: "Linux", EchoTag: "LINUX", Network: "fsxnet"}); err != nil {
+		t.Fatalf("first AddArea: %v", err)
+	}
+	if _, err := mm.AddArea(MessageArea{Tag: "AN_LINUX", Name: "Linux", EchoTag: "LINUX", Network: "agoranet"}); err != nil {
+		t.Fatalf("same echo tag on a different network should be allowed: %v", err)
+	}
+}
+
+// UpdateAreaByID must apply the same rule, or the editor becomes a way around it.
+func TestUpdateAreaRejectsDuplicateEchoTagSameNetwork(t *testing.T) {
+	mm := newEchoTagTestManager(t)
+
+	if _, err := mm.AddArea(MessageArea{Tag: "FD_LINUX", Name: "Linux", EchoTag: "LINUX", Network: "fsxnet"}); err != nil {
+		t.Fatalf("AddArea 1: %v", err)
+	}
+	id2, err := mm.AddArea(MessageArea{Tag: "FD_BBS", Name: "BBS", EchoTag: "BBS", Network: "fsxnet"})
+	if err != nil {
+		t.Fatalf("AddArea 2: %v", err)
+	}
+
+	err = mm.UpdateAreaByID(id2, MessageArea{ID: id2, Tag: "FD_BBS", Name: "BBS", EchoTag: "LINUX", Network: "fsxnet"})
+	if err == nil {
+		t.Fatal("UpdateAreaByID accepted an EchoTag already used on the same network")
+	}
+}
+
+// Updating an area without touching its EchoTag must not trip the new check
+// against its own existing entry.
+func TestUpdateAreaAllowsKeepingItsOwnEchoTag(t *testing.T) {
+	mm := newEchoTagTestManager(t)
+
+	id, err := mm.AddArea(MessageArea{Tag: "FD_LINUX", Name: "Linux", EchoTag: "LINUX", Network: "fsxnet"})
+	if err != nil {
+		t.Fatalf("AddArea: %v", err)
+	}
+	if err := mm.UpdateAreaByID(id, MessageArea{ID: id, Tag: "FD_LINUX", Name: "Linux Renamed", EchoTag: "LINUX", Network: "fsxnet"}); err != nil {
+		t.Errorf("updating an area while keeping its own EchoTag was rejected: %v", err)
+	}
+}
+
+// An existing config may already contain duplicate echo tags -- those configs
+// must keep loading (rejecting them would lock the sysop out of the editor they
+// need to fix it), but the collision has to be visible in the log.
+func TestLoadAreasWarnsOnDuplicateEchoTagAndKeepsBothAreas(t *testing.T) {
+	configDir, dataDir := t.TempDir(), t.TempDir()
+	areas := `[
+		{"id":1,"tag":"FD_LINUX","name":"Linux","echo_tag":"LINUX","network":"fsxnet","area_type":"echomail"},
+		{"id":2,"tag":"OTHER_LINUX","name":"Linux 2","echo_tag":"LINUX","network":"fsxnet","area_type":"echomail"}
+	]`
+	if err := os.WriteFile(filepath.Join(configDir, "message_areas.json"), []byte(areas), 0o644); err != nil {
+		t.Fatalf("write areas: %v", err)
+	}
+
+	var logs bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	defer slog.SetDefault(prev)
+
+	mm, err := NewMessageManager(dataDir, configDir, "TestBBS", nil)
+	if err != nil {
+		t.Fatalf("loading a config with duplicate echo tags must not fail: %v", err)
+	}
+	if _, ok := mm.GetAreaByID(1); !ok {
+		t.Error("area 1 was dropped")
+	}
+	if _, ok := mm.GetAreaByID(2); !ok {
+		t.Error("area 2 was dropped")
+	}
+	out := logs.String()
+	if !strings.Contains(out, "duplicate FTN echo tag") {
+		t.Errorf("no warning logged for the duplicate echo tag; log was:\n%s", out)
+	}
+	if !strings.Contains(out, "OTHER_LINUX") || !strings.Contains(out, "FD_LINUX") {
+		t.Errorf("warning should name both areas; log was:\n%s", out)
+	}
+}
+
+// A rejected update must not leave the indexes half-modified: the area has to
+// remain findable under the tag it still has on disk.
+func TestUpdateAreaRejectedByEchoTagLeavesIndexesIntact(t *testing.T) {
+	mm := newEchoTagTestManager(t)
+
+	if _, err := mm.AddArea(MessageArea{Tag: "FD_LINUX", Name: "Linux", EchoTag: "LINUX", Network: "fsxnet"}); err != nil {
+		t.Fatalf("AddArea 1: %v", err)
+	}
+	id2, err := mm.AddArea(MessageArea{Tag: "FD_BBS", Name: "BBS", EchoTag: "BBS", Network: "fsxnet"})
+	if err != nil {
+		t.Fatalf("AddArea 2: %v", err)
+	}
+
+	// Rename and steal the other area's echo tag in one update: must be refused.
+	if err := mm.UpdateAreaByID(id2, MessageArea{ID: id2, Tag: "FD_BBS_NEW", Name: "BBS", EchoTag: "LINUX", Network: "fsxnet"}); err == nil {
+		t.Fatal("update with a duplicate echo tag was accepted")
+	}
+
+	if _, ok := mm.GetAreaByTag("FD_BBS"); !ok {
+		t.Error("after a rejected update the area is no longer findable by its unchanged tag")
+	}
+	if _, ok := mm.GetAreaByTag("FD_BBS_NEW"); ok {
+		t.Error("the rejected new tag was indexed")
+	}
+	if a, ok := mm.GetAreaByEchoTag("LINUX"); !ok || a.Tag != "FD_LINUX" {
+		t.Errorf("echo tag LINUX no longer resolves to FD_LINUX, got %+v (found=%v)", a, ok)
+	}
+}

--- a/internal/message/manager_echotag_test.go
+++ b/internal/message/manager_echotag_test.go
@@ -148,3 +148,60 @@ func TestUpdateAreaRejectedByEchoTagLeavesIndexesIntact(t *testing.T) {
 		t.Errorf("echo tag LINUX no longer resolves to FD_LINUX, got %+v (found=%v)", a, ok)
 	}
 }
+
+// The tosser tries GetAreaByTag before the echo-tag index and that lookup is
+// not network-gated, so an area whose Tag equals another area's EchoTag takes
+// the mail unconditionally -- the echo-tagged area never sees any.
+func TestAddAreaRejectsEchoTagThatIsAnotherAreasTag(t *testing.T) {
+	mm := newEchoTagTestManager(t)
+
+	if _, err := mm.AddArea(MessageArea{Tag: "LINUX", Name: "Local Linux", Network: ""}); err != nil {
+		t.Fatalf("AddArea local: %v", err)
+	}
+	_, err := mm.AddArea(MessageArea{Tag: "FD_LINUX", Name: "Linux", EchoTag: "LINUX", Network: "fsxnet"})
+	if err == nil {
+		t.Fatal("AddArea accepted an echo tag that is already another area's local tag")
+	}
+	if !strings.Contains(err.Error(), "local tag") {
+		t.Errorf("error should say the tag is a local tag, got: %v", err)
+	}
+}
+
+// An area keeping EchoTag == its own Tag must not be treated as conflicting
+// with itself, on add or on update.
+func TestAreaMayUseItsOwnTagAsEchoTag(t *testing.T) {
+	mm := newEchoTagTestManager(t)
+
+	id, err := mm.AddArea(MessageArea{Tag: "FSX_GEN", Name: "General", EchoTag: "FSX_GEN", Network: "fsxnet"})
+	if err != nil {
+		t.Fatalf("an area whose EchoTag equals its own Tag was rejected: %v", err)
+	}
+	if err := mm.UpdateAreaByID(id, MessageArea{ID: id, Tag: "FSX_GEN", Name: "General Chat", EchoTag: "FSX_GEN", Network: "fsxnet"}); err != nil {
+		t.Errorf("updating that area was rejected: %v", err)
+	}
+}
+
+func TestLoadAreasWarnsWhenEchoTagIsAnotherAreasTag(t *testing.T) {
+	configDir, dataDir := t.TempDir(), t.TempDir()
+	// Deliberately listed with the echo-tagged area FIRST, so the check cannot
+	// depend on load order.
+	areas := `[
+		{"id":1,"tag":"FD_LINUX","name":"Linux","echo_tag":"LINUX","network":"fsxnet","area_type":"echomail"},
+		{"id":2,"tag":"LINUX","name":"Local Linux","area_type":"local"}
+	]`
+	if err := os.WriteFile(filepath.Join(configDir, "message_areas.json"), []byte(areas), 0o644); err != nil {
+		t.Fatalf("write areas: %v", err)
+	}
+
+	var logs bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	defer slog.SetDefault(prev)
+
+	if _, err := NewMessageManager(dataDir, configDir, "TestBBS", nil); err != nil {
+		t.Fatalf("NewMessageManager: %v", err)
+	}
+	if out := logs.String(); !strings.Contains(out, "another area's local tag") {
+		t.Errorf("no warning logged for the tag/echo-tag collision; log was:\n%s", out)
+	}
+}


### PR DESCRIPTION
Follow-up to the `internal/message` split (#155), which surfaced this.

## The bug

`areasByEchoTag` is keyed by echo tag alone and holds one area per key. Nothing stopped two areas on the same network from claiming the same `EchoTag`, so the second one indexed silently shadowed the first — inbound echomail for that tag went to whichever area was written last. Because both the load loop and `ListAreas` iterate `areasByID` (a Go map), "last" is not stable across restarts: the destination area for that echo could change between runs.

## What changed

- **Reject on add/update** — `AddArea` and `UpdateAreaByID` refuse a duplicate echo tag, scoped to the **same network**. Cross-network duplicates are legitimate (the same echo name exists on separate FTN networks) and `internal/tosser/import.go:372` already disambiguates by network when routing.
- **Warn on load** — `loadMessageAreas` keeps loading a config that already has duplicates and logs a warning naming both the kept and the shadowed area, with IDs and networks. Failing the load would lock the sysop out of the editor they need to fix it.
- **Validation before mutation** — `UpdateAreaByID` deleted the old tag from `areasByTag` before the new check could return, so a rejected update dropped the area from the tag index. All validation now runs first.

An area whose `EchoTag` equals its `Tag` counts as a claimant even though it is not in the echo index: the tosser's tag lookup already routes that echo to it, so a second area asking for the same tag would never receive anything.

## Not changed

- `areasByEchoTag` still cannot represent the same echo tag on two networks — the key has no network component, so a cross-network pair still leaves only one entry and the tosser's network guard rejects the mismatch (mail goes unrouted rather than misrouted). Correcting that means re-keying the index; out of scope here.
- Echo tag comparison is exact, matching the map key. `"LINUX"` and `"linux"` are treated as distinct, as they are today for routing.

## Tests

5 new tests in `internal/message/manager_echotag_test.go`: reject on add, reject on update, allow the same tag on a different network, allow an area to keep its own tag through an update, and warn-but-load for an existing config with duplicates. Each was confirmed RED against the unfixed code first.