### PR TITLE
chore: bump version to 0.6.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,4 +3,4 @@ package version
 // Number is the global ViSiON/3 version.
 // Set this at build time with:
 // -ldflags "-X github.com/ViSiON-3/vision-3-bbs/internal/version.Number=1.0.0"
-var Number = "0.6.0"
+var Number = "0.6.1"


### PR DESCRIPTION
Version bump for the v0.6.1 release (WFC security hardening, #174).