### PR TITLE
fix(file): validate record filenames and roll back moves by identity

### DIFF
--- a/internal/file/filename.go
+++ b/internal/file/filename.go
@@ -1,0 +1,55 @@
+package file
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// validateFilename checks that name is a plain file name that stays inside the
+// area directory it will be joined to, and returns it unchanged.
+//
+// File records are joined against an area path as filepath.Join(base, area, name),
+// so anything carrying a separator -- or the literal ".." -- escapes the area.
+// filepath.Base is not enough on its own: it returns ".." for "..", which lands
+// on the area's parent directory.
+//
+// Names that merely contain ".." (patch..v2.zip) are fine: once separators are
+// rejected there is nothing left for them to traverse.
+func validateFilename(name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("filename is empty")
+	}
+	if name == "." || name == ".." {
+		return "", fmt.Errorf("invalid filename %q: refers to a directory", name)
+	}
+	// Reject both separators regardless of host OS: records may have been
+	// written by a Windows node or imported from a foreign file list.
+	if strings.ContainsAny(name, `/\`) {
+		return "", fmt.Errorf("invalid filename %q: contains a path separator", name)
+	}
+	if strings.ContainsRune(name, 0) {
+		return "", fmt.Errorf("invalid filename %q: contains a NUL byte", name)
+	}
+	if filepath.Base(name) != name {
+		return "", fmt.Errorf("invalid filename %q: not a plain file name", name)
+	}
+	return name, nil
+}
+
+// removeRecordByID returns records without the entry whose ID matches, leaving
+// the remaining order intact. Removing by identity rather than by position
+// matters during rollback: muFiles is released while records are persisted, so
+// the slice may have grown since the index was taken.
+func removeRecordByID(records []FileRecord, id uuid.UUID) []FileRecord {
+	out := make([]FileRecord, 0, len(records))
+	for _, r := range records {
+		if r.ID == id {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}

--- a/internal/file/manager_filename_test.go
+++ b/internal/file/manager_filename_test.go
@@ -1,0 +1,241 @@
+package file
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestValidateFilenameRejectsTraversal(t *testing.T) {
+	bad := []string{"", ".", "..", "../evil", "sub/dir.zip", `sub\dir.zip`, "/etc/passwd", "a\x00b"}
+	for _, name := range bad {
+		if _, err := validateFilename(name); err == nil {
+			t.Errorf("validateFilename(%q) was accepted", name)
+		}
+	}
+}
+
+// filepath.Base leaves ".." intact, so a record holding it produces
+// filepath.Join(base, areaPath, "..") -- the area's parent directory.
+func TestValidateFilenameRejectsDotDotSpecifically(t *testing.T) {
+	if _, err := validateFilename(".."); err == nil {
+		t.Fatal(`validateFilename("..") was accepted; it resolves to the area's parent directory`)
+	}
+}
+
+// The old check rejected any name containing "..", which also refused ordinary
+// files. Base() already guarantees there are no separators, so an embedded ".."
+// cannot traverse anywhere.
+func TestValidateFilenameAcceptsOrdinaryNames(t *testing.T) {
+	good := []string{"README.TXT", "patch..v2.zip", "file.name.with.dots.lha", "..hidden-ish.txt", "a.zip"}
+	for _, name := range good {
+		got, err := validateFilename(name)
+		if err != nil {
+			t.Errorf("validateFilename(%q) rejected a legitimate name: %v", name, err)
+			continue
+		}
+		if got != name {
+			t.Errorf("validateFilename(%q) = %q, want it returned unchanged", name, got)
+		}
+	}
+}
+
+func TestAddFileRecordRejectsPathInFilename(t *testing.T) {
+	fm := setupTestFileManager(t, []FileArea{{ID: 1, Tag: "UTILS", Name: "Utilities", Path: "utils"}})
+
+	err := fm.AddFileRecord(FileRecord{ID: uuid.New(), AreaID: 1, Filename: "../../etc/passwd"})
+	if err == nil {
+		t.Fatal("AddFileRecord accepted a filename containing a path")
+	}
+	if len(fm.GetFilesForArea(1)) != 0 {
+		t.Error("the rejected record was stored anyway")
+	}
+}
+
+// A record whose filename escapes the area must not be able to delete a file
+// outside it. Metadata-only deletion stays available so a corrupt record can
+// still be removed through the UI.
+func TestDeleteFileRecordRefusesDiskDeleteForUnsafeFilename(t *testing.T) {
+	fm := setupTestFileManager(t, []FileArea{{ID: 1, Tag: "UTILS", Name: "Utilities", Path: "utils"}})
+
+	id := uuid.New()
+	fm.muFiles.Lock()
+	fm.fileRecords[1] = append(fm.fileRecords[1], FileRecord{ID: id, AreaID: 1, Filename: ".."})
+	fm.muFiles.Unlock()
+
+	err := fm.DeleteFileRecord(id, true)
+	if err == nil {
+		t.Fatal("DeleteFileRecord agreed to delete from disk using an unsafe filename")
+	}
+	// Without the name check this still errors, but only because os.Remove
+	// happens to fail on the directory it resolved to -- which it would not do
+	// if that directory were empty. Assert the refusal came from validation.
+	if !strings.Contains(err.Error(), "invalid filename") {
+		t.Errorf("delete failed for the wrong reason: %v", err)
+	}
+	if len(fm.GetFilesForArea(1)) != 1 {
+		t.Error("the record was removed even though the delete failed")
+	}
+	if err := fm.DeleteFileRecord(id, false); err != nil {
+		t.Errorf("metadata-only deletion of a corrupt record should still work: %v", err)
+	}
+}
+
+func TestMoveFileRecordRejectsUnsafeFilename(t *testing.T) {
+	fm := setupTestFileManager(t, []FileArea{
+		{ID: 1, Tag: "UTILS", Name: "Utilities", Path: "utils"},
+		{ID: 2, Tag: "TEXTS", Name: "Texts", Path: "texts"},
+	})
+
+	id := uuid.New()
+	fm.muFiles.Lock()
+	fm.fileRecords[1] = append(fm.fileRecords[1], FileRecord{ID: id, AreaID: 1, Filename: ".."})
+	fm.muFiles.Unlock()
+
+	err := fm.MoveFileRecord(id, 2)
+	if err == nil {
+		t.Fatal("MoveFileRecord accepted a record whose filename escapes its area")
+	}
+	// As above: the rename would fail anyway here, so check it was refused
+	// before any filesystem call rather than by one.
+	if !strings.Contains(err.Error(), "invalid filename") {
+		t.Errorf("move failed for the wrong reason: %v", err)
+	}
+}
+
+// GetFilePath must not reject legitimate names that merely contain "..".
+func TestGetFilePathAllowsDotsInsideFilename(t *testing.T) {
+	fm := setupTestFileManager(t, []FileArea{{ID: 1, Tag: "UTILS", Name: "Utilities", Path: "utils"}})
+
+	id := uuid.New()
+	fm.muFiles.Lock()
+	fm.fileRecords[1] = append(fm.fileRecords[1], FileRecord{ID: id, AreaID: 1, Filename: "patch..v2.zip"})
+	fm.muFiles.Unlock()
+
+	got, err := fm.GetFilePath(id)
+	if err != nil {
+		t.Fatalf("GetFilePath rejected a legitimate filename: %v", err)
+	}
+	if filepath.Base(got) != "patch..v2.zip" {
+		t.Errorf("GetFilePath returned %q, want it to end in patch..v2.zip", got)
+	}
+}
+
+func TestGetFilePathRejectsTraversalRecord(t *testing.T) {
+	fm := setupTestFileManager(t, []FileArea{{ID: 1, Tag: "UTILS", Name: "Utilities", Path: "utils"}})
+
+	id := uuid.New()
+	fm.muFiles.Lock()
+	fm.fileRecords[1] = append(fm.fileRecords[1], FileRecord{ID: id, AreaID: 1, Filename: ".."})
+	fm.muFiles.Unlock()
+
+	if _, err := fm.GetFilePath(id); err == nil {
+		t.Fatal(`GetFilePath accepted a record with filename ".."`)
+	}
+}
+
+// A non-positive page would make startIndex negative and panic the slice; the
+// guard that prevents it sits at the top of the function, far from the
+// arithmetic it protects. This pins it there.
+func TestGetFilesForAreaPaginatedHandlesNonPositiveArgs(t *testing.T) {
+	fm := setupTestFileManager(t, []FileArea{{ID: 1, Tag: "UTILS", Name: "Utilities", Path: "utils"}})
+	fm.muFiles.Lock()
+	for i := 0; i < 3; i++ {
+		fm.fileRecords[1] = append(fm.fileRecords[1], FileRecord{ID: uuid.New(), AreaID: 1, Filename: "a.zip"})
+	}
+	fm.muFiles.Unlock()
+
+	cases := []struct{ page, pageSize int }{{0, 10}, {-1, 10}, {1, 0}, {1, -5}, {-100, -100}}
+	for _, c := range cases {
+		got, err := fm.GetFilesForAreaPaginated(1, c.page, c.pageSize)
+		if err == nil && len(got) != 0 {
+			t.Errorf("page=%d pageSize=%d returned %d records with no error", c.page, c.pageSize, len(got))
+		}
+	}
+}
+
+// The rollback used to truncate the target slice by position. muFiles is
+// released around the saves just above it, so a record added in that window is
+// what the truncation would drop. Removal is by identity now; this covers the
+// helper directly, since the race itself cannot be scheduled deterministically.
+func TestRemoveRecordByID(t *testing.T) {
+	a, b, c := uuid.New(), uuid.New(), uuid.New()
+	records := []FileRecord{{ID: a, Filename: "a.zip"}, {ID: b, Filename: "b.zip"}, {ID: c, Filename: "c.zip"}}
+
+	got := removeRecordByID(records, b)
+	if len(got) != 2 {
+		t.Fatalf("got %d records, want 2", len(got))
+	}
+	for _, r := range got {
+		if r.ID == b {
+			t.Error("the named record is still present")
+		}
+	}
+	if got[0].ID != a || got[1].ID != c {
+		t.Error("the other records were reordered or replaced")
+	}
+
+	if n := len(removeRecordByID(records, uuid.New())); n != 3 {
+		t.Errorf("removing an absent ID changed the slice length to %d", n)
+	}
+}
+
+// End to end: when the target-area save fails, the moved record must be gone
+// from the target and back in the source.
+func TestMoveFileRecordRollsBackOnTargetSaveFailure(t *testing.T) {
+	fm := setupTestFileManager(t, []FileArea{
+		{ID: 1, Tag: "UTILS", Name: "Utilities", Path: "utils"},
+		{ID: 2, Tag: "TEXTS", Name: "Texts", Path: "texts"},
+	})
+
+	movedID := uuid.New()
+	fm.muFiles.Lock()
+	fm.fileRecords[1] = append(fm.fileRecords[1], FileRecord{ID: movedID, AreaID: 1, Filename: "moved.zip"})
+	fm.muFiles.Unlock()
+
+	srcDir, err := fm.GetAreaUploadPath(1)
+	if err != nil {
+		t.Fatalf("GetAreaUploadPath(1): %v", err)
+	}
+	dstDir, err := fm.GetAreaUploadPath(2)
+	if err != nil {
+		t.Fatalf("GetAreaUploadPath(2): %v", err)
+	}
+	for _, d := range []string{srcDir, dstDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "moved.zip"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	// A directory where the metadata file belongs makes the target-area save fail.
+	if err := os.MkdirAll(filepath.Join(dstDir, "metadata.json"), 0o755); err != nil {
+		t.Fatalf("mkdir metadata.json: %v", err)
+	}
+
+	if err := fm.MoveFileRecord(movedID, 2); err == nil {
+		t.Fatal("expected the move to fail on the target-area save")
+	}
+
+	for _, r := range fm.GetFilesForArea(2) {
+		if r.ID == movedID {
+			t.Error("the rolled-back record is still in the target area")
+		}
+	}
+	back := false
+	for _, r := range fm.GetFilesForArea(1) {
+		if r.ID == movedID {
+			back = true
+		}
+	}
+	if !back {
+		t.Error("the record was not restored to the source area")
+	}
+	if _, err := os.Stat(filepath.Join(srcDir, "moved.zip")); err != nil {
+		t.Errorf("the file was not renamed back into the source area: %v", err)
+	}
+}

--- a/internal/file/manager_mutate.go
+++ b/internal/file/manager_mutate.go
@@ -48,7 +48,14 @@ searchLoop:
 		if err != nil {
 			return fmt.Errorf("failed to get absolute base path: %w", err)
 		}
-		fullPath := filepath.Join(absBasePath, area.Path, filepath.Base(foundFilename))
+		// Only gate the disk delete: a record with a corrupt filename must
+		// still be removable from metadata (deleteFromDisk=false), or the
+		// sysop has no way to clear it.
+		safeName, err := validateFilename(foundFilename)
+		if err != nil {
+			return fmt.Errorf("refusing to delete from disk: %w", err)
+		}
+		fullPath := filepath.Join(absBasePath, area.Path, safeName)
 		if err := os.Remove(fullPath); err != nil && !os.IsNotExist(err) {
 			slog.Warn("failed to delete file from disk", "path", fullPath, "error", err)
 			return fmt.Errorf("failed to delete file from disk: %w", err)
@@ -119,7 +126,10 @@ searchLoop:
 	if err != nil {
 		return fmt.Errorf("failed to get absolute base path: %w", err)
 	}
-	safeFilename := filepath.Base(record.Filename)
+	safeFilename, err := validateFilename(record.Filename)
+	if err != nil {
+		return fmt.Errorf("refusing to move file record %s: %w", fileID, err)
+	}
 	srcPath := filepath.Join(absBasePath, srcArea.Path, safeFilename)
 	dstPath := filepath.Join(absBasePath, targetArea.Path, safeFilename)
 
@@ -150,8 +160,9 @@ searchLoop:
 			slog.Error("failed to roll back file rename after metadata save failure", "from", dstPath, "to", srcPath, "error", renameBackErr)
 		} else {
 			// Restore in-memory state.
-			tgtRecords := fm.fileRecords[targetAreaID]
-			fm.fileRecords[targetAreaID] = tgtRecords[:len(tgtRecords)-1]
+			// By identity, not position: muFiles was released for the saves
+			// above, so another writer may have appended in the meantime.
+			fm.fileRecords[targetAreaID] = removeRecordByID(fm.fileRecords[targetAreaID], fileID)
 			record.AreaID = srcAreaID
 			fm.fileRecords[srcAreaID] = append(fm.fileRecords[srcAreaID], record)
 			// Re-persist both areas so disk reflects the restored in-memory state.

--- a/internal/file/manager_paths.go
+++ b/internal/file/manager_paths.go
@@ -11,7 +11,11 @@ import (
 )
 
 // GetFilePath returns the full, absolute path to a file given its record ID.
-// It checks that the file exists and constructs the path safely.
+// The path is constructed safely: the record's filename must be a plain name,
+// and the result must resolve inside the base directory.
+//
+// It does NOT check that the file exists on disk -- callers that need that must
+// stat the returned path themselves.
 func (fm *FileManager) GetFilePath(fileID uuid.UUID) (string, error) {
 	fm.muFiles.RLock() // Need read lock to find the file record
 	defer fm.muFiles.RUnlock()
@@ -50,9 +54,9 @@ searchLoop:
 	}
 	// Area path is relative to base path
 	// Filename should be just the base name
-	safeFilename := filepath.Base(foundRecord.Filename)
-	if safeFilename == "." || safeFilename == "/" || strings.Contains(safeFilename, "..") {
-		return "", fmt.Errorf("invalid filename in record: %s", foundRecord.Filename)
+	safeFilename, err := validateFilename(foundRecord.Filename)
+	if err != nil {
+		return "", fmt.Errorf("file record %s: %w", fileID, err)
 	}
 
 	fullPath := filepath.Join(absBasePath, foundArea.Path, safeFilename)
@@ -61,11 +65,6 @@ searchLoop:
 	if !strings.HasPrefix(fullPath, absBasePath) {
 		return "", fmt.Errorf("constructed file path '%s' is outside base directory '%s'", fullPath, absBasePath)
 	}
-
-	// Optional: Check if file actually exists on disk?
-	// if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-	// 	return "", fmt.Errorf("file '%s' not found on disk at expected path '%s'", safeFilename, fullPath)
-	// }
 
 	return fullPath, nil
 }

--- a/internal/file/manager_records.go
+++ b/internal/file/manager_records.go
@@ -20,6 +20,9 @@ func (fm *FileManager) AddFileRecord(record FileRecord) error {
 	if record.Filename == "" {
 		return fmt.Errorf("file record must have a Filename")
 	}
+	if _, err := validateFilename(record.Filename); err != nil {
+		return fmt.Errorf("file record %s: %w", record.ID, err)
+	}
 
 	fm.muAreas.RLock() // Check if area exists
 	_, areaExists := fm.fileAreas[record.AreaID]


### PR DESCRIPTION
Follow-up to #158. Everything here is pre-existing behavior — the split made it readable, and the review threads on that PR found it. Each item was verified against `main:internal/file/manager.go` before the split.

## 1. Filename validation (was: four sites, three different rules)

| Site | Before |
|---|---|
| `AddFileRecord` | non-empty only |
| `DeleteFileRecord` | `filepath.Base` |
| `MoveFileRecord` | `filepath.Base` |
| `GetFilePath` | `Base` + reject any name containing `..` |

`filepath.Base("..")` returns `".."`, so `filepath.Join(base, area.Path, "..")` resolves to the area's **parent** directory. The delete path then calls `os.Remove` on it. Running the new test against the old code shows exactly that:

```
failed to delete file from disk: remove .../001/data/files: directory not empty
```

It errored only because that directory happened to be non-empty. `os.Remove` succeeds on an empty directory.

One `validateFilename` now covers all four: rejects empty, `.`, `..`, both `/` and `\` regardless of host OS, and NUL.

It is also *less* strict in one place, deliberately: `GetFilePath` used to reject any name containing `..`, which refused ordinary files like `patch..v2.zip`. Once separators are rejected there is nothing an embedded `..` can traverse.

`DeleteFileRecord` gates only the **disk** removal, not the metadata removal — a record with a corrupt filename must still be clearable through the UI, or the sysop is stuck with it.

## 2. `MoveFileRecord` rollback removed by position

```go
tgtRecords := fm.fileRecords[targetAreaID]
fm.fileRecords[targetAreaID] = tgtRecords[:len(tgtRecords)-1]   // "the one we appended"
```

`muFiles` is released around the two `saveFileRecords` calls immediately above, so a concurrent `AddFileRecord` on the target area can append in that window — and the rollback then drops *that* record instead of the moved one. Now removed by record ID via `removeRecordByID`.

## 3. `GetFilePath` doc contradicted the code

Doc said "It checks that the file exists"; the `os.Stat` was commented out. Corrected the doc to say it does not, and removed the dead block. Re-enabling the check is a separate call — callers may legitimately want the path for a file they are about to create.

## Correction to a finding on #158

The `startIndex` overflow reported at `manager_query.go:158` is a **false positive**, and my reply on that thread confirming it was wrong. `GetFilesForAreaPaginated` already rejects `page <= 0 || pageSize <= 0` at the top of the function, ~25 lines above the arithmetic. I wrote the guard before checking, then found the existing one and removed mine. The test for it is kept — it pins the guard in place, since it sits far from the arithmetic it protects.

## Tests

10 tests in `internal/file/manager_filename_test.go`. RED-verified by reverting only the production files to their `main` versions and keeping the tests:

- `AddFileRecordRejectsPathInFilename` — "accepted a filename containing a path"
- `DeleteFileRecordRefusesDiskDeleteForUnsafeFilename` — failed for the wrong reason (the `os.Remove` above)
- `MoveFileRecordRejectsUnsafeFilename` — failed for the wrong reason (`file ".." already exists in target area 2`)
- `GetFilePathAllowsDotsInsideFilename` — "rejected a legitimate filename: patch..v2.zip"

The two "wrong reason" cases are the point: against the old code those calls *did* return an error, just not from validation — an `err != nil` assertion alone would have passed and proved nothing.

`TestRemoveRecordByID` covers the rollback helper directly; the concurrent-append race it fixes cannot be scheduled deterministically, so the end-to-end test asserts the weaker property (failed save → record back in the source area, file renamed back).

No caller is affected by the stricter validation: the only external `AddFileRecord` call site (`executor_files_upload_register.go:156`) takes its name from `os.ReadDir` entries, which are always base names.

Build, vet, gofmt, and the full suite pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against unsafe filenames and path traversal during file creation, deletion, moving, and path lookup.
  * Prevented invalid file operations from affecting files outside the intended area.
  * Improved rollback behavior when moving files fails.
  * Corrected handling of non-positive pagination values.
* **Documentation**
  * Clarified that generated file paths are safe paths and do not confirm on-disk file existence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->