### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,4 +3,4 @@ package version
 // Number is the global ViSiON/3 version.
 // Set this at build time with:
 // -ldflags "-X github.com/ViSiON-3/vision-3-bbs/internal/version.Number=1.0.0"
-var Number = "0.5.0"
+var Number = "0.6.0"


### PR DESCRIPTION
Version bump for the v0.6.0 release (V3Net node management for hub-hosted networks).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application version to 0.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->