### PR TITLE
fix(configeditor): advertise N (node management) in hub record list help

### DIFF
--- a/internal/configeditor/view_list.go
+++ b/internal/configeditor/view_list.go
@@ -151,7 +151,7 @@ func (m Model) viewRecordList() string {
 	} else if m.recordType == "v3netleaf" {
 		helpStr = "Enter - Edit  |  I - New (Wizard)  |  B - Registry  |  D - Delete  |  S - Save  |  ESC - Return"
 	} else if m.recordType == "v3nethub" {
-		helpStr = "Enter - Edit  |  I - New (Wizard)  |  D - Delete  |  S - Save  |  ESC - Return"
+		helpStr = "Enter - Edit  |  I - New (Wizard)  |  N - Nodes  |  D - Delete  |  S - Save  |  ESC - Return"
 	} else if m.recordType == "ftnlink" {
 		helpStr = "Enter - Edit  |  I - Insert  |  D - Delete  |  ESC - Return"
 	} else {

--- a/internal/configeditor/view_list_help_test.go
+++ b/internal/configeditor/view_list_help_test.go
@@ -1,0 +1,25 @@
+package configeditor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+)
+
+// TestHubRecordListHelp_MentionsNodesKey ensures the hosted-networks list
+// advertises the N (node management) key added with the nodes screen.
+func TestHubRecordListHelp_MentionsNodesKey(t *testing.T) {
+	m := Model{
+		width: 80, height: 25,
+		mode:       modeRecordList,
+		recordType: "v3nethub",
+		configs: &allConfigs{V3Net: config.V3NetConfig{
+			Hub: config.V3NetHubConfig{Networks: []config.V3NetHubNetwork{{Name: "felonynet"}}},
+		}},
+	}
+	view := m.viewRecordList()
+	if !strings.Contains(view, "N - Nodes") {
+		t.Error("v3nethub record list help should mention N - Nodes")
+	}
+}


### PR DESCRIPTION
The **N** key opens Node Management for a hosted network (added in #171), but the v3nethub record list help bar never mentioned it — discovered immediately by the first real user of the screen.

Adds `N - Nodes` to the help line, with a view test asserting it stays there.

Testing: new `TestHubRecordListHelp_MentionsNodesKey` (watched failing first); full `internal/configeditor` suite, gofmt, vet clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated hosted-network help text to include the `N - Nodes` action.

* **Tests**
  * Added coverage to verify the new help entry appears correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->