### PR TITLE
feat(editor): terminal test double for internal/editor

### DIFF
--- a/internal/editor/fseditor_run_test.go
+++ b/internal/editor/fseditor_run_test.go
@@ -1,53 +1,13 @@
 package editor
 
 import (
-	"errors"
 	"io"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/gliderlabs/ssh"
-
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/editor/testterm"
 )
-
-// fakeEditorSession is a minimal ssh.Session for driving FSEditor in tests.
-// Read replays scripted keystrokes; once they are exhausted it blocks like a
-// live connection until the read interrupt fires (mirroring the ssh/telnet
-// adapters' SetReadInterrupt support). The embedded nil ssh.Session supplies
-// the rest of the interface.
-type fakeEditorSession struct {
-	ssh.Session
-	mu        sync.Mutex
-	data      []byte
-	interrupt <-chan struct{}
-}
-
-func (fs *fakeEditorSession) Read(p []byte) (int, error) {
-	fs.mu.Lock()
-	if len(fs.data) > 0 {
-		n := copy(p, fs.data)
-		fs.data = fs.data[n:]
-		fs.mu.Unlock()
-		return n, nil
-	}
-	interrupt := fs.interrupt
-	fs.mu.Unlock()
-	if interrupt == nil {
-		return 0, io.EOF
-	}
-	<-interrupt
-	return 0, errors.New("read interrupted")
-}
-
-func (fs *fakeEditorSession) Write(p []byte) (int, error) { return len(p), nil }
-
-func (fs *fakeEditorSession) SetReadInterrupt(ch <-chan struct{}) {
-	fs.mu.Lock()
-	fs.interrupt = ch
-	fs.mu.Unlock()
-}
 
 // TestRunClosesSelfCreatedInputHandler guards against the "double key press"
 // bug: when NewFSEditor is passed a nil InputHandler it creates its own, and
