### PR TITLE
fix(menu): make the sysop menu reachable on a fresh install

### DIFF
--- a/internal/menu/menu_art_hotkeys_test.go
+++ b/internal/menu/menu_art_hotkeys_test.go
@@ -1,0 +1,100 @@
+package menu
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+)
+
+// advertisedHotkey matches a hotkey as menu art presents one: a single
+// character in brackets or parentheses, e.g. "[X] Sysop Menu" or "(%) Sysop".
+var advertisedHotkey = regexp.MustCompile(`[(\[]([A-Za-z0-9%/!^+*-])[)\]]`)
+
+// conditionalMarker matches the {{ACS}}...{{/}} wrappers used for
+// access-gated lines. The markers come out; the text between them stays,
+// because a key advertised only to sysops still has to work for sysops.
+var conditionalMarker = regexp.MustCompile(`\{\{[^}]*\}\}`)
+
+// knownUnboundHotkeys records art that advertises a key its CFG does not bind,
+// where that is understood rather than a defect to fix now. Anything not listed
+// here is drift and fails the test.
+var knownUnboundHotkeys = map[string]map[string]string{
+	"DOORSM": {
+		"B": "sample Synchronet door in the shipped art; doors are site-specific and sysops bind their own",
+		"C": "sample Synchronet door in the shipped art; doors are site-specific and sysops bind their own",
+	},
+	"SPONSORM": {
+		"P": "'Re-Order Sub-Boards' is advertised but not implemented; see issue #176",
+	},
+}
+
+// TestMenuArtHotkeysAreBound guards against art and CFG drifting apart, which
+// leaves a key printed on screen that does nothing when pressed. That is how
+// the sysop menu became unreachable: MAIN.ANS advertised "(%) Sysop Menu" while
+// MAIN.CFG bound only X and /SYSOP, so the one account able to see the option
+// could not use it (issue #176).
+func TestMenuArtHotkeysAreBound(t *testing.T) {
+	menuSet := filepath.Join("..", "..", "menus", "v3")
+	ansiDir := filepath.Join(menuSet, "ansi")
+	cfgDir := filepath.Join(menuSet, "cfg")
+
+	entries, err := os.ReadDir(ansiDir)
+	if err != nil {
+		t.Skipf("menu set not available: %v", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".ANS") {
+			continue
+		}
+		name := strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name()))
+
+		if _, err := os.Stat(filepath.Join(cfgDir, name+".CFG")); err != nil {
+			continue // art with no command set of its own
+		}
+
+		commands, err := LoadCommands(name, cfgDir)
+		if err != nil {
+			t.Errorf("%s.CFG: %v", name, err)
+			continue
+		}
+		bound := make(map[string]bool)
+		for _, cmd := range commands {
+			for _, key := range strings.Fields(strings.ToUpper(cmd.Keys)) {
+				bound[key] = true
+			}
+		}
+
+		raw, err := ansi.GetAnsiFileContent(filepath.Join(ansiDir, entry.Name()))
+		if err != nil {
+			t.Errorf("%s.ANS: %v", name, err)
+			continue
+		}
+		text := conditionalMarker.ReplaceAllString(string(ansi.StripAnsi(string(raw))), "")
+
+		var missing []string
+		for _, match := range advertisedHotkey.FindAllStringSubmatch(text, -1) {
+			key := strings.ToUpper(match[1])
+			if bound[key] {
+				continue
+			}
+			if reason, known := knownUnboundHotkeys[name][key]; known {
+				t.Logf("%s: %q advertised but unbound (known: %s)", name, key, reason)
+				continue
+			}
+			missing = append(missing, key)
+		}
+
+		if len(missing) > 0 {
+			sort.Strings(missing)
+			t.Errorf("%s.ANS advertises %v but %s.CFG does not bind %v; "+
+				"either bind the key or stop printing it in the art",
+				name, missing, name, missing)
+		}
+	}
+}

