### PR TITLE
feat(v3net): node management for hub-hosted networks

### DIFF
--- a/docs/sysop/v3net/configuration.md
+++ b/docs/sysop/v3net/configuration.md
@@ -172,6 +172,23 @@ plain HTTP.
 
 ---
 
+### Managing Subscriber Nodes
+
+From the Networks list, press **N** on a hosted network to open Node
+Management. The screen lists every BBS registered with your hub:
+
+- **A** — approve a `pending` node (required when Auto-Approve is off)
+- **B** — ban a node (its requests are rejected) or unban it
+- **D** — delete a registration entirely; the node may re-subscribe fresh
+- **R** — refresh the list
+
+The BBS (and its hub) must be running: the screen talks to the live hub
+so changes take effect immediately, with no restart. With **Auto-Approve**
+set to `Y`, new nodes activate on registration and approval is never
+needed; ban and delete still apply.
+
+---
+
 ## Node Identity
 
 ```

--- a/internal/configeditor/model.go
+++ b/internal/configeditor/model.go
@@ -58,6 +58,7 @@ const (
 	modeFTNAreaDownloading                       // Progress state while downloading echolist
 	modeFTNNodelistLookup                        // Progress state while downloading nodelist
 	modeQuitConfirm                              // Plain Exit? Y/N confirm (used by Task 10)
+	modeV3NetNodes                               // Node management (hosted network node approvals)
 )
 
 // topMenuItem defines an entry in the top-level menu.
@@ -237,6 +238,15 @@ type Model struct {
 	regBrowserError     string                   // error from fetch
 	regBrowserReturn    editorMode               // mode to return to on ESC
 
+	// V3Net node management state
+	nodesNetwork       string              // hosted network being managed
+	nodesList          []protocol.NodeInfo // fetched node registrations
+	nodesCursor        int                 // highlighted row
+	nodesScroll        int                 // scroll offset
+	nodesLoading       bool                // true while node fetch in flight
+	nodesError         string              // error from fetch
+	nodesConfirmDelete bool                // true while awaiting Y/N for remove
+
 	// FTN setup wizard state
 	ftnWizard       *ftnWizardState // pointer so field closures survive value-receiver copies
 	ftnWizardFields []fieldDef      // fields for FTN wizard form
@@ -380,6 +390,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case subscribeAreasMsg:
 		return m.handleSubscribeAreasMsg(msg)
 
+	case fetchNodesMsg:
+		return m.handleFetchNodesMsg(msg)
+
+	case nodeActionMsg:
+		return m.handleNodeActionMsg(msg)
+
 	case fetchRegistryMsg:
 		return m.handleFetchRegistryMsg(msg)
 
@@ -444,6 +460,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			result, cmd = m.updateWizardExitConfirm(msg)
 		case modeV3NetAreaBrowser:
 			result, cmd = m.updateV3NetAreaBrowser(msg)
+		case modeV3NetNodes:
+			result, cmd = m.updateV3NetNodes(msg)
 		case modeRegistryBrowser:
 			result, cmd = m.updateRegistryBrowser(msg)
 		case modeFTNWizardForm:

--- a/internal/configeditor/update_records.go
+++ b/internal/configeditor/update_records.go
@@ -105,6 +105,11 @@ func (m Model) updateRecordList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m.enterRegistryBrowserForLeafList()
 			}
 			return m, nil
+		case "n", "N":
+			if m.recordType == "v3nethub" && total > 0 {
+				return m.enterNodeManagement(m.configs.V3Net.Hub.Networks[m.recordCursor].Name)
+			}
+			return m, nil
 		case "p", "P":
 			if total > 0 && m.recordTypeSupportsReorder() {
 				m.reorderSourceIdx = m.recordCursor

--- a/internal/configeditor/update_v3net_nodes.go
+++ b/internal/configeditor/update_v3net_nodes.go
@@ -20,11 +20,23 @@ func (m Model) enterNodeManagement(network string) (tea.Model, tea.Cmd) {
 	return m, fetchHubNodes(m.configs.V3Net.Hub.Port, network, m.configs.V3Net.KeystorePath)
 }
 
+// nodeActionMessages maps a node action to its past-tense status message.
+var nodeActionMessages = map[string]string{
+	"approve": "Node approved",
+	"ban":     "Node banned",
+	"unban":   "Node unbanned",
+}
+
 // handleFetchNodesMsg processes the node list fetch result.
 func (m Model) handleFetchNodesMsg(msg fetchNodesMsg) (tea.Model, tea.Cmd) {
+	if m.mode != modeV3NetNodes || msg.network != m.nodesNetwork {
+		return m, nil // stale response from a previous network's fetch
+	}
 	m.nodesLoading = false
 	if msg.err != nil {
-		m.nodesError = hubErrorText("Could not fetch nodes", msg.err)
+		errText := hubErrorText("Could not fetch nodes", msg.err)
+		m.nodesError = errText
+		m.message = errText
 		return m, nil
 	}
 	m.nodesList = msg.nodes
@@ -36,6 +48,9 @@ func (m Model) handleFetchNodesMsg(msg fetchNodesMsg) (tea.Model, tea.Cmd) {
 
 // handleNodeActionMsg processes an approve/ban/unban/remove result.
 func (m Model) handleNodeActionMsg(msg nodeActionMsg) (tea.Model, tea.Cmd) {
+	if m.mode != modeV3NetNodes || msg.network != m.nodesNetwork {
+		return m, nil // stale response from a previous network's action
+	}
 	if msg.err != nil {
 		m.message = hubErrorText("Action failed", msg.err)
 		return m, nil
@@ -59,7 +74,11 @@ func (m Model) handleNodeActionMsg(msg nodeActionMsg) (tea.Model, tea.Cmd) {
 			m.nodesList[i].Status = msg.status
 		}
 	}
-	m.message = "Node " + msg.action + "d" // approved / banned / unbanned reads fine
+	if text, ok := nodeActionMessages[msg.action]; ok {
+		m.message = text
+	} else {
+		m.message = "Node updated"
+	}
 	return m, nil
 }
 

--- a/internal/configeditor/update_v3net_nodes.go
+++ b/internal/configeditor/update_v3net_nodes.go
@@ -82,16 +82,13 @@ func (m Model) updateV3NetNodes(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	switch msg.Type {
-	case tea.KeyUp:
-		if m.nodesCursor > 0 {
-			m.nodesCursor--
-		}
-	case tea.KeyDown:
-		if m.nodesCursor < total-1 {
-			m.nodesCursor++
-		}
-	case tea.KeyEscape:
+	if cursor, ok := listNavKey(msg, m.nodesCursor, total); ok {
+		m.nodesCursor = cursor
+		m.nodesScroll = clampListScroll(cursor, m.nodesScroll, nodesListVisible)
+		return m, nil
+	}
+
+	if msg.Type == tea.KeyEscape {
 		m.mode = modeRecordList
 		return m, nil
 	}

--- a/internal/configeditor/update_v3net_nodes.go
+++ b/internal/configeditor/update_v3net_nodes.go
@@ -66,6 +66,13 @@ func (m Model) handleNodeActionMsg(msg nodeActionMsg) (tea.Model, tea.Cmd) {
 		if m.nodesCursor >= len(m.nodesList) && m.nodesCursor > 0 {
 			m.nodesCursor--
 		}
+		m.nodesScroll = clampListScroll(m.nodesCursor, m.nodesScroll, nodesListVisible)
+		if maxScroll := len(m.nodesList) - nodesListVisible; m.nodesScroll > maxScroll {
+			if maxScroll < 0 {
+				maxScroll = 0
+			}
+			m.nodesScroll = maxScroll
+		}
 		m.message = "Node removed"
 		return m, nil
 	}
@@ -89,6 +96,9 @@ func (m Model) updateV3NetNodes(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.nodesConfirmDelete {
 		switch msg.String() {
 		case "y", "Y":
+			if m.nodesLoading {
+				return m, nil // ignore confirm while a refresh is in flight
+			}
 			m.nodesConfirmDelete = false
 			if n := m.currentNode(); n != nil {
 				return m, nodeAction(m.configs.V3Net.Hub.Port, m.nodesNetwork,
@@ -110,6 +120,15 @@ func (m Model) updateV3NetNodes(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if msg.Type == tea.KeyEscape {
 		m.mode = modeRecordList
 		return m, nil
+	}
+
+	// Ignore action keys while a refresh is in flight: the list backing
+	// them may be stale by the time the response lands.
+	if m.nodesLoading {
+		switch msg.String() {
+		case "a", "A", "b", "B", "d", "D":
+			return m, nil
+		}
 	}
 
 	switch msg.String() {

--- a/internal/configeditor/update_v3net_nodes.go
+++ b/internal/configeditor/update_v3net_nodes.go
@@ -1,0 +1,131 @@
+package configeditor
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+)
+
+// enterNodeManagement opens the node screen for a hosted network.
+func (m Model) enterNodeManagement(network string) (tea.Model, tea.Cmd) {
+	m.nodesNetwork = network
+	m.nodesList = nil
+	m.nodesCursor = 0
+	m.nodesScroll = 0
+	m.nodesLoading = true
+	m.nodesError = ""
+	m.nodesConfirmDelete = false
+	m.message = ""
+	m.mode = modeV3NetNodes
+	return m, fetchHubNodes(m.configs.V3Net.Hub.Port, network, m.configs.V3Net.KeystorePath)
+}
+
+// handleFetchNodesMsg processes the node list fetch result.
+func (m Model) handleFetchNodesMsg(msg fetchNodesMsg) (tea.Model, tea.Cmd) {
+	m.nodesLoading = false
+	if msg.err != nil {
+		m.nodesError = hubErrorText("Could not fetch nodes", msg.err)
+		return m, nil
+	}
+	m.nodesList = msg.nodes
+	m.nodesCursor = 0
+	m.nodesScroll = 0
+	m.nodesError = ""
+	return m, nil
+}
+
+// handleNodeActionMsg processes an approve/ban/unban/remove result.
+func (m Model) handleNodeActionMsg(msg nodeActionMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		m.message = hubErrorText("Action failed", msg.err)
+		return m, nil
+	}
+	if msg.action == "remove" {
+		kept := m.nodesList[:0:0]
+		for _, n := range m.nodesList {
+			if n.NodeID != msg.nodeID {
+				kept = append(kept, n)
+			}
+		}
+		m.nodesList = kept
+		if m.nodesCursor >= len(m.nodesList) && m.nodesCursor > 0 {
+			m.nodesCursor--
+		}
+		m.message = "Node removed"
+		return m, nil
+	}
+	for i := range m.nodesList {
+		if m.nodesList[i].NodeID == msg.nodeID {
+			m.nodesList[i].Status = msg.status
+		}
+	}
+	m.message = "Node " + msg.action + "d" // approved / banned / unbanned reads fine
+	return m, nil
+}
+
+// updateV3NetNodes handles key events on the node management screen.
+func (m Model) updateV3NetNodes(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	total := len(m.nodesList)
+
+	if m.nodesConfirmDelete {
+		switch msg.String() {
+		case "y", "Y":
+			m.nodesConfirmDelete = false
+			if n := m.currentNode(); n != nil {
+				return m, nodeAction(m.configs.V3Net.Hub.Port, m.nodesNetwork,
+					m.configs.V3Net.KeystorePath, n.NodeID, "remove")
+			}
+			return m, nil
+		default:
+			m.nodesConfirmDelete = false
+			return m, nil
+		}
+	}
+
+	switch msg.Type {
+	case tea.KeyUp:
+		if m.nodesCursor > 0 {
+			m.nodesCursor--
+		}
+	case tea.KeyDown:
+		if m.nodesCursor < total-1 {
+			m.nodesCursor++
+		}
+	case tea.KeyEscape:
+		m.mode = modeRecordList
+		return m, nil
+	}
+
+	switch msg.String() {
+	case "a", "A":
+		if n := m.currentNode(); n != nil && n.Status == "pending" {
+			return m, nodeAction(m.configs.V3Net.Hub.Port, m.nodesNetwork,
+				m.configs.V3Net.KeystorePath, n.NodeID, "approve")
+		}
+	case "b", "B":
+		if n := m.currentNode(); n != nil {
+			action := "ban"
+			if n.Status == "banned" {
+				action = "unban"
+			}
+			return m, nodeAction(m.configs.V3Net.Hub.Port, m.nodesNetwork,
+				m.configs.V3Net.KeystorePath, n.NodeID, action)
+		}
+	case "d", "D":
+		if total > 0 {
+			m.nodesConfirmDelete = true
+		}
+	case "r", "R":
+		m.nodesLoading = true
+		return m, fetchHubNodes(m.configs.V3Net.Hub.Port, m.nodesNetwork, m.configs.V3Net.KeystorePath)
+	}
+	return m, nil
+}
+
+// currentNode returns the node under the cursor, or nil.
+func (m *Model) currentNode() *protocol.NodeInfo {
+	if m.nodesCursor < 0 || m.nodesCursor >= len(m.nodesList) {
+		return nil
+	}
+	return &m.nodesList[m.nodesCursor]
+}

--- a/internal/configeditor/update_v3net_nodes_test.go
+++ b/internal/configeditor/update_v3net_nodes_test.go
@@ -97,6 +97,39 @@ func TestNodesScreen_RemoveMsgDropsRow(t *testing.T) {
 	}
 }
 
+func TestNodesScreen_CursorMoveScrollsList(t *testing.T) {
+	m := newNodesModel()
+	nodes := make([]protocol.NodeInfo, 15)
+	for i := range nodes {
+		nodes[i] = protocol.NodeInfo{NodeID: string(rune('a' + i)), Status: "active"}
+	}
+	m.nodesList = nodes
+	m.nodesCursor = 0
+	m.nodesScroll = 0
+
+	for i := 0; i < 10; i++ {
+		result, _ := m.updateV3NetNodes(tea.KeyMsg{Type: tea.KeyDown})
+		m = result.(Model)
+	}
+	if m.nodesCursor != 10 {
+		t.Fatalf("cursor = %d, want 10", m.nodesCursor)
+	}
+	if m.nodesScroll == 0 {
+		t.Error("nodesScroll should follow the cursor past the visible window")
+	}
+
+	for i := 0; i < 10; i++ {
+		result, _ := m.updateV3NetNodes(tea.KeyMsg{Type: tea.KeyUp})
+		m = result.(Model)
+	}
+	if m.nodesCursor != 0 {
+		t.Fatalf("cursor = %d, want 0", m.nodesCursor)
+	}
+	if m.nodesScroll != 0 {
+		t.Errorf("nodesScroll should return to 0 when cursor moves back above it, got %d", m.nodesScroll)
+	}
+}
+
 func TestNodesScreen_EscReturnsToRecordList(t *testing.T) {
 	m := newNodesModel()
 	result, _ := m.updateV3NetNodes(tea.KeyMsg{Type: tea.KeyEscape})

--- a/internal/configeditor/update_v3net_nodes_test.go
+++ b/internal/configeditor/update_v3net_nodes_test.go
@@ -30,7 +30,7 @@ func TestNodesScreen_FetchMsgPopulatesList(t *testing.T) {
 	m := newNodesModel()
 	m.nodesList = nil
 	m.nodesLoading = true
-	result, _ := m.handleFetchNodesMsg(fetchNodesMsg{nodes: []protocol.NodeInfo{{NodeID: "cccc000000000003"}}})
+	result, _ := m.handleFetchNodesMsg(fetchNodesMsg{network: "testnet", nodes: []protocol.NodeInfo{{NodeID: "cccc000000000003"}}})
 	rm := result.(Model)
 	if rm.nodesLoading || len(rm.nodesList) != 1 || rm.nodesError != "" {
 		t.Errorf("model %+v", rm)
@@ -39,10 +39,52 @@ func TestNodesScreen_FetchMsgPopulatesList(t *testing.T) {
 
 func TestNodesScreen_FetchErrorUsesFriendlyText(t *testing.T) {
 	m := newNodesModel()
-	result, _ := m.handleFetchNodesMsg(fetchNodesMsg{err: errors.New("boom")})
+	result, _ := m.handleFetchNodesMsg(fetchNodesMsg{network: "testnet", err: errors.New("boom")})
 	rm := result.(Model)
 	if rm.nodesError == "" {
 		t.Error("error should be surfaced")
+	}
+}
+
+func TestNodesScreen_FetchErrorWithExistingListSurfacesMessage(t *testing.T) {
+	m := newNodesModel()
+	original := m.nodesList
+	result, _ := m.handleFetchNodesMsg(fetchNodesMsg{network: "testnet", err: errors.New("boom")})
+	rm := result.(Model)
+	if rm.message == "" {
+		t.Error("message row should surface the fetch error when the list is non-empty")
+	}
+	if len(rm.nodesList) != len(original) {
+		t.Errorf("nodesList should remain unchanged on fetch error, got %+v", rm.nodesList)
+	}
+}
+
+func TestNodesScreen_FetchMsgFromOtherNetworkIgnored(t *testing.T) {
+	m := newNodesModel()
+	original := m.nodesList
+	m.nodesLoading = true
+	result, cmd := m.handleFetchNodesMsg(fetchNodesMsg{network: "othernet", nodes: []protocol.NodeInfo{{NodeID: "zzzz000000000009"}}})
+	rm := result.(Model)
+	if cmd != nil {
+		t.Error("stale fetch message should not produce a command")
+	}
+	if !rm.nodesLoading {
+		t.Error("stale fetch message should not clear nodesLoading")
+	}
+	if len(rm.nodesList) != len(original) {
+		t.Errorf("stale fetch message should not replace nodesList, got %+v", rm.nodesList)
+	}
+}
+
+func TestNodesScreen_ActionMsgFromOtherNetworkIgnored(t *testing.T) {
+	m := newNodesModel()
+	result, _ := m.handleNodeActionMsg(nodeActionMsg{network: "othernet", nodeID: "aaaa000000000001", action: "approve", status: "active"})
+	rm := result.(Model)
+	if rm.nodesList[0].Status != "pending" {
+		t.Errorf("stale action message should not update status, got %q", rm.nodesList[0].Status)
+	}
+	if rm.message != "" {
+		t.Errorf("stale action message should not set message, got %q", rm.message)
 	}
 }
 
@@ -81,16 +123,28 @@ func TestNodesScreen_DeleteNeedsConfirm(t *testing.T) {
 
 func TestNodesScreen_ActionMsgUpdatesRowStatus(t *testing.T) {
 	m := newNodesModel()
-	result, _ := m.handleNodeActionMsg(nodeActionMsg{nodeID: "aaaa000000000001", action: "approve", status: "active"})
+	result, _ := m.handleNodeActionMsg(nodeActionMsg{network: "testnet", nodeID: "aaaa000000000001", action: "approve", status: "active"})
 	rm := result.(Model)
 	if rm.nodesList[0].Status != "active" {
 		t.Errorf("status = %q, want active", rm.nodesList[0].Status)
+	}
+	if rm.message != "Node approved" {
+		t.Errorf("message = %q, want %q", rm.message, "Node approved")
+	}
+}
+
+func TestNodesScreen_BanActionMsgUsesCorrectGrammar(t *testing.T) {
+	m := newNodesModel()
+	result, _ := m.handleNodeActionMsg(nodeActionMsg{network: "testnet", nodeID: "bbbb000000000002", action: "ban", status: "banned"})
+	rm := result.(Model)
+	if rm.message != "Node banned" {
+		t.Errorf("message = %q, want %q", rm.message, "Node banned")
 	}
 }
 
 func TestNodesScreen_RemoveMsgDropsRow(t *testing.T) {
 	m := newNodesModel()
-	result, _ := m.handleNodeActionMsg(nodeActionMsg{nodeID: "aaaa000000000001", action: "remove"})
+	result, _ := m.handleNodeActionMsg(nodeActionMsg{network: "testnet", nodeID: "aaaa000000000001", action: "remove"})
 	rm := result.(Model)
 	if len(rm.nodesList) != 1 || rm.nodesList[0].NodeID != "bbbb000000000002" {
 		t.Errorf("list %+v", rm.nodesList)

--- a/internal/configeditor/update_v3net_nodes_test.go
+++ b/internal/configeditor/update_v3net_nodes_test.go
@@ -1,0 +1,106 @@
+package configeditor
+
+import (
+	"errors"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+)
+
+func newNodesModel() Model {
+	return Model{
+		width: 80, height: 25,
+		mode:         modeV3NetNodes,
+		nodesNetwork: "testnet",
+		nodesList: []protocol.NodeInfo{
+			{NodeID: "aaaa000000000001", BBSName: "Alpha BBS", Status: "pending"},
+			{NodeID: "bbbb000000000002", BBSName: "Beta BBS", Status: "active"},
+		},
+		configs: &allConfigs{V3Net: config.V3NetConfig{
+			KeystorePath: "data/v3net.key",
+			Hub:          config.V3NetHubConfig{Port: 8765},
+		}},
+	}
+}
+
+func TestNodesScreen_FetchMsgPopulatesList(t *testing.T) {
+	m := newNodesModel()
+	m.nodesList = nil
+	m.nodesLoading = true
+	result, _ := m.handleFetchNodesMsg(fetchNodesMsg{nodes: []protocol.NodeInfo{{NodeID: "cccc000000000003"}}})
+	rm := result.(Model)
+	if rm.nodesLoading || len(rm.nodesList) != 1 || rm.nodesError != "" {
+		t.Errorf("model %+v", rm)
+	}
+}
+
+func TestNodesScreen_FetchErrorUsesFriendlyText(t *testing.T) {
+	m := newNodesModel()
+	result, _ := m.handleFetchNodesMsg(fetchNodesMsg{err: errors.New("boom")})
+	rm := result.(Model)
+	if rm.nodesError == "" {
+		t.Error("error should be surfaced")
+	}
+}
+
+func TestNodesScreen_ApproveKeyFiresActionForPendingNode(t *testing.T) {
+	m := newNodesModel()
+	m.nodesCursor = 0 // pending node
+	_, cmd := m.updateV3NetNodes(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if cmd == nil {
+		t.Fatal("A on a pending node should return a tea.Cmd")
+	}
+}
+
+func TestNodesScreen_ApproveKeyIgnoredForActiveNode(t *testing.T) {
+	m := newNodesModel()
+	m.nodesCursor = 1 // active node
+	_, cmd := m.updateV3NetNodes(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if cmd != nil {
+		t.Error("A on an active node should do nothing")
+	}
+}
+
+func TestNodesScreen_DeleteNeedsConfirm(t *testing.T) {
+	m := newNodesModel()
+	m.nodesCursor = 0
+	result, cmd := m.updateV3NetNodes(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	rm := result.(Model)
+	if cmd != nil || !rm.nodesConfirmDelete {
+		t.Fatal("D should arm confirmation, not fire the action")
+	}
+	result, cmd = rm.updateV3NetNodes(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	rm = result.(Model)
+	if cmd == nil || rm.nodesConfirmDelete {
+		t.Error("Y should fire remove and disarm confirmation")
+	}
+}
+
+func TestNodesScreen_ActionMsgUpdatesRowStatus(t *testing.T) {
+	m := newNodesModel()
+	result, _ := m.handleNodeActionMsg(nodeActionMsg{nodeID: "aaaa000000000001", action: "approve", status: "active"})
+	rm := result.(Model)
+	if rm.nodesList[0].Status != "active" {
+		t.Errorf("status = %q, want active", rm.nodesList[0].Status)
+	}
+}
+
+func TestNodesScreen_RemoveMsgDropsRow(t *testing.T) {
+	m := newNodesModel()
+	result, _ := m.handleNodeActionMsg(nodeActionMsg{nodeID: "aaaa000000000001", action: "remove"})
+	rm := result.(Model)
+	if len(rm.nodesList) != 1 || rm.nodesList[0].NodeID != "bbbb000000000002" {
+		t.Errorf("list %+v", rm.nodesList)
+	}
+}
+
+func TestNodesScreen_EscReturnsToRecordList(t *testing.T) {
+	m := newNodesModel()
+	result, _ := m.updateV3NetNodes(tea.KeyMsg{Type: tea.KeyEscape})
+	if result.(Model).mode != modeRecordList {
+		t.Error("ESC should return to the record list")
+	}
+}

--- a/internal/configeditor/update_v3net_nodes_test.go
+++ b/internal/configeditor/update_v3net_nodes_test.go
@@ -97,6 +97,33 @@ func TestNodesScreen_ApproveKeyFiresActionForPendingNode(t *testing.T) {
 	}
 }
 
+func TestNodesScreen_ActionKeysIgnoredWhileLoading(t *testing.T) {
+	m := newNodesModel()
+	m.nodesCursor = 0 // pending node
+	m.nodesLoading = true
+
+	if _, cmd := m.updateV3NetNodes(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}}); cmd != nil {
+		t.Error("A while loading should do nothing")
+	}
+	if _, cmd := m.updateV3NetNodes(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'b'}}); cmd != nil {
+		t.Error("B while loading should do nothing")
+	}
+	result, cmd := m.updateV3NetNodes(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if cmd != nil || result.(Model).nodesConfirmDelete {
+		t.Error("D while loading should do nothing")
+	}
+
+	// A pending confirm-delete's 'y' should also be ignored while loading.
+	m.nodesConfirmDelete = true
+	result, cmd = m.updateV3NetNodes(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd != nil {
+		t.Error("confirm Y while loading should do nothing")
+	}
+	if !result.(Model).nodesConfirmDelete {
+		t.Error("confirm Y while loading should leave confirmation armed")
+	}
+}
+
 func TestNodesScreen_ApproveKeyIgnoredForActiveNode(t *testing.T) {
 	m := newNodesModel()
 	m.nodesCursor = 1 // active node
@@ -148,6 +175,35 @@ func TestNodesScreen_RemoveMsgDropsRow(t *testing.T) {
 	rm := result.(Model)
 	if len(rm.nodesList) != 1 || rm.nodesList[0].NodeID != "bbbb000000000002" {
 		t.Errorf("list %+v", rm.nodesList)
+	}
+}
+
+func TestNodesScreen_RemoveMsgClampsScrollToShorterList(t *testing.T) {
+	m := newNodesModel()
+	nodes := make([]protocol.NodeInfo, 11)
+	for i := range nodes {
+		nodes[i] = protocol.NodeInfo{NodeID: string(rune('a' + i)), Status: "active"}
+	}
+	m.nodesList = nodes
+	// Cursor/scroll pinned at the bottom of an 11-row list with a
+	// nodesListVisible(10)-row window: scroll = 1 shows rows [1..10].
+	m.nodesCursor = 10
+	m.nodesScroll = 1
+
+	result, _ := m.handleNodeActionMsg(nodeActionMsg{network: "testnet", nodeID: nodes[10].NodeID, action: "remove"})
+	rm := result.(Model)
+
+	if len(rm.nodesList) != 10 {
+		t.Fatalf("nodesList len = %d, want 10", len(rm.nodesList))
+	}
+	// With only 10 rows left and a 10-row window, scroll must be 0 or the
+	// window renders past the end of the list (blank rows).
+	maxScroll := len(rm.nodesList) - nodesListVisible
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if rm.nodesScroll > maxScroll {
+		t.Errorf("nodesScroll = %d, want <= %d after removal shrank the list", rm.nodesScroll, maxScroll)
 	}
 }
 

--- a/internal/configeditor/v3net_nodes_cmds.go
+++ b/internal/configeditor/v3net_nodes_cmds.go
@@ -1,0 +1,124 @@
+package configeditor
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/keystore"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+)
+
+// fetchNodesMsg is the result of listing a hosted network's nodes.
+type fetchNodesMsg struct {
+	nodes []protocol.NodeInfo
+	err   error
+}
+
+// nodeActionMsg is the result of an approve/ban/unban/remove call.
+type nodeActionMsg struct {
+	nodeID string
+	action string
+	status string // new status returned by the hub ("" for remove)
+	err    error
+}
+
+// loadAdminKeystore loads the BBS keystore for signing admin requests.
+// A missing file is an error — the TUI must never mint a new identity.
+func loadAdminKeystore(path string) (*keystore.Keystore, error) {
+	if _, err := os.Stat(path); err != nil {
+		return nil, fmt.Errorf("keystore not found at %s - has the BBS run once?", path)
+	}
+	ks, _, err := keystore.Load(path)
+	if err != nil {
+		return nil, fmt.Errorf("load keystore: %w", err)
+	}
+	return ks, nil
+}
+
+// signedHubRequest builds a signed request to the local hub.
+func signedHubRequest(ks *keystore.Keystore, method string, hubPort int, path string) (*http.Request, error) {
+	emptyHash := sha256.Sum256(nil)
+	bodySHA := hex.EncodeToString(emptyHash[:])
+	dateStr := time.Now().UTC().Format(http.TimeFormat)
+
+	sig, err := ks.Sign(method, path, dateStr, bodySHA)
+	if err != nil {
+		return nil, fmt.Errorf("sign request: %w", err)
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d%s", hubPort, path)
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Date", dateStr)
+	req.Header.Set("X-V3Net-Node-ID", ks.NodeID())
+	req.Header.Set("X-V3Net-Signature", sig)
+	return req, nil
+}
+
+// fetchHubNodes lists node registrations for a hosted network.
+func fetchHubNodes(hubPort int, network, keystorePath string) tea.Cmd {
+	return func() tea.Msg {
+		ks, err := loadAdminKeystore(keystorePath)
+		if err != nil {
+			return fetchNodesMsg{err: err}
+		}
+		req, err := signedHubRequest(ks, "GET", hubPort, "/v3net/v1/"+network+"/nodes")
+		if err != nil {
+			return fetchNodesMsg{err: err}
+		}
+		client := &http.Client{Timeout: 10 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			return fetchNodesMsg{err: err}
+		}
+		defer func() { _ = resp.Body.Close() }() // read-only
+		if resp.StatusCode != http.StatusOK {
+			return fetchNodesMsg{err: fmt.Errorf("hub returned status %d", resp.StatusCode)}
+		}
+		var nodes []protocol.NodeInfo
+		if err := json.NewDecoder(resp.Body).Decode(&nodes); err != nil {
+			return fetchNodesMsg{err: fmt.Errorf("decode nodes: %w", err)}
+		}
+		return fetchNodesMsg{nodes: nodes}
+	}
+}
+
+// nodeAction performs approve/ban/unban/remove on a node registration.
+func nodeAction(hubPort int, network, keystorePath, nodeID, action string) tea.Cmd {
+	return func() tea.Msg {
+		ks, err := loadAdminKeystore(keystorePath)
+		if err != nil {
+			return nodeActionMsg{nodeID: nodeID, action: action, err: err}
+		}
+		path := "/v3net/v1/" + network + "/nodes/" + nodeID + "/" + action
+		req, err := signedHubRequest(ks, "POST", hubPort, path)
+		if err != nil {
+			return nodeActionMsg{nodeID: nodeID, action: action, err: err}
+		}
+		client := &http.Client{Timeout: 10 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nodeActionMsg{nodeID: nodeID, action: action, err: err}
+		}
+		defer func() { _ = resp.Body.Close() }() // read-only
+		if resp.StatusCode != http.StatusOK {
+			return nodeActionMsg{nodeID: nodeID, action: action,
+				err: fmt.Errorf("hub returned status %d", resp.StatusCode)}
+		}
+		var out struct {
+			Status string `json:"status"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			return nodeActionMsg{nodeID: nodeID, action: action, err: fmt.Errorf("decode response: %w", err)}
+		}
+		return nodeActionMsg{nodeID: nodeID, action: action, status: out.Status}
+	}
+}