@@ -56,7 +16,7 @@ func (fs *fakeEditorSession) SetReadInterrupt(ch <-chan struct{}) {
 // the menu's reader for the rest of the session.
 func TestRunClosesSelfCreatedInputHandler(t *testing.T) {
 	// "hi" then Ctrl-Z (save and exit).
-	sess := &fakeEditorSession{data: []byte("hi\x1a")}
+	sess := testterm.NewSession(nil, "hi\x1a")
 	ed := NewFSEditor(sess, io.Discard, ansi.OutputModeUTF8, 80, 24,
 		"", "", "", "", "", "", nil)
 
@@ -80,7 +40,7 @@ func TestRunClosesSelfCreatedInputHandler(t *testing.T) {
 // a caller-provided (session-scoped, shared) InputHandler must survive Run so
 // the menu keeps receiving keystrokes through it after the editor exits.
 func TestRunLeavesSharedInputHandlerOpen(t *testing.T) {
-	sess := &fakeEditorSession{data: []byte("hi\x1a")}
+	sess := testterm.NewSession(nil, "hi\x1a")
 	shared := NewInputHandler(sess)
 	ed := NewFSEditor(sess, io.Discard, ansi.OutputModeUTF8, 80, 24,
 		"", "", "", "", "", "", shared)

--- a/internal/editor/screen_render_test.go
+++ b/internal/editor/screen_render_test.go
@@ -1,0 +1,166 @@
+package editor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/editor/testterm"
+)
+
+// GoXY takes (column, row) — the one place in this package where the order is
+// x,y rather than row,col.
+func TestScreenGoXYAndWriteDirect(t *testing.T) {
+	tt := testterm.New(40, 10)
+	s := NewScreen(tt, ansi.OutputModeUTF8, 40, 10)
+
+	s.GoXY(5, 3)
+	s.WriteDirect("Hello")
+
+	if got := tt.Row(3); got != "    Hello" {
+		t.Errorf("Row(3) = %q, want %q", got, "    Hello")
+	}
+	if got := tt.Unhandled(); len(got) != 0 {
+		t.Errorf("Unhandled() = %q, want empty — the double missed output Screen emitted", got)
+	}
+}
+
+func TestScreenClearEOL(t *testing.T) {
+	tt := testterm.New(40, 10)
+	s := NewScreen(tt, ansi.OutputModeUTF8, 40, 10)
+
+	s.GoXY(1, 2)
+	s.WriteDirect("abcdefgh")
+	s.GoXY(4, 2)
+	s.ClearEOL()
+
+	if got := tt.Row(2); got != "abc" {
+		t.Errorf("Row(2) = %q, want %q", got, "abc")
+	}
+}
+
+func TestScreenClearScreen(t *testing.T) {
+	tt := testterm.New(40, 10)
+	s := NewScreen(tt, ansi.OutputModeUTF8, 40, 10)
+
+	s.GoXY(1, 1)
+	s.WriteDirect("junk")
+	s.GoXY(1, 5)
+	s.WriteDirect("more junk")
+	s.ClearScreen()
+
+	if got := tt.Snapshot(); got != "" {
+		t.Errorf("Snapshot() = %q, want empty", got)
+	}
+	if row, col := tt.Cursor(); row != 1 || col != 1 {
+		t.Errorf("Cursor() = (%d,%d), want (1,1) — ClearScreen homes the cursor", row, col)
+	}
+}
+
+// WriteDirectProcessed runs the real pipe-code table, so this covers SGR
+// arriving from production code rather than from a hand-written escape.
+func TestScreenWriteDirectProcessedAppliesPipeCodeColour(t *testing.T) {
+	tt := testterm.New(40, 10)
+	s := NewScreen(tt, ansi.OutputModeUTF8, 40, 10)
+
+	s.GoXY(1, 1)
+	s.WriteDirectProcessed("|09Bright")
+
+	if got := tt.Row(1); got != "Bright" {
+		t.Errorf("Row(1) = %q, want %q — pipe code leaked into the text", got, "Bright")
+	}
+	if c := tt.Cell(1, 1); c.Fg == -1 {
+		t.Errorf("Cell(1,1) = %+v, want a foreground colour from |09", c)
+	}
+	if got := tt.Unhandled(); len(got) != 0 {
+		t.Errorf("Unhandled() = %q, want empty", got)
+	}
+}
+
+// The same source text must land as the same runes in both output modes: in
+// CP437 mode Screen puts single high bytes on the wire, in UTF-8 mode it puts
+// multi-byte sequences.
+func TestScreenRendersSameRunesInBothOutputModes(t *testing.T) {
+	const shade = "░░░"
+
+	utf8Term := testterm.New(40, 10)
+	utf8Screen := NewScreen(utf8Term, ansi.OutputModeUTF8, 40, 10)
+	utf8Screen.GoXY(1, 1)
+	utf8Screen.WriteDirect(shade)
+
+	cp437Term := testterm.New(40, 10, testterm.CP437())
+	cp437Screen := NewScreen(cp437Term, ansi.OutputModeCP437, 40, 10)
+	cp437Screen.GoXY(1, 1)
+	cp437Screen.WriteDirect(shade)
+
+	if got := utf8Term.Row(1); got != shade {
+		t.Errorf("UTF-8 mode Row(1) = %q, want %q", got, shade)
+	}
+	if got := cp437Term.Row(1); got != shade {
+		t.Errorf("CP437 mode Row(1) = %q, want %q", got, shade)
+	}
+	ur, uc := utf8Term.Cursor()
+	cr, cc := cp437Term.Cursor()
+	if ur != cr || uc != cc {
+		t.Errorf("cursor differs between modes: UTF-8 (%d,%d) vs CP437 (%d,%d) — one glyph must be one column in both", ur, uc, cr, cc)
+	}
+}
+
+// writeEditorTemplate writes a minimal FSEDITOR.ANS containing an @I@
+// placeholder and returns the menu-set path to pass to LoadHeaderTemplate.
+// A template needs at least one @CODE@ marker for Screen to treat it as the
+// current format, which is what makes it track the @I@ position.
+func writeEditorTemplate(t *testing.T) string {
+	t.Helper()
+	menuSet := t.TempDir()
+	ansiDir := filepath.Join(menuSet, "ansi")
+	if err := os.MkdirAll(ansiDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Row 1: subject. Row 2: the insert-mode indicator at column 7.
+	template := "Subj: @E@\r\nMode: @I@\r\n"
+	if err := os.WriteFile(filepath.Join(ansiDir, "FSEDITOR.ANS"), []byte(template), 0o644); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+	return menuSet
+}
+
+// DisplayStatusLine writes the insert-mode indicator through a
+// save / jump / colour / write / reset / restore sequence. It exercises more of
+// the parser in one call than any other Screen method.
+func TestScreenInsertModeIndicator(t *testing.T) {
+	menuSet := writeEditorTemplate(t)
+
+	tt := testterm.New(40, 10)
+	s := NewScreen(tt, ansi.OutputModeUTF8, 40, 10)
+	if err := s.LoadHeaderTemplate(menuSet, "Test subject", "someone", "me", false); err != nil {
+		t.Fatalf("LoadHeaderTemplate: %v", err)
+	}
+	s.DisplayHeader()
+
+	// The @E@ placeholder is substituted with the subject, so this also covers
+	// the header render path.
+	if got := tt.Row(1); got != "Subj: Test subject" {
+		t.Errorf("Row(1) = %q, want %q", got, "Subj: Test subject")
+	}
+
+	// Park the cursor somewhere identifiable, then update the indicator.
+	s.GoXY(10, 8)
+	s.DisplayStatusLine(true, 1, 1)
+
+	if got := tt.Row(2); got != "Mode: Ins" {
+		t.Errorf("Row(2) = %q, want %q", got, "Mode: Ins")
+	}
+	if row, col := tt.Cursor(); row != 8 || col != 10 {
+		t.Errorf("Cursor() = (%d,%d), want (8,10) — the indicator write must restore the cursor", row, col)
+	}
+
+	s.DisplayStatusLine(false, 1, 1)
+	if got := tt.Row(2); got != "Mode: Ovr" {
+		t.Errorf("Row(2) = %q, want %q", got, "Mode: Ovr")
+	}
+	if got := tt.Unhandled(); len(got) != 0 {
+		t.Errorf("Unhandled() = %q, want empty", got)
+	}
+}

--- a/internal/editor/screen_render_test.go
+++ b/internal/editor/screen_render_test.go
@@ -38,6 +38,9 @@ func TestScreenClearEOL(t *testing.T) {
 	if got := tt.Row(2); got != "abc" {
 		t.Errorf("Row(2) = %q, want %q", got, "abc")
 	}
+	if got := tt.Unhandled(); len(got) != 0 {
+		t.Errorf("Unhandled() = %q, want empty — the double missed output Screen emitted", got)
+	}
 }
 
 func TestScreenClearScreen(t *testing.T) {
@@ -56,6 +59,9 @@ func TestScreenClearScreen(t *testing.T) {
 	if row, col := tt.Cursor(); row != 1 || col != 1 {
 		t.Errorf("Cursor() = (%d,%d), want (1,1) — ClearScreen homes the cursor", row, col)
 	}
+	if got := tt.Unhandled(); len(got) != 0 {
+		t.Errorf("Unhandled() = %q, want empty — the double missed output Screen emitted", got)
+	}
 }
 
 // WriteDirectProcessed runs the real pipe-code table, so this covers SGR
@@ -70,8 +76,9 @@ func TestScreenWriteDirectProcessedAppliesPipeCodeColour(t *testing.T) {
 	if got := tt.Row(1); got != "Bright" {
 		t.Errorf("Row(1) = %q, want %q — pipe code leaked into the text", got, "Bright")
 	}
-	if c := tt.Cell(1, 1); c.Fg == -1 {
-		t.Errorf("Cell(1,1) = %+v, want a foreground colour from |09", c)
+	// |09 expands to ESC[1;34m: bright (bold) blue foreground.
+	if c := tt.Cell(1, 1); c.Fg != 34 || !c.Bold {
+		t.Errorf("Cell(1,1) = %+v, want Fg=34 Bold=true from |09", c)
 	}
 	if got := tt.Unhandled(); len(got) != 0 {
 		t.Errorf("Unhandled() = %q, want empty", got)

--- a/internal/editor/testterm/erase.go
+++ b/internal/editor/testterm/erase.go
@@ -53,7 +53,7 @@ func (t *Term) eraseLine(mode int) bool {
 		// next character), so ESC[1K issued in that state would index one
 		// past the end of the row without it.
 		if c >= 1 && c <= t.width {
-			t.cells[t.row-1][c-1] = Cell{Rune: ' ', Fg: t.pen.Fg, Bg: t.pen.Bg}
+			t.cells[t.row-1][c-1] = Cell{Rune: ' ', Fg: t.pen.Fg, Bg: t.pen.Bg, Bold: t.pen.Bold}
 		}
 	}
 	return true
@@ -87,7 +87,7 @@ func (t *Term) eraseRows(from, to int) {
 			continue
 		}
 		for c := range t.cells[r-1] {
-			t.cells[r-1][c] = Cell{Rune: ' ', Fg: t.pen.Fg, Bg: t.pen.Bg}
+			t.cells[r-1][c] = Cell{Rune: ' ', Fg: t.pen.Fg, Bg: t.pen.Bg, Bold: t.pen.Bold}
 		}
 	}
 }

--- a/internal/editor/testterm/erase.go
+++ b/internal/editor/testterm/erase.go
@@ -1,0 +1,93 @@
+package testterm
+
+// applyControl handles the C0 control characters the editor emits.
+func (t *Term) applyControl(b byte) {
+	switch b {
+	case '\r':
+		t.col = 1
+	case '\n':
+		// row >= height, not >: applyControl advances the row itself, unlike
+		// putRune, which only wraps col back to 1 and lets row run one past
+		// height before scrolling. A bare '\n' must scroll as soon as the
+		// cursor is already on the last row, not after stepping past it.
+		if t.row >= t.height {
+			t.scrollUp()
+			t.row = t.height
+		} else {
+			t.row++
+		}
+	case '\b':
+		if t.col > 1 {
+			t.col--
+		}
+	case '\t':
+		next := ((t.col-1)/8+1)*8 + 1
+		t.col = next
+	default:
+		t.unhandled = append(t.unhandled, string([]byte{b}))
+	}
+}
+
+// eraseLine clears part of the cursor's row: 0 = cursor to end, 1 = start to
+// cursor, 2 = the whole row. Erased cells take the current pen's colours,
+// which is how a coloured background survives a clear on a real terminal. It
+// reports whether mode was recognised; the caller records the sequence in
+// Unhandled when it was not.
+func (t *Term) eraseLine(mode int) bool {
+	if t.row < 1 || t.row > t.height {
+		return true
+	}
+	from, to := 1, t.width
+	switch mode {
+	case 0:
+		from = t.col
+	case 1:
+		to = t.col
+	case 2:
+	default:
+		return false
+	}
+	for c := from; c <= to; c++ {
+		// This guard is reachable, not dead: putRune leaves t.col ==
+		// t.width+1 after writing the last column (wrap is deferred to the
+		// next character), so ESC[1K issued in that state would index one
+		// past the end of the row without it.
+		if c >= 1 && c <= t.width {
+			t.cells[t.row-1][c-1] = Cell{Rune: ' ', Fg: t.pen.Fg, Bg: t.pen.Bg}
+		}
+	}
+	return true
+}
+
+// eraseDisplay clears part of the screen: 0 = cursor to end, 1 = start to
+// cursor, 2 = everything. It reports whether mode was recognised; the caller
+// records the sequence in Unhandled when it was not.
+func (t *Term) eraseDisplay(mode int) bool {
+	switch mode {
+	case 0:
+		t.eraseLine(0)
+		t.eraseRows(t.row+1, t.height)
+	case 1:
+		t.eraseLine(1)
+		t.eraseRows(1, t.row-1)
+	case 2:
+		t.eraseRows(1, t.height)
+	default:
+		return false
+	}
+	return true
+}
+
+// eraseRows blanks every cell in rows from..to (inclusive, 1-based) using the
+// current pen's colours. Rows outside the screen are skipped, so callers do
+// not need to clamp their range before calling it.
+func (t *Term) eraseRows(from, to int) {
+	for r := from; r <= to; r++ {
+		if r < 1 || r > t.height {
+			continue
+		}
+		for c := range t.cells[r-1] {
+			t.cells[r-1][c] = Cell{Rune: ' ', Fg: t.pen.Fg, Bg: t.pen.Bg}
+		}
+	}
+}

--- a/internal/editor/testterm/erase.go
+++ b/internal/editor/testterm/erase.go
@@ -5,7 +5,21 @@ func (t *Term) applyControl(b byte) {
 	switch b {
 	case '\r':
 		t.col = 1
+		t.wrapPending = false
 	case '\n':
+		// A '\n' arriving with a wrap pending consumes it: clear the flag and
+		// reset the column, so the row advances once rather than twice.
+		//
+		// Deliberate divergence: a real terminal clears the pending-wrap flag
+		// but leaves the column where it was, so text after a full row plus a
+		// bare '\n' would resume under the right margin. Column 1 is what a
+		// test author means by "\n", and the editor always emits "\r\n", where
+		// the '\r' makes the two models identical. Without a pending wrap,
+		// '\n' leaves the column untouched, as a real terminal does.
+		if t.wrapPending {
+			t.wrapPending = false
+			t.col = 1
+		}
 		// row >= height, not >: applyControl advances the row itself, unlike
 		// putRune, which only wraps col back to 1 and lets row run one past
 		// height before scrolling. A bare '\n' must scroll as soon as the
@@ -20,9 +34,14 @@ func (t *Term) applyControl(b byte) {
 		if t.col > 1 {
 			t.col--
 		}
+		t.wrapPending = false
 	case '\t':
 		next := ((t.col-1)/8+1)*8 + 1
+		if next > t.width {
+			next = t.width
+		}
 		t.col = next
+		t.wrapPending = false
 	default:
 		t.unhandled = append(t.unhandled, string([]byte{b}))
 	}
@@ -48,10 +67,10 @@ func (t *Term) eraseLine(mode int) bool {
 		return false
 	}
 	for c := from; c <= to; c++ {
-		// This guard is reachable, not dead: putRune leaves t.col ==
-		// t.width+1 after writing the last column (wrap is deferred to the
-		// next character), so ESC[1K issued in that state would index one
-		// past the end of the row without it.
+		// t.col cannot exceed t.width — putRune's deferred wrap holds it at
+		// width rather than stepping past the margin — so this guard should
+		// never trigger in practice. It stays as cheap defensive bounds
+		// checking rather than something load-bearing.
 		if c >= 1 && c <= t.width {
 			t.cells[t.row-1][c-1] = Cell{Rune: ' ', Fg: t.pen.Fg, Bg: t.pen.Bg, Bold: t.pen.Bold}
 		}

--- a/internal/editor/testterm/parse.go
+++ b/internal/editor/testterm/parse.go
@@ -11,7 +11,13 @@ import (
 //
 // Bytes held back mid-sequence or mid-rune are carried over to the next call,
 // so a sequence split across writes is still parsed as one sequence.
+//
+// Write takes Term's mutex for the whole call, so a Write racing with an
+// accessor on another goroutine (the shape a Session-driven test uses) is
+// safe.
 func (t *Term) Write(p []byte) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	n := len(p)
 	buf := p
 	if len(t.pending) > 0 {
@@ -71,6 +77,16 @@ func scanEscape(buf []byte) (seq, rest []byte, complete bool) {
 		return nil, buf, false
 	}
 	if buf[1] != '[' {
+		if buf[1] == '(' || buf[1] == ')' {
+			// Character-set designation (ESC ( / ESC )) takes a third byte
+			// naming the set, e.g. ESC(B for US-ASCII. ansi.CP437BytesToUTF8
+			// passes these through, so this codebase does emit them; consume
+			// all three bytes or the designator leaks into the grid as text.
+			if len(buf) < 3 {
+				return nil, buf, false
+			}
+			return buf[:3], buf[3:], true
+		}
 		// Not CSI; consume ESC plus one byte so it cannot be printed as text.
 		return buf[:2], buf[2:], true
 	}
@@ -130,6 +146,17 @@ func param(params []int, i, def int) int {
 	return params[i]
 }
 
+// moveCount returns how far a relative cursor movement (A/B/C/D) should go.
+// An omitted parameter defaults to 1, and — matching real terminals — an
+// explicit 0 is coerced to 1 too: ESC[0B still moves one row, it does not
+// stay put.
+func moveCount(params []int) int {
+	if n := param(params, 0, 1); n > 0 {
+		return n
+	}
+	return 1
+}
+
 func (t *Term) applyEscape(seq []byte) {
 	params, final, private := csiParams(seq)
 	if final == 0 {
@@ -154,16 +181,16 @@ func (t *Term) applyEscape(seq []byte) {
 		t.col = param(params, 1, 1)
 		t.clampCursor()
 	case 'A':
-		t.row -= param(params, 0, 1)
+		t.row -= moveCount(params)
 		t.clampCursor()
 	case 'B':
-		t.row += param(params, 0, 1)
+		t.row += moveCount(params)
 		t.clampCursor()
 	case 'C':
-		t.col += param(params, 0, 1)
+		t.col += moveCount(params)
 		t.clampCursor()
 	case 'D':
-		t.col -= param(params, 0, 1)
+		t.col -= moveCount(params)
 		t.clampCursor()
 	case 's':
 		t.savedRow, t.savedCol = t.row, t.col
@@ -171,9 +198,13 @@ func (t *Term) applyEscape(seq []byte) {
 		t.row, t.col = t.savedRow, t.savedCol
 		t.clampCursor()
 	case 'K':
-		t.eraseLine(param(params, 0, 0))
+		if !t.eraseLine(param(params, 0, 0)) {
+			t.unhandled = append(t.unhandled, string(seq))
+		}
 	case 'J':
-		t.eraseDisplay(param(params, 0, 0))
+		if !t.eraseDisplay(param(params, 0, 0)) {
+			t.unhandled = append(t.unhandled, string(seq))
+		}
 	case 'm':
 		t.applySGR(params)
 	default:
@@ -195,80 +226,6 @@ func (t *Term) clampCursor() {
 	}
 	if t.col > t.width {
 		t.col = t.width
-	}
-}
-
-// applyControl handles the C0 control characters the editor emits.
-func (t *Term) applyControl(b byte) {
-	switch b {
-	case '\r':
-		t.col = 1
-	case '\n':
-		if t.row >= t.height {
-			t.scrollUp()
-			t.row = t.height
-		} else {
-			t.row++
-		}
-	case '\b':
-		if t.col > 1 {
-			t.col--
-		}
-	case '\t':
-		next := ((t.col-1)/8+1)*8 + 1
-		t.col = next
-	default:
-		t.unhandled = append(t.unhandled, string([]byte{b}))
-	}
-}
-
-// eraseLine clears part of the cursor's row: 0 = cursor to end, 1 = start to
-// cursor, 2 = the whole row. Erased cells take the current pen's colours, which
-// is how a coloured background survives a clear on a real terminal.
-func (t *Term) eraseLine(mode int) {
-	if t.row < 1 || t.row > t.height {
-		return
-	}
-	from, to := 1, t.width
-	switch mode {
-	case 0:
-		from = t.col
-	case 1:
-		to = t.col
-	case 2:
-	default:
-		return
-	}
-	for c := from; c <= to; c++ {
-		if c >= 1 && c <= t.width {
-			t.cells[t.row-1][c-1] = Cell{Rune: ' ', Fg: t.pen.Fg, Bg: t.pen.Bg}
-		}
-	}
-}
-
-// eraseDisplay clears part of the screen: 0 = cursor to end, 1 = start to
-// cursor, 2 = everything.
-func (t *Term) eraseDisplay(mode int) {
-	switch mode {
-	case 0:
-		t.eraseLine(0)
-		t.eraseRows(t.row+1, t.height)
-	case 1:
-		t.eraseLine(1)
-		t.eraseRows(1, t.row-1)
-	case 2:
-		t.eraseRows(1, t.height)
-	}
-}
-
-func (t *Term) eraseRows(from, to int) {
-	for r := from; r <= to; r++ {
-		if r < 1 || r > t.height {
-			continue
-		}
-		for c := range t.cells[r-1] {
-			t.cells[r-1][c] = Cell{Rune: ' ', Fg: t.pen.Fg, Bg: t.pen.Bg}
-		}
 	}
 }
 

--- a/internal/editor/testterm/parse.go
+++ b/internal/editor/testterm/parse.go
@@ -102,6 +102,17 @@ func scanEscape(buf []byte) (seq, rest []byte, complete bool) {
 // csiParams splits a CSI sequence into its numeric parameters and final byte.
 // private reports a "?" prefix (as in ESC[?25l). Empty parameters are returned
 // as -1 so a caller can tell "omitted" from "zero".
+//
+// A parameter body byte that is neither a digit nor ';' — most notably ':',
+// the sub-parameter separator used by the colon form of 24-bit/indexed
+// colour (ESC[38:2:R:G:Bm) — is not silently skipped. Skipping it would
+// concatenate the digits on either side into one wrong parameter (ESC[1:2H
+// would read as "12", not "1" and "2") and the sequence would then be applied
+// as if it had parsed correctly. Instead csiParams reports final = 0, the
+// same sentinel applyEscape already uses for a sequence it cannot make sense
+// of, so the caller records the whole sequence in Unhandled instead of
+// acting on it. Colon-form parameters themselves are not modelled — this
+// only stops them from being misread as something else.
 func csiParams(seq []byte) (params []int, final byte, private bool) {
 	if len(seq) < 3 || seq[1] != '[' {
 		return nil, 0, false
@@ -128,6 +139,8 @@ func csiParams(seq []byte) (params []int, final byte, private bool) {
 				params = append(params, -1)
 			}
 			cur, has = 0, false
+		default:
+			return nil, 0, false
 		}
 	}
 	if has {

--- a/internal/editor/testterm/parse.go
+++ b/internal/editor/testterm/parse.go
@@ -227,7 +227,12 @@ func (t *Term) applyEscape(seq []byte) {
 
 // clampCursor keeps the cursor inside the screen. Writing past the last column
 // is handled at write time (Task 5), not here.
+//
+// Every caller repositions the cursor explicitly (CUP/HVP or a relative
+// move), so — like any cursor movement on a real terminal — it clears a
+// deferred wrap from a previous write that landed on the last column.
 func (t *Term) clampCursor() {
+	t.wrapPending = false
 	if t.row < 1 {
 		t.row = 1
 	}

--- a/internal/editor/testterm/parse.go
+++ b/internal/editor/testterm/parse.go
@@ -168,6 +168,10 @@ func (t *Term) applyEscape(seq []byte) {
 	case 'u':
 		t.row, t.col = t.savedRow, t.savedCol
 		t.clampCursor()
+	case 'K':
+		t.eraseLine(param(params, 0, 0))
+	case 'J':
+		t.eraseDisplay(param(params, 0, 0))
 	default:
 		t.unhandled = append(t.unhandled, string(seq))
 	}
@@ -206,6 +210,56 @@ func (t *Term) applyControl(b byte) {
 		t.col = next
 	default:
 		t.unhandled = append(t.unhandled, string([]byte{b}))
+	}
+}
+
+// eraseLine clears part of the cursor's row: 0 = cursor to end, 1 = start to
+// cursor, 2 = the whole row. Erased cells take the current pen's colours, which
+// is how a coloured background survives a clear on a real terminal.
+func (t *Term) eraseLine(mode int) {
+	if t.row < 1 || t.row > t.height {
+		return
+	}
+	from, to := 1, t.width
+	switch mode {
+	case 0:
+		from = t.col
+	case 1:
+		to = t.col
+	case 2:
+	default:
+		return
+	}
+	for c := from; c <= to; c++ {
+		if c >= 1 && c <= t.width {
+			t.cells[t.row-1][c-1] = Cell{Rune: ' ', Fg: t.pen.Fg, Bg: t.pen.Bg}
+		}
+	}
+}
+
+// eraseDisplay clears part of the screen: 0 = cursor to end, 1 = start to
+// cursor, 2 = everything.
+func (t *Term) eraseDisplay(mode int) {
+	switch mode {
+	case 0:
+		t.eraseLine(0)
+		t.eraseRows(t.row+1, t.height)
+	case 1:
+		t.eraseLine(1)
+		t.eraseRows(1, t.row-1)
+	case 2:
+		t.eraseRows(1, t.height)
+	}
+}
+
+func (t *Term) eraseRows(from, to int) {
+	for r := from; r <= to; r++ {
+		if r < 1 || r > t.height {
+			continue
+		}
+		for c := range t.cells[r-1] {
+			t.cells[r-1][c] = Cell{Rune: ' ', Fg: t.pen.Fg, Bg: t.pen.Bg}
+		}
 	}
 }
 

--- a/internal/editor/testterm/parse.go
+++ b/internal/editor/testterm/parse.go
@@ -1,0 +1,110 @@
+package testterm
+
+import (
+	"unicode/utf8"
+)
+
+// Write feeds terminal output to the screen. It never returns an error; the
+// io.Writer signature is what the code under test expects.
+//
+// Bytes held back mid-sequence or mid-rune are carried over to the next call,
+// so a sequence split across writes is still parsed as one sequence.
+func (t *Term) Write(p []byte) (int, error) {
+	n := len(p)
+	buf := p
+	if len(t.pending) > 0 {
+		buf = append(t.pending, p...)
+		t.pending = nil
+	}
+
+	for len(buf) > 0 {
+		b := buf[0]
+
+		if b == 0x1b {
+			seq, rest, complete := scanEscape(buf)
+			if !complete {
+				t.pending = append([]byte(nil), buf...)
+				return n, nil
+			}
+			t.applyEscape(seq)
+			buf = rest
+			continue
+		}
+
+		if b < 0x20 {
+			t.applyControl(b)
+			buf = buf[1:]
+			continue
+		}
+
+		r, size := t.decodeRune(buf)
+		if size == 0 { // incomplete UTF-8 rune at the end of the chunk
+			t.pending = append([]byte(nil), buf...)
+			return n, nil
+		}
+		t.putRune(r)
+		buf = buf[size:]
+	}
+	return n, nil
+}
+
+// decodeRune reads one character from the head of buf. In CP437 mode a high
+// byte is one character; otherwise the stream is UTF-8. A size of 0 means the
+// buffer ends mid-rune.
+func (t *Term) decodeRune(buf []byte) (rune, int) {
+	if t.cp437 {
+		return cp437Rune(buf[0]), 1
+	}
+	r, size := utf8.DecodeRune(buf)
+	if r == utf8.RuneError && size <= 1 && !utf8.FullRune(buf) {
+		return 0, 0
+	}
+	return r, size
+}
+
+// scanEscape splits a CSI sequence off the head of buf. complete is false when
+// buf ends before the sequence's final byte.
+func scanEscape(buf []byte) (seq, rest []byte, complete bool) {
+	if len(buf) < 2 {
+		return nil, buf, false
+	}
+	if buf[1] != '[' {
+		// Not CSI; consume ESC plus one byte so it cannot be printed as text.
+		return buf[:2], buf[2:], true
+	}
+	for i := 2; i < len(buf); i++ {
+		c := buf[i]
+		if c >= '@' && c <= '~' {
+			return buf[:i+1], buf[i+1:], true
+		}
+	}
+	return nil, buf, false
+}
+
+// applyEscape interprets one sequence. Task 1 records everything; later tasks
+// replace this body with real handling.
+func (t *Term) applyEscape(seq []byte) {
+	t.unhandled = append(t.unhandled, string(seq))
+}
+
+// applyControl handles the C0 control characters the editor emits.
+func (t *Term) applyControl(b byte) {
+	switch b {
+	case '\r':
+		t.col = 1
+	case '\n':
+		t.row++
+	case '\b':
+		if t.col > 1 {
+			t.col--
+		}
+	case '\t':
+		next := ((t.col-1)/8+1)*8 + 1
+		t.col = next
+	default:
+		t.unhandled = append(t.unhandled, string([]byte{b}))
+	}
+}
+
+// cp437Rune is replaced with a real decode in Task 6.
+func cp437Rune(b byte) rune { return rune(b) }

--- a/internal/editor/testterm/parse.go
+++ b/internal/editor/testterm/parse.go
@@ -81,10 +81,113 @@ func scanEscape(buf []byte) (seq, rest []byte, complete bool) {
 	return nil, buf, false
 }
 
-// applyEscape interprets one sequence. Task 1 records everything; later tasks
-// replace this body with real handling.
+// csiParams splits a CSI sequence into its numeric parameters and final byte.
+// private reports a "?" prefix (as in ESC[?25l). Empty parameters are returned
+// as -1 so a caller can tell "omitted" from "zero".
+func csiParams(seq []byte) (params []int, final byte, private bool) {
+	if len(seq) < 3 || seq[1] != '[' {
+		return nil, 0, false
+	}
+	final = seq[len(seq)-1]
+	body := seq[2 : len(seq)-1]
+	if len(body) > 0 && body[0] == '?' {
+		private = true
+		body = body[1:]
+	}
+	if len(body) == 0 {
+		return nil, final, private
+	}
+	cur, has := 0, false
+	for _, c := range body {
+		switch {
+		case c >= '0' && c <= '9':
+			cur = cur*10 + int(c-'0')
+			has = true
+		case c == ';':
+			if has {
+				params = append(params, cur)
+			} else {
+				params = append(params, -1)
+			}
+			cur, has = 0, false
+		}
+	}
+	if has {
+		params = append(params, cur)
+	} else {
+		params = append(params, -1)
+	}
+	return params, final, private
+}
+
+// param returns the i-th parameter, or def when it is missing or omitted.
+func param(params []int, i, def int) int {
+	if i >= len(params) || params[i] < 0 {
+		return def
+	}
+	return params[i]
+}
+
 func (t *Term) applyEscape(seq []byte) {
-	t.unhandled = append(t.unhandled, string(seq))
+	params, final, private := csiParams(seq)
+	if final == 0 {
+		t.unhandled = append(t.unhandled, string(seq))
+		return
+	}
+
+	if private {
+		if final == 'h' || final == 'l' {
+			if param(params, 0, 0) == 25 {
+				t.cursorHidden = final == 'l'
+				return
+			}
+		}
+		t.unhandled = append(t.unhandled, string(seq))
+		return
+	}
+
+	switch final {
+	case 'H', 'f':
+		t.row = param(params, 0, 1)
+		t.col = param(params, 1, 1)
+		t.clampCursor()
+	case 'A':
+		t.row -= param(params, 0, 1)
+		t.clampCursor()
+	case 'B':
+		t.row += param(params, 0, 1)
+		t.clampCursor()
+	case 'C':
+		t.col += param(params, 0, 1)
+		t.clampCursor()
+	case 'D':
+		t.col -= param(params, 0, 1)
+		t.clampCursor()
+	case 's':
+		t.savedRow, t.savedCol = t.row, t.col
+	case 'u':
+		t.row, t.col = t.savedRow, t.savedCol
+		t.clampCursor()
+	default:
+		t.unhandled = append(t.unhandled, string(seq))
+	}
+}
+
+// clampCursor keeps the cursor inside the screen. Writing past the last column
+// is handled at write time (Task 5), not here.
+func (t *Term) clampCursor() {
+	if t.row < 1 {
+		t.row = 1
+	}
+	if t.row > t.height {
+		t.row = t.height
+	}
+	if t.col < 1 {
+		t.col = 1
+	}
+	if t.col > t.width {
+		t.col = t.width
+	}
 }
 
 // applyControl handles the C0 control characters the editor emits.

--- a/internal/editor/testterm/parse.go
+++ b/internal/editor/testterm/parse.go
@@ -2,6 +2,8 @@ package testterm
 
 import (
 	"unicode/utf8"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 )
 
 // Write feeds terminal output to the screen. It never returns an error; the
@@ -270,5 +272,13 @@ func (t *Term) eraseRows(from, to int) {
 	}
 }
 
-// cp437Rune is replaced with a real decode in Task 6.
-func cp437Rune(b byte) rune { return rune(b) }
+// cp437Rune decodes one CP437 byte. It goes through ansi.CP437BytesToUTF8 so
+// there is exactly one CP437 table in the codebase rather than another copy.
+func cp437Rune(b byte) rune {
+	if b < 0x80 {
+		return rune(b)
+	}
+	decoded := ansi.CP437BytesToUTF8([]byte{b})
+	r, _ := utf8.DecodeRune(decoded)
+	return r
+}

--- a/internal/editor/testterm/parse.go
+++ b/internal/editor/testterm/parse.go
@@ -202,7 +202,12 @@ func (t *Term) applyControl(b byte) {
 	case '\r':
 		t.col = 1
 	case '\n':
-		t.row++
+		if t.row >= t.height {
+			t.scrollUp()
+			t.row = t.height
+		} else {
+			t.row++
+		}
 	case '\b':
 		if t.col > 1 {
 			t.col--

--- a/internal/editor/testterm/parse.go
+++ b/internal/editor/testterm/parse.go
@@ -172,6 +172,8 @@ func (t *Term) applyEscape(seq []byte) {
 		t.eraseLine(param(params, 0, 0))
 	case 'J':
 		t.eraseDisplay(param(params, 0, 0))
+	case 'm':
+		t.applySGR(params)
 	default:
 		t.unhandled = append(t.unhandled, string(seq))
 	}

--- a/internal/editor/testterm/parse_test.go
+++ b/internal/editor/testterm/parse_test.go
@@ -167,3 +167,69 @@ func TestEraseDisplayToEndAndToStart(t *testing.T) {
 		t.Errorf("Row(3) = %q, want unchanged %q", got, "ccccc")
 	}
 }
+
+func TestSGRAppliesToSubsequentCells(t *testing.T) {
+	tt := New(20, 3)
+	tt.Write([]byte("\x1b[1;36;44mHi\x1b[0mLo"))
+
+	h := tt.Cell(1, 1)
+	if h.Fg != 36 || h.Bg != 44 || !h.Bold {
+		t.Errorf("Cell(1,1) = %+v, want Fg=36 Bg=44 Bold=true", h)
+	}
+	l := tt.Cell(1, 3)
+	if l.Fg != -1 || l.Bg != -1 || l.Bold {
+		t.Errorf("Cell(1,3) = %+v, want defaults after reset", l)
+	}
+}
+
+// A bare ESC[m is a reset, as is ESC[0m.
+func TestSGRBareResets(t *testing.T) {
+	tt := New(20, 3)
+	tt.Write([]byte("\x1b[31mA\x1b[mB"))
+
+	if got := tt.Cell(1, 1).Fg; got != 31 {
+		t.Errorf("Cell(1,1).Fg = %d, want 31", got)
+	}
+	if got := tt.Cell(1, 2).Fg; got != -1 {
+		t.Errorf("Cell(1,2).Fg = %d, want -1", got)
+	}
+}
+
+func TestSGRBrightColours(t *testing.T) {
+	tt := New(20, 3)
+	tt.Write([]byte("\x1b[93;104mX"))
+
+	c := tt.Cell(1, 1)
+	if c.Fg != 93 || c.Bg != 104 {
+		t.Errorf("Cell(1,1) = %+v, want Fg=93 Bg=104", c)
+	}
+}
+
+// SGR must never reach Unhandled, or every coloured write would trip a test
+// that asserts the list is empty.
+func TestSGRIsNotRecordedAsUnhandled(t *testing.T) {
+	tt := New(20, 3)
+	tt.Write([]byte("\x1b[0m\x1b[1;36;44m\x1b[22m\x1b[39;49mX"))
+
+	if got := tt.Unhandled(); len(got) != 0 {
+		t.Errorf("Unhandled() = %q, want empty", got)
+	}
+}
+
+func TestSGRBoldOffAndDefaultColours(t *testing.T) {
+	tt := New(20, 3)
+	tt.Write([]byte("\x1b[1;31;41mA\x1b[22mB\x1b[39mC\x1b[49mD"))
+
+	if c := tt.Cell(1, 1); !c.Bold || c.Fg != 31 || c.Bg != 41 {
+		t.Errorf("Cell(1,1) = %+v, want Bold Fg=31 Bg=41", c)
+	}
+	if c := tt.Cell(1, 2); c.Bold || c.Fg != 31 {
+		t.Errorf("Cell(1,2) = %+v, want bold off, Fg still 31", c)
+	}
+	if c := tt.Cell(1, 3); c.Fg != -1 || c.Bg != 41 {
+		t.Errorf("Cell(1,3) = %+v, want Fg default, Bg still 41", c)
+	}
+	if c := tt.Cell(1, 4); c.Bg != -1 {
+		t.Errorf("Cell(1,4) = %+v, want Bg default", c)
+	}
+}

--- a/internal/editor/testterm/parse_test.go
+++ b/internal/editor/testterm/parse_test.go
@@ -1,0 +1,94 @@
+package testterm
+
+import "testing"
+
+func TestAbsoluteCursorPositioning(t *testing.T) {
+	tt := New(20, 10)
+	tt.Write([]byte("\x1b[3;5HX"))
+
+	if got := tt.Cell(3, 5).Rune; got != 'X' {
+		t.Errorf("Cell(3,5).Rune = %q, want 'X'", got)
+	}
+	if row, col := tt.Cursor(); row != 3 || col != 6 {
+		t.Errorf("Cursor() = (%d,%d), want (3,6)", row, col)
+	}
+}
+
+// ESC[H with no parameters homes the cursor.
+func TestCursorHomeWithoutParams(t *testing.T) {
+	tt := New(20, 10)
+	tt.Write([]byte("\x1b[5;5Hxx\x1b[HA"))
+
+	if got := tt.Cell(1, 1).Rune; got != 'A' {
+		t.Errorf("Cell(1,1).Rune = %q, want 'A'", got)
+	}
+}
+
+func TestRelativeCursorMovement(t *testing.T) {
+	tt := New(20, 10)
+	// Home, down 2, right 3, write, up 1, left 2, write.
+	tt.Write([]byte("\x1b[H\x1b[2B\x1b[3CX\x1b[1A\x1b[2DY"))
+
+	if got := tt.Cell(3, 4).Rune; got != 'X' {
+		t.Errorf("Cell(3,4).Rune = %q, want 'X'", got)
+	}
+	if got := tt.Cell(2, 3).Rune; got != 'Y' {
+		t.Errorf("Cell(2,3).Rune = %q, want 'Y'", got)
+	}
+}
+
+// A movement with no parameter moves by one.
+func TestRelativeMovementDefaultsToOne(t *testing.T) {
+	tt := New(20, 10)
+	tt.Write([]byte("\x1b[5;5H\x1b[BX"))
+
+	if got := tt.Cell(6, 5).Rune; got != 'X' {
+		t.Errorf("Cell(6,5).Rune = %q, want 'X'", got)
+	}
+}
+
+// Movement must not walk off the grid.
+func TestCursorMovementClampsToScreen(t *testing.T) {
+	tt := New(10, 4)
+	tt.Write([]byte("\x1b[1;1H\x1b[9A\x1b[9D"))
+	if row, col := tt.Cursor(); row != 1 || col != 1 {
+		t.Errorf("Cursor() = (%d,%d), want (1,1)", row, col)
+	}
+
+	tt.Write([]byte("\x1b[99;99H"))
+	if row, col := tt.Cursor(); row != 4 || col != 10 {
+		t.Errorf("Cursor() = (%d,%d), want (4,10)", row, col)
+	}
+}
+
+// This is the exact shape updateDynamicHeaderFields uses: save, jump, write,
+// restore.
+func TestSaveAndRestoreCursor(t *testing.T) {
+	tt := New(20, 10)
+	tt.Write([]byte("\x1b[4;2HAB\x1b[s\x1b[1;1HZ\x1b[uC"))
+
+	if got := tt.Row(1); got != "Z" {
+		t.Errorf("Row(1) = %q, want %q", got, "Z")
+	}
+	if got := tt.Row(4); got != " ABC" {
+		t.Errorf("Row(4) = %q, want %q", got, " ABC")
+	}
+}
+
+func TestCursorVisibility(t *testing.T) {
+	tt := New(20, 10)
+	if !tt.CursorVisible() {
+		t.Error("cursor should start visible")
+	}
+	tt.Write([]byte("\x1b[?25l"))
+	if tt.CursorVisible() {
+		t.Error("cursor should be hidden after ESC[?25l")
+	}
+	tt.Write([]byte("\x1b[?25h"))
+	if !tt.CursorVisible() {
+		t.Error("cursor should be visible after ESC[?25h")
+	}
+	if got := tt.Unhandled(); len(got) != 0 {
+		t.Errorf("Unhandled() = %q, want empty", got)
+	}
+}

--- a/internal/editor/testterm/parse_test.go
+++ b/internal/editor/testterm/parse_test.go
@@ -168,68 +168,42 @@ func TestEraseDisplayToEndAndToStart(t *testing.T) {
 	}
 }
 
-func TestSGRAppliesToSubsequentCells(t *testing.T) {
-	tt := New(20, 3)
-	tt.Write([]byte("\x1b[1;36;44mHi\x1b[0mLo"))
-
-	h := tt.Cell(1, 1)
-	if h.Fg != 36 || h.Bg != 44 || !h.Bold {
-		t.Errorf("Cell(1,1) = %+v, want Fg=36 Bg=44 Bold=true", h)
+// An unrecognised erase mode must not be a silent no-op.
+func TestUnrecognisedEraseModesAreRecorded(t *testing.T) {
+	tt := New(10, 3)
+	tt.Write([]byte("\x1b[9K"))
+	if got := tt.Unhandled(); len(got) != 1 || got[0] != "\x1b[9K" {
+		t.Errorf("Unhandled() after ESC[9K = %q, want [%q]", got, "\x1b[9K")
 	}
-	l := tt.Cell(1, 3)
-	if l.Fg != -1 || l.Bg != -1 || l.Bold {
-		t.Errorf("Cell(1,3) = %+v, want defaults after reset", l)
-	}
-}
 
-// A bare ESC[m is a reset, as is ESC[0m.
-func TestSGRBareResets(t *testing.T) {
-	tt := New(20, 3)
-	tt.Write([]byte("\x1b[31mA\x1b[mB"))
-
-	if got := tt.Cell(1, 1).Fg; got != 31 {
-		t.Errorf("Cell(1,1).Fg = %d, want 31", got)
-	}
-	if got := tt.Cell(1, 2).Fg; got != -1 {
-		t.Errorf("Cell(1,2).Fg = %d, want -1", got)
+	tt2 := New(10, 3)
+	tt2.Write([]byte("\x1b[5J"))
+	if got := tt2.Unhandled(); len(got) != 1 || got[0] != "\x1b[5J" {
+		t.Errorf("Unhandled() after ESC[5J = %q, want [%q]", got, "\x1b[5J")
 	}
 }
 
-func TestSGRBrightColours(t *testing.T) {
-	tt := New(20, 3)
-	tt.Write([]byte("\x1b[93;104mX"))
+// An explicit 0 count on a relative move must still move by one, matching
+// real terminals — only an omitted parameter is the "default to 1" case.
+func TestRelativeMovementExplicitZeroStillMovesOne(t *testing.T) {
+	tt := New(20, 10)
+	tt.Write([]byte("\x1b[5;5H\x1b[0BX"))
 
-	c := tt.Cell(1, 1)
-	if c.Fg != 93 || c.Bg != 104 {
-		t.Errorf("Cell(1,1) = %+v, want Fg=93 Bg=104", c)
+	if got := tt.Cell(6, 5).Rune; got != 'X' {
+		t.Errorf("Cell(6,5).Rune = %q, want 'X' — ESC[0B must move down by one", got)
 	}
 }
 
-// SGR must never reach Unhandled, or every coloured write would trip a test
-// that asserts the list is empty.
-func TestSGRIsNotRecordedAsUnhandled(t *testing.T) {
+// ESC( and ESC) designate a character set and take a third byte naming it;
+// that byte must be consumed with the escape, not printed as text.
+func TestCharsetDesignationConsumesDesignatorByte(t *testing.T) {
 	tt := New(20, 3)
-	tt.Write([]byte("\x1b[0m\x1b[1;36;44m\x1b[22m\x1b[39;49mX"))
+	tt.Write([]byte("A\x1b(BC"))
 
-	if got := tt.Unhandled(); len(got) != 0 {
-		t.Errorf("Unhandled() = %q, want empty", got)
+	if got := tt.Row(1); got != "AC" {
+		t.Errorf("Row(1) = %q, want %q — designator byte leaked into the grid", got, "AC")
 	}
-}
-
-func TestSGRBoldOffAndDefaultColours(t *testing.T) {
-	tt := New(20, 3)
-	tt.Write([]byte("\x1b[1;31;41mA\x1b[22mB\x1b[39mC\x1b[49mD"))
-
-	if c := tt.Cell(1, 1); !c.Bold || c.Fg != 31 || c.Bg != 41 {
-		t.Errorf("Cell(1,1) = %+v, want Bold Fg=31 Bg=41", c)
-	}
-	if c := tt.Cell(1, 2); c.Bold || c.Fg != 31 {
-		t.Errorf("Cell(1,2) = %+v, want bold off, Fg still 31", c)
-	}
-	if c := tt.Cell(1, 3); c.Fg != -1 || c.Bg != 41 {
-		t.Errorf("Cell(1,3) = %+v, want Fg default, Bg still 41", c)
-	}
-	if c := tt.Cell(1, 4); c.Bg != -1 {
-		t.Errorf("Cell(1,4) = %+v, want Bg default", c)
+	if got := tt.Unhandled(); len(got) != 1 || got[0] != "\x1b(B" {
+		t.Errorf("Unhandled() = %q, want [%q]", got, "\x1b(B")
 	}
 }

--- a/internal/editor/testterm/parse_test.go
+++ b/internal/editor/testterm/parse_test.go
@@ -194,6 +194,70 @@ func TestRelativeMovementExplicitZeroStillMovesOne(t *testing.T) {
 	}
 }
 
+// A parameter body byte that is neither a digit nor ';' must not be silently
+// dropped: skipping it concatenates the digits on either side into a
+// different, wrong parameter. This is the colon sub-parameter form used by
+// 24-bit/indexed colour (e.g. ESC[38:2:R:G:Bm); nothing in this codebase
+// emits it, but a parser that mis-happens to produce a valid-looking
+// parameter from it would silently apply the wrong thing while Unhandled()
+// stayed empty.
+func TestCsiColonSubParametersAreUnhandledNotMisapplied(t *testing.T) {
+	// Without the fix this reads as the single parameter "22" (bold off),
+	// which SGR does recognise — so it would be silently applied.
+	tt := New(20, 10)
+	tt.Write([]byte("\x1b[1m\x1b[2:2m"))
+
+	if !tt.pen.Bold {
+		t.Error("ESC[2:2m must not be applied as SGR 22 (bold off) via concatenated digits")
+	}
+	if got := tt.Unhandled(); len(got) != 1 || got[0] != "\x1b[2:2m" {
+		t.Errorf("Unhandled() = %q, want [%q]", got, "\x1b[2:2m")
+	}
+
+	// Without the fix this reads as the single parameter "12", moving the
+	// cursor to row 12 (clamped to the last row) — a positioning sequence
+	// silently misapplied while Unhandled() stayed empty.
+	tt2 := New(20, 10)
+	tt2.Write([]byte("\x1b[1:2H"))
+
+	if row, col := tt2.Cursor(); row != 1 || col != 1 {
+		t.Errorf("Cursor() = (%d,%d), want (1,1) — ESC[1:2H must not move the cursor", row, col)
+	}
+	if got := tt2.Unhandled(); len(got) != 1 || got[0] != "\x1b[1:2H" {
+		t.Errorf("Unhandled() = %q, want [%q]", got, "\x1b[1:2H")
+	}
+
+	// The '?' private-mode prefix must still parse correctly.
+	tt3 := New(20, 10)
+	tt3.Write([]byte("\x1b[?25l"))
+	if tt3.CursorVisible() {
+		t.Error("cursor should be hidden after ESC[?25l")
+	}
+	if got := tt3.Unhandled(); len(got) != 0 {
+		t.Errorf("Unhandled() = %q, want empty", got)
+	}
+}
+
+// Erasing must carry the pen's Bold along with Fg/Bg: a real terminal fills
+// erased cells with the full current SGR state, and Cell models Bold
+// explicitly, so dropping it would leave an erased cell with an attribute
+// that never existed.
+func TestEraseCarriesPenBold(t *testing.T) {
+	tt := New(10, 3)
+	tt.Write([]byte("\x1b[1mabc\x1b[1;1H\x1b[K"))
+
+	if got := tt.Cell(1, 1); !got.Bold {
+		t.Errorf("Cell(1,1) after erase = %+v, want Bold=true (carried from pen)", got)
+	}
+
+	tt2 := New(10, 3)
+	tt2.Write([]byte("\x1b[1mabc\x1b[2J"))
+
+	if got := tt2.Cell(1, 1); !got.Bold {
+		t.Errorf("Cell(1,1) after ESC[2J = %+v, want Bold=true (carried from pen)", got)
+	}
+}
+
 // ESC( and ESC) designate a character set and take a third byte naming it;
 // that byte must be consumed with the escape, not printed as text.
 func TestCharsetDesignationConsumesDesignatorByte(t *testing.T) {

--- a/internal/editor/testterm/parse_test.go
+++ b/internal/editor/testterm/parse_test.go
@@ -92,3 +92,78 @@ func TestCursorVisibility(t *testing.T) {
 		t.Errorf("Unhandled() = %q, want empty", got)
 	}
 }
+
+// ESC[K is what Screen.ClearEOL emits.
+func TestEraseToEndOfLine(t *testing.T) {
+	tt := New(10, 3)
+	tt.Write([]byte("abcdef\x1b[1;4H\x1b[K"))
+
+	if got := tt.Row(1); got != "abc" {
+		t.Errorf("Row(1) = %q, want %q", got, "abc")
+	}
+}
+
+func TestEraseToStartOfLine(t *testing.T) {
+	tt := New(10, 3)
+	tt.Write([]byte("abcdef\x1b[1;3H\x1b[1K"))
+
+	// Columns 1..3 cleared, the rest kept.
+	if got := tt.Row(1); got != "   def" {
+		t.Errorf("Row(1) = %q, want %q", got, "   def")
+	}
+}
+
+func TestEraseWholeLine(t *testing.T) {
+	tt := New(10, 3)
+	tt.Write([]byte("abcdef\x1b[2;1Hxyz\x1b[1;1H\x1b[2K"))
+
+	if got := tt.Row(1); got != "" {
+		t.Errorf("Row(1) = %q, want empty", got)
+	}
+	if got := tt.Row(2); got != "xyz" {
+		t.Errorf("Row(2) = %q, want %q — other rows must be untouched", got, "xyz")
+	}
+}
+
+// ESC[2J ESC[H is what ansi.ClearScreen() emits and Screen.ClearScreen uses.
+func TestEraseWholeDisplayAndHome(t *testing.T) {
+	tt := New(10, 3)
+	tt.Write([]byte("aaa\x1b[2;1Hbbb\x1b[2J\x1b[H"))
+
+	if got := tt.Snapshot(); got != "" {
+		t.Errorf("Snapshot() = %q, want empty", got)
+	}
+	if row, col := tt.Cursor(); row != 1 || col != 1 {
+		t.Errorf("Cursor() = (%d,%d), want (1,1)", row, col)
+	}
+}
+
+func TestEraseDisplayToEndAndToStart(t *testing.T) {
+	tt := New(5, 3)
+	tt.Write([]byte("aaaaa\x1b[2;1Hbbbbb\x1b[3;1Hccccc"))
+	tt.Write([]byte("\x1b[2;3H\x1b[J")) // erase from cursor to end of screen
+
+	if got := tt.Row(1); got != "aaaaa" {
+		t.Errorf("Row(1) = %q, want unchanged %q", got, "aaaaa")
+	}
+	if got := tt.Row(2); got != "bb" {
+		t.Errorf("Row(2) = %q, want %q", got, "bb")
+	}
+	if got := tt.Row(3); got != "" {
+		t.Errorf("Row(3) = %q, want empty", got)
+	}
+
+	tt2 := New(5, 3)
+	tt2.Write([]byte("aaaaa\x1b[2;1Hbbbbb\x1b[3;1Hccccc"))
+	tt2.Write([]byte("\x1b[2;3H\x1b[1J")) // erase from start of screen to cursor
+
+	if got := tt2.Row(1); got != "" {
+		t.Errorf("Row(1) = %q, want empty", got)
+	}
+	if got := tt2.Row(2); got != "   bb" {
+		t.Errorf("Row(2) = %q, want %q", got, "   bb")
+	}
+	if got := tt2.Row(3); got != "ccccc" {
+		t.Errorf("Row(3) = %q, want unchanged %q", got, "ccccc")
+	}
+}

--- a/internal/editor/testterm/session.go
+++ b/internal/editor/testterm/session.go
@@ -1,0 +1,76 @@
+package testterm
+
+import (
+	"errors"
+	"io"
+	"sync"
+
+	"github.com/gliderlabs/ssh"
+)
+
+// Session is a scripted ssh.Session for driving interactive terminal code.
+// Read replays the keystrokes it was given; Write forwards to a Term so one
+// object covers both directions of a test.
+//
+// Once the scripted input is exhausted, Read blocks until the read interrupt
+// fires if one is set, and returns io.EOF otherwise. That mirrors the ssh and
+// telnet adapters: a live connection does not report EOF just because the user
+// has stopped typing, and code that relies on a read returning is what leaks
+// goroutines when it is wrong.
+type Session struct {
+	ssh.Session // nil; supplies the rest of the interface
+
+	term *Term
+
+	mu        sync.Mutex
+	data      []byte
+	interrupt <-chan struct{}
+}
+
+// NewSession creates a session that replays keys and renders output to term.
+// term may be nil, in which case output is discarded.
+func NewSession(term *Term, keys string) *Session {
+	return &Session{term: term, data: []byte(keys)}
+}
+
+// Send appends more input, for tests that feed keys in stages.
+func (s *Session) Send(keys string) {
+	s.mu.Lock()
+	s.data = append(s.data, keys...)
+	s.mu.Unlock()
+}
+
+// SetReadInterrupt installs the channel that unblocks a pending Read.
+func (s *Session) SetReadInterrupt(ch <-chan struct{}) {
+	s.mu.Lock()
+	s.interrupt = ch
+	s.mu.Unlock()
+}
+
+// Read replays scripted input. See the type comment for exhausted-input
+// behaviour.
+func (s *Session) Read(p []byte) (int, error) {
+	s.mu.Lock()
+	if len(s.data) > 0 {
+		n := copy(p, s.data)
+		s.data = s.data[n:]
+		s.mu.Unlock()
+		return n, nil
+	}
+	interrupt := s.interrupt
+	s.mu.Unlock()
+
+	if interrupt == nil {
+		return 0, io.EOF
+	}
+	<-interrupt
+	return 0, errors.New("read interrupted")
+}
+
+// Write renders output to the session's Term, or discards it when there is none.
+func (s *Session) Write(p []byte) (int, error) {
+	if s.term == nil {
+		return len(p), nil
+	}
+	return s.term.Write(p)
+}

--- a/internal/editor/testterm/session.go
+++ b/internal/editor/testterm/session.go
@@ -17,6 +17,10 @@ import (
 // telnet adapters: a live connection does not report EOF just because the user
 // has stopped typing, and code that relies on a read returning is what leaks
 // goroutines when it is wrong.
+//
+// Session embeds a nil ssh.Session only to satisfy the rest of the interface;
+// Read, Write and Pty are implemented here, but any other promoted method
+// (Environ, Command, Exit, ...) panics on the nil receiver if called.
 type Session struct {
 	ssh.Session // nil; supplies the rest of the interface
 
@@ -25,19 +29,37 @@ type Session struct {
 	mu        sync.Mutex
 	data      []byte
 	interrupt <-chan struct{}
+	sent      chan struct{} // signaled (non-blocking) by Send to wake a pending Read
 }
 
 // NewSession creates a session that replays keys and renders output to term.
 // term may be nil, in which case output is discarded.
 func NewSession(term *Term, keys string) *Session {
-	return &Session{term: term, data: []byte(keys)}
+	return &Session{term: term, data: []byte(keys), sent: make(chan struct{}, 1)}
 }
 
-// Send appends more input, for tests that feed keys in stages.
+// Send appends more input, for tests that feed keys in stages. It wakes a
+// Read that is already blocked waiting for the interrupt, so keys fed after
+// Read has been called are delivered instead of sitting unseen until the
+// interrupt fires.
 func (s *Session) Send(keys string) {
 	s.mu.Lock()
 	s.data = append(s.data, keys...)
 	s.mu.Unlock()
+
+	select {
+	case s.sent <- struct{}{}:
+	default:
+		// A signal is already pending; Read will see the new data when it
+		// re-checks the buffer, so there is nothing more to do here.
+	}
+}
+
+// Pty reports that the session has no PTY. Session does not model PTY
+// negotiation; RunEditorWithMetadata and similar callers treat a false isPty
+// as "use default dimensions", which is what tests driving a Session want.
+func (s *Session) Pty() (ssh.Pty, <-chan ssh.Window, bool) {
+	return ssh.Pty{}, nil, false
 }
 
 // SetReadInterrupt installs the channel that unblocks a pending Read.
@@ -49,22 +71,37 @@ func (s *Session) SetReadInterrupt(ch <-chan struct{}) {
 
 // Read replays scripted input. See the type comment for exhausted-input
 // behaviour.
+//
+// When input is exhausted and an interrupt is set, Read also watches for a
+// Send: Send is how a test feeds keys in stages to code running concurrently
+// on another goroutine, which only makes sense if a Read blocked waiting for
+// those keys actually wakes up when they arrive. Send's non-blocking signal
+// on s.sent is buffered (capacity 1), so a Send landing between the buffer
+// check below and the select is not lost — it is sitting in the channel
+// ready for the select to consume immediately.
 func (s *Session) Read(p []byte) (int, error) {
-	s.mu.Lock()
-	if len(s.data) > 0 {
-		n := copy(p, s.data)
-		s.data = s.data[n:]
+	for {
+		s.mu.Lock()
+		if len(s.data) > 0 {
+			n := copy(p, s.data)
+			s.data = s.data[n:]
+			s.mu.Unlock()
+			return n, nil
+		}
+		interrupt := s.interrupt
 		s.mu.Unlock()
-		return n, nil
-	}
-	interrupt := s.interrupt
-	s.mu.Unlock()
 
-	if interrupt == nil {
-		return 0, io.EOF
+		if interrupt == nil {
+			return 0, io.EOF
+		}
+
+		select {
+		case <-s.sent:
+			continue // new input may have arrived; re-check the buffer
+		case <-interrupt:
+			return 0, errors.New("read interrupted")
+		}
 	}
-	<-interrupt
-	return 0, errors.New("read interrupted")
 }
 
 // Write renders output to the session's Term, or discards it when there is none.

--- a/internal/editor/testterm/session_test.go
+++ b/internal/editor/testterm/session_test.go
@@ -78,6 +78,67 @@ func TestSessionSendAppendsInput(t *testing.T) {
 	}
 }
 
+// Send issued while a Read is already blocked (input exhausted, interrupt
+// set, nothing sent yet) must wake it and deliver the new keys. This is
+// Send's entire purpose: feeding input in stages to code under test that runs
+// concurrently with the test goroutine, the shape an interactive prompt loop
+// test takes. Without a wakeup, Read stays parked on the interrupt and never
+// sees the new input.
+func TestSessionSendUnblocksPendingRead(t *testing.T) {
+	sess := NewSession(nil, "")
+	ch := make(chan struct{})
+	defer close(ch) // in case the test fails before Send unblocks Read
+	sess.SetReadInterrupt(ch)
+
+	type result struct {
+		n   int
+		err error
+	}
+	buf := make([]byte, 8)
+	done := make(chan result, 1)
+	go func() {
+		n, err := sess.Read(buf)
+		done <- result{n, err}
+	}()
+
+	// Confirm Read is actually blocked before sending, or this test could
+	// pass merely because Send happened to run before Read checked the
+	// buffer rather than because Send woke a pending Read.
+	select {
+	case res := <-done:
+		t.Fatalf("Read returned (%d, %v) before any input was sent", res.n, res.err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	sess.Send("hi")
+
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Fatalf("Read after Send: %v", res.err)
+		}
+		if got := string(buf[:res.n]); got != "hi" {
+			t.Errorf("Read = %q, want %q", got, "hi")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Read did not return after Send supplied input to a pending Read")
+	}
+}
+
+// Pty has a demonstrated caller (RunEditorWithMetadata) that would otherwise
+// panic on the embedded nil ssh.Session. Session must answer "no PTY" instead.
+func TestSessionPtyReportsNoPty(t *testing.T) {
+	sess := NewSession(nil, "")
+
+	_, winCh, isPty := sess.Pty()
+	if isPty {
+		t.Error("Pty() isPty = true, want false")
+	}
+	if winCh != nil {
+		t.Error("Pty() winCh != nil, want nil")
+	}
+}
+
 func TestSessionWriteGoesToTerm(t *testing.T) {
 	tt := New(20, 3)
 	sess := NewSession(tt, "")

--- a/internal/editor/testterm/session_test.go
+++ b/internal/editor/testterm/session_test.go
@@ -1,0 +1,98 @@
+package testterm
+
+import (
+	"errors"
+	"io"
+	"testing"
+	"time"
+)
+
+func TestSessionReplaysKeys(t *testing.T) {
+	sess := NewSession(nil, "hi")
+
+	buf := make([]byte, 8)
+	n, err := sess.Read(buf)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got := string(buf[:n]); got != "hi" {
+		t.Errorf("Read = %q, want %q", got, "hi")
+	}
+}
+
+// With no interrupt set, exhausted input reads as EOF.
+func TestSessionReturnsEOFWhenExhausted(t *testing.T) {
+	sess := NewSession(nil, "a")
+	buf := make([]byte, 8)
+	sess.Read(buf)
+
+	if _, err := sess.Read(buf); !errors.Is(err, io.EOF) {
+		t.Errorf("second Read err = %v, want io.EOF", err)
+	}
+}
+
+// With an interrupt channel set, exhausted input blocks like a live connection
+// until the interrupt fires. This is what makes the input-handler leak test
+// meaningful, so it is preserved exactly.
+func TestSessionBlocksUntilInterrupt(t *testing.T) {
+	sess := NewSession(nil, "")
+	ch := make(chan struct{})
+	sess.SetReadInterrupt(ch)
+
+	done := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 4)
+		_, err := sess.Read(buf)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("Read returned %v before the interrupt fired", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(ch)
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("Read err = nil after interrupt, want an error")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Read did not return after the interrupt fired")
+	}
+}
+
+func TestSessionSendAppendsInput(t *testing.T) {
+	sess := NewSession(nil, "a")
+	buf := make([]byte, 8)
+	sess.Read(buf)
+
+	sess.Send("bc")
+	n, err := sess.Read(buf)
+	if err != nil {
+		t.Fatalf("Read after Send: %v", err)
+	}
+	if got := string(buf[:n]); got != "bc" {
+		t.Errorf("Read = %q, want %q", got, "bc")
+	}
+}
+
+func TestSessionWriteGoesToTerm(t *testing.T) {
+	tt := New(20, 3)
+	sess := NewSession(tt, "")
+
+	if _, err := sess.Write([]byte("\x1b[2;1HX")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got := tt.Cell(2, 1).Rune; got != 'X' {
+		t.Errorf("Cell(2,1).Rune = %q, want 'X'", got)
+	}
+}
+
+func TestSessionWriteWithNilTermDiscards(t *testing.T) {
+	sess := NewSession(nil, "")
+	if _, err := sess.Write([]byte("anything")); err != nil {
+		t.Errorf("Write with nil Term: %v", err)
+	}
+}

--- a/internal/editor/testterm/sgr.go
+++ b/internal/editor/testterm/sgr.go
@@ -1,8 +1,13 @@
 package testterm
 
+import "fmt"
+
 // applySGR updates the pen from a Select Graphic Rendition sequence. Only the
 // attributes internal/editor emits are modelled: reset, bold on/off, the eight
-// standard and eight bright colours, and the default-colour codes.
+// standard and eight bright colours, and the default-colour codes. Any other
+// parameter (blink, reverse, 256-colour, ...) is recorded in Unhandled instead
+// of being silently dropped; a 256-colour sequence like ESC[48;5;12m records
+// each of its three parameters separately rather than as one entry.
 func (t *Term) applySGR(params []int) {
 	if len(params) == 0 {
 		t.pen = blankCell()
@@ -24,6 +29,8 @@ func (t *Term) applySGR(params []int) {
 			t.pen.Bg = p
 		case p == 49:
 			t.pen.Bg = -1
+		default:
+			t.unhandled = append(t.unhandled, fmt.Sprintf("SGR %d", p))
 		}
 	}
 }

--- a/internal/editor/testterm/sgr.go
+++ b/internal/editor/testterm/sgr.go
@@ -1,0 +1,29 @@
+package testterm
+
+// applySGR updates the pen from a Select Graphic Rendition sequence. Only the
+// attributes internal/editor emits are modelled: reset, bold on/off, the eight
+// standard and eight bright colours, and the default-colour codes.
+func (t *Term) applySGR(params []int) {
+	if len(params) == 0 {
+		t.pen = blankCell()
+		return
+	}
+	for _, p := range params {
+		switch {
+		case p <= 0: // 0 or omitted: reset
+			t.pen = blankCell()
+		case p == 1:
+			t.pen.Bold = true
+		case p == 22:
+			t.pen.Bold = false
+		case p >= 30 && p <= 37, p >= 90 && p <= 97:
+			t.pen.Fg = p
+		case p == 39:
+			t.pen.Fg = -1
+		case p >= 40 && p <= 47, p >= 100 && p <= 107:
+			t.pen.Bg = p
+		case p == 49:
+			t.pen.Bg = -1
+		}
+	}
+}

--- a/internal/editor/testterm/sgr_test.go
+++ b/internal/editor/testterm/sgr_test.go
@@ -1,0 +1,113 @@
+package testterm
+
+import "testing"
+
+func TestSGRAppliesToSubsequentCells(t *testing.T) {
+	tt := New(20, 3)
+	tt.Write([]byte("\x1b[1;36;44mHi\x1b[0mLo"))
+
+	h := tt.Cell(1, 1)
+	if h.Fg != 36 || h.Bg != 44 || !h.Bold {
+		t.Errorf("Cell(1,1) = %+v, want Fg=36 Bg=44 Bold=true", h)
+	}
+	l := tt.Cell(1, 3)
+	if l.Fg != -1 || l.Bg != -1 || l.Bold {
+		t.Errorf("Cell(1,3) = %+v, want defaults after reset", l)
+	}
+}
+
+// A bare ESC[m is a reset, as is ESC[0m.
+func TestSGRBareResets(t *testing.T) {
+	tt := New(20, 3)
+	tt.Write([]byte("\x1b[31mA\x1b[mB"))
+
+	if got := tt.Cell(1, 1).Fg; got != 31 {
+		t.Errorf("Cell(1,1).Fg = %d, want 31", got)
+	}
+	if got := tt.Cell(1, 2).Fg; got != -1 {
+		t.Errorf("Cell(1,2).Fg = %d, want -1", got)
+	}
+}
+
+func TestSGRBrightColours(t *testing.T) {
+	tt := New(20, 3)
+	tt.Write([]byte("\x1b[93;104mX"))
+
+	c := tt.Cell(1, 1)
+	if c.Fg != 93 || c.Bg != 104 {
+		t.Errorf("Cell(1,1) = %+v, want Fg=93 Bg=104", c)
+	}
+}
+
+// SGR must never reach Unhandled, or every coloured write would trip a test
+// that asserts the list is empty.
+func TestSGRIsNotRecordedAsUnhandled(t *testing.T) {
+	tt := New(20, 3)
+	tt.Write([]byte("\x1b[0m\x1b[1;36;44m\x1b[22m\x1b[39;49mX"))
+
+	if got := tt.Unhandled(); len(got) != 0 {
+		t.Errorf("Unhandled() = %q, want empty", got)
+	}
+}
+
+// Unknown SGR parameters (blink, reverse, 256-colour) must not vanish
+// silently: internal/ansi's |B12 pipe code expands to
+// ESC[104m ESC[48;5;12m, and the 48;5;12 half of that is unmodelled.
+func TestSGRUnknownParametersAreRecorded(t *testing.T) {
+	tt := New(20, 3)
+	tt.Write([]byte("\x1b[5mA"))
+	if got := tt.Unhandled(); len(got) != 1 || got[0] != "SGR 5" {
+		t.Errorf("Unhandled() after ESC[5m = %q, want [%q]", got, "SGR 5")
+	}
+
+	tt2 := New(20, 3)
+	tt2.Write([]byte("\x1b[7mA"))
+	if got := tt2.Unhandled(); len(got) != 1 || got[0] != "SGR 7" {
+		t.Errorf("Unhandled() after ESC[7m = %q, want [%q]", got, "SGR 7")
+	}
+
+	tt3 := New(20, 3)
+	tt3.Write([]byte("\x1b[48;5;12mA"))
+	want := []string{"SGR 48", "SGR 5", "SGR 12"}
+	got := tt3.Unhandled()
+	if len(got) != len(want) {
+		t.Fatalf("Unhandled() after ESC[48;5;12m = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Unhandled()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// A reset combined with other codes in the same sequence must apply left to
+// right, so the reset only clears what came before it. This shape is
+// production-reachable: screen.go emits ESC[0;34m directly, and pipe codes
+// |01-|07 all expand to ESC[0;3Xm.
+func TestSGRResetMidSequenceThenNewColour(t *testing.T) {
+	tt := New(20, 3)
+	tt.Write([]byte("\x1b[31;0;36mX"))
+
+	c := tt.Cell(1, 1)
+	if c.Fg != 36 || c.Bold || c.Bg != -1 {
+		t.Errorf("Cell(1,1) = %+v, want Fg=36 Bold=false Bg=-1", c)
+	}
+}
+
+func TestSGRBoldOffAndDefaultColours(t *testing.T) {
+	tt := New(20, 3)
+	tt.Write([]byte("\x1b[1;31;41mA\x1b[22mB\x1b[39mC\x1b[49mD"))
+
+	if c := tt.Cell(1, 1); !c.Bold || c.Fg != 31 || c.Bg != 41 {
+		t.Errorf("Cell(1,1) = %+v, want Bold Fg=31 Bg=41", c)
+	}
+	if c := tt.Cell(1, 2); c.Bold || c.Fg != 31 {
+		t.Errorf("Cell(1,2) = %+v, want bold off, Fg still 31", c)
+	}
+	if c := tt.Cell(1, 3); c.Fg != -1 || c.Bg != 41 {
+		t.Errorf("Cell(1,3) = %+v, want Fg default, Bg still 41", c)
+	}
+	if c := tt.Cell(1, 4); c.Bg != -1 {
+		t.Errorf("Cell(1,4) = %+v, want Bg default", c)
+	}
+}

--- a/internal/editor/testterm/term.go
+++ b/internal/editor/testterm/term.go
@@ -122,10 +122,32 @@ func (t *Term) Unhandled() []string {
 	return out
 }
 
-// putRune writes r at the cursor using the current pen and advances the cursor.
+// putRune writes r at the cursor using the current pen and advances the cursor,
+// wrapping at the right margin and scrolling at the bottom of the screen.
 func (t *Term) putRune(r rune) {
+	if t.col > t.width {
+		t.col = 1
+		t.row++
+	}
+	if t.row > t.height {
+		t.scrollUp()
+		t.row = t.height
+	}
 	if t.row >= 1 && t.row <= t.height && t.col >= 1 && t.col <= t.width {
 		t.cells[t.row-1][t.col-1] = Cell{Rune: r, Fg: t.pen.Fg, Bg: t.pen.Bg, Bold: t.pen.Bold}
 	}
 	t.col++
+}
+
+// scrollUp discards the top row and appends a blank row at the bottom.
+func (t *Term) scrollUp() {
+	if t.height == 0 {
+		return
+	}
+	copy(t.cells, t.cells[1:])
+	last := make([]Cell, t.width)
+	for c := range last {
+		last[c] = blankCell()
+	}
+	t.cells[t.height-1] = last
 }

--- a/internal/editor/testterm/term.go
+++ b/internal/editor/testterm/term.go
@@ -51,6 +51,7 @@ type Term struct {
 	row, col           int // cursor, 1-based
 	savedRow, savedCol int
 	cursorHidden       bool
+	wrapPending        bool // set when a write landed exactly on the last column; see putRune
 
 	pen   Cell // current SGR state; Rune is unused
 	cp437 bool
@@ -115,10 +116,10 @@ func (t *Term) Cell(row, col int) Cell {
 	return t.cells[row-1][col-1]
 }
 
-// Cursor returns the 1-based cursor position. The column can be width+1 right
-// after a write that lands exactly on the last column: wrap is deferred until
-// the next character arrives (see putRune), so the cursor briefly points one
-// past the right margin, matching real terminal behaviour.
+// Cursor returns the 1-based cursor position. After a write that lands
+// exactly on the last column, the column stays at width — never past it — while
+// the wrap to the next row is deferred until the next character arrives (see
+// putRune's wrapPending flag), matching real terminal behaviour.
 func (t *Term) Cursor() (row, col int) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -170,8 +171,16 @@ func (t *Term) Unhandled() []string {
 
 // putRune writes r at the cursor using the current pen and advances the cursor,
 // wrapping at the right margin and scrolling at the bottom of the screen.
+//
+// Wrapping is deferred: a write that lands exactly on the last column sets
+// wrapPending and leaves col at width rather than stepping it past the right
+// margin. The next putRune call consumes that flag first, moving to column 1
+// of the next row before it writes. That mirrors real terminal behaviour,
+// where the cursor visibly sits on the last column — not one past it — until
+// something is actually written there.
 func (t *Term) putRune(r rune) {
-	if t.col > t.width {
+	if t.wrapPending {
+		t.wrapPending = false
 		t.col = 1
 		t.row++
 	}
@@ -186,7 +195,11 @@ func (t *Term) putRune(r rune) {
 	if t.row >= 1 && t.row <= t.height && t.col >= 1 && t.col <= t.width {
 		t.cells[t.row-1][t.col-1] = Cell{Rune: r, Fg: t.pen.Fg, Bg: t.pen.Bg, Bold: t.pen.Bold}
 	}
-	t.col++
+	if t.col >= t.width {
+		t.wrapPending = true
+	} else {
+		t.col++
+	}
 }
 
 // scrollUp discards the top row and appends a blank row at the bottom. The new

--- a/internal/editor/testterm/term.go
+++ b/internal/editor/testterm/term.go
@@ -27,6 +27,11 @@ func blankCell() Cell { return Cell{Rune: ' ', Fg: -1, Bg: -1} }
 // Option configures a Term at construction.
 type Option func(*Term)
 
+// CP437 makes the Term treat each byte 0x80-0xFF as one CP437 character,
+// matching what ansi.OutputModeCP437 puts on the wire. Without it the stream is
+// read as UTF-8.
+func CP437() Option { return func(t *Term) { t.cp437 = true } }
+
 // Term is a virtual screen that records what was drawn on it.
 type Term struct {
 	width, height int

--- a/internal/editor/testterm/term.go
+++ b/internal/editor/testterm/term.go
@@ -10,7 +10,11 @@
 // catch output the double does not understand rather than silently passing.
 package testterm
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
 
 // Cell is one character position on the screen.
 //
@@ -33,7 +37,14 @@ type Option func(*Term)
 func CP437() Option { return func(t *Term) { t.cp437 = true } }
 
 // Term is a virtual screen that records what was drawn on it.
+//
+// Term is safe for concurrent use: Write and every accessor take an internal
+// mutex. That matters when a test drives interactive code through a Session —
+// the code under test writes to the Term on its own goroutine while the test
+// goroutine reads Row, Cell, Cursor or Snapshot to make assertions.
 type Term struct {
+	mu sync.Mutex
+
 	width, height int
 	cells         [][]Cell
 
@@ -75,6 +86,14 @@ func New(width, height int, opts ...Option) *Term {
 // Row returns the text of a 1-based row with trailing blanks removed.
 // An out-of-range row returns "".
 func (t *Term) Row(row int) string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.rowLocked(row)
+}
+
+// rowLocked is Row's implementation, callable from methods that already hold
+// t.mu so they do not recursively lock it.
+func (t *Term) rowLocked(row int) string {
 	if row < 1 || row > t.height {
 		return ""
 	}
@@ -88,26 +107,41 @@ func (t *Term) Row(row int) string {
 // Cell returns the cell at a 1-based row and column. Out-of-range coordinates
 // return a blank cell so that a mistaken assertion fails rather than panics.
 func (t *Term) Cell(row, col int) Cell {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	if row < 1 || row > t.height || col < 1 || col > t.width {
 		return blankCell()
 	}
 	return t.cells[row-1][col-1]
 }
 
-// Cursor returns the 1-based cursor position.
-func (t *Term) Cursor() (row, col int) { return t.row, t.col }
+// Cursor returns the 1-based cursor position. The column can be width+1 right
+// after a write that lands exactly on the last column: wrap is deferred until
+// the next character arrives (see putRune), so the cursor briefly points one
+// past the right margin, matching real terminal behaviour.
+func (t *Term) Cursor() (row, col int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.row, t.col
+}
 
 // CursorVisible reports whether the cursor is shown (ESC[?25h / ESC[?25l).
-func (t *Term) CursorVisible() bool { return !t.cursorHidden }
+func (t *Term) CursorVisible() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return !t.cursorHidden
+}
 
 // Snapshot returns the whole screen as text: rows joined by "\n", with trailing
 // blanks on each row and trailing blank rows removed. Colour is deliberately
 // excluded — assert colour through Cell.
 func (t *Term) Snapshot() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	rows := make([]string, t.height)
 	last := -1
 	for i := 1; i <= t.height; i++ {
-		rows[i-1] = t.Row(i)
+		rows[i-1] = t.rowLocked(i)
 		if rows[i-1] != "" {
 			last = i - 1
 		}
@@ -119,11 +153,18 @@ func (t *Term) Snapshot() string {
 }
 
 // Unhandled returns the escape sequences this Term consumed but did not model,
-// in the order they arrived. A test that wants to be sure the double kept up
+// in the order they arrived, plus a trailing entry when the stream ended
+// mid-sequence (bytes are still sitting in the pending buffer, waiting for a
+// Write that never came). A test that wants to be sure the double kept up
 // with the code under test asserts this is empty.
 func (t *Term) Unhandled() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	out := make([]string, len(t.unhandled))
 	copy(out, t.unhandled)
+	if len(t.pending) > 0 {
+		out = append(out, fmt.Sprintf("pending: %q", string(t.pending)))
+	}
 	return out
 }
 
@@ -134,6 +175,10 @@ func (t *Term) putRune(r rune) {
 		t.col = 1
 		t.row++
 	}
+	// row > height, not >=: a bare '\n' (applyControl) advances the row itself
+	// and must scroll as soon as it reaches the last row, but putRune only
+	// wrapped col back to 1 above and needs the increment to have already
+	// landed one row past the bottom before it scrolls.
 	if t.row > t.height {
 		t.scrollUp()
 		t.row = t.height
@@ -144,7 +189,10 @@ func (t *Term) putRune(r rune) {
 	t.col++
 }
 
-// scrollUp discards the top row and appends a blank row at the bottom.
+// scrollUp discards the top row and appends a blank row at the bottom. The new
+// row is filled with default colours rather than the current pen's background;
+// a real terminal paints it in the pen's background, but this Term deliberately
+// does not model that.
 func (t *Term) scrollUp() {
 	if t.height == 0 {
 		return

--- a/internal/editor/testterm/term.go
+++ b/internal/editor/testterm/term.go
@@ -1,0 +1,131 @@
+// Package testterm provides an ANSI-interpreting virtual terminal for testing
+// terminal output, plus a scripted session for driving interactive code.
+//
+// A Term is an io.Writer: hand it to the code under test in place of the real
+// connection, then assert on the resulting screen with Row, Cell, Cursor and
+// Snapshot instead of on raw escape sequences.
+//
+// Term is not a terminal emulator. It models the subset of ANSI that
+// internal/editor emits and records everything else in Unhandled, so a test can
+// catch output the double does not understand rather than silently passing.
+package testterm
+
+import "strings"
+
+// Cell is one character position on the screen.
+//
+// Fg and Bg hold the SGR parameter as written (30-37 and 90-97 for foreground,
+// 40-47 and 100-107 for background); -1 means the terminal default.
+type Cell struct {
+	Rune   rune
+	Fg, Bg int
+	Bold   bool
+}
+
+func blankCell() Cell { return Cell{Rune: ' ', Fg: -1, Bg: -1} }
+
+// Option configures a Term at construction.
+type Option func(*Term)
+
+// Term is a virtual screen that records what was drawn on it.
+type Term struct {
+	width, height int
+	cells         [][]Cell
+
+	row, col           int // cursor, 1-based
+	savedRow, savedCol int
+	cursorHidden       bool
+
+	pen   Cell // current SGR state; Rune is unused
+	cp437 bool
+
+	pending   []byte // bytes held back mid-sequence or mid-rune
+	unhandled []string
+}
+
+// New creates a Term of the given size with an empty screen and the cursor at
+// row 1, column 1.
+func New(width, height int, opts ...Option) *Term {
+	t := &Term{
+		width:  width,
+		height: height,
+		row:    1,
+		col:    1,
+		pen:    blankCell(),
+	}
+	t.cells = make([][]Cell, height)
+	for r := range t.cells {
+		t.cells[r] = make([]Cell, width)
+		for c := range t.cells[r] {
+			t.cells[r][c] = blankCell()
+		}
+	}
+	t.savedRow, t.savedCol = 1, 1
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
+}
+
+// Row returns the text of a 1-based row with trailing blanks removed.
+// An out-of-range row returns "".
+func (t *Term) Row(row int) string {
+	if row < 1 || row > t.height {
+		return ""
+	}
+	var sb strings.Builder
+	for _, c := range t.cells[row-1] {
+		sb.WriteRune(c.Rune)
+	}
+	return strings.TrimRight(sb.String(), " ")
+}
+
+// Cell returns the cell at a 1-based row and column. Out-of-range coordinates
+// return a blank cell so that a mistaken assertion fails rather than panics.
+func (t *Term) Cell(row, col int) Cell {
+	if row < 1 || row > t.height || col < 1 || col > t.width {
+		return blankCell()
+	}
+	return t.cells[row-1][col-1]
+}
+
+// Cursor returns the 1-based cursor position.
+func (t *Term) Cursor() (row, col int) { return t.row, t.col }
+
+// CursorVisible reports whether the cursor is shown (ESC[?25h / ESC[?25l).
+func (t *Term) CursorVisible() bool { return !t.cursorHidden }
+
+// Snapshot returns the whole screen as text: rows joined by "\n", with trailing
+// blanks on each row and trailing blank rows removed. Colour is deliberately
+// excluded — assert colour through Cell.
+func (t *Term) Snapshot() string {
+	rows := make([]string, t.height)
+	last := -1
+	for i := 1; i <= t.height; i++ {
+		rows[i-1] = t.Row(i)
+		if rows[i-1] != "" {
+			last = i - 1
+		}
+	}
+	if last < 0 {
+		return ""
+	}
+	return strings.Join(rows[:last+1], "\n")
+}
+
+// Unhandled returns the escape sequences this Term consumed but did not model,
+// in the order they arrived. A test that wants to be sure the double kept up
+// with the code under test asserts this is empty.
+func (t *Term) Unhandled() []string {
+	out := make([]string, len(t.unhandled))
+	copy(out, t.unhandled)
+	return out
+}
+
+// putRune writes r at the cursor using the current pen and advances the cursor.
+func (t *Term) putRune(r rune) {
+	if t.row >= 1 && t.row <= t.height && t.col >= 1 && t.col <= t.width {
+		t.cells[t.row-1][t.col-1] = Cell{Rune: r, Fg: t.pen.Fg, Bg: t.pen.Bg, Bold: t.pen.Bold}
+	}
+	t.col++
+}

--- a/internal/editor/testterm/term_test.go
+++ b/internal/editor/testterm/term_test.go
@@ -1,0 +1,94 @@
+package testterm
+
+import "testing"
+
+func TestWritePlacesTextAtCursor(t *testing.T) {
+	tt := New(20, 5)
+
+	if _, err := tt.Write([]byte("Hello")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if got := tt.Row(1); got != "Hello" {
+		t.Errorf("Row(1) = %q, want %q", got, "Hello")
+	}
+	if row, col := tt.Cursor(); row != 1 || col != 6 {
+		t.Errorf("Cursor() = (%d,%d), want (1,6)", row, col)
+	}
+}
+
+func TestRowTrimsTrailingBlanks(t *testing.T) {
+	tt := New(20, 5)
+	tt.Write([]byte("Hi"))
+
+	if got := tt.Row(1); got != "Hi" {
+		t.Errorf("Row(1) = %q, want %q (no padding to width)", got, "Hi")
+	}
+	if got := tt.Row(2); got != "" {
+		t.Errorf("Row(2) = %q, want empty", got)
+	}
+}
+
+// Out-of-range access must not panic: a wrong assertion should report a bad
+// value, not take the test binary down.
+func TestCellOutOfRangeIsBlank(t *testing.T) {
+	tt := New(20, 5)
+	for _, c := range []struct{ row, col int }{{0, 1}, {1, 0}, {6, 1}, {1, 21}, {-3, -3}} {
+		if got := tt.Cell(c.row, c.col); got.Rune != ' ' {
+			t.Errorf("Cell(%d,%d).Rune = %q, want blank", c.row, c.col, got.Rune)
+		}
+	}
+}
+
+func TestSnapshotJoinsRowsAndDropsTrailingBlankRows(t *testing.T) {
+	tt := New(10, 4)
+	tt.Write([]byte("ab"))
+
+	want := "ab"
+	if got := tt.Snapshot(); got != want {
+		t.Errorf("Snapshot() = %q, want %q", got, want)
+	}
+}
+
+// Unrecognised sequences must be consumed (not printed as text) and recorded,
+// so a test can assert the double did not silently ignore output.
+func TestUnknownEscapeIsConsumedAndRecorded(t *testing.T) {
+	tt := New(20, 5)
+	tt.Write([]byte("A\x1b[5nB"))
+
+	if got := tt.Row(1); got != "AB" {
+		t.Errorf("Row(1) = %q, want %q — escape bytes leaked into the grid", got, "AB")
+	}
+	if got := tt.Unhandled(); len(got) != 1 || got[0] != "\x1b[5n" {
+		t.Errorf("Unhandled() = %q, want [%q]", got, "\x1b[5n")
+	}
+}
+
+// A sequence split across two Writes must still be parsed as one sequence.
+func TestEscapeSplitAcrossWrites(t *testing.T) {
+	tt := New(20, 5)
+	tt.Write([]byte("A\x1b[5"))
+	tt.Write([]byte("nB"))
+
+	if got := tt.Row(1); got != "AB" {
+		t.Errorf("Row(1) = %q, want %q", got, "AB")
+	}
+	if got := tt.Unhandled(); len(got) != 1 || got[0] != "\x1b[5n" {
+		t.Errorf("Unhandled() = %q, want [%q]", got, "\x1b[5n")
+	}
+}
+
+func TestWriteDecodesMultiByteUTF8(t *testing.T) {
+	tt := New(20, 5)
+	tt.Write([]byte("░é"))
+
+	if got := tt.Cell(1, 1).Rune; got != '░' {
+		t.Errorf("Cell(1,1).Rune = %q, want '░'", got)
+	}
+	if got := tt.Cell(1, 2).Rune; got != 'é' {
+		t.Errorf("Cell(1,2).Rune = %q, want 'é'", got)
+	}
+	if row, col := tt.Cursor(); row != 1 || col != 3 {
+		t.Errorf("Cursor() = (%d,%d), want (1,3) — one column per rune", row, col)
+	}
+}

--- a/internal/editor/testterm/term_test.go
+++ b/internal/editor/testterm/term_test.go
@@ -159,3 +159,49 @@ func TestCarriageReturnAndBackspaceAndTab(t *testing.T) {
 		t.Errorf("Cell(1,9).Rune = %q, want 'X' (tab stop at column 9)", got)
 	}
 }
+
+// 0xB0 is ░ and 0xDB is █ in CP437. Both are single bytes on the wire.
+func TestCP437ModeDecodesHighBytes(t *testing.T) {
+	tt := New(10, 3, CP437())
+	tt.Write([]byte{0xB0, 0xDB, 'A'})
+
+	if got := tt.Cell(1, 1).Rune; got != '░' {
+		t.Errorf("Cell(1,1).Rune = %q, want '░'", got)
+	}
+	if got := tt.Cell(1, 2).Rune; got != '█' {
+		t.Errorf("Cell(1,2).Rune = %q, want '█'", got)
+	}
+	if got := tt.Cell(1, 3).Rune; got != 'A' {
+		t.Errorf("Cell(1,3).Rune = %q, want 'A'", got)
+	}
+	if row, col := tt.Cursor(); row != 1 || col != 4 {
+		t.Errorf("Cursor() = (%d,%d), want (1,4) — one column per byte", row, col)
+	}
+}
+
+// A CP437 byte pair that happens to be valid UTF-8 must still decode as two
+// separate glyphs. 0xDB 0xB2 is █▓ in CP437 but U+06F2 read as UTF-8.
+func TestCP437ModeDoesNotMisreadBytePairsAsUTF8(t *testing.T) {
+	tt := New(10, 3, CP437())
+	tt.Write([]byte{0xDB, 0xB2})
+
+	if got := tt.Cell(1, 1).Rune; got != '█' {
+		t.Errorf("Cell(1,1).Rune = %q, want '█'", got)
+	}
+	if got := tt.Cell(1, 2).Rune; got != '▓' {
+		t.Errorf("Cell(1,2).Rune = %q, want '▓'", got)
+	}
+}
+
+// Escape sequences are ASCII and must be interpreted the same in CP437 mode.
+func TestCP437ModeStillParsesEscapes(t *testing.T) {
+	tt := New(10, 3, CP437())
+	tt.Write([]byte("\x1b[2;3HX"))
+
+	if got := tt.Cell(2, 3).Rune; got != 'X' {
+		t.Errorf("Cell(2,3).Rune = %q, want 'X'", got)
+	}
+	if got := tt.Unhandled(); len(got) != 0 {
+		t.Errorf("Unhandled() = %q, want empty", got)
+	}
+}

--- a/internal/editor/testterm/term_test.go
+++ b/internal/editor/testterm/term_test.go
@@ -78,6 +78,19 @@ func TestEscapeSplitAcrossWrites(t *testing.T) {
 	}
 }
 
+// Bytes left over when the stream ends mid-sequence must not vanish: without
+// a trace, an incomplete escape sequence swallowed by a test double looks
+// identical to one that never happened.
+func TestIncompletePendingSequenceIsRecorded(t *testing.T) {
+	tt := New(20, 5)
+	tt.Write([]byte("\x1b[3"))
+
+	got := tt.Unhandled()
+	if len(got) != 1 || got[0] != `pending: "\x1b[3"` {
+		t.Errorf("Unhandled() = %q, want [%q]", got, `pending: "\x1b[3"`)
+	}
+}
+
 func TestWriteDecodesMultiByteUTF8(t *testing.T) {
 	tt := New(20, 5)
 	tt.Write([]byte("░é"))

--- a/internal/editor/testterm/term_test.go
+++ b/internal/editor/testterm/term_test.go
@@ -173,6 +173,38 @@ func TestCarriageReturnAndBackspaceAndTab(t *testing.T) {
 	}
 }
 
+// A bare '\n' arriving right after a write that lands on the last column
+// must not double-advance the row. putRune defers wrapping (see wrapPending)
+// rather than stepping the column past the margin; if '\n' does not resolve
+// that pending state itself, the next character sees the stale state and
+// wraps a second time. Real terminals clear the deferred wrap when '\n' moves
+// the cursor down, so the wrap "uses up" the row '\n' already advanced.
+func TestBareLineFeedDoesNotDoubleAdvanceRow(t *testing.T) {
+	tt := New(4, 3)
+	tt.Write([]byte("abcd\nX"))
+
+	if got := tt.Cell(2, 1).Rune; got != 'X' {
+		t.Errorf("Cell(2,1).Rune = %q, want 'X'", got)
+	}
+	if got := tt.Row(3); got != "" {
+		t.Errorf("Row(3) = %q, want empty — a bare '\\n' after a full-width write must only advance one row", got)
+	}
+	if row, col := tt.Cursor(); row != 2 || col != 2 {
+		t.Errorf("Cursor() = (%d,%d), want (2,2)", row, col)
+	}
+}
+
+// A tab stop past the right margin must clamp to width, not run past it the
+// way a bare column overflow would.
+func TestTabClampsToWidth(t *testing.T) {
+	tt := New(6, 3)
+	tt.Write([]byte("abcde\t"))
+
+	if row, col := tt.Cursor(); row != 1 || col != 6 {
+		t.Errorf("Cursor() = (%d,%d), want (1,6) — tab stop clamped to width", row, col)
+	}
+}
+
 // 0xB0 is ░ and 0xDB is █ in CP437. Both are single bytes on the wire.
 func TestCP437ModeDecodesHighBytes(t *testing.T) {
 	tt := New(10, 3, CP437())

--- a/internal/editor/testterm/term_test.go
+++ b/internal/editor/testterm/term_test.go
@@ -92,3 +92,70 @@ func TestWriteDecodesMultiByteUTF8(t *testing.T) {
 		t.Errorf("Cursor() = (%d,%d), want (1,3) — one column per rune", row, col)
 	}
 }
+
+func TestWriteWrapsAtRightMargin(t *testing.T) {
+	tt := New(4, 3)
+	tt.Write([]byte("abcdef"))
+
+	if got := tt.Row(1); got != "abcd" {
+		t.Errorf("Row(1) = %q, want %q", got, "abcd")
+	}
+	if got := tt.Row(2); got != "ef" {
+		t.Errorf("Row(2) = %q, want %q", got, "ef")
+	}
+	if row, col := tt.Cursor(); row != 2 || col != 3 {
+		t.Errorf("Cursor() = (%d,%d), want (2,3)", row, col)
+	}
+}
+
+func TestLineFeedOnLastRowScrolls(t *testing.T) {
+	tt := New(6, 3)
+	tt.Write([]byte("one\r\ntwo\r\nthree"))
+
+	if got := tt.Snapshot(); got != "one\ntwo\nthree" {
+		t.Errorf("Snapshot() = %q, want %q", got, "one\ntwo\nthree")
+	}
+
+	tt.Write([]byte("\r\nfour"))
+
+	if got := tt.Snapshot(); got != "two\nthree\nfour" {
+		t.Errorf("Snapshot() = %q, want %q — top row should have scrolled off", got, "two\nthree\nfour")
+	}
+	if row := tt.row; row != 3 {
+		t.Errorf("cursor row = %d, want 3 (stays on the last row)", row)
+	}
+}
+
+func TestWrapOnLastRowScrolls(t *testing.T) {
+	tt := New(3, 2)
+	tt.Write([]byte("abc\r\ndef"))
+	if got := tt.Snapshot(); got != "abc\ndef" {
+		t.Fatalf("setup: Snapshot() = %q, want %q", got, "abc\ndef")
+	}
+
+	tt.Write([]byte("g")) // wraps past the last column on the last row
+
+	if got := tt.Snapshot(); got != "def\ng" {
+		t.Errorf("Snapshot() = %q, want %q", got, "def\ng")
+	}
+}
+
+func TestCarriageReturnAndBackspaceAndTab(t *testing.T) {
+	tt := New(20, 3)
+	tt.Write([]byte("abc\rX"))
+	if got := tt.Row(1); got != "Xbc" {
+		t.Errorf("Row(1) = %q, want %q", got, "Xbc")
+	}
+
+	tt2 := New(20, 3)
+	tt2.Write([]byte("abc\b\bX"))
+	if got := tt2.Row(1); got != "aXc" {
+		t.Errorf("Row(1) = %q, want %q", got, "aXc")
+	}
+
+	tt3 := New(20, 3)
+	tt3.Write([]byte("ab\tX"))
+	if got := tt3.Cell(1, 9).Rune; got != 'X' {
+		t.Errorf("Cell(1,9).Rune = %q, want 'X' (tab stop at column 9)", got)
+	}
+}


### PR DESCRIPTION
Builds `internal/editor/testterm`, the highest-leverage unblocking item in the size-reduction backlog's Tier 4. `internal/editor`'s two largest files — `screen.go` (775) and `commands.go` (555) — have effectively no tests, and the backlog lists both as blocked on exactly this.

The obstacle was never dependency injection: `Screen` already takes an `io.Writer` and `FSEditor` already accepts a substitute `ssh.Session`. The obstacle was that the only thing a test could observe was a stream of escape sequences, so the existing tests assert on goroutine lifecycle rather than on output.

## What this adds

A `Term` is an `io.Writer` you hand to `NewScreen` in place of the real connection. It parses the escape stream into a cell grid, so tests assert on what a user would see:

```go
tt := testterm.New(40, 10)
s := editor.NewScreen(tt, ansi.OutputModeUTF8, 40, 10)

s.GoXY(5, 3)
s.WriteDirect("Hello")

tt.Row(3)        // "    Hello"
tt.Cursor()      // (3, 10)
tt.Cell(3, 5)    // Cell{Rune:'H', Fg:-1, Bg:-1}
tt.Unhandled()   // [] — nothing the double failed to model
```

| File | Lines | |
|---|---|---|
| `testterm/term.go` | 206 | grid, cursor, queries, locking |
| `testterm/parse.go` | 241 | `Write`, escape scanning, cursor control |
| `testterm/erase.go` | 93 | erase-line / erase-display |
| `testterm/session.go` | 76 | scripted `ssh.Session` (input side) |
| `testterm/sgr.go` | 36 | colour and bold |
| `editor/screen_render_test.go` | 166 | six tests driving the **real** `Screen` |

## Why the ANSI subset is small

`screen.go` turns out to be the sole output funnel for the package — all 12 terminal writes are there, and `commands.go`/`fseditor.go` reach the terminal only through `Screen` methods. The subset was verified against all three sources of output: the editor's own literals, both ANS art files (`FSEDITOR.ANS` and `FSEDITORF.ANS` contain *only* SGR — no cursor movement), and the pipe-code table behind `WriteDirectProcessed`.

CP437 mode decodes through the existing `ansi.CP437BytesToUTF8`. The codebase already has several CP437 tables; this does not add another.

## `Unhandled()` is the point

The double models a subset, so the risk is that it silently drifts from reality as the code under test changes — every test still passing while the model is wrong. `Unhandled()` records anything the parser consumed without acting on, and the proving tests assert it is empty.

The final review found that this net had a hole, and it was reachable in production rather than theoretical: `applySGR` had no `default` branch, so an unmodelled SGR parameter was dropped while `Unhandled()` stayed empty — because `case 'm'` counted the sequence as handled. `internal/ansi/ansi.go:176` maps the pipe code `|B12` to `ESC[104m ESC[48;5;12m`, and that 256-colour half vanished without a trace. The design doc's audit of the pipe table had claimed complete coverage and missed it.

Fixed, along with the same class of hole in unrecognised erase modes (`ESC[9K`), leftover partial sequences at end of stream, and the charset-designator byte of `ESC(B`. The rule now stated in the design: consuming bytes and doing nothing with them is only safe if it is visible.

## `Term` is safe for concurrent use

`Session.Send` exists for feeding input in stages, which only makes sense when the code under test runs concurrently with the test goroutine — exactly the shape a test for `commands.go`'s prompt loops will take. In that shape the editor goroutine calls `Term.Write` while the test calls `Row`/`Cell`/`Cursor`. `Term` now takes a mutex across `Write` and every accessor rather than documenting a caveat that would be discovered as a flaky `-race` failure.

## Migration

`fseditor_run_test.go`'s local `fakeEditorSession` is deleted in favour of `testterm.Session`. Its exhausted-input behaviour is copied verbatim — block on the read interrupt if one is set, `io.EOF` otherwise — because that is what makes `TestRunClosesSelfCreatedInputHandler` catch the double-keypress bug where a leaked input handler steals alternate keystrokes. Both migrated tests still pass under `-race`, with their assertions untouched.

## Deliberately not done

Decomposing `screen.go` or `commands.go`, and the full characterization sweep of every rendering path. This delivers the tool and enough tests to trust it; those are the follow-ups it unblocks.

## Verification

Nine commits, each with its own review. `go build ./...`, `go vet ./...`, `gofmt -l` (empty), `go test ./...`, and `go test ./internal/editor/... -race` all clean. No new module dependency — `go.mod` unchanged.

The six proving tests in `screen_render_test.go` are the load-bearing ones: they drive real `Screen` methods (`GoXY`, `WriteDirect`, `WriteDirectProcessed`, `ClearEOL`, `ClearScreen`, `LoadHeaderTemplate`/`DisplayHeader`, `DisplayStatusLine`) and assert on the result, including the same content rendered in both UTF-8 and CP437 output modes and the insert-mode indicator's save/jump/write/restore sequence. Parser tests alone would only prove the parser agrees with itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded editor coverage for screen positioning, clearing, cursor behavior, text rendering, colors, scrolling, and status indicators.
  * Added comprehensive terminal emulation tests for ANSI controls, UTF-8 and CP437 text, cursor movement, erasure, color attributes, and screen updates.
  * Added scripted session tests covering input replay, blocking reads, interruptions, and output handling.
  * Replaced a custom test session with a reusable testing session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->