--- a/internal/user/manager.go
+++ b/internal/user/manager.go
@@ -118,7 +118,12 @@ func NewUserManager(dataPath string) (*UserMgr, error) { // Return renamed type
 			if saveErr != nil {
 				return nil, fmt.Errorf("failed to save default felonius user: %w", saveErr)
 			}
-			slog.Info("default felonius user created (felonius/password)")
+			// Warn, not Info: this account has a published default password
+			// and now holds sysop rights, so the operator needs to see this on
+			// a first start they may not be watching closely.
+			slog.Warn("created default sysop account with the published default password — change it now",
+				"handle", defaultUser.Handle, "password", "password", "accessLevel", defaultUser.AccessLevel,
+				"how", "log in and use the change-password option, or run ./ue")
 			// Determine next user ID after creating the default user
 			um.determineNextUserID()
 			return um, nil // Return successfully after creating default

--- a/internal/user/manager.go
+++ b/internal/user/manager.go
@@ -97,11 +97,18 @@ func NewUserManager(dataPath string) (*UserMgr, error) { // Return renamed type
 				GroupLocation: "ViSiON/3",
 				PrivateNote:   "SysOp",
 				PasswordHash:  string(hashedPw),
-				AccessLevel:   10,
-				Validated:     true,
-				TimeLimit:     60,
-				CreatedAt:     now,
-				UpdatedAt:     now,
+				// Sysop level. This account is the only one a fresh install
+				// has, and every sysop function (the ADMIN menu, user
+				// validation) gates on S255, so anything less locks the
+				// operator out of their own board with no in-BBS way back --
+				// raising a level needs the admin menu, which needs the level.
+				// setup.sh and dev-setup.sh already write 255 here; this path
+				// runs when neither did, such as a Docker first start.
+				AccessLevel: 255,
+				Validated:   true,
+				TimeLimit:   60,
+				CreatedAt:   now,
+				UpdatedAt:   now,
 			}
 			um.mu.Lock()
 			um.users[strings.ToLower(defaultUser.Handle)] = defaultUser

--- a/internal/user/manager_core_test.go
+++ b/internal/user/manager_core_test.go
@@ -64,8 +64,13 @@ func TestNewUserManager_EmptyDir_CreatesDefault(t *testing.T) {
 	if u.Handle != "Felonius" {
 		t.Errorf("expected handle Felonius, got %q", u.Handle)
 	}
-	if u.AccessLevel != 10 {
-		t.Errorf("expected access level 10, got %d", u.AccessLevel)
+	// Must be sysop level: this is the only account a fresh install has, and
+	// the ADMIN menu and user validation both gate on S255. Anything less
+	// locks the operator out of their own board, with no in-BBS way to raise
+	// it. Keep in step with the users.json that setup.sh and dev-setup.sh
+	// write, which has always used 255.
+	if u.AccessLevel != 255 {
+		t.Errorf("expected default sysop access level 255, got %d", u.AccessLevel)
 	}
 	if !u.Validated {
 		t.Error("expected default user to be validated")

--- a/menus/v3/cfg/MAIN.CFG
+++ b/menus/v3/cfg/MAIN.CFG
@@ -182,6 +182,13 @@
         "NODE_ACTIVITY": "SysOp Admin"
     },
     {
+        "KEYS": "%",
+        "CMD": "GOTO:ADMIN",
+        "ACS": "S255",
+        "HIDDEN": true,
+        "NODE_ACTIVITY": "SysOp Admin"
+    },
+    {
         "KEYS": "!",
         "CMD": "RUN:CHAT",
         "ACS": "*",


### PR DESCRIPTION
Fixes items 1 and 2 of #176. Item 3 (FTN wizard) is being handled separately.

## Item 2a — the art advertises a key the config never bound

`MAIN.ANS` prints the option inside an `{{S255}}` block:

```
{{S255}}|(%) Sysop Menu{{/}}
```

but `MAIN.CFG` bound `GOTO:ADMIN` to `X` and `/SYSOP` only. So the one account that can *see* the option could not use the key it was told to press. The reporter did exactly the right thing and got nothing.

`%` now maps to `GOTO:ADMIN` alongside the existing keys, which keep working.

## Item 2b — the bootstrap sysop account was not a sysop

`setup.sh` and `dev-setup.sh` both write Felonius with `"accessLevel": 255`. The Go fallback in `internal/user/manager.go`, which creates the same account when `users.json` is missing at runtime, used **10**. Every other field matches the scripts — handle, `"Joe Sysop"`, the `"SysOp"` note, `timeLimit: 60`, the password — so the level was drift between two paths that are meant to agree.

That fallback is not a rare path. `docker-entrypoint.sh` creates `data/users` but never writes `users.json`, and `docs/sysop/getting-started/docker.md` lists "Create default user (felonius/password)" as something first run does — so **every Docker install got level 10**.

The lockout is total: `ADMIN.MNU` is `ACS: S255`, user validation gates on S255, and raising a level requires the admin menu that the level guards. The only way out is the standalone `./ue` editor, if you know it exists. The reporter didn't, hence "there's no way to upgrade(validate?) any users".

The existing test asserted `AccessLevel != 10` → it was pinning the bug rather than the intent. It now asserts 255 and explains why.

## Item 1 — already fixed

"Screen showing Fast Login! v1.0 has duplicate options slightly offset" was `FASTLOGN.BAR` drawing the list at rows 8–11 while the art printed it at 14–17. Fixed in #177 (a38c5ee), which shipped after v0.6.1.

## Guard

`TestMenuArtHotkeysAreBound` scans every shipped `.ANS` with a matching `.CFG`, extracts keys the art advertises in `[X]` / `(X)` form, and fails when the CFG doesn't bind them. Conditional `{{S255}}` blocks are unwrapped rather than skipped, since a key shown only to sysops still has to work for sysops. Verified it catches this bug by reverting the `%` binding:

```
--- FAIL: TestMenuArtHotkeysAreBound
    MAIN.ANS advertises [%] but MAIN.CFG does not bind [%];
    either bind the key or stop printing it in the art
```

Three pre-existing gaps are recorded as explained exemptions rather than quietly excluded:

- `DOORSM` `[B]`, `[C]` — sample Synchronet doors in the shipped art; doors are site-specific and sysops bind their own.
- `SPONSORM` `[P]` "Re-Order Sub-Boards" — **advertised but never implemented**. A genuine dead key found by this test; noted on #176 rather than fixed here.

This is the same failure mode as #177, where `FASTLOGN.BAR` drifted from its art. Coordinates and keys are duplicated between art and config with nothing checking they agree — that's now two guards covering both halves.

## Verification

`go build ./...`, `go vet ./...`, `gofmt`, `go test ./...` and `go test -race ./...` all pass locally.

Worth a reviewer's eye: the `%` binding is `HIDDEN: true`, matching how `MSGMENU` treats its own `%` sponsor-menu key, since the art draws the option itself and doesn't need it in a generated list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a hidden `%` hotkey for authorized SysOps to access the Admin menu.
  - New installations now assign the default `Felonius` account full SysOp access.
  - Startup now displays a warning with default account details and password-change instructions.

- **Bug Fixes**
  - Improved consistency between fresh-install account permissions and the generated user configuration.

- **Tests**
  - Added validation to detect menu hotkeys that are advertised but not properly configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->