--- a/internal/configeditor/v3net_nodes_cmds.go
+++ b/internal/configeditor/v3net_nodes_cmds.go
@@ -17,16 +17,18 @@ import (
 
 // fetchNodesMsg is the result of listing a hosted network's nodes.
 type fetchNodesMsg struct {
-	nodes []protocol.NodeInfo
-	err   error
+	network string // network this fetch was issued for; guards stale responses
+	nodes   []protocol.NodeInfo
+	err     error
 }
 
 // nodeActionMsg is the result of an approve/ban/unban/remove call.
 type nodeActionMsg struct {
-	nodeID string
-	action string
-	status string // new status returned by the hub ("" for remove)
-	err    error
+	network string // network this action was issued for; guards stale responses
+	nodeID  string
+	action  string
+	status  string // new status returned by the hub ("" for remove)
+	err     error
 }
 
 // loadAdminKeystore loads the BBS keystore for signing admin requests.
@@ -68,26 +70,26 @@ func fetchHubNodes(hubPort int, network, keystorePath string) tea.Cmd {
 	return func() tea.Msg {
 		ks, err := loadAdminKeystore(keystorePath)
 		if err != nil {
-			return fetchNodesMsg{err: err}
+			return fetchNodesMsg{network: network, err: err}
 		}
 		req, err := signedHubRequest(ks, "GET", hubPort, "/v3net/v1/"+network+"/nodes")
 		if err != nil {
-			return fetchNodesMsg{err: err}
+			return fetchNodesMsg{network: network, err: err}
 		}
 		client := &http.Client{Timeout: 10 * time.Second}
 		resp, err := client.Do(req)
 		if err != nil {
-			return fetchNodesMsg{err: err}
+			return fetchNodesMsg{network: network, err: err}
 		}
 		defer func() { _ = resp.Body.Close() }() // read-only
 		if resp.StatusCode != http.StatusOK {
-			return fetchNodesMsg{err: fmt.Errorf("hub returned status %d", resp.StatusCode)}
+			return fetchNodesMsg{network: network, err: fmt.Errorf("hub returned status %d", resp.StatusCode)}
 		}
 		var nodes []protocol.NodeInfo
 		if err := json.NewDecoder(resp.Body).Decode(&nodes); err != nil {
-			return fetchNodesMsg{err: fmt.Errorf("decode nodes: %w", err)}
+			return fetchNodesMsg{network: network, err: fmt.Errorf("decode nodes: %w", err)}
 		}
-		return fetchNodesMsg{nodes: nodes}
+		return fetchNodesMsg{network: network, nodes: nodes}
 	}
 }
 
@@ -96,29 +98,29 @@ func nodeAction(hubPort int, network, keystorePath, nodeID, action string) tea.C
 	return func() tea.Msg {
 		ks, err := loadAdminKeystore(keystorePath)
 		if err != nil {
-			return nodeActionMsg{nodeID: nodeID, action: action, err: err}
+			return nodeActionMsg{network: network, nodeID: nodeID, action: action, err: err}
 		}
 		path := "/v3net/v1/" + network + "/nodes/" + nodeID + "/" + action
 		req, err := signedHubRequest(ks, "POST", hubPort, path)
 		if err != nil {
-			return nodeActionMsg{nodeID: nodeID, action: action, err: err}
+			return nodeActionMsg{network: network, nodeID: nodeID, action: action, err: err}
 		}
 		client := &http.Client{Timeout: 10 * time.Second}
 		resp, err := client.Do(req)
 		if err != nil {
-			return nodeActionMsg{nodeID: nodeID, action: action, err: err}
+			return nodeActionMsg{network: network, nodeID: nodeID, action: action, err: err}
 		}
 		defer func() { _ = resp.Body.Close() }() // read-only
 		if resp.StatusCode != http.StatusOK {
-			return nodeActionMsg{nodeID: nodeID, action: action,
+			return nodeActionMsg{network: network, nodeID: nodeID, action: action,
 				err: fmt.Errorf("hub returned status %d", resp.StatusCode)}
 		}
 		var out struct {
 			Status string `json:"status"`
 		}
 		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-			return nodeActionMsg{nodeID: nodeID, action: action, err: fmt.Errorf("decode response: %w", err)}
+			return nodeActionMsg{network: network, nodeID: nodeID, action: action, err: fmt.Errorf("decode response: %w", err)}
 		}
-		return nodeActionMsg{nodeID: nodeID, action: action, status: out.Status}
+		return nodeActionMsg{network: network, nodeID: nodeID, action: action, status: out.Status}
 	}
 }

