### PR TITLE
feat(configeditor): let the FTN wizard edit an existing network

### DIFF
--- a/internal/configeditor/fields_ftn_wizard.go
+++ b/internal/configeditor/fields_ftn_wizard.go
@@ -9,13 +9,25 @@ import (
 	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 )
 
+// networkFieldHelp explains the Network row, which is a browse action when
+// adding and a fixed label when editing.
+func networkFieldHelp(w *ftnWizardState) string {
+	if w.editing() {
+		return "Editing an existing network; its name is fixed"
+	}
+	return "Press Enter to browse known FTN networks"
+}
+
 // fieldsFTNWizard returns field definitions for the FTN setup wizard form.
 func (m *Model) fieldsFTNWizard() []fieldDef {
 	w := m.ftnWizard
 	return []fieldDef{
 		{
-			Label: "Network", Help: "Press Enter to browse known FTN networks", Type: ftDisplay, Col: 3, Row: 1, Width: 40,
+			Label: "Network", Help: networkFieldHelp(w), Type: ftDisplay, Col: 3, Row: 1, Width: 40,
 			Get: func() string {
+				if w.editing() {
+					return w.networkName + "  (editing — name cannot be changed)"
+				}
 				if w.networkName != "" {
 					return w.networkName
 				}
@@ -198,6 +210,12 @@ func (m *Model) fieldsFTNWizard() []fieldDef {
 				if n == 0 {
 					if w.areasFetched {
 						return "(none selected — press Enter to browse)"
+					}
+					// Editing: report what is already configured instead of
+					// implying nothing is subscribed just because this run has
+					// not downloaded the echolist yet.
+					if len(w.subscribedTags) > 0 {
+						return fmt.Sprintf("%d already subscribed — press Enter to change", len(w.subscribedTags))
 					}
 					return "(press Enter to download area list)"
 				}

--- a/internal/configeditor/ftn_wizard_edit_test.go
+++ b/internal/configeditor/ftn_wizard_edit_test.go
@@ -1,6 +1,8 @@
 package configeditor
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -202,5 +204,82 @@ func TestConfirmFTNWizardAddRefusesDuplicate(t *testing.T) {
 	}
 	if !strings.Contains(m.message, "edit") {
 		t.Errorf("message = %q, should point the sysop at editing", m.message)
+	}
+}
+
+// TestConfirmFTNWizardEditUpdatesAreaOriginAddr covers changing your own FTN
+// address on an existing network. Areas carry the origin they were created
+// with and createFTNMsgAreaIfNeeded leaves existing ones alone, so without an
+// explicit update every area would keep stamping outbound mail with the old
+// address while ftn.json showed the new one.
+func TestConfirmFTNWizardEditUpdatesAreaOriginAddr(t *testing.T) {
+	m, _ := configuredModel().startFTNWizardEdit("fsxnet")
+	for i := range m.configs.MsgAreas {
+		m.configs.MsgAreas[i].OriginAddr = "21:4/158"
+	}
+	m.ftnWizard.ownAddress = "21:4/159"
+	m.configPath = t.TempDir()
+
+	m, _ = m.confirmFTNWizard()
+
+	for _, area := range m.configs.MsgAreas {
+		if !strings.EqualFold(area.Network, "fsxnet") {
+			continue
+		}
+		if area.OriginAddr != "21:4/159" {
+			t.Errorf("area %s OriginAddr = %q, want the edited address", area.Tag, area.OriginAddr)
+		}
+	}
+}
+
+// TestConfirmFTNWizardKeepsBinkdWarning makes sure a binkd.conf failure is not
+// buried by the success message. Telling the operator to restart when the
+// mailer never got the new details is worse than saying nothing.
+func TestConfirmFTNWizardKeepsBinkdWarning(t *testing.T) {
+	m, _ := configuredModel().startFTNWizardEdit("fsxnet")
+
+	// configPath must be writable so the config save succeeds and we reach the
+	// success message -- that is the path the warning used to be lost on.
+	// binkd.conf resolves to configPath/../data/ftn/binkd.conf, so making
+	// "data" a regular file fails only the binkd write.
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "configs"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "data"), []byte("not a directory"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	m.configPath = filepath.Join(dir, "configs")
+
+	m, _ = m.confirmFTNWizard()
+
+	if strings.HasPrefix(m.message, "SAVE ERROR") {
+		t.Fatalf("config save failed, so this did not exercise the success path: %q", m.message)
+	}
+	if !strings.Contains(m.message, "updated") {
+		t.Errorf("message = %q, want the success result retained", m.message)
+	}
+	if !strings.Contains(m.message, "binkd.conf update failed") {
+		t.Errorf("message = %q, want the binkd warning kept alongside the success result", m.message)
+	}
+}
+
+// TestUnsubscribedTagCountIgnoresAreasAbsentFromEcholist: an area the echolist
+// no longer offers cannot be unticked, so it was never the operator's decision
+// and must not be reported as one.
+func TestUnsubscribedTagCountIgnoresAreasAbsentFromEcholist(t *testing.T) {
+	w := &ftnWizardState{
+		subscribedTags: map[string]bool{"FSX_GEN": true, "FSX_RETIRED": true},
+		areasFetched:   true,
+		availableAreas: []ftn.EchoArea{{Tag: "FSX_GEN"}},
+		selectedAreas:  []bool{true},
+	}
+	if n := w.unsubscribedTagCount(); n != 0 {
+		t.Errorf("dropped = %d, want 0 — FSX_RETIRED is not in the echolist so it was never unticked", n)
+	}
+
+	w.selectedAreas = []bool{false}
+	if n := w.unsubscribedTagCount(); n != 1 {
+		t.Errorf("dropped = %d, want 1 — FSX_GEN was offered and unticked", n)
 	}
 }

--- a/internal/configeditor/ftn_wizard_edit_test.go
+++ b/internal/configeditor/ftn_wizard_edit_test.go
@@ -1,0 +1,206 @@
+package configeditor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+	"github.com/ViSiON-3/vision-3-bbs/internal/ftn"
+	"github.com/ViSiON-3/vision-3-bbs/internal/message"
+)
+
+// configuredModel builds a Model with one FTN network already set up, the
+// situation the wizard used to ignore entirely (issue #176).
+func configuredModel() Model {
+	return Model{
+		configs: &allConfigs{
+			FTN: config.FTNConfig{
+				Networks: map[string]config.FTNNetworkConfig{
+					"fsxnet": {
+						InternalTosserEnabled: true,
+						OwnAddress:            "21:4/158",
+						PollSeconds:           900,
+						Tearline:              "Custom Tearline",
+						Links: []config.FTNLinkConfig{{
+							Address:         "21:1/100",
+							Hostname:        "agency.bbs.nz",
+							Port:            24554,
+							AreafixPassword: "afpw",
+							SessionPassword: "sesspw",
+							PacketPassword:  "pktpw",
+							Name:            "fsxnet Hub",
+							Flavour:         "Crash",
+						}},
+					},
+				},
+			},
+			MsgAreas: []message.MessageArea{
+				{ID: 1, Tag: "fsxnet_netmail", Network: "fsxnet", AreaType: "netmail"},
+				{ID: 2, Tag: "fsxnet_fsx_gen", Network: "fsxnet", AreaType: "echomail", EchoTag: "FSX_GEN", AutoJoin: false},
+				{ID: 3, Tag: "fsxnet_fsx_bbs", Network: "fsxnet", AreaType: "echomail", EchoTag: "FSX_BBS", AutoJoin: false},
+			},
+		},
+	}
+}
+
+// TestEnterFTNWizardOffersPickerWhenConfigured is the reported bug: entering
+// the wizard with a network already set up must surface it rather than opening
+// a blank form that hides what exists.
+func TestEnterFTNWizardOffersPickerWhenConfigured(t *testing.T) {
+	m, _ := configuredModel().enterFTNWizard()
+
+	if m.mode != modeFTNWizardPicker {
+		t.Fatalf("mode = %v, want modeFTNWizardPicker", m.mode)
+	}
+	if len(m.ftnWizardPickerKeys) != 1 || m.ftnWizardPickerKeys[0] != "fsxnet" {
+		t.Errorf("picker keys = %v, want [fsxnet]", m.ftnWizardPickerKeys)
+	}
+}
+
+// TestEnterFTNWizardSkipsPickerWhenEmpty keeps first-run friction unchanged.
+func TestEnterFTNWizardSkipsPickerWhenEmpty(t *testing.T) {
+	m, _ := Model{configs: &allConfigs{}}.enterFTNWizard()
+
+	if m.mode != modeFTNWizardForm {
+		t.Fatalf("mode = %v, want modeFTNWizardForm on a fresh system", m.mode)
+	}
+	if m.ftnWizard.editing() {
+		t.Error("a fresh system should start in add mode")
+	}
+}
+
+// TestStartFTNWizardEditLoadsExistingConfig covers the reporter's actual ask:
+// the wizard should show what was originally added.
+func TestStartFTNWizardEditLoadsExistingConfig(t *testing.T) {
+	m, _ := configuredModel().startFTNWizardEdit("fsxnet")
+
+	w := m.ftnWizard
+	if !w.editing() || w.editingKey != "fsxnet" {
+		t.Fatalf("editingKey = %q, want fsxnet", w.editingKey)
+	}
+
+	for _, tc := range []struct{ name, got, want string }{
+		{"ownAddress", w.ownAddress, "21:4/158"},
+		{"hubAddress", w.hubAddress, "21:1/100"},
+		{"hubHostname", w.hubHostname, "agency.bbs.nz"},
+		{"areafixPassword", w.areafixPassword, "afpw"},
+		{"sessionPassword", w.sessionPassword, "sesspw"},
+		{"packetPassword", w.packetPassword, "pktpw"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s = %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+	if w.hubPort != 24554 {
+		t.Errorf("hubPort = %d, want 24554", w.hubPort)
+	}
+	if w.zone != 21 {
+		t.Errorf("zone = %d, want 21 (parsed from own address)", w.zone)
+	}
+	if !w.subscribedTags["FSX_GEN"] || !w.subscribedTags["FSX_BBS"] {
+		t.Errorf("subscribedTags = %v, want FSX_GEN and FSX_BBS", w.subscribedTags)
+	}
+	if w.autoJoinAreas {
+		t.Error("autoJoinAreas should reflect the configured areas (false), not the add-mode default")
+	}
+}
+
+// TestConfirmFTNWizardEditPreservesUnaskedSettings is the destructive case:
+// the wizard must not reset settings owned by the Echomail Networks editor.
+func TestConfirmFTNWizardEditPreservesUnaskedSettings(t *testing.T) {
+	m, _ := configuredModel().startFTNWizardEdit("fsxnet")
+	m.ftnWizard.hubHostname = "new.host.example"
+	m.configPath = t.TempDir()
+
+	m, _ = m.confirmFTNWizard()
+
+	net := m.configs.FTN.Networks["fsxnet"]
+	if net.PollSeconds != 900 {
+		t.Errorf("PollSeconds = %d, want 900 preserved", net.PollSeconds)
+	}
+	if net.Tearline != "Custom Tearline" {
+		t.Errorf("Tearline = %q, want preserved", net.Tearline)
+	}
+	if !net.InternalTosserEnabled {
+		t.Error("InternalTosserEnabled should be preserved")
+	}
+	if len(net.Links) != 1 {
+		t.Fatalf("expected 1 link, got %d", len(net.Links))
+	}
+	if net.Links[0].Hostname != "new.host.example" {
+		t.Errorf("Hostname = %q, want the edit applied", net.Links[0].Hostname)
+	}
+}
+
+// TestReplaceHubLinkKeepsDownstreamLinks guards the links the wizard does not
+// manage: nodes this system feeds must survive a wizard save.
+func TestReplaceHubLinkKeepsDownstreamLinks(t *testing.T) {
+	links := []config.FTNLinkConfig{
+		{Address: "21:1/100", Hostname: "old.host", Flavour: "Crash", Name: "fsxnet Hub"},
+		{Address: "21:4/900", Hostname: "downstream.example", Flavour: "Hold", Name: "A Point"},
+	}
+	hub := config.FTNLinkConfig{Address: "21:1/100", Hostname: "new.host", Flavour: "Direct", Name: "overwritten"}
+
+	got := replaceHubLink(links, hub)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 links, got %d", len(got))
+	}
+	if got[0].Hostname != "new.host" {
+		t.Errorf("hub hostname = %q, want new.host", got[0].Hostname)
+	}
+	if got[0].Flavour != "Crash" || got[0].Name != "fsxnet Hub" {
+		t.Errorf("hub flavour/name should be preserved, got %q/%q", got[0].Flavour, got[0].Name)
+	}
+	if got[1].Address != "21:4/900" || got[1].Hostname != "downstream.example" {
+		t.Errorf("downstream link was damaged: %+v", got[1])
+	}
+}
+
+// TestReplaceHubLinkHandlesChangedHubAddress covers moving to a different hub.
+func TestReplaceHubLinkHandlesChangedHubAddress(t *testing.T) {
+	links := []config.FTNLinkConfig{{Address: "21:1/100", Hostname: "old.host", Flavour: "Crash"}}
+	hub := config.FTNLinkConfig{Address: "21:1/200", Hostname: "new.host"}
+
+	got := replaceHubLink(links, hub)
+
+	if len(got) != 1 {
+		t.Fatalf("expected the hub replaced in place, got %d links", len(got))
+	}
+	if got[0].Address != "21:1/200" {
+		t.Errorf("address = %q, want the new hub", got[0].Address)
+	}
+}
+
+// TestUnsubscribedTagCountOnlyAfterReview makes sure an untouched wizard run
+// never reports areas as dropped just because no echolist was downloaded.
+func TestUnsubscribedTagCountOnlyAfterReview(t *testing.T) {
+	w := &ftnWizardState{subscribedTags: map[string]bool{"FSX_GEN": true, "FSX_BBS": true}}
+	if n := w.unsubscribedTagCount(); n != 0 {
+		t.Errorf("without a downloaded echolist, dropped = %d, want 0", n)
+	}
+
+	w.areasFetched = true
+	w.availableAreas = []ftn.EchoArea{{Tag: "FSX_GEN"}, {Tag: "FSX_BBS"}}
+	w.selectedAreas = []bool{true, false}
+	if n := w.unsubscribedTagCount(); n != 1 {
+		t.Errorf("dropped = %d, want 1 (FSX_BBS unticked)", n)
+	}
+}
+
+// TestConfirmFTNWizardAddRefusesDuplicate keeps add mode from merging into an
+// existing network, and points at the new way to change one.
+func TestConfirmFTNWizardAddRefusesDuplicate(t *testing.T) {
+	m := configuredModel()
+	m.ftnWizard = &ftnWizardState{networkName: "fsxnet"}
+	m.configPath = t.TempDir()
+
+	m, _ = m.confirmFTNWizard()
+
+	if !strings.Contains(m.message, "already exists") {
+		t.Errorf("message = %q, want a duplicate refusal", m.message)
+	}
+	if !strings.Contains(m.message, "edit") {
+		t.Errorf("message = %q, should point the sysop at editing", m.message)
+	}
+}

--- a/internal/configeditor/ftn_wizard_save.go
+++ b/internal/configeditor/ftn_wizard_save.go
@@ -79,6 +79,16 @@ func (m Model) confirmFTNWizard() (Model, tea.Cmd) {
 		existing.OwnAddress = w.ownAddress
 		existing.Links = replaceHubLink(existing.Links, link)
 		m.configs.FTN.Networks[netKey] = existing
+
+		// Areas carry the origin address they were created with, and
+		// createFTNMsgAreaIfNeeded leaves existing ones alone. Without this,
+		// editing the address updates ftn.json while every area keeps stamping
+		// outbound mail with the old one.
+		for i := range m.configs.MsgAreas {
+			if strings.EqualFold(m.configs.MsgAreas[i].Network, netKey) {
+				m.configs.MsgAreas[i].OriginAddr = w.ownAddress
+			}
+		}
 	} else {
 		m.configs.FTN.Networks[netKey] = config.FTNNetworkConfig{
 			InternalTosserEnabled: true,
@@ -162,9 +172,12 @@ func (m Model) confirmFTNWizard() (Model, tea.Cmd) {
 			NetworkName: w.networkName,
 		},
 	}
+	// Non-fatal: binkd.conf update is best-effort, but the operator has to be
+	// told, because the final status below otherwise says "restart to
+	// activate" for a mailer that never got the new details.
+	binkdWarning := ""
 	if err := ftn.UpdateBinkdConf(binkdPath, binkdCfg); err != nil {
-		// Non-fatal: binkd.conf update is best-effort.
-		m.message = fmt.Sprintf("Warning: binkd.conf update failed: %v (network saved OK)", err)
+		binkdWarning = fmt.Sprintf(" Warning: binkd.conf update failed: %v — fix it before restarting.", err)
 	}
 
 	// 6. Wire scheduler events for mail flow (hub poll + supporting events).
@@ -174,6 +187,7 @@ func (m Model) confirmFTNWizard() (Model, tea.Cmd) {
 	m.dirty = true
 	m.saveAll()
 	if strings.HasPrefix(m.message, "SAVE ERROR") {
+		m.message += binkdWarning
 		return m, nil
 	}
 
@@ -194,6 +208,7 @@ func (m Model) confirmFTNWizard() (Model, tea.Cmd) {
 	} else {
 		m.message = fmt.Sprintf("FTN network %q saved — %d area(s) created. Restart BBS to activate.", w.networkName, selectedCount)
 	}
+	m.message += binkdWarning
 	m.mode = modeCategoryMenu
 	return m, nil
 }

--- a/internal/configeditor/ftn_wizard_save.go
+++ b/internal/configeditor/ftn_wizard_save.go
@@ -19,16 +19,23 @@ func (m Model) confirmFTNWizard() (Model, tea.Cmd) {
 
 	// Derive network key (lowercase).
 	netKey := strings.ToLower(w.networkName)
+	editing := w.editing()
+	if editing {
+		// The name is fixed while editing, so the key the fields describe is
+		// the key we loaded from.
+		netKey = w.editingKey
+	}
 
-	// Duplicate check.
-	if m.configs.FTN.Networks != nil {
+	// Adding a network that already exists would silently merge into it, so
+	// refuse. Editing is the supported way to change one.
+	if !editing && m.configs.FTN.Networks != nil {
 		if _, exists := m.configs.FTN.Networks[netKey]; exists {
-			m.message = fmt.Sprintf("Network %q already exists in ftn.json", netKey)
+			m.message = fmt.Sprintf("Network %q already exists — go back and choose it to edit instead", netKey)
 			return m, nil
 		}
 	}
 
-	// 1. Create FTN network entry.
+	// 1. Create or update the FTN network entry.
 	if m.configs.FTN.Networks == nil {
 		m.configs.FTN.Networks = make(map[string]config.FTNNetworkConfig)
 	}
@@ -64,12 +71,22 @@ func (m Model) confirmFTNWizard() (Model, tea.Cmd) {
 		Port:            w.hubPort,
 	}
 
-	m.configs.FTN.Networks[netKey] = config.FTNNetworkConfig{
-		InternalTosserEnabled: true,
-		OwnAddress:            w.ownAddress,
-		PollSeconds:           300,
-		Tearline:              "ViSiON/3",
-		Links:                 []config.FTNLinkConfig{link},
+	if existing, ok := m.configs.FTN.Networks[netKey]; ok && editing {
+		// Keep the settings this wizard does not ask about. Tosser, poll
+		// interval and tearline are all editable under Echomail Networks, and
+		// rewriting them with the wizard's create-time defaults would throw
+		// away whatever the sysop set there.
+		existing.OwnAddress = w.ownAddress
+		existing.Links = replaceHubLink(existing.Links, link)
+		m.configs.FTN.Networks[netKey] = existing
+	} else {
+		m.configs.FTN.Networks[netKey] = config.FTNNetworkConfig{
+			InternalTosserEnabled: true,
+			OwnAddress:            w.ownAddress,
+			PollSeconds:           300,
+			Tearline:              "ViSiON/3",
+			Links:                 []config.FTNLinkConfig{link},
+		}
 	}
 
 	// 2. Create conference for the network.
@@ -161,9 +178,51 @@ func (m Model) confirmFTNWizard() (Model, tea.Cmd) {
 	}
 
 	selectedCount := w.selectedAreaCount()
-	m.message = fmt.Sprintf("FTN network %q saved — %d area(s) created. Restart BBS to activate.", w.networkName, selectedCount)
+	if editing {
+		// Areas are only ever added here. Removing one would mean deleting a
+		// message base with real mail in it, which is not something to do as a
+		// side effect of saving a form, so say so rather than quietly ignoring
+		// the untick.
+		dropped := w.unsubscribedTagCount()
+		m.message = fmt.Sprintf("FTN network %q updated — %d area(s) subscribed. Restart BBS to activate.",
+			netKey, selectedCount)
+		if dropped > 0 {
+			m.message = fmt.Sprintf("FTN network %q updated — %d area(s) subscribed. "+
+				"%d existing area(s) left in place: remove them under Message Areas. Restart BBS to activate.",
+				netKey, selectedCount, dropped)
+		}
+	} else {
+		m.message = fmt.Sprintf("FTN network %q saved — %d area(s) created. Restart BBS to activate.", w.networkName, selectedCount)
+	}
 	m.mode = modeCategoryMenu
 	return m, nil
+}
+
+// replaceHubLink updates the hub entry in a link list, leaving every other link
+// alone. The hub is the first link the wizard wrote; any links after it are
+// downstream systems this node feeds, which the wizard does not manage and must
+// not drop. Matching by address first keeps the right entry when the list has
+// been reordered under Echomail Networks.
+func replaceHubLink(links []config.FTNLinkConfig, hub config.FTNLinkConfig) []config.FTNLinkConfig {
+	for i := range links {
+		if strings.EqualFold(links[i].Address, hub.Address) {
+			// Preserve fields the wizard does not ask about.
+			hub.Flavour = links[i].Flavour
+			if links[i].Name != "" {
+				hub.Name = links[i].Name
+			}
+			links[i] = hub
+			return links
+		}
+	}
+	if len(links) == 0 {
+		return []config.FTNLinkConfig{hub}
+	}
+	// The hub address itself changed: replace the first entry, which is where
+	// the wizard puts the hub.
+	hub.Flavour = links[0].Flavour
+	links[0] = hub
+	return links
 }
 
 // createFTNMsgAreaIfNeeded creates a message area if one with the given tag

--- a/internal/configeditor/ftn_wizard_state.go
+++ b/internal/configeditor/ftn_wizard_state.go
@@ -96,18 +96,29 @@ func (s *ftnWizardState) unsubscribedTagCount() int {
 	if s == nil || len(s.subscribedTags) == 0 {
 		return 0
 	}
-	stillSelected := make(map[string]bool, len(s.availableAreas))
-	for i, sel := range s.selectedAreas {
-		if sel && i < len(s.availableAreas) {
-			stillSelected[strings.ToUpper(s.availableAreas[i].Tag)] = true
-		}
-	}
 	// Without a downloaded echolist nothing was reviewed, so nothing dropped.
 	if !s.areasFetched {
 		return 0
 	}
+
+	available := make(map[string]bool, len(s.availableAreas))
+	stillSelected := make(map[string]bool, len(s.availableAreas))
+	for i, area := range s.availableAreas {
+		tag := strings.ToUpper(area.Tag)
+		available[tag] = true
+		if i < len(s.selectedAreas) && s.selectedAreas[i] {
+			stillSelected[tag] = true
+		}
+	}
+
 	n := 0
 	for tag := range s.subscribedTags {
+		// A tag the echolist no longer offers could not have been unticked,
+		// so it was not a decision the operator made and must not be
+		// reported as one. The area is still configured and still works.
+		if !available[tag] {
+			continue
+		}
 		if !stillSelected[tag] {
 			n++
 		}

--- a/internal/configeditor/ftn_wizard_state.go
+++ b/internal/configeditor/ftn_wizard_state.go
@@ -2,6 +2,7 @@ package configeditor
 
 import (
 	"context"
+	"strings"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ftn"
 )
@@ -40,6 +41,18 @@ type ftnWizardState struct {
 	areasFetched   bool
 	areasFetchErr  string
 
+	// Editing an already-configured network. Empty means this run adds a new
+	// one. When set, it is the ftn.json network key being edited, and the
+	// network name is fixed: renaming would have to migrate the conference,
+	// every area tag and every msgbase path on disk, so the wizard does not
+	// offer it.
+	editingKey string
+
+	// Echo tags (upper-cased) this network is already subscribed to, read
+	// from the configured message areas. Used to tick the area browser to
+	// match reality, and to report the count before any echolist download.
+	subscribedTags map[string]bool
+
 	// Registry data (for pre-fill).
 	registryEntry *ftn.RegistryNetwork // nil if manual/custom
 
@@ -64,6 +77,38 @@ func (s *ftnWizardState) selectedAreaCount() int {
 	n := 0
 	for _, sel := range s.selectedAreas {
 		if sel {
+			n++
+		}
+	}
+	return n
+}
+
+// editing reports whether this wizard run is modifying an existing network
+// rather than adding a new one.
+func (s *ftnWizardState) editing() bool {
+	return s != nil && s.editingKey != ""
+}
+
+// unsubscribedTagCount returns how many already-configured echo areas are no
+// longer ticked in the area browser. Those areas stay on disk; this only
+// reports them so the save message can be honest about it.
+func (s *ftnWizardState) unsubscribedTagCount() int {
+	if s == nil || len(s.subscribedTags) == 0 {
+		return 0
+	}
+	stillSelected := make(map[string]bool, len(s.availableAreas))
+	for i, sel := range s.selectedAreas {
+		if sel && i < len(s.availableAreas) {
+			stillSelected[strings.ToUpper(s.availableAreas[i].Tag)] = true
+		}
+	}
+	// Without a downloaded echolist nothing was reviewed, so nothing dropped.
+	if !s.areasFetched {
+		return 0
+	}
+	n := 0
+	for tag := range s.subscribedTags {
+		if !stillSelected[tag] {
 			n++
 		}
 	}

--- a/internal/configeditor/model.go
+++ b/internal/configeditor/model.go
@@ -53,6 +53,7 @@ const (
 	modeRegistryBrowser                          // Registry browser (discover networks)
 	modeFTNWizardForm                            // FTN wizard form navigation
 	modeFTNWizardField                           // FTN wizard field editing (textinput active)
+	modeFTNWizardPicker                          // Add-new vs edit-existing choice on wizard entry
 	modeFTNNetworkBrowser                        // Known FTN network list with info panel
 	modeFTNAreaBrowser                           // FTN echo area selection from downloaded echolist
 	modeFTNAreaDownloading                       // Progress state while downloading echolist
@@ -255,6 +256,13 @@ type Model struct {
 	ftnNetBrowserEntries []ftn.RegistryNetwork // loaded from embedded registry
 	ftnNetBrowserCursor  int
 	ftnNetBrowserScroll  int
+
+	// FTN wizard entry picker: choose between adding a network and editing
+	// one that is already configured. Entry 0 is always "add new"; the rest
+	// index into ftnWizardPickerKeys.
+	ftnWizardPickerKeys   []string
+	ftnWizardPickerCursor int
+	ftnWizardPickerScroll int
 
 	// FTN area browser state
 	ftnAreaBrowserAreas    []ftn.EchoArea // parsed from downloaded echolist
@@ -468,6 +476,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			result, cmd = m.updateFTNWizardForm(msg)
 		case modeFTNWizardField:
 			result, cmd = m.updateFTNWizardField(msg)
+		case modeFTNWizardPicker:
+			result, cmd = m.updateFTNWizardPicker(msg)
 		case modeFTNNetworkBrowser:
 			result, cmd = m.updateFTNNetworkBrowser(msg)
 		case modeFTNAreaBrowser:

--- a/internal/configeditor/update_ftn_area_browser.go
+++ b/internal/configeditor/update_ftn_area_browser.go
@@ -44,6 +44,15 @@ func (m Model) handleFTNEcholistMsg(msg ftnEcholistMsg) (tea.Model, tea.Cmd) {
 	// Preserve existing selections if re-downloading.
 	if len(m.ftnWizard.selectedAreas) != len(msg.areas) {
 		m.ftnWizard.selectedAreas = make([]bool, len(msg.areas))
+
+		// Editing an existing network: start from what is actually
+		// configured, so the list shows the current subscriptions rather
+		// than an empty slate the sysop would have to re-tick from memory.
+		for i, area := range msg.areas {
+			if m.ftnWizard.subscribedTags[strings.ToUpper(area.Tag)] {
+				m.ftnWizard.selectedAreas[i] = true
+			}
+		}
 	}
 
 	// Copy to browser state. selectedAreas must be a distinct copy so that

--- a/internal/configeditor/update_ftn_wizard.go
+++ b/internal/configeditor/update_ftn_wizard.go
@@ -2,15 +2,49 @@ package configeditor
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ftn"
 )
 
-// enterFTNWizard initializes the FTN setup wizard and transitions to the form.
+// ftnWizardPickerVisible is how many picker rows fit on screen at once.
+const ftnWizardPickerVisible = 12
+
+// enterFTNWizard opens the FTN setup wizard. With networks already configured
+// it offers the choice of adding another or editing one of them; on a fresh
+// system it goes straight to the blank form, since there is nothing to pick
+// between.
 func (m Model) enterFTNWizard() (Model, tea.Cmd) {
+	if keys := m.configuredFTNNetworkKeys(); len(keys) > 0 {
+		m.ftnWizardPickerKeys = keys
+		m.ftnWizardPickerCursor = 0
+		m.ftnWizardPickerScroll = 0
+		m.mode = modeFTNWizardPicker
+		return m, nil
+	}
+	return m.startFTNWizardAdd()
+}
+
+// configuredFTNNetworkKeys returns the ftn.json network keys, sorted.
+func (m Model) configuredFTNNetworkKeys() []string {
+	if m.configs == nil || len(m.configs.FTN.Networks) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m.configs.FTN.Networks))
+	for k := range m.configs.FTN.Networks {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// startFTNWizardAdd initializes a blank wizard for adding a new network.
+func (m Model) startFTNWizardAdd() (Model, tea.Cmd) {
 	origin := ""
 	if m.configs != nil {
 		origin = m.configs.Server.BoardName
@@ -26,6 +60,129 @@ func (m Model) enterFTNWizard() (Model, tea.Cmd) {
 		originLine:    origin,
 		autoJoinAreas: true,
 	}
+	m.ftnWizardFields = m.fieldsFTNWizard()
+	m.editField = 0
+	m.fieldScroll = 0
+	m.mode = modeFTNWizardForm
+	return m, nil
+}
+
+// updateFTNWizardPicker handles the add-new vs edit-existing choice. Entry 0
+// is "add a new network"; the rest are configured networks.
+func (m Model) updateFTNWizardPicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	total := len(m.ftnWizardPickerKeys) + 1
+
+	if cursor, ok := listNavKey(msg, m.ftnWizardPickerCursor, total); ok {
+		m.ftnWizardPickerCursor = cursor
+		m.ftnWizardPickerScroll = clampListScroll(cursor, m.ftnWizardPickerScroll, ftnWizardPickerVisible)
+		return m, nil
+	}
+
+	switch msg.Type {
+	case tea.KeyEnter:
+		if m.ftnWizardPickerCursor == 0 {
+			return m.startFTNWizardAdd()
+		}
+		key := m.ftnWizardPickerKeys[m.ftnWizardPickerCursor-1]
+		return m.startFTNWizardEdit(key)
+
+	case tea.KeyEscape:
+		m.mode = modeCategoryMenu
+		return m, nil
+	}
+
+	if strings.EqualFold(msg.String(), "n") {
+		return m.startFTNWizardAdd()
+	}
+	return m, nil
+}
+
+// startFTNWizardEdit loads an already-configured network into the wizard so the
+// sysop can see what was set up and change it.
+func (m Model) startFTNWizardEdit(netKey string) (Model, tea.Cmd) {
+	net, ok := m.configs.FTN.Networks[netKey]
+	if !ok {
+		m.message = fmt.Sprintf("Network %q is no longer configured", netKey)
+		m.mode = modeCategoryMenu
+		return m, nil
+	}
+
+	w := &ftnWizardState{
+		editingKey:     netKey,
+		networkName:    netKey,
+		ownAddress:     net.OwnAddress,
+		hubPort:        24554,
+		autoJoinAreas:  true,
+		subscribedTags: make(map[string]bool),
+	}
+
+	// Zone comes from the configured address, since ftn.json does not store
+	// it separately and binkd.conf needs it on save.
+	if zone, err := ftn.ParseAddress(net.OwnAddress); err == nil {
+		w.zone = zone.Zone
+	}
+
+	// Hub details live on the first link; later links are other systems this
+	// node feeds and are left untouched.
+	if len(net.Links) > 0 {
+		link := net.Links[0]
+		w.hubAddress = link.Address
+		w.hubHostname = link.Hostname
+		if link.Port > 0 {
+			w.hubPort = link.Port
+		}
+		w.areafixPassword = link.AreafixPassword
+		w.sessionPassword = link.SessionPassword
+		w.packetPassword = link.PacketPassword
+	}
+
+	// Description comes from the network's conference, which is where the
+	// wizard put it on the way in.
+	for _, c := range m.configs.Conferences {
+		if strings.EqualFold(c.Name, netKey) || strings.EqualFold(c.Name, net.OwnAddress) {
+			w.networkDesc = c.Description
+			break
+		}
+	}
+
+	// Existing subscriptions, and the newscan default they were created with.
+	autoJoinSeen := false
+	for _, area := range m.configs.MsgAreas {
+		if !strings.EqualFold(area.Network, netKey) || area.EchoTag == "" {
+			continue
+		}
+		w.subscribedTags[strings.ToUpper(area.EchoTag)] = true
+		if !autoJoinSeen {
+			w.autoJoinAreas = area.AutoJoin
+			autoJoinSeen = true
+		}
+	}
+
+	// Registry data (echolist and nodelist URLs, description) if this network
+	// is one we ship an entry for, so Echo Areas and Node Lookup still work.
+	if regNets, err := ftn.LoadRegistry(); err == nil {
+		for i := range regNets {
+			if !strings.EqualFold(regNets[i].Name, netKey) {
+				continue
+			}
+			reg := regNets[i]
+			w.registryEntry = &reg
+			w.echolistURL = reg.EcholistURL
+			w.nodelistURL = reg.NodelistURL
+			w.coordinator = reg.Coordinator
+			w.coordinatorEmail = reg.CoordinatorEmail
+			w.infoURL = reg.InfoURL
+			if w.networkDesc == "" {
+				w.networkDesc = reg.Description
+			}
+			if w.zone == 0 {
+				w.zone = reg.Zone
+			}
+			break
+		}
+	}
+
+	m.ftnWizard = w
 	m.ftnWizardFields = m.fieldsFTNWizard()
 	m.editField = 0
 	m.fieldScroll = 0
@@ -51,8 +208,14 @@ func (m Model) updateFTNWizardForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		// "Network" field → open network browser.
+		// "Network" field → open network browser. Not while editing: the
+		// wizard is bound to one configured network, and swapping the identity
+		// underneath the loaded fields would write them to the wrong one.
 		if f.Type == ftDisplay && f.Label == "Network" {
+			if m.ftnWizard.editing() {
+				m.message = "Network name is fixed while editing — ESC and choose Add a new network instead"
+				return m, nil
+			}
 			return m.enterFTNNetworkBrowser()
 		}
 

--- a/internal/configeditor/view.go
+++ b/internal/configeditor/view.go
@@ -80,6 +80,8 @@ func (m Model) View() string {
 		return m.viewRegistryBrowser()
 	case modeFTNWizardForm, modeFTNWizardField, modeFTNNodelistLookup:
 		return m.viewFTNWizardForm()
+	case modeFTNWizardPicker:
+		return m.viewFTNWizardPicker()
 	case modeFTNNetworkBrowser:
 		return m.viewFTNNetworkBrowser()
 	case modeFTNAreaBrowser, modeFTNAreaDownloading:

--- a/internal/configeditor/view_ftn_wizard_picker.go
+++ b/internal/configeditor/view_ftn_wizard_picker.go
@@ -1,0 +1,105 @@
+package configeditor
+
+import (
+	"fmt"
+	"strings"
+)
+
+// viewFTNWizardPicker renders the wizard's opening choice: add another network,
+// or edit one that is already configured. It exists because the wizard used to
+// open on a blank form no matter what was already set up, which left sysops
+// unable to see what they had configured (issue #176).
+func (m Model) viewFTNWizardPicker() string {
+	boxW := 70
+	total := len(m.ftnWizardPickerKeys) + 1
+
+	lb := m.newListBox(boxW, ftnWizardPickerVisible+13)
+
+	lb.topBorder()
+	lb.title("FTN Setup Wizard")
+	lb.colHeader(fmt.Sprintf("  %-14s  %-16s  %s", "Network", "Your Address", "Hub"))
+	lb.separator()
+
+	lb.list(ftnWizardPickerVisible, m.ftnWizardPickerScroll, m.ftnWizardPickerCursor, total,
+		func(i int) string {
+			if i == 0 {
+				return "+ Add a new network..."
+			}
+			key := m.ftnWizardPickerKeys[i-1]
+			net := m.configs.FTN.Networks[key]
+
+			hub := "(no link configured)"
+			if len(net.Links) > 0 {
+				hub = net.Links[0].Hostname
+				if net.Links[0].Port > 0 {
+					hub = fmt.Sprintf("%s:%d", hub, net.Links[0].Port)
+				}
+			}
+
+			hubW := boxW - 2 - 14 - 2 - 16 - 2
+			if truncateToDisplayWidth(hub, hubW) != hub {
+				hub = truncateToDisplayWidth(hub, hubW-3) + "..."
+			}
+			return fmt.Sprintf("  %-14s  %-16s  %s", padRight(key, 14), padRight(net.OwnAddress, 16), hub)
+		})
+
+	lb.separator()
+
+	// Detail panel for the highlighted entry.
+	if m.ftnWizardPickerCursor == 0 {
+		lb.row(editInfoValueStyle.Render(padRight("  Set up a network this system does not carry yet.", boxW)))
+		lb.emptyRows(3)
+	} else {
+		key := m.ftnWizardPickerKeys[m.ftnWizardPickerCursor-1]
+		net := m.configs.FTN.Networks[key]
+
+		lb.row(editInfoValueStyle.Render(padRight(fmt.Sprintf("  %s — address %s", key, net.OwnAddress), boxW)))
+
+		if len(net.Links) > 0 {
+			link := net.Links[0]
+			lb.row(editInfoValueStyle.Render(padRight(
+				fmt.Sprintf("  Hub: %s at %s:%d", link.Address, link.Hostname, link.Port), boxW)))
+		} else {
+			lb.row(editInfoValueStyle.Render(padRight("  Hub: none configured", boxW)))
+		}
+
+		echos, netmail := m.ftnAreaCounts(key)
+		areas := fmt.Sprintf("  Areas: %d echo", echos)
+		if echos != 1 {
+			areas += "s"
+		}
+		if netmail > 0 {
+			areas += " + netmail"
+		}
+		lb.row(editInfoValueStyle.Render(padRight(areas, boxW)))
+
+		tosser := "off"
+		if net.InternalTosserEnabled {
+			tosser = "on"
+		}
+		lb.row(editInfoValueStyle.Render(padRight(
+			fmt.Sprintf("  Tosser: %s   Poll: %ds", tosser, net.PollSeconds), boxW)))
+	}
+
+	lb.bottomBorder()
+	lb.bgRows(lb.bottomPad + 1)
+
+	return lb.finish("Enter - Select  |  N - Add New  |  ESC - Back")
+}
+
+// ftnAreaCounts returns how many echomail and netmail areas are configured for
+// a network, for the picker's detail panel.
+func (m Model) ftnAreaCounts(netKey string) (echos, netmail int) {
+	for _, area := range m.configs.MsgAreas {
+		if !strings.EqualFold(area.Network, netKey) {
+			continue
+		}
+		switch strings.ToLower(area.AreaType) {
+		case "netmail":
+			netmail++
+		default:
+			echos++
+		}
+	}
+	return echos, netmail
+}

--- a/internal/configeditor/view_ftn_wizard_picker.go
+++ b/internal/configeditor/view_ftn_wizard_picker.go
@@ -30,9 +30,10 @@ func (m Model) viewFTNWizardPicker() string {
 
 			hub := "(no link configured)"
 			if len(net.Links) > 0 {
-				hub = net.Links[0].Hostname
-				if net.Links[0].Port > 0 {
-					hub = fmt.Sprintf("%s:%d", hub, net.Links[0].Port)
+				if hp := net.Links[0].HostPort(); hp != "" {
+					hub = hp
+				} else {
+					hub = "(no hostname)"
 				}
 			}
 
@@ -57,8 +58,14 @@ func (m Model) viewFTNWizardPicker() string {
 
 		if len(net.Links) > 0 {
 			link := net.Links[0]
+			// HostPort fills in the default port, so an unset one reads as
+			// 24554 rather than the ":0" a raw Port would print.
+			where := link.HostPort()
+			if where == "" {
+				where = "(no hostname)"
+			}
 			lb.row(editInfoValueStyle.Render(padRight(
-				fmt.Sprintf("  Hub: %s at %s:%d", link.Address, link.Hostname, link.Port), boxW)))
+				fmt.Sprintf("  Hub: %s at %s", link.Address, where), boxW)))
 		} else {
 			lb.row(editInfoValueStyle.Render(padRight("  Hub: none configured", boxW)))
 		}

--- a/internal/ftn/binkd.go
+++ b/internal/ftn/binkd.go
@@ -71,9 +71,17 @@ func UpdateBinkdConf(confPath string, cfg BinkdConfig) error {
 		return fmt.Errorf("reading binkd.conf: %w", err)
 	}
 
-	// Check if this node address already exists — skip if so.
+	// This node is already defined: rewrite its line in place rather than
+	// skipping. The wizard can be re-run to change a hub's hostname, port or
+	// session password, and skipping would leave binkd talking to the old
+	// details while ftn.json showed the new ones. Appending instead would give
+	// binkd two lines for one address.
 	if len(existing) > 0 && nodeExists(string(existing), cfg.Node.Address) {
-		return nil
+		updated, changed := replaceNodeLine(string(existing), cfg.Node.Address, buildNodeLine(cfg))
+		if !changed {
+			return nil
+		}
+		return writeFileAtomic(confPath, updated, 0600)
 	}
 
 	outPath := filepath.Join(cfg.BBSRoot, "data", "ftn", "out")
@@ -95,17 +103,51 @@ func UpdateBinkdConf(confPath string, cfg BinkdConfig) error {
 	}
 
 	// Append the new node block.
+	fmt.Fprintf(&out, "\n%s\n%s\n", sectionMarker(cfg.Node.NetworkName), buildNodeLine(cfg))
+
+	return writeFileAtomic(confPath, out.String(), 0600)
+}
+
+// buildNodeLine renders the binkd "node" directive for a link.
+func buildNodeLine(cfg BinkdConfig) string {
 	pwd := cfg.Node.SessionPwd
 	if pwd == "" {
 		pwd = "-"
 	}
-	fmt.Fprintf(&out, "\n%s\nnode %s %s %s\n",
-		sectionMarker(cfg.Node.NetworkName),
-		cfg.Node.Address,
-		cfg.Node.Hostname,
-		pwd)
+	return fmt.Sprintf("node %s %s %s", cfg.Node.Address, cfg.Node.Hostname, pwd)
+}
 
-	return writeFileAtomic(confPath, out.String(), 0600)
+// replaceNodeLine swaps the "node <address> ..." directive for the given
+// address, preserving the rest of the file and the line's own indentation. It
+// reports whether anything actually changed, so an unchanged config is left
+// untouched on disk.
+func replaceNodeLine(content, address, newLine string) (string, bool) {
+	lines := confLines(content)
+	changed := false
+	for i, l := range lines {
+		trimmed := strings.TrimSpace(l)
+		if !strings.HasPrefix(trimmed, "node ") {
+			continue
+		}
+		fields := strings.Fields(trimmed)
+		if len(fields) < 2 || fields[1] != address {
+			continue
+		}
+		if trimmed == newLine {
+			continue // already correct
+		}
+		indent := l[:len(l)-len(strings.TrimLeft(l, " \t"))]
+		lines[i] = indent + newLine
+		changed = true
+	}
+	if !changed {
+		return content, false
+	}
+	out := strings.Join(lines, "\n")
+	if strings.HasSuffix(content, "\n") {
+		out += "\n"
+	}
+	return out, true
 }
 
 // nodeExists checks whether a node address is already defined in the config.

--- a/internal/ftn/binkd.go
+++ b/internal/ftn/binkd.go
@@ -77,7 +77,7 @@ func UpdateBinkdConf(confPath string, cfg BinkdConfig) error {
 	// details while ftn.json showed the new ones. Appending instead would give
 	// binkd two lines for one address.
 	if len(existing) > 0 && nodeExists(string(existing), cfg.Node.Address) {
-		updated, changed := replaceNodeLine(string(existing), cfg.Node.Address, buildNodeLine(cfg))
+		updated, changed := replaceNodeLine(string(existing), cfg.Node.Address, cfg.Node.Hostname, cfg.Node.SessionPwd)
 		if !changed {
 			return nil
 		}
@@ -110,18 +110,45 @@ func UpdateBinkdConf(confPath string, cfg BinkdConfig) error {
 
 // buildNodeLine renders the binkd "node" directive for a link.
 func buildNodeLine(cfg BinkdConfig) string {
-	pwd := cfg.Node.SessionPwd
-	if pwd == "" {
-		pwd = "-"
-	}
-	return fmt.Sprintf("node %s %s %s", cfg.Node.Address, cfg.Node.Hostname, pwd)
+	return fmt.Sprintf("node %s %s %s", cfg.Node.Address, cfg.Node.Hostname, nodePassword(cfg.Node.SessionPwd))
 }
 
-// replaceNodeLine swaps the "node <address> ..." directive for the given
-// address, preserving the rest of the file and the line's own indentation. It
-// reports whether anything actually changed, so an unchanged config is left
-// untouched on disk.
-func replaceNodeLine(content, address, newLine string) (string, bool) {
+// nodePassword renders a session password, using binkd's "-" for none.
+func nodePassword(pwd string) string {
+	if pwd == "" {
+		return "-"
+	}
+	return pwd
+}
+
+// mergeNodeFields rewrites the host and password of an existing binkd node
+// directive while keeping everything else on the line.
+//
+// The directive is "node <address> [host[:port]] [password] [flags...]", and
+// binkd accepts trailing options such as -md, -ip or filebox settings that the
+// wizard knows nothing about. Rewriting the whole line would silently drop a
+// sysop's hand-added flags, so only the two fields the wizard owns are
+// replaced and any beyond them are carried across untouched.
+func mergeNodeFields(existing []string, address, hostname, pwd string) []string {
+	merged := append([]string(nil), existing...)
+
+	// Grow to at least "node <address> <host> <pwd>" so a short directive can
+	// still take the values.
+	for len(merged) < 4 {
+		merged = append(merged, "-")
+	}
+	merged[0] = "node"
+	merged[1] = address
+	merged[2] = hostname
+	merged[3] = nodePassword(pwd)
+	return merged
+}
+
+// replaceNodeLine updates the "node <address> ..." directive for the given
+// address in place, preserving the line's indentation, any binkd flags beyond
+// the fields the wizard manages, and the rest of the file. It reports whether
+// anything actually changed, so an unchanged config is left untouched on disk.
+func replaceNodeLine(content, address, hostname, pwd string) (string, bool) {
 	lines := confLines(content)
 	changed := false
 	for i, l := range lines {
@@ -133,11 +160,13 @@ func replaceNodeLine(content, address, newLine string) (string, bool) {
 		if len(fields) < 2 || fields[1] != address {
 			continue
 		}
-		if trimmed == newLine {
+
+		merged := strings.Join(mergeNodeFields(fields, address, hostname, pwd), " ")
+		if trimmed == merged {
 			continue // already correct
 		}
 		indent := l[:len(l)-len(strings.TrimLeft(l, " \t"))]
-		lines[i] = indent + newLine
+		lines[i] = indent + merged
 		changed = true
 	}
 	if !changed {

--- a/internal/ftn/binkd_node_update_test.go
+++ b/internal/ftn/binkd_node_update_test.go
@@ -1,0 +1,114 @@
+package ftn
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestUpdateBinkdConfUpdatesExistingNode covers re-running the FTN wizard to
+// change a hub's details. UpdateBinkdConf used to return early when the node
+// address was already present, so an edited hostname or session password never
+// reached binkd.conf and binkd kept dialling the old host.
+func TestUpdateBinkdConfUpdatesExistingNode(t *testing.T) {
+	dir := t.TempDir()
+	conf := filepath.Join(dir, "binkd.conf")
+
+	existing := strings.Join([]string{
+		"domain fsxnet /home/bbs/data/ftn/out 21",
+		"address 21:4/158@fsxnet",
+		"",
+		"# --- fsxnet (added by FTN Setup Wizard) ---",
+		"node 21:1/100@fsxnet agency.bbs.nz:24554 oldpassword",
+		"",
+		"# --- othernet (added by FTN Setup Wizard) ---",
+		"node 99:1/1@othernet other.example:24554 otherpw",
+		"",
+	}, "\n")
+	if err := os.WriteFile(conf, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := BinkdConfig{
+		BBSRoot:   dir,
+		BoardName: "Test BBS",
+		Domains:   map[string]int{"fsxnet": 21},
+		Addresses: []string{"21:4/158@fsxnet"},
+		Node: BinkdNode{
+			Address:     "21:1/100@fsxnet",
+			Hostname:    "new.agency.example:24554",
+			SessionPwd:  "newpassword",
+			NetworkName: "fsxnet",
+		},
+	}
+	if err := UpdateBinkdConf(conf, cfg); err != nil {
+		t.Fatalf("UpdateBinkdConf: %v", err)
+	}
+
+	out, err := os.ReadFile(conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+
+	if !strings.Contains(got, "node 21:1/100@fsxnet new.agency.example:24554 newpassword") {
+		t.Errorf("edited node line missing from:\n%s", got)
+	}
+	if strings.Contains(got, "oldpassword") || strings.Contains(got, "agency.bbs.nz:24554 ") {
+		t.Errorf("stale hub details left behind in:\n%s", got)
+	}
+	if strings.Count(got, "node 21:1/100@fsxnet") != 1 {
+		t.Errorf("expected exactly one line for the hub, got:\n%s", got)
+	}
+	// A second network's link must survive an edit to the first.
+	if !strings.Contains(got, "node 99:1/1@othernet other.example:24554 otherpw") {
+		t.Errorf("unrelated network's node line was lost from:\n%s", got)
+	}
+}
+
+// TestUpdateBinkdConfNoOpWhenUnchanged keeps a re-save from rewriting a file
+// that already says the right thing.
+func TestUpdateBinkdConfNoOpWhenUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	conf := filepath.Join(dir, "binkd.conf")
+
+	existing := "address 21:4/158@fsxnet\nnode 21:1/100@fsxnet agency.bbs.nz:24554 pw\n"
+	if err := os.WriteFile(conf, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := BinkdConfig{
+		BBSRoot: dir,
+		Domains: map[string]int{"fsxnet": 21},
+		Node: BinkdNode{
+			Address:     "21:1/100@fsxnet",
+			Hostname:    "agency.bbs.nz:24554",
+			SessionPwd:  "pw",
+			NetworkName: "fsxnet",
+		},
+	}
+	if err := UpdateBinkdConf(conf, cfg); err != nil {
+		t.Fatalf("UpdateBinkdConf: %v", err)
+	}
+
+	out, err := os.ReadFile(conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != existing {
+		t.Errorf("unchanged config was rewritten:\ngot:\n%s\nwant:\n%s", out, existing)
+	}
+}
+
+// TestReplaceNodeLinePreservesIndentation keeps an indented directive indented.
+func TestReplaceNodeLinePreservesIndentation(t *testing.T) {
+	content := "  node 1:2/3 old.host pw\n"
+	got, changed := replaceNodeLine(content, "1:2/3", "node 1:2/3 new.host pw2")
+	if !changed {
+		t.Fatal("expected a change")
+	}
+	if got != "  node 1:2/3 new.host pw2\n" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/internal/ftn/binkd_node_update_test.go
+++ b/internal/ftn/binkd_node_update_test.go
@@ -104,11 +104,41 @@ func TestUpdateBinkdConfNoOpWhenUnchanged(t *testing.T) {
 // TestReplaceNodeLinePreservesIndentation keeps an indented directive indented.
 func TestReplaceNodeLinePreservesIndentation(t *testing.T) {
 	content := "  node 1:2/3 old.host pw\n"
-	got, changed := replaceNodeLine(content, "1:2/3", "node 1:2/3 new.host pw2")
+	got, changed := replaceNodeLine(content, "1:2/3", "new.host", "pw2")
 	if !changed {
 		t.Fatal("expected a change")
 	}
 	if got != "  node 1:2/3 new.host pw2\n" {
 		t.Errorf("got %q", got)
+	}
+}
+
+// TestReplaceNodeLinePreservesExtraFields covers binkd options the wizard knows
+// nothing about. The directive is "node <address> [host] [password] [flags...]"
+// and a sysop may have added -md, -ip or filebox settings by hand; rewriting
+// the whole line would throw them away.
+func TestReplaceNodeLinePreservesExtraFields(t *testing.T) {
+	content := "node 1:2/3 old.host:24554 oldpw -md -ip 10.0.0.1\n"
+
+	got, changed := replaceNodeLine(content, "1:2/3", "new.host:24554", "newpw")
+
+	if !changed {
+		t.Fatal("expected a change")
+	}
+	want := "node 1:2/3 new.host:24554 newpw -md -ip 10.0.0.1\n"
+	if got != want {
+		t.Errorf("extra binkd fields were not preserved:\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+// TestReplaceNodeLineGrowsShortDirective covers a directive with no password
+// field, which must still take the new values.
+func TestReplaceNodeLineGrowsShortDirective(t *testing.T) {
+	got, changed := replaceNodeLine("node 1:2/3 old.host\n", "1:2/3", "new.host", "")
+	if !changed {
+		t.Fatal("expected a change")
+	}
+	if got != "node 1:2/3 new.host -\n" {
+		t.Errorf("got %q, want an empty password rendered as -", got)
 	}
 }


### PR DESCRIPTION
Item 3 of #176. Items 1–2 are in #177 (merged) and #178.

## Problem

`enterFTNWizard` built a blank `ftnWizardState` on every entry and never read existing config. So a sysop who had already set up a network couldn't see any of it, and re-running the wizard for that network just reported `already exists in ftn.json` without showing what was there. The reporter asked for the wizard to show what was originally added.

## What it does now

Entering with networks configured opens a picker; a fresh system still goes straight to the blank form, since there's nothing to choose between.

```
┌──────────────────────────────────────────────────────────────────────┐
│                           FTN Setup Wizard                           │
│  Network         Your Address      Hub                               │
│──────────────────────────────────────────────────────────────────────│
│+ Add a new network...                                                │
│  fsxnet          21:4/158          agency.bbs.nz:24554               │
│──────────────────────────────────────────────────────────────────────│
│  fsxnet — address 21:4/158                                           │
│  Hub: 21:1/100 at agency.bbs.nz:24554                                │
│  Areas: 2 echos + netmail                                            │
│  Tosser: on   Poll: 900s                                             │
└──────────────────────────────────────────────────────────────────────┘
                 Enter - Select  |  N - Add New  |  ESC - Back
```

Selecting a network loads its address, hub details and all three passwords into the form, ticks the echo areas it already carries once the echolist arrives, and reports the subscription count *before* any download — so an unfetched list doesn't read as "nothing subscribed".

## Saving an edit — the destructive cases

Editing deliberately does **not** reuse the create path, because that path had three ways to destroy configuration:

| Risk | Handling |
|---|---|
| Tosser / poll interval / tearline are editable under Echomail Networks and the wizard never asks about them | An edit updates the existing entry in place rather than writing a fresh struct with create-time defaults |
| Links after the first are downstream systems this node feeds | `replaceHubLink` updates the hub entry alone, matching on address so a reordered list still resolves, preserving flavour and name |
| Unticking an area | Areas are **never deleted** — that's a message base with real mail in it. They stay, and the save message says so and where to remove them, rather than silently ignoring the untick |

The network name is fixed while editing. Renaming would have to migrate the conference, every area tag and every msgbase path on disk, so the form says so and the network browser is blocked rather than letting the identity swap underneath loaded fields.

## A real bug this surfaced

`UpdateBinkdConf` returned early when the node address was already present. Correct for adding, wrong here: an edited hostname, port or session password **never reached binkd.conf**, leaving binkd dialling the old host while `ftn.json` showed the new one. It now rewrites that node's line in place, preserving indentation and every other network's links, and still leaves the file untouched when nothing changed.

## Found but not fixed

The wizard's **"Origin Line" field is collected, validated, and then dropped.** Nothing in the save path reads `w.originLine`, and no config field stores it — the origin line is generated at post time from the board name and address. It should be wired or removed, but that's a separate change from making edit work, so I've left it alone rather than expand this PR.

## Tests

`ftn_wizard_edit_test.go` covers the picker appearing only when networks exist, the load round-trip (address, hub, passwords, zone parsed from the address, subscribed tags, autojoin taken from existing areas), and each destructive case above — including that a downstream link survives a hub edit and that unticking is only reported once an echolist has actually been reviewed.

`binkd_node_update_test.go` covers the in-place node rewrite, that a second network's node line survives, that an unchanged config isn't rewritten, and that indentation is preserved.

`go build ./...`, `go vet ./...`, `gofmt`, `go test ./...` and `go test -race ./...` all pass locally. The picker view was render-checked at 80×25 against the existing browser styling with no line exceeding 80 columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an FTN network picker for creating new networks or editing existing ones.
  * Editing loads configured network details, subscriptions, links, and related settings.
  * Existing networks display hub, address, area counts, tosser status, and polling details.
  * Previously subscribed areas are restored when matching areas are downloaded.
  * Network details remain fixed during editing, with contextual help available.

* **Bug Fixes**
  * Network edits preserve unmanaged settings and downstream links.
  * Area changes clearly report retained subscriptions.
  * Binkd updates preserve extra configuration and warnings while avoiding duplicate entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->