### PR TITLE
fix(configeditor): friendly transport errors in V3Net area browser

### DIFF
--- a/internal/configeditor/v3net_area_browser_helpers.go
+++ b/internal/configeditor/v3net_area_browser_helpers.go
@@ -3,9 +3,11 @@ package configeditor
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -28,16 +30,43 @@ func defaultLocalBoardName(network, areaName string) string {
 	return titled + " " + areaName
 }
 
+// friendlyNetErrorText maps common transport-level failures to a short
+// message a sysop can act on. Returns "" when the error is not recognized.
+func friendlyNetErrorText(err error) string {
+	var dnsErr *net.DNSError
+	switch {
+	case errors.Is(err, syscall.ECONNREFUSED):
+		return "connection refused - no hub is listening at that address"
+	case errors.As(err, &dnsErr) && dnsErr.IsNotFound:
+		return "host not found - check the hub URL"
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return "hub not responding (timed out) - it may be down or unreachable"
+	}
+	return ""
+}
+
+// hubErrorText formats a hub request error for the status line as
+// "{prefix}: {cause}", preferring a friendly transport-level explanation
+// over the raw error chain.
+func hubErrorText(prefix string, err error) string {
+	if friendly := friendlyNetErrorText(err); friendly != "" {
+		return prefix + ": " + friendly
+	}
+	cause := err
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		cause = urlErr.Err
+	}
+	return fmt.Sprintf("%s: %v", prefix, cause)
+}
+
 // handleFetchNALMsg processes the NAL fetch result.
 func (m Model) handleFetchNALMsg(msg fetchNALMsg) (tea.Model, tea.Cmd) {
 	m.areaBrowserLoading = false
 	if msg.err != nil {
-		cause := msg.err
-		var urlErr *url.Error
-		if errors.As(msg.err, &urlErr) {
-			cause = urlErr.Err
-		}
-		m.areaBrowserError = fmt.Sprintf("Could not fetch areas: %v", cause)
+		m.areaBrowserError = hubErrorText("Could not fetch areas", msg.err)
 		return m, nil
 	}
 
@@ -93,7 +122,7 @@ func (m Model) handleFetchNALMsg(msg fetchNALMsg) (tea.Model, tea.Cmd) {
 // handleSubscribeAreasMsg processes the subscribe response.
 func (m Model) handleSubscribeAreasMsg(msg subscribeAreasMsg) (tea.Model, tea.Cmd) {
 	if msg.err != nil {
-		m.message = fmt.Sprintf("Subscribe failed: %v", msg.err)
+		m.message = hubErrorText("Subscribe failed", msg.err)
 		return m, nil
 	}
 	statusMap := make(map[string]string)

--- a/internal/configeditor/v3net_area_browser_helpers_test.go
+++ b/internal/configeditor/v3net_area_browser_helpers_test.go
@@ -1,0 +1,86 @@
+package configeditor
+
+import (
+	"errors"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// timeoutErr implements net.Error with Timeout() == true, mimicking the
+// error http.Client produces when its Timeout elapses.
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string {
+	return "context deadline exceeded (Client.Timeout exceeded while awaiting headers)"
+}
+func (timeoutErr) Timeout() bool   { return true }
+func (timeoutErr) Temporary() bool { return true }
+
+func fetchErrorFor(t *testing.T, err error) string {
+	t.Helper()
+	m := Model{mode: modeV3NetAreaBrowser, configs: &allConfigs{}}
+	result, _ := m.handleFetchNALMsg(fetchNALMsg{err: err})
+	return result.(Model).areaBrowserError
+}
+
+func TestHandleFetchNALMsg_TimeoutShowsFriendlyError(t *testing.T) {
+	err := &url.Error{Op: "Get", URL: "http://felonynet.org:8765/v3net/v1/felonynet/nal", Err: timeoutErr{}}
+	got := fetchErrorFor(t, err)
+	want := "Could not fetch areas: hub not responding (timed out) - it may be down or unreachable"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestHandleFetchNALMsg_ConnectionRefusedShowsFriendlyError(t *testing.T) {
+	opErr := &net.OpError{Op: "dial", Net: "tcp",
+		Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED}}
+	err := &url.Error{Op: "Get", URL: "http://felonynet.org:8765/v3net/v1/felonynet/nal", Err: opErr}
+	got := fetchErrorFor(t, err)
+	want := "Could not fetch areas: connection refused - no hub is listening at that address"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestHandleFetchNALMsg_DNSErrorShowsFriendlyError(t *testing.T) {
+	dnsErr := &net.DNSError{Err: "no such host", Name: "felonynet.orgg", IsNotFound: true}
+	err := &url.Error{Op: "Get", URL: "http://felonynet.orgg:8765/v3net/v1/felonynet/nal",
+		Err: &net.OpError{Op: "dial", Net: "tcp", Err: dnsErr}}
+	got := fetchErrorFor(t, err)
+	want := "Could not fetch areas: host not found - check the hub URL"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestHandleFetchNALMsg_UnrecognizedErrorKeepsCause(t *testing.T) {
+	err := &url.Error{Op: "Get", URL: "http://felonynet.org:8765/v3net/v1/felonynet/nal",
+		Err: errors.New("some other failure")}
+	got := fetchErrorFor(t, err)
+	if !strings.Contains(got, "some other failure") {
+		t.Errorf("expected cause preserved, got %q", got)
+	}
+}
+
+func TestHandleSubscribeAreasMsg_TimeoutShowsFriendlyError(t *testing.T) {
+	m := Model{mode: modeV3NetAreaBrowser, configs: &allConfigs{}}
+	err := &url.Error{Op: "Post", URL: "http://felonynet.org:8765/v3net/v1/subscribe", Err: timeoutErr{}}
+	result, _ := m.handleSubscribeAreasMsg(subscribeAreasMsg{err: err})
+	got := result.(Model).message
+	want := "Subscribe failed: hub not responding (timed out) - it may be down or unreachable"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestHandleFetchNALMsg_NonURLErrorKeepsMessage(t *testing.T) {
+	got := fetchErrorFor(t, errors.New("hub returned status 404: not found"))
+	if !strings.Contains(got, "hub returned status 404") {
+		t.Errorf("expected message preserved, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

A felonynet user reported `Could not fetch areas: context deadline exceeded (Client.Timeout e...` in the Area Browser — the raw Go error chain truncates in the status line and gives sysops nothing actionable. (Root cause of that report was the felonynet hub being unreachable on `felonynet.org:8765`, not a client bug.)

This maps common transport failures on the hub NAL fetch and subscribe calls to short, actionable messages:

- timeout → `hub not responding (timed out) - it may be down or unreachable`
- connection refused → `connection refused - no hub is listening at that address`
- DNS not-found → `host not found - check the hub URL`

Unrecognized errors keep their underlying cause (unwrapping `url.Error` as before). Detection uses `errors.Is`/`errors.As` on `net.Error`, `net.DNSError`, and `syscall.ECONNREFUSED` — no string matching.

## Testing

- New TDD tests in `v3net_area_browser_helpers_test.go` covering timeout, refused, DNS, and both fallback paths (all watched failing first)
- `go test ./...` passes, `go vet` and `gofmt` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when area data cannot be loaded or subscriptions fail due to connection refusals, DNS issues, or timeouts.
  * Preserved useful underlying details for unexpected or non-network errors.

* **Tests**
  * Added coverage for network failures, subscription timeouts, and preservation of unrecognized error information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->