--- a/internal/configeditor/v3net_nodes_cmds_test.go
+++ b/internal/configeditor/v3net_nodes_cmds_test.go
@@ -57,6 +57,9 @@ func TestFetchHubNodes_ReturnsNodes(t *testing.T) {
 	if fm.err != nil || len(fm.nodes) != 1 || fm.nodes[0].NodeID != "aaaa000000000001" {
 		t.Errorf("msg %+v", fm)
 	}
+	if fm.network != "testnet" {
+		t.Errorf("network = %q, want testnet", fm.network)
+	}
 }
 
 func TestFetchHubNodes_MissingKeystoreErrorsWithoutCreatingKey(t *testing.T) {
@@ -83,6 +86,9 @@ func TestNodeAction_ReturnsStatus(t *testing.T) {
 	}
 	if am.err != nil || am.status != "active" || am.nodeID != "aaaa000000000001" || am.action != "approve" {
 		t.Errorf("msg %+v", am)
+	}
+	if am.network != "testnet" {
+		t.Errorf("network = %q, want testnet", am.network)
 	}
 }
 

--- a/internal/configeditor/v3net_nodes_cmds_test.go
+++ b/internal/configeditor/v3net_nodes_cmds_test.go
@@ -1,0 +1,95 @@
+package configeditor
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/keystore"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+)
+
+// newNodesTestServer returns a server that requires V3Net auth headers and
+// serves nodesJSON for GET /nodes, actionJSON for POST /{action}.
+func newNodesTestServer(t *testing.T, nodesJSON, actionJSON string) (*httptest.Server, int) {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-V3Net-Node-ID") == "" || r.Header.Get("X-V3Net-Signature") == "" || r.Header.Get("Date") == "" {
+			http.Error(w, `{"error":"missing auth headers"}`, http.StatusUnauthorized)
+			return
+		}
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(nodesJSON))
+			return
+		}
+		_, _ = w.Write([]byte(actionJSON))
+	}))
+	t.Cleanup(ts.Close)
+	u, _ := url.Parse(ts.URL)
+	port, _ := strconv.Atoi(u.Port())
+	return ts, port
+}
+
+func testKeystorePath(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "test.key")
+	if _, _, err := keystore.Load(p); err != nil {
+		t.Fatalf("create keystore: %v", err)
+	}
+	return p
+}
+
+func TestFetchHubNodes_ReturnsNodes(t *testing.T) {
+	nodes := []protocol.NodeInfo{{NodeID: "aaaa000000000001", BBSName: "Test BBS", Status: "pending", CreatedAt: "2026-08-03 12:00:00"}}
+	data, _ := json.Marshal(nodes)
+	_, port := newNodesTestServer(t, string(data), "{}")
+
+	msg := fetchHubNodes(port, "testnet", testKeystorePath(t))()
+	fm, ok := msg.(fetchNodesMsg)
+	if !ok {
+		t.Fatalf("got %T, want fetchNodesMsg", msg)
+	}
+	if fm.err != nil || len(fm.nodes) != 1 || fm.nodes[0].NodeID != "aaaa000000000001" {
+		t.Errorf("msg %+v", fm)
+	}
+}
+
+func TestFetchHubNodes_MissingKeystoreErrorsWithoutCreatingKey(t *testing.T) {
+	_, port := newNodesTestServer(t, "[]", "{}")
+	missing := filepath.Join(t.TempDir(), "absent.key")
+
+	msg := fetchHubNodes(port, "testnet", missing)()
+	fm := msg.(fetchNodesMsg)
+	if fm.err == nil {
+		t.Fatal("missing keystore should error")
+	}
+	if _, statErr := os.Stat(missing); statErr == nil {
+		t.Error("fetchHubNodes must not create a keystore file")
+	}
+}
+
+func TestNodeAction_ReturnsStatus(t *testing.T) {
+	_, port := newNodesTestServer(t, "[]", `{"ok":true,"status":"active"}`)
+
+	msg := nodeAction(port, "testnet", testKeystorePath(t), "aaaa000000000001", "approve")()
+	am, ok := msg.(nodeActionMsg)
+	if !ok {
+		t.Fatalf("got %T, want nodeActionMsg", msg)
+	}
+	if am.err != nil || am.status != "active" || am.nodeID != "aaaa000000000001" || am.action != "approve" {
+		t.Errorf("msg %+v", am)
+	}
+}
+
+func TestNodeAction_HubDownReturnsError(t *testing.T) {
+	msg := nodeAction(1, "testnet", testKeystorePath(t), "aaaa000000000001", "approve")()
+	am := msg.(nodeActionMsg)
+	if am.err == nil {
+		t.Fatal("port 1 should refuse connections")
+	}
+}

