### PR TITLE
fix(wfc): security hardening from WFC audit + expanded sysop guide

### DIFF
--- a/cmd/vision3/wfc_admin.go
+++ b/cmd/vision3/wfc_admin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/gliderlabs/ssh"
@@ -34,6 +35,11 @@ var wfcEnabled func() bool
 // wfcAdminHandleKey is the context key used to stash the admin handle during
 // public-key authentication so wfcAdminSubsystem can re-verify it.
 type wfcAdminHandleKey struct{}
+
+// wfcAdminPubKey is the context key used to stash the marshaled public key that
+// authenticated the session, so authorization can be re-verified against the
+// key itself — not just the account — for the life of the session.
+type wfcAdminPubKey struct{}
 
 // wfcPublicKeyHandler is the SSH-level public-key auth handler for admin clients.
 // If the key is registered to a BBS user with sufficient access level, the
@@ -68,6 +74,7 @@ func wfcPublicKeyHandler(ctx ssh.Context, key ssh.PublicKey) bool {
 		return false
 	}
 	ctx.SetValue(wfcAdminHandleKey{}, u.Handle)
+	ctx.SetValue(wfcAdminPubKey{}, key.Marshal())
 	slog.Info("wfc-admin: public key accepted", "user", u.Handle, "addr", ctx.RemoteAddr())
 	return true
 }
