### PR TITLE
fix(configeditor): fit friendly errors in the 70-char browser row

### DIFF
--- a/internal/configeditor/v3net_area_browser_helpers.go
+++ b/internal/configeditor/v3net_area_browser_helpers.go
@@ -36,13 +36,13 @@ func friendlyNetErrorText(err error) string {
 	var dnsErr *net.DNSError
 	switch {
 	case errors.Is(err, syscall.ECONNREFUSED):
-		return "connection refused - no hub is listening at that address"
+		return "connection refused - no hub at that address"
 	case errors.As(err, &dnsErr) && dnsErr.IsNotFound:
 		return "host not found - check the hub URL"
 	}
 	var netErr net.Error
 	if errors.As(err, &netErr) && netErr.Timeout() {
-		return "hub not responding (timed out) - it may be down or unreachable"
+		return "hub timed out - it may be down or unreachable"
 	}
 	return ""
 }

--- a/internal/configeditor/v3net_area_browser_helpers_test.go
+++ b/internal/configeditor/v3net_area_browser_helpers_test.go
@@ -30,7 +30,7 @@ func fetchErrorFor(t *testing.T, err error) string {
 func TestHandleFetchNALMsg_TimeoutShowsFriendlyError(t *testing.T) {
 	err := &url.Error{Op: "Get", URL: "http://felonynet.org:8765/v3net/v1/felonynet/nal", Err: timeoutErr{}}
 	got := fetchErrorFor(t, err)
-	want := "Could not fetch areas: hub not responding (timed out) - it may be down or unreachable"
+	want := "Could not fetch areas: hub timed out - it may be down or unreachable"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -41,7 +41,7 @@ func TestHandleFetchNALMsg_ConnectionRefusedShowsFriendlyError(t *testing.T) {
 		Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED}}
 	err := &url.Error{Op: "Get", URL: "http://felonynet.org:8765/v3net/v1/felonynet/nal", Err: opErr}
 	got := fetchErrorFor(t, err)
-	want := "Could not fetch areas: connection refused - no hub is listening at that address"
+	want := "Could not fetch areas: connection refused - no hub at that address"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -72,9 +72,29 @@ func TestHandleSubscribeAreasMsg_TimeoutShowsFriendlyError(t *testing.T) {
 	err := &url.Error{Op: "Post", URL: "http://felonynet.org:8765/v3net/v1/subscribe", Err: timeoutErr{}}
 	result, _ := m.handleSubscribeAreasMsg(subscribeAreasMsg{err: err})
 	got := result.(Model).message
-	want := "Subscribe failed: hub not responding (timed out) - it may be down or unreachable"
+	want := "Subscribe failed: hub timed out - it may be down or unreachable"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestFriendlyErrors_FitBrowserStatusRow ensures every friendly message,
+// with the longest prefix, fits the area browser's 70-wide error row
+// (69 usable characters) without truncation.
+func TestFriendlyErrors_FitBrowserStatusRow(t *testing.T) {
+	const maxLen = 69
+	errs := []error{
+		&url.Error{Op: "Get", URL: "http://x/nal", Err: timeoutErr{}},
+		&url.Error{Op: "Get", URL: "http://x/nal", Err: &net.OpError{Op: "dial", Net: "tcp",
+			Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED}}},
+		&url.Error{Op: "Get", URL: "http://x/nal", Err: &net.OpError{Op: "dial", Net: "tcp",
+			Err: &net.DNSError{Err: "no such host", Name: "x", IsNotFound: true}}},
+	}
+	for _, err := range errs {
+		msg := hubErrorText("Could not fetch areas", err)
+		if n := len([]rune(msg)); n > maxLen {
+			t.Errorf("message is %d chars, exceeds %d-char row: %q", n, maxLen, msg)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #168, which merged before its final commit synced on GitHub's side — this is that stranded commit (d2d2007), cherry-picked.

The area browser `errorRow`/`messageRow` truncate at the 70-wide box (69 usable chars); the timeout and refused wordings from #168 overflow and get clipped. Shortens both:

- `hub not responding (timed out) - it may be down or unreachable` → `hub timed out - it may be down or unreachable`
- `connection refused - no hub is listening at that address` → `connection refused - no hub at that address`

Adds `TestFriendlyErrors_FitBrowserStatusRow` asserting every friendly message with the longest prefix fits the row.

## Testing

- `go test ./internal/configeditor/` passes