--- a/internal/configeditor/view.go
+++ b/internal/configeditor/view.go
@@ -74,6 +74,8 @@ func (m Model) View() string {
 			"Rename JAM base path on disk?")
 	case modeV3NetAreaBrowser:
 		return m.viewV3NetAreaBrowser()
+	case modeV3NetNodes:
+		return m.viewV3NetNodes()
 	case modeRegistryBrowser:
 		return m.viewRegistryBrowser()
 	case modeFTNWizardForm, modeFTNWizardField, modeFTNNodelistLookup:

--- a/internal/configeditor/view_v3net_nodes.go
+++ b/internal/configeditor/view_v3net_nodes.go
@@ -34,7 +34,7 @@ func (m Model) viewV3NetNodes() string {
 				joined = joined[:10] // date only
 			}
 			return fmt.Sprintf("   %-16s %-20s %-8s %s",
-				n.NodeID, padRight(n.BBSName, 20), padRight(n.Status, 8), joined)
+				n.NodeID, padRight(sanitizeRegistryField(n.BBSName), 20), padRight(n.Status, 8), joined)
 		})
 	lb.bottomBorder()
 	lb.bgRows(lb.bottomPad)

--- a/internal/configeditor/view_v3net_nodes.go
+++ b/internal/configeditor/view_v3net_nodes.go
@@ -1,0 +1,48 @@
+package configeditor
+
+import "fmt"
+
+// nodesListVisible is the number of rows shown in the node management list.
+const nodesListVisible = 10
+
+// viewV3NetNodes renders the node management screen for a hosted network.
+func (m Model) viewV3NetNodes() string {
+	boxW := 70
+	listVisible := nodesListVisible
+	total := len(m.nodesList)
+
+	lb := m.newListBox(boxW, listVisible+9)
+	lb.topBorder()
+	lb.title(fmt.Sprintf("Node Management — %s", m.nodesNetwork))
+
+	if m.nodesLoading {
+		return lb.statusScreen(menuItemStyle.Render(centerText("Fetching nodes...", boxW)),
+			listVisible, 3, "ESC - Cancel")
+	}
+	if m.nodesError != "" && total == 0 {
+		return lb.statusScreen(lb.errorRow(m.nodesError),
+			listVisible, 3, "R - Retry  |  ESC - Back")
+	}
+
+	lb.colHeader(fmt.Sprintf("   %-16s %-20s %-8s %s", "Node ID", "BBS Name", "Status", "Joined"))
+	lb.separator()
+	lb.list(listVisible, m.nodesScroll, m.nodesCursor, total,
+		func(i int) string {
+			n := m.nodesList[i]
+			joined := n.CreatedAt
+			if len(joined) > 10 {
+				joined = joined[:10] // date only
+			}
+			return fmt.Sprintf("   %-16s %-20s %-8s %s",
+				n.NodeID, padRight(n.BBSName, 20), padRight(n.Status, 8), joined)
+		})
+	lb.bottomBorder()
+	lb.bgRows(lb.bottomPad)
+	if m.nodesConfirmDelete {
+		lb.messageRow("Remove this node registration? Y/N")
+	} else {
+		lb.messageRow(m.message)
+	}
+	lb.bgRows(1)
+	return lb.finish("A - Approve  |  B - Ban/Unban  |  D - Delete  |  R - Refresh  |  ESC - Back")
+}