@@ -82,6 +89,25 @@ func authorizeAdmin(handle string) bool {
 	}
 	u, found := userMgr.GetUser(handle)
 	if !found || u == nil {
+		return false
+	}
+	return u.AccessLevel >= adminMinLevel()
+}
+
+// authorizeAdminKey reports whether the session opened by keyBytes is still
+// authorized. Unlike authorizeAdmin it re-verifies the key itself, so removing
+// the key — or soft-deleting the account, which the by-handle lookup does not
+// catch — revokes access. handle must still own the key, guarding against a
+// key that has been moved to another account mid-session.
+func authorizeAdminKey(handle string, keyBytes []byte) bool {
+	if userMgr == nil || adminMinLevel == nil || wfcEnabled == nil || !wfcEnabled() {
+		return false
+	}
+	u, found := userMgr.FindByAuthorizedKey(keyBytes)
+	if !found || u == nil {
+		return false
+	}
+	if !strings.EqualFold(u.Handle, handle) {
 		return false
 	}
 	return u.AccessLevel >= adminMinLevel()
@@ -108,10 +134,12 @@ func watchAdminAuthorization(ctx context.Context, handle string, interval time.D
 
 // wfcAdminSubsystem handles an SSH "wfc-admin" subsystem session by serving
 // the binary admin RPC protocol over the session stream. Access is re-checked
-// against the stashed handle before any data is exchanged.
+// against the stashed handle and public key before any data is exchanged, and
+// periodically for the life of the session.
 func wfcAdminSubsystem(sess ssh.Session) {
 	handle, _ := sess.Context().Value(wfcAdminHandleKey{}).(string)
-	if handle == "" || !authorizeAdmin(handle) {
+	keyBytes, _ := sess.Context().Value(wfcAdminPubKey{}).([]byte)
+	if handle == "" || len(keyBytes) == 0 || !authorizeAdminKey(handle, keyBytes) {
 		slog.Warn("wfc-admin: subsystem access denied", "user", handle, "addr", sess.RemoteAddr())
 		_, _ = fmt.Fprintf(sess, "access denied\n") // best-effort notice to client
 		return
@@ -133,7 +161,8 @@ func wfcAdminSubsystem(sess ssh.Session) {
 	// revocation (key removed, level lowered, WFC disabled) kicks the client.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go watchAdminAuthorization(ctx, handle, wfcReauthInterval, authorizeAdmin, func() {
+	stillAuthorized := func(h string) bool { return authorizeAdminKey(h, keyBytes) }
+	go watchAdminAuthorization(ctx, handle, wfcReauthInterval, stillAuthorized, func() {
 		slog.Warn("wfc-admin: session revoked, disconnecting", "user", handle, "addr", sess.RemoteAddr())
 		_ = sess.Close() // unblocks ServeRPC's read loop
 	})

--- a/cmd/vision3/wfc_admin.go
+++ b/cmd/vision3/wfc_admin.go
@@ -4,11 +4,19 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/gliderlabs/ssh"
+	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/admin"
 )
+
+// wfcReauthInterval is how often an open admin session re-checks that its
+// authorization still holds (key not revoked, level not lowered, WFC not
+// disabled). Revocation therefore takes effect within this window instead of
+// only at the next connection.
+const wfcReauthInterval = 30 * time.Second
 
 // adminServer is the WFC admin server instance shared across all admin sessions.
 var adminServer *admin.Server
@@ -38,6 +46,11 @@ func wfcPublicKeyHandler(ctx ssh.Context, key ssh.PublicKey) bool {
 	}
 	u, found := userMgr.FindByAuthorizedKey(key.Marshal())
 	if !found || u == nil {
+		// Debug level: unknown keys are routine (every non-WFC pubkey offer
+		// lands here), but the fingerprint makes key-scanning visible when
+		// debug logging is enabled.
+		slog.Debug("wfc-admin: public key not registered",
+			"fingerprint", gossh.FingerprintSHA256(key), "addr", ctx.RemoteAddr())
 		return false
 	}
 	if !authorizeAdmin(u.Handle) {
@@ -74,6 +87,25 @@ func authorizeAdmin(handle string) bool {
 	return u.AccessLevel >= adminMinLevel()
 }
 
+// watchAdminAuthorization re-checks authorized(handle) every interval and
+// calls kick once when it stops holding. It exits on ctx cancellation (normal
+// session end) without kicking.
+func watchAdminAuthorization(ctx context.Context, handle string, interval time.Duration, authorized func(string) bool, kick func()) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if !authorized(handle) {
+				kick()
+				return
+			}
+		}
+	}
+}
+
 // wfcAdminSubsystem handles an SSH "wfc-admin" subsystem session by serving
 // the binary admin RPC protocol over the session stream. Access is re-checked
 // against the stashed handle before any data is exchanged.
@@ -97,9 +129,18 @@ func wfcAdminSubsystem(sess ssh.Session) {
 		return
 	}
 
+	// Re-check authorization for the lifetime of the session so mid-session
+	// revocation (key removed, level lowered, WFC disabled) kicks the client.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go watchAdminAuthorization(ctx, handle, wfcReauthInterval, authorizeAdmin, func() {
+		slog.Warn("wfc-admin: session revoked, disconnecting", "user", handle, "addr", sess.RemoteAddr())
+		_ = sess.Close() // unblocks ServeRPC's read loop
+	})
+
 	// ServeRPC's context governs only the internal subscriber goroutine; connection
 	// lifetime is enforced by the SSH session closing, which unblocks the read loop.
-	if err := admin.ServeRPC(context.Background(), sess, adminServer, audit); err != nil {
+	if err := admin.ServeRPC(ctx, sess, adminServer, audit); err != nil {
 		slog.Info("wfc-admin: session closed", "user", handle, "addr", sess.RemoteAddr(), "reason", err)
 	} else {
 		slog.Info("wfc-admin: session closed", "user", handle, "addr", sess.RemoteAddr())

--- a/cmd/vision3/wfc_admin_key_test.go
+++ b/cmd/vision3/wfc_admin_key_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// testKeyLine is a throwaway ed25519 public key used only as authorized-key
+// fixture data; no private half exists anywhere.
+const testKeyLine = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKxXeniKraUkypfTmKhIriFllkZ1EqIlW7Vjq4XzXqV/ test@fixture"
+
+func mustKeyBytes(t *testing.T, line string) []byte {
+	t.Helper()
+	pub, _, _, _, err := gossh.ParseAuthorizedKey([]byte(line))
+	if err != nil {
+		t.Fatalf("parse fixture key: %v", err)
+	}
+	return pub.Marshal()
+}
+
+// TestAuthorizeAdminKey verifies the session predicate authorizes only when the
+// presented key is still registered to a qualifying account.
+func TestAuthorizeAdminKey(t *testing.T) {
+	keyBytes := mustKeyBytes(t, testKeyLine)
+	adminMinLevel = func() int { return 250 }
+	wfcEnabled = func() bool { return true }
+	t.Cleanup(func() { userMgr, adminMinLevel, wfcEnabled = nil, nil, nil })
+
+	t.Run("registered sysop is authorized", func(t *testing.T) {
+		userMgr = user.NewUserMgrForTest(
+			&user.User{Handle: "boss", AccessLevel: 255, PublicKeys: []string{testKeyLine}},
+		)
+		if !authorizeAdminKey("boss", keyBytes) {
+			t.Error("expected sysop with registered key to be authorized")
+		}
+	})
+
+	t.Run("key removed revokes authorization", func(t *testing.T) {
+		userMgr = user.NewUserMgrForTest(
+			&user.User{Handle: "boss", AccessLevel: 255}, // key no longer listed
+		)
+		if authorizeAdminKey("boss", keyBytes) {
+			t.Error("expected authorization denied after the key was removed")
+		}
+	})
+
+	t.Run("soft-deleted account revokes authorization", func(t *testing.T) {
+		userMgr = user.NewUserMgrForTest(
+			&user.User{Handle: "boss", AccessLevel: 255, PublicKeys: []string{testKeyLine},
+				DeletedUser: true},
+		)
+		if authorizeAdminKey("boss", keyBytes) {
+			t.Error("expected authorization denied for a soft-deleted account")
+		}
+	})
+
+	t.Run("demotion revokes authorization", func(t *testing.T) {
+		userMgr = user.NewUserMgrForTest(
+			&user.User{Handle: "boss", AccessLevel: 10, PublicKeys: []string{testKeyLine}},
+		)
+		if authorizeAdminKey("boss", keyBytes) {
+			t.Error("expected authorization denied after demotion below CoSysOp")
+		}
+	})
+
+	t.Run("key belonging to a different account is denied", func(t *testing.T) {
+		userMgr = user.NewUserMgrForTest(
+			&user.User{Handle: "other", AccessLevel: 255, PublicKeys: []string{testKeyLine}},
+		)
+		if authorizeAdminKey("boss", keyBytes) {
+			t.Error("expected denial when the key maps to a different handle")
+		}
+	})
+
+	t.Run("wfc disabled revokes authorization", func(t *testing.T) {
+		userMgr = user.NewUserMgrForTest(
+			&user.User{Handle: "boss", AccessLevel: 255, PublicKeys: []string{testKeyLine}},
+		)
+		wfcEnabled = func() bool { return false }
+		defer func() { wfcEnabled = func() bool { return true } }()
+		if authorizeAdminKey("boss", keyBytes) {
+			t.Error("expected authorization denied when WFC access is disabled")
+		}
+	})
+}

--- a/cmd/vision3/wfc_admin_reauth_test.go
+++ b/cmd/vision3/wfc_admin_reauth_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestWatchAdminAuthorizationKicksOnRevocation verifies that an open admin
+// session is terminated when its authorization stops holding (key revoked,
+// user demoted, or WFC access disabled mid-session).
+func TestWatchAdminAuthorizationKicksOnRevocation(t *testing.T) {
+	var allowed atomic.Bool
+	allowed.Store(true)
+	kicked := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go watchAdminAuthorization(ctx, "boss", time.Millisecond,
+		func(string) bool { return allowed.Load() },
+		func() { close(kicked) })
+
+	// Still authorized: must not be kicked.
+	select {
+	case <-kicked:
+		t.Fatal("session kicked while still authorized")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	allowed.Store(false)
+	select {
+	case <-kicked:
+	case <-time.After(time.Second):
+		t.Fatal("session not kicked after authorization was revoked")
+	}
+}
+
+// TestWatchAdminAuthorizationStopsOnContextCancel verifies the watcher exits
+// without kicking when the session ends normally.
+func TestWatchAdminAuthorizationStopsOnContextCancel(t *testing.T) {
+	var kicks atomic.Int32
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		watchAdminAuthorization(ctx, "boss", time.Millisecond,
+			func(string) bool { return true },
+			func() { kicks.Add(1) })
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("watcher did not exit on context cancellation")
+	}
+	if kicks.Load() != 0 {
+		t.Fatalf("watcher kicked %d times on a normal shutdown, want 0", kicks.Load())
+	}
+}

--- a/docs/sysop/how-to-guides/wfc-console.md
+++ b/docs/sysop/how-to-guides/wfc-console.md
@@ -28,6 +28,49 @@ A key that isn't registered, belongs to a below-CoSysOp user, or arrives while
 WFC Access is disabled simply falls through to the **normal caller login**.
 Adding WFC access never affects regular logins.
 
+## Getting an SSH key onto the server
+
+WFC authenticates with an SSH keypair on the machine you run `wfc` from. The
+**private** key stays on that machine; only the **public** half is registered
+on the BBS. The whole flow is:
+
+### 1. Obtain a keypair (on your own machine)
+
+Check whether you already have one:
+
+```bash
+ls ~/.ssh/id_ed25519.pub
+```
+
+If not, generate one (accept the defaults; a passphrase is optional):
+
+```bash
+ssh-keygen -t ed25519
+```
+
+### 2. Transfer the public key to the server
+
+Send the **`.pub` file only**. Any channel works — it's public material:
+
+```bash
+cat ~/.ssh/id_ed25519.pub        # copy this one line and paste it server-side
+scp ~/.ssh/id_ed25519.pub sysop@your-bbs-host:/tmp/my.pub   # or copy the file
+```
+
+A public key is a single line starting `ssh-ed25519 AAAA…` ending in a
+comment. If you're onboarding a remote co-sysop, this is the line they email
+or DM you.
+
+### 3. Register it and restart (on the server)
+
+```bash
+helper users addkey "J0hnny A1pha" /tmp/my.pub   # quote handles with spaces
+helper users listkeys "J0hnny A1pha"             # confirm it landed
+```
+
+Or pipe the pasted line via stdin: `helper users addkey "J0hnny A1pha" -`.
+Then **restart the BBS** — the daemon reads `users.json` at startup only.
+
 ## Enabling access for a sysop
 
 A user can use WFC once their `accessLevel` is ≥ your `coSysOpLevel` (the
@@ -94,6 +137,11 @@ wfc --connect ssh://Felonius@your-bbs-host:2222 --identity ~/.ssh/id_ed25519
 
 - The user in the URL is your BBS **handle**; the port is the BBS's SSH port
   (`sshPort` in `config.json`, default 2222).
+- Handles with **spaces** must be percent-encoded — a raw space is not valid in
+  a URL. For example, `J0hnny A1pha` connects as
+  `--connect 'ssh://J0hnny%20A1pha@brokenbit.us:2222'`. (Authorization is
+  matched on your SSH key, not the username, so an imperfectly-typed handle
+  won't lock you out as long as the key is registered.)
 - `--identity` defaults to `~/.ssh/id_ed25519` if omitted.
 - On first connect the server's host key is verified against your
   `~/.ssh/known_hosts`. If the host isn't known yet, add it (e.g. with
@@ -110,9 +158,81 @@ wfc --connect ssh://Felonius@your-bbs-host:2222 --identity ~/.ssh/id_ed25519
 | `--insecure` | Skip SSH host-key verification (dev/first-run only) |
 | `--ascii` | ASCII borders instead of box-drawing characters |
 | `--no-color` | Disable color |
+| `--refresh <ms>` | Snapshot poll interval in milliseconds (default 1000) |
 | `--max-events <n>` | Events kept in the feed (default 200) |
 | `--readonly` | View-only (always true in this version) |
 | `--version` / `--help` | Print version / usage |
+
+## Console functions
+
+The console is a single full-screen view with four parts: a status header, the
+node table, an optional event log, and a command bar. It refreshes on its own
+(once a second by default; tune with `--refresh`).
+
+### Status header
+
+One line across the top with live system stats:
+
+| Field | Meaning |
+|-------|---------|
+| System name | The BBS name from `config.json` (falls back to `ViSiON/3 WFC` before the first snapshot arrives) |
+| `Nodes` | Number of currently active nodes (connections) |
+| `Calls Today` | Calls answered since midnight; shows `—` if the counter is unavailable |
+| `Uptime` | How long the daemon has been running, as `Xd Xh Xm` |
+| Clock | Current local time on *your* machine (`HH:MM:SS`) |
+
+### Node table
+
+One row per active connection, including callers still at the login prompt:
+
+| Column | Meaning |
+|--------|---------|
+| `Handle` | The caller's handle, or `(login)` if not yet logged in |
+| `Status` | Coarse node status — see below |
+| `Activity` | What the caller is doing right now (e.g. reading messages), if the current screen reports it |
+| `Menu` | The menu the caller is currently in |
+| `Address` | The caller's remote IP address and port |
+
+Status values:
+
+- **`login`** — connected but not yet authenticated
+- **`online`** — logged in
+- **`menu`** — logged in and sitting in a menu (no other activity reported)
+- **`chat`** / **`idle`** — reserved for later releases
+
+Use `↑`/`↓` to select a row and `Enter` to open the details view.
+
+### Node details
+
+`Enter` on a node shows everything the daemon knows about that session: node
+number, status, handle, user ID, access level, remote address, current menu,
+current activity, connect time, last-activity time, and **time left** in the
+caller's session (minutes remaining against their time limit, `(unknown)` if
+the account has no limit). `Esc` returns to the node table.
+
+### Event log
+
+Press `L` to split the screen and show a live feed of recent system events,
+newest at the bottom, each stamped `HH:MM:SS` with the handle involved:
+
+| Event | Fired when |
+|-------|-----------|
+| `caller.connected` | A new connection appears |
+| `caller.disconnected` | A node drops or logs off |
+| `menu.changed` | A caller moves to a different menu |
+| `activity.changed` | A caller's reported activity changes |
+
+The feed keeps the most recent events in memory (200 by default; adjust with
+`--max-events`). Press `L` again to hide the log and give the node table the
+full screen.
+
+### Refresh and reconnect
+
+The console polls the daemon for a fresh snapshot once a second (configurable
+with `--refresh`) and receives events as they happen; `R` forces an immediate
+refresh. If the SSH connection drops, a **Disconnected** banner replaces the
+screen — press `R` to reconnect (the console re-subscribes to the event feed
+automatically) or `Q` to quit.
 
 ## Navigating the console
 
@@ -129,6 +249,34 @@ The screen refreshes about once a second on its own. If the connection drops,
 the console shows a **Disconnected** banner; press `R` to reconnect or `Q` to
 quit — it will not crash.
 
+## Troubleshooting
+
+**`ssh: handshake failed: … unable to authenticate, attempted methods [none
+publickey], no supported methods remain`** — the server saw your key and
+declined it. `wfc` has no password fallback, so the connection ends. In order
+of likelihood:
+
+1. The public key isn't registered on the account — or was registered but the
+   **BBS wasn't restarted** afterward.
+2. The key was added to a different account than you're thinking of, or the
+   account's `accessLevel` is below `coSysOpLevel` (default 250).
+3. `wfcEnabled` is toggled off in the server config.
+
+Check which key your client is offering with
+`ssh-keygen -lf ~/.ssh/id_ed25519.pub` and compare fingerprints against
+`helper users listkeys "Your Handle"` on the server. The server also logs
+every rejection with a reason (`wfc access disabled` vs `insufficient access
+level`), so the BBS log tells you exactly which rule fired.
+
+**`Host key verification failed`** — the server isn't in your
+`~/.ssh/known_hosts` yet. Add it with
+`ssh-keyscan -p 2222 your-bbs-host >> ~/.ssh/known_hosts`, or use
+`--insecure` for a one-off first connection.
+
+**Connection lands at the normal BBS login screen instead of the console** —
+same causes as the handshake failure above: the key fell through to caller
+login because it didn't match a qualifying account.
+
 ## Security model
 
 - **Key-based auth only.** WFC presents your SSH public key; there is no
@@ -138,8 +286,22 @@ quit — it will not crash.
   level.
 - **Additive, non-disruptive.** Unknown or under-privileged keys fall through
   to the normal caller login; existing logins are unchanged.
+- **Re-checked while connected.** An open WFC session re-verifies its
+  authorization every 30 seconds. Turning **WFC Access** off, or banning or
+  demoting the user from within the running BBS, disconnects their open
+  console within that window. Key removals made with `ue` or `helper` edit
+  `users.json` on disk, which the daemon only reads at startup — so **revoking
+  a key still requires a BBS restart** to lock out new connections.
+- **Everything is visible to every qualifying account.** The console shows all
+  active sessions — including **invisible** ones — with each caller's handle,
+  IP address, and activity, to *any* account at or above `coSysOpLevel`.
+  Granting level 250 grants this visibility; set `coSysOpLevel` accordingly.
+- **Sanitized display.** Caller-supplied text (handles) is stripped of
+  terminal control characters before rendering, and control characters are
+  rejected in new handles at registration.
 - **Audited.** Every admin session open/close (and every command) is written to
-  the BBS log via structured logging.
+  the BBS log via structured logging. Unknown public-key offers are logged at
+  debug level with the key fingerprint.
 - **Host-key verified.** The client checks the daemon's SSH host key against
   `known_hosts` unless you pass `--insecure`.
 

--- a/docs/sysop/how-to-guides/wfc-console.md
+++ b/docs/sysop/how-to-guides/wfc-console.md
@@ -264,9 +264,15 @@ of likelihood:
 
 Check which key your client is offering with
 `ssh-keygen -lf ~/.ssh/id_ed25519.pub` and compare fingerprints against
-`helper users listkeys "Your Handle"` on the server. The server also logs
-every rejection with a reason (`wfc access disabled` vs `insufficient access
-level`), so the BBS log tells you exactly which rule fired.
+`helper users listkeys "Your Handle"` on the server.
+
+The BBS log narrows it down, but note the two levels:
+
+- A **registered** key rejected for insufficient access level or disabled WFC
+  access is logged at **info**, with the reason.
+- An **unregistered** key is logged at **debug** with its fingerprint only, so
+  at normal log levels a wrong or unknown key leaves no visible record. Raise
+  the log level to debug if you see no rejection logged at all.
 
 **`Host key verification failed`** — the server isn't in your
 `~/.ssh/known_hosts` yet. Add it with
@@ -286,12 +292,13 @@ login because it didn't match a qualifying account.
   level.
 - **Additive, non-disruptive.** Unknown or under-privileged keys fall through
   to the normal caller login; existing logins are unchanged.
-- **Re-checked while connected.** An open WFC session re-verifies its
-  authorization every 30 seconds. Turning **WFC Access** off, or banning or
-  demoting the user from within the running BBS, disconnects their open
-  console within that window. Key removals made with `ue` or `helper` edit
-  `users.json` on disk, which the daemon only reads at startup — so **revoking
-  a key still requires a BBS restart** to lock out new connections.
+- **Re-checked while connected.** An open WFC session re-verifies every 30
+  seconds that the *key* it authenticated with is still registered to a
+  qualifying account. Turning **WFC Access** off, or banning, demoting, or
+  deleting the user in the running BBS, disconnects their console within that
+  window. Key edits made with `ue` or `helper` change `users.json` on disk,
+  which the daemon only reads at startup — so revoking a key that way still
+  requires a **BBS restart** to take effect.
 - **Everything is visible to every qualifying account.** The console shows all
   active sessions — including **invisible** ones — with each caller's handle,
   IP address, and activity, to *any* account at or above `coSysOpLevel`.

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -66,7 +66,29 @@ func (s *Server) Run(ctx context.Context) {
 func (s *Server) tick(now time.Time) {
 	s.tickMu.Lock()
 	defer s.tickMu.Unlock()
+	s.tickLocked(now)
+}
 
+// refreshIfDue runs a tick only if the last one is older than the refresh
+// interval. The freshness check happens under tickMu, and the timestamp is
+// taken there too, so concurrent CommandRefresh calls collapse into a single
+// poll instead of each observing the same stale lastTick.
+func (s *Server) refreshIfDue() {
+	s.tickMu.Lock()
+	defer s.tickMu.Unlock()
+
+	now := timeNow()
+	s.mu.RLock()
+	fresh := now.Sub(s.lastTick) < s.cfg.Refresh
+	s.mu.RUnlock()
+	if fresh {
+		return
+	}
+	s.tickLocked(now)
+}
+
+// tickLocked is the body of tick. Callers must hold tickMu.
+func (s *Server) tickLocked(now time.Time) {
 	calls := -1
 	if s.cfg.CallsToday != nil {
 		calls = s.cfg.CallsToday()
@@ -138,13 +160,7 @@ func (s *Server) Execute(cmd AdminCommand) (*Result, error) {
 	case CommandRefresh:
 		// Rate-limit forced ticks: a client spamming refresh must not drive
 		// snapshot rebuilds faster than the configured polling interval.
-		now := timeNow()
-		s.mu.RLock()
-		fresh := now.Sub(s.lastTick) < s.cfg.Refresh
-		s.mu.RUnlock()
-		if !fresh {
-			s.tick(now)
-		}
+		s.refreshIfDue()
 		return &Result{OK: true}, nil
 	default:
 		return nil, fmt.Errorf("admin: command not supported in read-only v1: %s", cmd.Command)

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -76,7 +76,12 @@ func (s *Server) tick(now time.Time) {
 	s.mu.Lock()
 	events := DiffSnapshots(s.prev, snap)
 	s.prev = snap
-	s.lastTick = now
+	// Monotonic: tick() captures `now` before contending for tickMu, so a
+	// refresh-forced tick can land after a later periodic tick. Letting the
+	// stale timestamp win would weaken the refresh rate limit.
+	if now.After(s.lastTick) {
+		s.lastTick = now
+	}
 	for _, e := range events {
 		s.ring = append(s.ring, e)
 		if len(s.ring) > s.cfg.MaxEvents {

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -23,12 +23,13 @@ type ServerConfig struct {
 // Server polls SessionRegistry, keeps the latest snapshot, and fans out
 // diff-synthesized events to subscribers. Read-only; v1 implements no mutations.
 type Server struct {
-	cfg    ServerConfig
-	mu     sync.RWMutex
-	tickMu sync.Mutex // serialises tick end-to-end to prevent out-of-order snapshots
-	prev   *SystemSnapshot
-	ring   []Event
-	subs   map[chan Event]struct{}
+	cfg      ServerConfig
+	mu       sync.RWMutex
+	tickMu   sync.Mutex // serialises tick end-to-end to prevent out-of-order snapshots
+	prev     *SystemSnapshot
+	ring     []Event
+	subs     map[chan Event]struct{}
+	lastTick time.Time
 }
 
 // RefreshInterval returns the configured polling interval.
@@ -75,6 +76,7 @@ func (s *Server) tick(now time.Time) {
 	s.mu.Lock()
 	events := DiffSnapshots(s.prev, snap)
 	s.prev = snap
+	s.lastTick = now
 	for _, e := range events {
 		s.ring = append(s.ring, e)
 		if len(s.ring) > s.cfg.MaxEvents {
@@ -129,7 +131,15 @@ func (s *Server) Subscribe(ctx context.Context) <-chan Event {
 func (s *Server) Execute(cmd AdminCommand) (*Result, error) {
 	switch cmd.Command {
 	case CommandRefresh:
-		s.tick(time.Now())
+		// Rate-limit forced ticks: a client spamming refresh must not drive
+		// snapshot rebuilds faster than the configured polling interval.
+		now := timeNow()
+		s.mu.RLock()
+		fresh := now.Sub(s.lastTick) < s.cfg.Refresh
+		s.mu.RUnlock()
+		if !fresh {
+			s.tick(now)
+		}
 		return &Result{OK: true}, nil
 	default:
 		return nil, fmt.Errorf("admin: command not supported in read-only v1: %s", cmd.Command)

--- a/internal/admin/server_ratelimit_test.go
+++ b/internal/admin/server_ratelimit_test.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -44,6 +45,55 @@ func TestExecuteRefreshRateLimited(t *testing.T) {
 	if reg.polls != 2 {
 		t.Fatalf("refresh after interval polled registry %d times, want 2", reg.polls)
 	}
+}
+
+// TestConcurrentRefreshPollsOnce verifies that simultaneous CommandRefresh
+// calls collapse into a single registry poll. Checking freshness outside the
+// serialized tick path lets every racing caller observe the same stale
+// timestamp and each run a full snapshot rebuild.
+func TestConcurrentRefreshPollsOnce(t *testing.T) {
+	reg := &lockedRegistry{}
+	srv := NewServer(ServerConfig{Reg: reg, Refresh: time.Minute, MaxEvents: 4})
+
+	const callers = 16
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if _, err := srv.Execute(AdminCommand{Command: CommandRefresh}); err != nil {
+				t.Errorf("refresh failed: %v", err)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := reg.count(); got != 1 {
+		t.Fatalf("%d concurrent refreshes polled registry %d times, want 1", callers, got)
+	}
+}
+
+// lockedRegistry counts polls safely under concurrent access.
+type lockedRegistry struct {
+	mu     sync.Mutex
+	polls  int
+	unused []*session.BbsSession
+}
+
+func (r *lockedRegistry) ListActive() []*session.BbsSession {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.polls++
+	return r.unused
+}
+
+func (r *lockedRegistry) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.polls
 }
 
 // TestLastTickIsMonotonic verifies that an out-of-order tick cannot move

--- a/internal/admin/server_ratelimit_test.go
+++ b/internal/admin/server_ratelimit_test.go
@@ -1,0 +1,47 @@
+package admin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/session"
+)
+
+// countingRegistry counts how many times the server polls it.
+type countingRegistry struct{ polls int }
+
+func (r *countingRegistry) ListActive() []*session.BbsSession {
+	r.polls++
+	return nil
+}
+
+// TestExecuteRefreshRateLimited verifies that a client spamming
+// CommandRefresh cannot force snapshot rebuilds faster than the configured
+// refresh interval: the command still succeeds, but the poll is skipped when
+// the last tick is fresh enough.
+func TestExecuteRefreshRateLimited(t *testing.T) {
+	base := time.Now()
+	now := base
+	timeNow = func() time.Time { return now }
+	defer func() { timeNow = time.Now }()
+
+	reg := &countingRegistry{}
+	srv := NewServer(ServerConfig{Reg: reg, Refresh: time.Second, MaxEvents: 4})
+
+	for i := 0; i < 5; i++ {
+		if r, err := srv.Execute(AdminCommand{Command: CommandRefresh}); err != nil || !r.OK {
+			t.Fatalf("refresh %d should succeed: %v %+v", i, err, r)
+		}
+	}
+	if reg.polls != 1 {
+		t.Fatalf("5 rapid refreshes polled registry %d times, want 1", reg.polls)
+	}
+
+	now = base.Add(2 * time.Second)
+	if r, err := srv.Execute(AdminCommand{Command: CommandRefresh}); err != nil || !r.OK {
+		t.Fatalf("refresh after interval should succeed: %v %+v", err, r)
+	}
+	if reg.polls != 2 {
+		t.Fatalf("refresh after interval polled registry %d times, want 2", reg.polls)
+	}
+}

--- a/internal/admin/server_ratelimit_test.go
+++ b/internal/admin/server_ratelimit_test.go
@@ -45,3 +45,23 @@ func TestExecuteRefreshRateLimited(t *testing.T) {
 		t.Fatalf("refresh after interval polled registry %d times, want 2", reg.polls)
 	}
 }
+
+// TestLastTickIsMonotonic verifies that an out-of-order tick cannot move
+// lastTick backwards. tick() captures its `now` before contending for tickMu,
+// so a refresh-forced tick can land after a later periodic tick; if the older
+// timestamp won, the rate limit would be weakened or defeated.
+func TestLastTickIsMonotonic(t *testing.T) {
+	base := time.Now()
+	reg := &countingRegistry{}
+	srv := NewServer(ServerConfig{Reg: reg, Refresh: time.Second, MaxEvents: 4})
+
+	srv.tick(base.Add(10 * time.Second)) // later tick lands first
+	srv.tick(base)                       // stale tick applied afterwards
+
+	srv.mu.RLock()
+	last := srv.lastTick
+	srv.mu.RUnlock()
+	if last.Before(base.Add(10 * time.Second)) {
+		t.Fatalf("lastTick moved backwards to %v, want >= %v", last, base.Add(10*time.Second))
+	}
+}

--- a/internal/menu/newuser.go
+++ b/internal/menu/newuser.go
@@ -621,12 +621,14 @@ func validateHandle(handle string) bool {
 		return false
 	}
 
-	// Cannot contain special characters or control bytes. Control bytes would
+	// Cannot contain special characters or control characters. Controls would
 	// replay terminal escape sequences wherever the handle is later rendered
-	// (node lists, WFC console, logs).
+	// (node lists, WFC console, logs). The C1 range U+0080–U+009F is included
+	// because U+009B is the 8-bit form of CSI; CP437 input decodes its high
+	// bytes to printable codepoints, so legitimate handles are unaffected.
 	invalidChars := "?#/*&:"
 	for _, c := range handle {
-		if strings.ContainsRune(invalidChars, c) || c < 0x20 || c == 0x7f {
+		if strings.ContainsRune(invalidChars, c) || c < 0x20 || c == 0x7f || (c >= 0x80 && c <= 0x9f) {
 			return false
 		}
 	}

--- a/internal/menu/newuser.go
+++ b/internal/menu/newuser.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/message"
@@ -612,6 +613,12 @@ func (e *MenuExecutor) promptForUserNote(
 // cannot be "new" or "q", cannot be purely numeric.
 func validateHandle(handle string) bool {
 	if len(handle) < 3 {
+		return false
+	}
+
+	// Reject invalid UTF-8 outright: malformed byte sequences render
+	// unpredictably and defeat per-rune inspection below.
+	if !utf8.ValidString(handle) {
 		return false
 	}
 

--- a/internal/menu/newuser.go
+++ b/internal/menu/newuser.go
@@ -621,10 +621,12 @@ func validateHandle(handle string) bool {
 		return false
 	}
 
-	// Cannot contain special characters
+	// Cannot contain special characters or control bytes. Control bytes would
+	// replay terminal escape sequences wherever the handle is later rendered
+	// (node lists, WFC console, logs).
 	invalidChars := "?#/*&:"
 	for _, c := range handle {
-		if strings.ContainsRune(invalidChars, c) {
+		if strings.ContainsRune(invalidChars, c) || c < 0x20 || c == 0x7f {
 			return false
 		}
 	}

--- a/internal/menu/newuser_validate_test.go
+++ b/internal/menu/newuser_validate_test.go
@@ -1,0 +1,46 @@
+package menu
+
+import "testing"
+
+// TestValidateHandleRules covers the Pascal-derived rules: length, reserved
+// names, banned specials, and not purely numeric.
+func TestValidateHandleRules(t *testing.T) {
+	cases := []struct {
+		handle string
+		want   bool
+	}{
+		{"J0hnny A1pha", true},
+		{"abc", true},
+		{"ab", false},        // too short
+		{"SysOp", false},     // reserved
+		{"new", false},       // reserved
+		{"what?", false},     // banned special
+		{"12345", false},     // purely numeric
+		{"", false},          // empty
+		{"Fel:onius", false}, // banned special
+	}
+	for _, c := range cases {
+		if got := validateHandle(c.handle); got != c.want {
+			t.Errorf("validateHandle(%q) = %v, want %v", c.handle, got, c.want)
+		}
+	}
+}
+
+// TestValidateHandleRejectsControlCharacters verifies that terminal control
+// bytes cannot be smuggled into a handle. A handle containing ESC/C0/DEL would
+// otherwise replay escape sequences into any terminal that later renders it
+// (node lists, WFC console, logs).
+func TestValidateHandleRejectsControlCharacters(t *testing.T) {
+	bad := []string{
+		"Bad\x1b]0;pwn\x07Guy", // OSC title change
+		"abc\x1b[2J",           // CSI clear screen
+		"tab\tname",            // C0 tab
+		"del\x7fete",           // DEL
+		"nul\x00name",          // NUL
+	}
+	for _, h := range bad {
+		if validateHandle(h) {
+			t.Errorf("validateHandle(%q) = true, want false (control character)", h)
+		}
+	}
+}

--- a/internal/menu/newuser_validate_test.go
+++ b/internal/menu/newuser_validate_test.go
@@ -39,6 +39,8 @@ func TestValidateHandleRejectsControlCharacters(t *testing.T) {
 		"nul\x00name",          // NUL
 		"csi\u009b2Jname",      // C1 8-bit CSI
 		"pad\u0080name",        // C1 PAD
+		"bad\xffbyte",          // invalid UTF-8
+		"lone\xc3",             // truncated multi-byte sequence
 	}
 	for _, h := range bad {
 		if validateHandle(h) {

--- a/internal/menu/newuser_validate_test.go
+++ b/internal/menu/newuser_validate_test.go
@@ -37,6 +37,8 @@ func TestValidateHandleRejectsControlCharacters(t *testing.T) {
 		"tab\tname",            // C0 tab
 		"del\x7fete",           // DEL
 		"nul\x00name",          // NUL
+		"csi\u009b2Jname",      // C1 8-bit CSI
+		"pad\u0080name",        // C1 PAD
 	}
 	for _, h := range bad {
 		if validateHandle(h) {

--- a/internal/wfcui/details.go
+++ b/internal/wfcui/details.go
@@ -51,7 +51,7 @@ func (m Model) detailsView() string {
 		sb.WriteString(" ")
 		sb.WriteString(st.dimmed.Render(label))
 		sb.WriteString(" ")
-		sb.WriteString(row.value)
+		sb.WriteString(sanitizeTerminal(row.value))
 		sb.WriteString("\n")
 	}
 

--- a/internal/wfcui/sanitize.go
+++ b/internal/wfcui/sanitize.go
@@ -1,0 +1,24 @@
+package wfcui
+
+// sanitizeTerminal strips terminal control bytes from server-supplied text
+// before it is rendered. Caller handles travel from the BBS into the sysop's
+// terminal; without this, a hostile handle could smuggle escape sequences
+// (title changes, screen clears, query responses) onto the admin's machine.
+func sanitizeTerminal(s string) string {
+	var b []rune
+	for i, r := range s {
+		if (r < 0x20) || r == 0x7f {
+			if b == nil {
+				b = []rune(s[:i])
+			}
+			continue
+		}
+		if b != nil {
+			b = append(b, r)
+		}
+	}
+	if b == nil {
+		return s
+	}
+	return string(b)
+}

--- a/internal/wfcui/sanitize.go
+++ b/internal/wfcui/sanitize.go
@@ -1,13 +1,24 @@
 package wfcui
 
-// sanitizeTerminal strips terminal control bytes from server-supplied text
-// before it is rendered. Caller handles travel from the BBS into the sysop's
-// terminal; without this, a hostile handle could smuggle escape sequences
-// (title changes, screen clears, query responses) onto the admin's machine.
+// isTerminalControl reports whether r is a control character a terminal may
+// act on: a C0 control, DEL, or a C1 control (U+0080–U+009F, which includes
+// U+009B — the 8-bit form of CSI).
+//
+// CP437 text decodes its high bytes to printable codepoints (0x82 → é,
+// 0x9B → ¢), so rejecting the C1 range never touches legitimate CP437 input.
+func isTerminalControl(r rune) bool {
+	return r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f)
+}
+
+// sanitizeTerminal strips terminal control characters from server-supplied
+// text before it is rendered. Caller handles travel from the BBS into the
+// sysop's terminal; without this, a hostile handle could smuggle escape
+// sequences (title changes, screen clears, query responses) onto the admin's
+// machine.
 func sanitizeTerminal(s string) string {
 	var b []rune
 	for i, r := range s {
-		if (r < 0x20) || r == 0x7f {
+		if isTerminalControl(r) {
 			if b == nil {
 				b = []rune(s[:i])
 			}

--- a/internal/wfcui/sanitize.go
+++ b/internal/wfcui/sanitize.go
@@ -1,5 +1,7 @@
 package wfcui
 
+import "strings"
+
 // isTerminalControl reports whether r is a control character a terminal may
 // act on: a C0 control, DEL, or a C1 control (U+0080–U+009F, which includes
 // U+009B — the 8-bit form of CSI).
@@ -11,25 +13,24 @@ func isTerminalControl(r rune) bool {
 }
 
 // sanitizeTerminal strips terminal control characters from server-supplied
-// text before it is rendered. Caller handles travel from the BBS into the
-// sysop's terminal; without this, a hostile handle could smuggle escape
-// sequences (title changes, screen clears, query responses) onto the admin's
-// machine.
+// text before it is rendered, and replaces invalid UTF-8 with U+FFFD. Caller
+// handles travel from the BBS into the sysop's terminal; without this, a
+// hostile handle could smuggle escape sequences (title changes, screen
+// clears, query responses) onto the admin's machine.
+//
+// Every byte is rewritten rather than returning the input unchanged on the
+// clean path: passing the original string through would preserve raw invalid
+// UTF-8, which terminals may decode in unintended ways.
 func sanitizeTerminal(s string) string {
-	var b []rune
-	for i, r := range s {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
 		if isTerminalControl(r) {
-			if b == nil {
-				b = []rune(s[:i])
-			}
 			continue
 		}
-		if b != nil {
-			b = append(b, r)
-		}
+		// Ranging a string yields utf8.RuneError for each invalid byte, and
+		// WriteRune encodes that as U+FFFD.
+		b.WriteRune(r)
 	}
-	if b == nil {
-		return s
-	}
-	return string(b)
+	return b.String()
 }

--- a/internal/wfcui/sanitize_test.go
+++ b/internal/wfcui/sanitize_test.go
@@ -11,15 +11,16 @@ import (
 // hostileHandle embeds an OSC title-change sequence and a C0 control byte —
 // the shape of a terminal-escape injection a caller could attempt via their
 // handle. No rendered view may pass these bytes through to the terminal.
-const hostileHandle = "Bad\x1b]0;pwned\x07Guy\x01"
+const hostileHandle = "Bad\x1b]0;pwned\x07Guy\x012K"
 
 // assertNoControlBytes fails if s contains any C0 control byte other than
-// newline, or a DEL. Views under NoColor emit no escapes of their own, so any
-// hit is injected data leaking through.
+// newline, a DEL, or a C1 control (U+0080–U+009F — U+009B is 8-bit CSI).
+// Views under NoColor emit no escapes of their own, so any hit is injected
+// data leaking through.
 func assertNoControlBytes(t *testing.T, view, s string) {
 	t.Helper()
 	for _, r := range s {
-		if (r < 0x20 && r != '\n') || r == 0x7f {
+		if (r < 0x20 && r != '\n') || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
 			t.Fatalf("%s leaked control byte %q into rendered output:\n%q", view, r, s)
 		}
 	}
@@ -83,10 +84,16 @@ func TestDetailsViewStripsControlBytes(t *testing.T) {
 func TestSanitizeTerminal(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"plain", "plain"},
-		{hostileHandle, "Bad]0;pwnedGuy"},
+		{hostileHandle, "Bad]0;pwnedGuy2K"},
 		{"tab\there", "tabhere"},
 		{"höla™", "höla™"},
 		{"", ""},
+		// C1 controls: U+009B is 8-bit CSI, so "2J" is a screen clear on
+		// terminals that honour C1. CP437 high bytes decode to printable
+		// codepoints (é, ü, ¢) outside this range, so they survive.
+		{"clear\u009b2J", "clear2J"},
+		{"pad\u0080ding", "padding"},
+		{"café ¢ ü", "café ¢ ü"},
 	}
 	for _, c := range cases {
 		if got := sanitizeTerminal(c.in); got != c.want {

--- a/internal/wfcui/sanitize_test.go
+++ b/internal/wfcui/sanitize_test.go
@@ -1,0 +1,96 @@
+package wfcui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/admin"
+)
+
+// hostileHandle embeds an OSC title-change sequence and a C0 control byte —
+// the shape of a terminal-escape injection a caller could attempt via their
+// handle. No rendered view may pass these bytes through to the terminal.
+const hostileHandle = "Bad\x1b]0;pwned\x07Guy\x01"
+
+// assertNoControlBytes fails if s contains any C0 control byte other than
+// newline, or a DEL. Views under NoColor emit no escapes of their own, so any
+// hit is injected data leaking through.
+func assertNoControlBytes(t *testing.T, view, s string) {
+	t.Helper()
+	for _, r := range s {
+		if (r < 0x20 && r != '\n') || r == 0x7f {
+			t.Fatalf("%s leaked control byte %q into rendered output:\n%q", view, r, s)
+		}
+	}
+}
+
+// TestNodeTableStripsControlBytes verifies a hostile handle cannot inject
+// terminal escapes via the node list.
+func TestNodeTableStripsControlBytes(t *testing.T) {
+	m := makeModel(Options{NoColor: true, ASCII: true}, 100, 30)
+	m.mode = modeList
+	m.snapshot = &admin.SystemSnapshot{
+		SystemName: "TestBBS",
+		Time:       time.Now(),
+		Nodes: []admin.NodeState{
+			{NodeID: 1, Handle: hostileHandle, Activity: "read\x1b[2Jing", Status: admin.StatusOnline},
+		},
+		Counters: admin.Counters{ActiveNodes: 1},
+	}
+	got := m.View()
+	assertNoControlBytes(t, "list view", got)
+	if !strings.Contains(got, "Bad") {
+		t.Errorf("printable part of handle missing; got:\n%s", got)
+	}
+}
+
+// TestEventFeedStripsControlBytes verifies a hostile handle cannot inject
+// terminal escapes via the event feed.
+func TestEventFeedStripsControlBytes(t *testing.T) {
+	m := makeModel(Options{NoColor: true, ASCII: true}, 100, 30)
+	m.mode = modeList
+	m.showLogs = true
+	m.snapshot = &admin.SystemSnapshot{SystemName: "TestBBS", Time: time.Now()}
+	m.events = []admin.Event{
+		{Time: time.Now(), Type: admin.EventCallerConnected, NodeID: 2,
+			Handle: hostileHandle, Message: "caller\x1b[31m connected"},
+	}
+	got := m.View()
+	assertNoControlBytes(t, "event feed", got)
+}
+
+// TestDetailsViewStripsControlBytes verifies a hostile handle cannot inject
+// terminal escapes via the node details view.
+func TestDetailsViewStripsControlBytes(t *testing.T) {
+	m := makeModel(Options{NoColor: true, ASCII: true}, 100, 30)
+	m.mode = modeDetails
+	m.selected = 0
+	m.snapshot = &admin.SystemSnapshot{
+		SystemName: "TestBBS",
+		Time:       time.Now(),
+		Nodes: []admin.NodeState{
+			{NodeID: 1, Handle: hostileHandle, Activity: "x\x1bc", CurrentMenu: "MAIN\x08\x08",
+				RemoteAddr: "10.0.0.1:9\x1b[9999", Status: admin.StatusOnline},
+		},
+	}
+	got := m.View()
+	assertNoControlBytes(t, "details view", got)
+}
+
+// TestSanitizeTerminal covers the helper directly: strips C0 controls and DEL,
+// keeps printable text (including non-ASCII) intact.
+func TestSanitizeTerminal(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"plain", "plain"},
+		{hostileHandle, "Bad]0;pwnedGuy"},
+		{"tab\there", "tabhere"},
+		{"höla™", "höla™"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := sanitizeTerminal(c.in); got != c.want {
+			t.Errorf("sanitizeTerminal(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/wfcui/sanitize_test.go
+++ b/internal/wfcui/sanitize_test.go
@@ -11,7 +11,7 @@ import (
 // hostileHandle embeds an OSC title-change sequence and a C0 control byte —
 // the shape of a terminal-escape injection a caller could attempt via their
 // handle. No rendered view may pass these bytes through to the terminal.
-const hostileHandle = "Bad\x1b]0;pwned\x07Guy\x012K"
+const hostileHandle = "Bad\x1b]0;pwned\x07Guy\x01\u009b2K"
 
 // assertNoControlBytes fails if s contains any C0 control byte other than
 // newline, a DEL, or a C1 control (U+0080–U+009F — U+009B is 8-bit CSI).
@@ -88,12 +88,16 @@ func TestSanitizeTerminal(t *testing.T) {
 		{"tab\there", "tabhere"},
 		{"höla™", "höla™"},
 		{"", ""},
-		// C1 controls: U+009B is 8-bit CSI, so "2J" is a screen clear on
+		// C1 controls: U+009B is 8-bit CSI, so "\u009b2J" is a screen clear on
 		// terminals that honour C1. CP437 high bytes decode to printable
 		// codepoints (é, ü, ¢) outside this range, so they survive.
 		{"clear\u009b2J", "clear2J"},
 		{"pad\u0080ding", "padding"},
 		{"café ¢ ü", "café ¢ ü"},
+		// Invalid UTF-8 must not reach the terminal raw; each bad byte
+		// becomes U+FFFD.
+		{"bad\xffbyte", "bad\ufffdbyte"},
+		{"lone\xc3", "lone\ufffd"},
 	}
 	for _, c := range cases {
 		if got := sanitizeTerminal(c.in); got != c.want {

--- a/internal/wfcui/view.go
+++ b/internal/wfcui/view.go
@@ -182,14 +182,14 @@ func (m Model) renderNodeTable(st colorSet, width, maxLines int) []string {
 		if len(lines) >= maxLines {
 			break
 		}
-		handle := truncate(n.Handle, colHandle)
+		handle := truncate(sanitizeTerminal(n.Handle), colHandle)
 		if handle == "" {
 			handle = "(login)"
 		}
-		status := truncate(string(n.Status), colStatus)
-		activity := truncate(n.Activity, colActivity)
-		menu := truncate(n.CurrentMenu, colMenu)
-		addr := truncate(n.RemoteAddr, colAddr)
+		status := truncate(sanitizeTerminal(string(n.Status)), colStatus)
+		activity := truncate(sanitizeTerminal(n.Activity), colActivity)
+		menu := truncate(sanitizeTerminal(n.CurrentMenu), colMenu)
+		addr := truncate(sanitizeTerminal(n.RemoteAddr), colAddr)
 
 		row := fmt.Sprintf(titleFmt, handle, status, activity, menu, addr)
 		if i == m.selected {
@@ -224,7 +224,7 @@ func (m Model) renderEventFeed(st colorSet, width, maxLines int) []string {
 		// consuming extra rows beyond maxLines.  tsLen accounts for the timestamp
 		// prefix plus the two two-space separators ("  " each).
 		const tsLen = 8 + 2 // "HH:MM:SS" + two-space separator
-		tail := ev.Handle + "  " + ev.Message
+		tail := sanitizeTerminal(ev.Handle + "  " + ev.Message)
 		tailRunes := []rune(tail)
 		maxTail := width - tsLen
 		if maxTail < 0 {


### PR DESCRIPTION
## Summary

Security audit of the WFC console and admin channel surfaced five findings; this PR addresses all of them and expands the sysop guide.

### Hardening
- **Terminal escape injection**: caller handles are now stripped of control bytes before the WFC TUI renders them (node table, event feed, details view), and `validateHandle` rejects control characters at registration. A hostile handle could previously replay escape sequences (title changes, screen clears) into the sysop's terminal.
- **Live re-authorization**: open wfc-admin sessions re-check `authorizeAdmin` every 30s and disconnect when it stops holding (WFC access disabled, user demoted or banned in the running daemon). Key removals via `ue`/`helper` still require a restart (daemon reads `users.json` at startup); documented.
- **Refresh rate-limit**: `CommandRefresh` no longer forces a snapshot rebuild more often than the configured tick interval, closing a CPU/log-flood nuisance from a compromised admin key.
- **Key-scan visibility**: unknown public-key offers are logged at debug level with their SHA256 fingerprint.

### Docs
- New "Console functions" reference (header, node table, statuses, details, event feed, refresh/reconnect)
- Key generation → transfer → registration walkthrough, and a troubleshooting section for the auth failure modes
- Security model updated: re-authorization window, revocation restart caveat, disclosure scope at `coSysOpLevel` (including invisible sessions — kept visible to admins by design), display sanitization

## Test plan
- New tests: escape-injection through all three views, `sanitizeTerminal` unit cases, `validateHandle` control-char rejection, refresh rate-limiting, re-auth watcher kick/shutdown
- `go test -race` on `cmd/vision3`, `internal/admin`, `internal/wfcui`; full `go test ./...` green; gofmt/vet clean

Note: sanitization is client-side — remote sysops need a rebuilt `wfc` binary to pick it up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Administration sessions now disconnect when authorization is revoked.
  * Terminal control characters are removed from displayed node and event data.
  * Invalid or unsafe handles are rejected during account setup.

* **Performance**
  * Rapid refresh requests are rate-limited to reduce unnecessary updates.

* **Documentation**
  * Expanded the WFC console guide with setup, usage, security, and troubleshooting instructions.

* **Tests**
  * Added coverage for authorization changes, refresh rate limiting, input validation, and terminal-output sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->