--- a/internal/configeditor/view_v3net_nodes_test.go
+++ b/internal/configeditor/view_v3net_nodes_test.go
@@ -1,0 +1,31 @@
+package configeditor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+)
+
+// TestViewV3NetNodes_SanitizesBBSNameControlChars ensures a BBSName from a
+// remote subscribe request (attacker-controlled) cannot inject ANSI/OSC
+// escape sequences into the sysop's terminal.
+func TestViewV3NetNodes_SanitizesBBSNameControlChars(t *testing.T) {
+	m := Model{
+		width: 80, height: 25,
+		mode:         modeV3NetNodes,
+		nodesNetwork: "testnet",
+		nodesList: []protocol.NodeInfo{
+			{NodeID: "aaaa000000000001", BBSName: "\x1b[2J evil", Status: "pending", CreatedAt: "2026-01-01"},
+		},
+		configs: &allConfigs{V3Net: config.V3NetConfig{
+			KeystorePath: "data/v3net.key",
+			Hub:          config.V3NetHubConfig{Port: 8765},
+		}},
+	}
+	out := m.viewV3NetNodes()
+	if strings.ContainsRune(out, 0x1b) {
+		t.Errorf("rendered view contains raw ESC byte from attacker-controlled BBSName: %q", out)
+	}
+}

--- a/internal/v3net/hub/hub_nodes_test.go
+++ b/internal/v3net/hub/hub_nodes_test.go
@@ -1,0 +1,159 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/keystore"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+)
+
+// setupNodesTest returns a hub with its operator self-registered active
+// and one pending leaf registered, plus the operator and leaf keystores.
+func setupNodesTest(t *testing.T) (*httptest.Server, *keystore.Keystore, *keystore.Keystore) {
+	t.Helper()
+	h, hubKS := setupTestHub(t)
+	// setupTestHub uses AutoApprove: true; flip the store entry to pending
+	// after registration to exercise approve.
+	if _, err := h.subscribers.Add(Subscriber{
+		NodeID: hubKS.NodeID(), Network: "testnet",
+		PubKeyB64: hubKS.PubKeyBase64(), BBSName: "hub", Status: "active",
+	}); err != nil {
+		t.Fatalf("self-register: %v", err)
+	}
+
+	leafKS, _, err := keystore.Load(filepath.Join(t.TempDir(), "leaf.key"))
+	if err != nil {
+		t.Fatalf("leaf keystore: %v", err)
+	}
+	ts := httptest.NewServer(h.newMux())
+	t.Cleanup(ts.Close)
+	registerLeaf(t, ts, leafKS)
+	if err := h.subscribers.SetStatus(leafKS.NodeID(), "testnet", "pending"); err != nil {
+		t.Fatalf("set pending: %v", err)
+	}
+	return ts, hubKS, leafKS
+}
+
+func doSigned(t *testing.T, ks *keystore.Keystore, method, url string) *http.Response {
+	t.Helper()
+	resp, err := http.DefaultClient.Do(signedRequest(t, ks, method, url, ""))
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	return resp
+}
+
+func TestNodesList_OperatorSeesRegistrations(t *testing.T) {
+	ts, hubKS, leafKS := setupNodesTest(t)
+	resp := doSigned(t, hubKS, "GET", ts.URL+"/v3net/v1/testnet/nodes")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d, want 200", resp.StatusCode)
+	}
+	var nodes []protocol.NodeInfo
+	if err := json.NewDecoder(resp.Body).Decode(&nodes); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(nodes) != 2 {
+		t.Fatalf("got %d nodes, want 2 (hub + leaf)", len(nodes))
+	}
+	var leaf *protocol.NodeInfo
+	for i := range nodes {
+		if nodes[i].NodeID == leafKS.NodeID() {
+			leaf = &nodes[i]
+		}
+	}
+	if leaf == nil || leaf.Status != "pending" || leaf.BBSName != "Test BBS" || leaf.CreatedAt == "" {
+		t.Errorf("leaf entry wrong: %+v", leaf)
+	}
+}
+
+func TestNodesList_NonOperatorForbidden(t *testing.T) {
+	ts, _, leafKS := setupNodesTest(t)
+	// Leaf must be active to pass auth at all; the operator check is what
+	// must reject it.
+	resp := doSigned(t, leafKS, "POST", ts.URL+"/v3net/v1/testnet/nodes/"+leafKS.NodeID()+"/approve")
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("pending leaf: status %d, want 401 (fails auth)", resp.StatusCode)
+	}
+}
+
+func TestNodesApprove_ActivatesPendingLeaf(t *testing.T) {
+	ts, hubKS, leafKS := setupNodesTest(t)
+	resp := doSigned(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/nodes/"+leafKS.NodeID()+"/approve")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d, want 200", resp.StatusCode)
+	}
+	var out struct {
+		OK     bool   `json:"ok"`
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil || !out.OK || out.Status != "active" {
+		t.Fatalf("body %+v err %v, want ok/active", out, err)
+	}
+	// The approved leaf can now hit an authed endpoint.
+	resp2 := doSigned(t, leafKS, "GET", ts.URL+"/v3net/v1/testnet/messages?since=0&limit=10")
+	if resp2.StatusCode != http.StatusOK {
+		t.Errorf("approved leaf messages: status %d, want 200", resp2.StatusCode)
+	}
+}
+
+func TestNodesBanUnban_TogglesAuth(t *testing.T) {
+	ts, hubKS, leafKS := setupNodesTest(t)
+	doSigned(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/nodes/"+leafKS.NodeID()+"/approve")
+
+	resp := doSigned(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/nodes/"+leafKS.NodeID()+"/ban")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("ban status %d", resp.StatusCode)
+	}
+	if r := doSigned(t, leafKS, "GET", ts.URL+"/v3net/v1/testnet/messages?since=0&limit=10"); r.StatusCode != http.StatusUnauthorized {
+		t.Errorf("banned leaf: status %d, want 401", r.StatusCode)
+	}
+
+	resp = doSigned(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/nodes/"+leafKS.NodeID()+"/unban")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unban status %d", resp.StatusCode)
+	}
+	if r := doSigned(t, leafKS, "GET", ts.URL+"/v3net/v1/testnet/messages?since=0&limit=10"); r.StatusCode != http.StatusOK {
+		t.Errorf("unbanned leaf: status %d, want 200 (unban goes straight to active)", r.StatusCode)
+	}
+}
+
+func TestNodesRemove_DeletesRegistration(t *testing.T) {
+	ts, hubKS, leafKS := setupNodesTest(t)
+	resp := doSigned(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/nodes/"+leafKS.NodeID()+"/remove")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("remove status %d", resp.StatusCode)
+	}
+	// Second remove: node no longer exists.
+	resp = doSigned(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/nodes/"+leafKS.NodeID()+"/remove")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("re-remove status %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestNodesSelfGuard_OperatorCannotActOnOwnNode(t *testing.T) {
+	ts, hubKS, _ := setupNodesTest(t)
+	for _, action := range []string{"approve", "ban", "unban", "remove"} {
+		resp := doSigned(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/nodes/"+hubKS.NodeID()+"/"+action)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("%s on self: status %d, want 400", action, resp.StatusCode)
+		}
+	}
+}
+
+func TestNodes_UnknownNetworkAndNode404(t *testing.T) {
+	ts, hubKS, _ := setupNodesTest(t)
+	// Unknown network fails auth lookup first (401) — acceptable; the
+	// contract we assert is non-200.
+	if r := doSigned(t, hubKS, "GET", ts.URL+"/v3net/v1/nosuchnet/nodes"); r.StatusCode == http.StatusOK {
+		t.Error("unknown network should not return 200")
+	}
+	if r := doSigned(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/nodes/ffffffffffffffff/approve"); r.StatusCode != http.StatusNotFound {
+		t.Errorf("unknown node: status %d, want 404", r.StatusCode)
+	}
+}

--- a/internal/v3net/hub/hub_nodes_test.go
+++ b/internal/v3net/hub/hub_nodes_test.go
@@ -123,6 +123,54 @@ func TestNodesBanUnban_TogglesAuth(t *testing.T) {
 	}
 }
 
+func TestNodesApprove_OnActiveNodeConflicts(t *testing.T) {
+	ts, hubKS, leafKS := setupNodesTest(t)
+	// Activate the leaf first.
+	resp := doSigned(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/nodes/"+leafKS.NodeID()+"/approve")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("first approve: status %d, want 200", resp.StatusCode)
+	}
+	// Approving an already-active node should be rejected.
+	resp = doSigned(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/nodes/"+leafKS.NodeID()+"/approve")
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("approve on active node: status %d, want 409", resp.StatusCode)
+	}
+	var out struct {
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil || out.Error != "node is not pending" {
+		t.Errorf("body %+v err %v, want error=node is not pending", out, err)
+	}
+}
+
+func TestNodesUnban_OnPendingNodeConflicts(t *testing.T) {
+	ts, hubKS, leafKS := setupNodesTest(t)
+	// leafKS is pending (not banned); unban should be rejected.
+	resp := doSigned(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/nodes/"+leafKS.NodeID()+"/unban")
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("unban on pending node: status %d, want 409", resp.StatusCode)
+	}
+	var out struct {
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil || out.Error != "node is not banned" {
+		t.Errorf("body %+v err %v, want error=node is not banned", out, err)
+	}
+}
+
+func TestNodesList_NonOperatorForbiddenForActiveLeaf(t *testing.T) {
+	ts, hubKS, leafKS := setupNodesTest(t)
+	resp := doSigned(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/nodes/"+leafKS.NodeID()+"/approve")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("approve leaf: status %d, want 200", resp.StatusCode)
+	}
+	// Now the leaf is active and passes auth; requireOperator must reject it.
+	resp = doSigned(t, leafKS, "GET", ts.URL+"/v3net/v1/testnet/nodes")
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("active non-operator leaf: status %d, want 403", resp.StatusCode)
+	}
+}
+
 func TestNodesRemove_DeletesRegistration(t *testing.T) {
 	ts, hubKS, leafKS := setupNodesTest(t)
 	resp := doSigned(t, hubKS, "POST", ts.URL+"/v3net/v1/testnet/nodes/"+leafKS.NodeID()+"/remove")

--- a/internal/v3net/hub/nodes_handler.go
+++ b/internal/v3net/hub/nodes_handler.go
@@ -1,0 +1,105 @@
+package hub
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+)
+
+// requireOperator returns false (and writes the error) unless the
+// authenticated node is the hub operator (the hub's own keystore ID).
+func (h *Hub) requireOperator(w http.ResponseWriter, r *http.Request) bool {
+	if r.Header.Get(headerNodeID) != h.cfg.Keystore.NodeID() {
+		http.Error(w, `{"error":"hub operator only"}`, http.StatusForbidden)
+		return false
+	}
+	return true
+}
+
+// handleListNodes serves GET /v3net/v1/{network}/nodes (operator only).
+func (h *Hub) handleListNodes(w http.ResponseWriter, r *http.Request) {
+	if !h.requireOperator(w, r) {
+		return
+	}
+	network := extractNetwork(r.URL.Path)
+	if h.findNetwork(network) == nil {
+		http.Error(w, `{"error":"network not found"}`, http.StatusNotFound)
+		return
+	}
+	subs, err := h.subscribers.List(network)
+	if err != nil {
+		slog.Error("list nodes", "error", err)
+		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		return
+	}
+	nodes := make([]protocol.NodeInfo, 0, len(subs))
+	for _, s := range subs {
+		nodes = append(nodes, protocol.NodeInfo{
+			NodeID: s.NodeID, BBSName: s.BBSName, BBSHost: s.BBSHost,
+			Status: s.Status, CreatedAt: s.CreatedAt,
+		})
+	}
+	writeJSON(w, http.StatusOK, nodes)
+}
+
+// handleNodeAction serves POST /v3net/v1/{network}/nodes/{id}/{action}
+// for approve, ban, unban, and remove (operator only).
+func (h *Hub) handleNodeAction(w http.ResponseWriter, r *http.Request, nodeID, action string) {
+	if !h.requireOperator(w, r) {
+		return
+	}
+	network := extractNetwork(r.URL.Path)
+	if h.findNetwork(network) == nil {
+		http.Error(w, `{"error":"network not found"}`, http.StatusNotFound)
+		return
+	}
+	if nodeID == h.cfg.Keystore.NodeID() {
+		http.Error(w, `{"error":"cannot modify the hub's own node"}`, http.StatusBadRequest)
+		return
+	}
+
+	var err error
+	status := ""
+	switch action {
+	case "approve", "unban":
+		status = "active"
+		err = h.subscribers.SetStatus(nodeID, network, status)
+	case "ban":
+		status = "banned"
+		err = h.subscribers.SetStatus(nodeID, network, status)
+	case "remove":
+		err = h.subscribers.Delete(nodeID, network)
+	default:
+		http.NotFound(w, r)
+		return
+	}
+	if errors.Is(err, ErrUnknownNode) {
+		http.Error(w, `{"error":"node not found"}`, http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		slog.Error("node action", "action", action, "node", nodeID, "error", err)
+		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		return
+	}
+	slog.Info("v3net hub: node status changed", "network", network, "node", nodeID, "action", action)
+	if status == "" {
+		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "status": status})
+}
+
+// matchNodeActionPath matches /v3net/v1/{network}/nodes/{id}/{action} and
+// returns the node ID and action.
+func matchNodeActionPath(path string) (nodeID, action string, ok bool) {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	// v3net/v1/{network}/nodes/{id}/{action}
+	if len(parts) != 6 || parts[3] != "nodes" {
+		return "", "", false
+	}
+	return parts[4], parts[5], true
+}

--- a/internal/v3net/hub/nodes_handler.go
+++ b/internal/v3net/hub/nodes_handler.go
@@ -64,7 +64,18 @@ func (h *Hub) handleNodeAction(w http.ResponseWriter, r *http.Request, nodeID, a
 	var err error
 	status := ""
 	switch action {
-	case "approve", "unban":
+	case "approve":
+		if sub := h.subscribers.Get(nodeID, network); sub != nil && sub.Status != "pending" {
+			http.Error(w, `{"error":"node is not pending"}`, http.StatusConflict)
+			return
+		}
+		status = "active"
+		err = h.subscribers.SetStatus(nodeID, network, status)
+	case "unban":
+		if sub := h.subscribers.Get(nodeID, network); sub != nil && sub.Status != "banned" {
+			http.Error(w, `{"error":"node is not banned"}`, http.StatusConflict)
+			return
+		}
 		status = "active"
 		err = h.subscribers.SetStatus(nodeID, network, status)
 	case "ban":

--- a/internal/v3net/hub/server.go
+++ b/internal/v3net/hub/server.go
@@ -101,6 +101,13 @@ func (h *Hub) newMux() http.Handler {
 			case strings.HasSuffix(path, "/coordinator/accept") && r.Method == http.MethodPost:
 				h.handleCoordAccept(w, r)
 
+			// Node management (hub operator only).
+			case strings.HasSuffix(path, "/nodes") && r.Method == http.MethodGet:
+				h.handleListNodes(w, r)
+			case r.Method == http.MethodPost && isNodeAction(path):
+				id, action, _ := matchNodeActionPath(path)
+				h.handleNodeAction(w, r, id, action)
+
 			default:
 				http.NotFound(w, r)
 			}
@@ -129,4 +136,10 @@ func matchProposalActionPath(path, action string) bool {
 		return false
 	}
 	return parts[3] == "areas" && parts[4] == "proposals" && parts[6] == action
+}
+
+// isNodeAction reports whether the path is a nodes admin action route.
+func isNodeAction(path string) bool {
+	_, _, ok := matchNodeActionPath(path)
+	return ok
 }

--- a/internal/v3net/hub/subscribers.go
+++ b/internal/v3net/hub/subscribers.go
@@ -106,11 +106,19 @@ func (ss *SubscriberStore) Add(s Subscriber) (string, error) {
 	return s.Status, nil
 }
 
-// Get returns a subscriber by node ID and network, or nil if not found.
+// Get returns a copy of the cached subscriber by node ID and network, or nil
+// if not found. A copy is returned (rather than the cache pointer) so that
+// SetStatus mutating the cached entry under the write lock can never race
+// with a caller reading the returned value after this call returns.
 func (ss *SubscriberStore) Get(nodeID, network string) *Subscriber {
 	ss.mu.RLock()
 	defer ss.mu.RUnlock()
-	return ss.cache[nodeID+":"+network]
+	s, ok := ss.cache[nodeID+":"+network]
+	if !ok {
+		return nil
+	}
+	cp := *s
+	return &cp
 }
 
 // GetPubKey returns the decoded ed25519 public key for an active subscriber,

--- a/internal/v3net/hub/subscribers.go
+++ b/internal/v3net/hub/subscribers.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ed25519"
 	"database/sql"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"sync"
 )
@@ -21,6 +22,10 @@ CREATE TABLE IF NOT EXISTS subscribers (
 );
 `
 
+// ErrUnknownNode is returned by SetStatus and Delete when no subscriber
+// row matches the node/network pair.
+var ErrUnknownNode = errors.New("hub: unknown node")
+
 // Subscriber represents a registered leaf node.
 type Subscriber struct {
 	NodeID    string
@@ -29,6 +34,7 @@ type Subscriber struct {
 	BBSName   string
 	BBSHost   string
 	Status    string // "active", "pending", "banned"
+	CreatedAt string // populated by List only
 }
 
 // SubscriberStore manages leaf node subscriptions with SQLite persistence
@@ -57,6 +63,7 @@ func NewSubscriberStore(db *sql.DB) (*SubscriberStore, error) {
 }
 
 func (ss *SubscriberStore) loadCache() error {
+	ss.cache = make(map[string]*Subscriber)
 	rows, err := ss.db.Query("SELECT node_id, network, pubkey_b64, COALESCE(bbs_name, ''), COALESCE(bbs_host, ''), status FROM subscribers")
 	if err != nil {
 		return fmt.Errorf("hub: load subscribers: %w", err)
@@ -132,4 +139,72 @@ func (ss *SubscriberStore) ActiveCount(network string) int {
 		}
 	}
 	return count
+}
+
+// List returns all subscribers for a network ordered by registration time.
+// Rows are read from the DB (created_at is not cached) and returned as
+// copies, never cache pointers.
+func (ss *SubscriberStore) List(network string) ([]Subscriber, error) {
+	rows, err := ss.db.Query(
+		`SELECT node_id, network, pubkey_b64, COALESCE(bbs_name, ''),
+		        COALESCE(bbs_host, ''), status, created_at
+		 FROM subscribers WHERE network = ? ORDER BY created_at`, network)
+	if err != nil {
+		return nil, fmt.Errorf("hub: list subscribers: %w", err)
+	}
+	defer func() { _ = rows.Close() }() // read-only
+
+	var subs []Subscriber
+	for rows.Next() {
+		var s Subscriber
+		if err := rows.Scan(&s.NodeID, &s.Network, &s.PubKeyB64,
+			&s.BBSName, &s.BBSHost, &s.Status, &s.CreatedAt); err != nil {
+			return nil, fmt.Errorf("hub: scan subscriber: %w", err)
+		}
+		subs = append(subs, s)
+	}
+	return subs, rows.Err()
+}
+
+// SetStatus updates a subscriber's status in the DB and cache together.
+func (ss *SubscriberStore) SetStatus(nodeID, network, status string) error {
+	switch status {
+	case "active", "pending", "banned":
+	default:
+		return fmt.Errorf("hub: invalid status %q", status)
+	}
+
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+
+	res, err := ss.db.Exec(
+		"UPDATE subscribers SET status = ? WHERE node_id = ? AND network = ?",
+		status, nodeID, network)
+	if err != nil {
+		return fmt.Errorf("hub: set status: %w", err)
+	}
+	if n, err := res.RowsAffected(); err == nil && n == 0 {
+		return fmt.Errorf("%w: %s on %s", ErrUnknownNode, nodeID, network)
+	}
+	if s := ss.cache[nodeID+":"+network]; s != nil {
+		s.Status = status
+	}
+	return nil
+}
+
+// Delete removes a subscriber registration from the DB and cache.
+func (ss *SubscriberStore) Delete(nodeID, network string) error {
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+
+	res, err := ss.db.Exec(
+		"DELETE FROM subscribers WHERE node_id = ? AND network = ?", nodeID, network)
+	if err != nil {
+		return fmt.Errorf("hub: delete subscriber: %w", err)
+	}
+	if n, err := res.RowsAffected(); err == nil && n == 0 {
+		return fmt.Errorf("%w: %s on %s", ErrUnknownNode, nodeID, network)
+	}
+	delete(ss.cache, nodeID+":"+network)
+	return nil
 }

--- a/internal/v3net/hub/subscribers_test.go
+++ b/internal/v3net/hub/subscribers_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	_ "modernc.org/sqlite"
@@ -108,4 +109,40 @@ func TestSubscriberStore_DeleteRemovesRowAndCache(t *testing.T) {
 	if err := ss.Delete("aaaa000000000001", "testnet"); !errors.Is(err, ErrUnknownNode) {
 		t.Errorf("second delete: got %v, want ErrUnknownNode", err)
 	}
+}
+
+// TestSubscriberStore_GetDuringConcurrentSetStatusIsRaceFree exercises Get
+// and SetStatus concurrently under -race. Get must never return a cache
+// pointer that SetStatus can mutate out from under a reader.
+func TestSubscriberStore_GetDuringConcurrentSetStatusIsRaceFree(t *testing.T) {
+	ss := newTestStore(t)
+	addTestSub(t, ss, "aaaa000000000001", "pending")
+
+	const iterations = 2000
+	var wg sync.WaitGroup
+
+	// Writer: flips status back and forth.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		statuses := []string{"active", "pending", "banned"}
+		for i := 0; i < iterations; i++ {
+			_ = ss.SetStatus("aaaa000000000001", "testnet", statuses[i%len(statuses)])
+		}
+	}()
+
+	// Readers: fetch the pointer and read its Status field repeatedly.
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				if sub := ss.Get("aaaa000000000001", "testnet"); sub != nil {
+					_ = sub.Status
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
 }

--- a/internal/v3net/hub/subscribers_test.go
+++ b/internal/v3net/hub/subscribers_test.go
@@ -1,0 +1,111 @@
+package hub
+
+import (
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func newTestStore(t *testing.T) *SubscriberStore {
+	t.Helper()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "subs.sqlite"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	ss, err := NewSubscriberStore(db)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	return ss
+}
+
+func addTestSub(t *testing.T, ss *SubscriberStore, nodeID, status string) {
+	t.Helper()
+	_, err := ss.Add(Subscriber{
+		NodeID: nodeID, Network: "testnet",
+		// 32 zero bytes, base64 — decodes to ed25519.PublicKeySize.
+		PubKeyB64: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+		BBSName:   "BBS " + nodeID, Status: status,
+	})
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+}
+
+func TestSubscriberStore_ListReturnsAllForNetwork(t *testing.T) {
+	ss := newTestStore(t)
+	addTestSub(t, ss, "aaaa000000000001", "active")
+	addTestSub(t, ss, "aaaa000000000002", "pending")
+
+	subs, err := ss.List("testnet")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(subs) != 2 {
+		t.Fatalf("got %d subscribers, want 2", len(subs))
+	}
+	if subs[0].CreatedAt == "" {
+		t.Error("CreatedAt should be populated by List")
+	}
+	if empty, err := ss.List("othernet"); err != nil || len(empty) != 0 {
+		t.Errorf("othernet: got %d, %v; want 0, nil", len(empty), err)
+	}
+}
+
+func TestSubscriberStore_SetStatusUpdatesDBAndCache(t *testing.T) {
+	ss := newTestStore(t)
+	addTestSub(t, ss, "aaaa000000000001", "pending")
+
+	if ss.GetPubKey("aaaa000000000001", "testnet") != nil {
+		t.Fatal("pending node should have no auth key")
+	}
+	if err := ss.SetStatus("aaaa000000000001", "testnet", "active"); err != nil {
+		t.Fatalf("set status: %v", err)
+	}
+	// Cache consistency: auth works immediately, no reload.
+	if ss.GetPubKey("aaaa000000000001", "testnet") == nil {
+		t.Error("active node should have auth key without store reload")
+	}
+	// DB consistency: a fresh cache load sees the change.
+	if err := ss.loadCache(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got := ss.Get("aaaa000000000001", "testnet").Status; got != "active" {
+		t.Errorf("persisted status = %q, want active", got)
+	}
+}
+
+func TestSubscriberStore_SetStatusRejectsUnknownNodeAndBadStatus(t *testing.T) {
+	ss := newTestStore(t)
+	if err := ss.SetStatus("ffff000000000000", "testnet", "active"); !errors.Is(err, ErrUnknownNode) {
+		t.Errorf("unknown node: got %v, want ErrUnknownNode", err)
+	}
+	addTestSub(t, ss, "aaaa000000000001", "pending")
+	if err := ss.SetStatus("aaaa000000000001", "testnet", "sideways"); err == nil {
+		t.Error("invalid status should error")
+	}
+}
+
+func TestSubscriberStore_DeleteRemovesRowAndCache(t *testing.T) {
+	ss := newTestStore(t)
+	addTestSub(t, ss, "aaaa000000000001", "active")
+	if err := ss.Delete("aaaa000000000001", "testnet"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if ss.Get("aaaa000000000001", "testnet") != nil {
+		t.Error("cache entry should be gone")
+	}
+	if err := ss.loadCache(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if ss.Get("aaaa000000000001", "testnet") != nil {
+		t.Error("db row should be gone")
+	}
+	if err := ss.Delete("aaaa000000000001", "testnet"); !errors.Is(err, ErrUnknownNode) {
+		t.Errorf("second delete: got %v, want ErrUnknownNode", err)
+	}
+}

--- a/internal/v3net/protocol/network.go
+++ b/internal/v3net/protocol/network.go
@@ -171,3 +171,13 @@ type CoordTransferRequest struct {
 type CoordAcceptRequest struct {
 	Token string `json:"token"`
 }
+
+// NodeInfo describes a subscriber node registration on a hub. Served by
+// the hub-operator nodes admin endpoints.
+type NodeInfo struct {
+	NodeID    string `json:"node_id"`
+	BBSName   string `json:"bbs_name"`
+	BBSHost   string `json:"bbs_host"`
+	Status    string `json:"status"` // "active" | "pending" | "banned"
+	CreatedAt string `json:"created_at"`
+}


### PR DESCRIPTION
## Summary

Hubs with `autoApprove: false` stranded subscribers: nodes registered as `pending` with no way to approve them — no store method, no endpoint, no UI. Surfaced in production on felonynet, where a sysop's node sat pending until the DB was hand-edited (and the hub's in-memory cache made even that require a restart).

This adds the full management path:

- **Store** (`internal/v3net/hub`): `SubscriberStore.List/SetStatus/Delete` mutating SQLite and the in-memory auth cache together; `ErrUnknownNode` sentinel; `loadCache` now reload-safe.
- **Hub endpoints** (operator-only, signed): `GET /v3net/v1/{network}/nodes` plus `POST .../nodes/{id}/{approve|ban|unban|remove}`. Guards: 403 non-operator (tested with an active non-operator leaf), 400 self-node (no sysop lockout), 404 unknown network/node, 409 on invalid transitions (approve requires pending, unban requires banned).
- **TUI** (`./config`): press **N** on a hosted network to open Node Management — approve/ban/unban/delete (with confirm)/refresh, keystore-signed requests to the live hub, no BBS restart needed. Stale-response guard (network carried in every msg), friendly errors via `hubErrorText`, scroll-clamped list.
- **Docs**: Managing Subscriber Nodes section in `docs/sysop/v3net/configuration.md`.

## Testing

- TDD throughout (every unit failing-first); 20+ new tests across store (DB+cache consistency), hub (`httptest` auth round-trips incl. ban→401, approve→can-poll), and TUI (key handling, confirm flow, stale-msg guards)
- Full `go test ./...`, `go test -race ./internal/v3net/hub/`, `go vet`, `gofmt` clean
- Reviewed per-task plus a whole-branch final review; all findings fixed and re-verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hosted-network node management from the Networks list.
  * View node IDs, BBS details, statuses, and join dates.
  * Approve, ban, unban, remove, and refresh node registrations.
  * Added deletion confirmation, loading and error states, and keyboard navigation.

* **Bug Fixes**
  * Improved handling of unavailable hubs, invalid actions, stale results, and unknown nodes.
  * Sanitized remote BBS names before display.

* **Documentation**
  * Added Auto-Approve and restart guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->