### PR TITLE
fix(qwkapi): log every request the API turns away

### DIFF
--- a/docs/sysop/messages/qwk-api.md
+++ b/docs/sysop/messages/qwk-api.md
@@ -85,8 +85,9 @@ Everything the API does goes to the normal BBS log (`data/logs/vision3.log` by
 default, JSON, one record per line) — there is no separate API log file. QWK API
 sessions do **not** appear in Last Callers; that list is for terminal logins.
 
-Every record's `msg` starts with `qwk api`, so `grep '"qwk api'` on the log gives
-you the full picture of API activity.
+Apart from the `QWK API listening` line at startup, every record's `msg` starts
+with `qwk api`, so `grep -i '"qwk api'` on the log gives you the full picture of
+API activity.
 
 | Level | `msg` | When |
 |-------|-------|------|
@@ -100,7 +101,7 @@ you the full picture of API activity.
 | WARN | `qwk api reply` | `outcome=tooLarge` — an upload over the 16 MiB cap. |
 | ERROR | `qwk api build packet` / `qwk api import rep` | A packet failed to build or import. |
 | WARN | `qwk api server` | Connection-level trouble from Go's HTTP server, e.g. `http: TLS handshake error from ...`. |
-| DEBUG | `qwk api rejected` | A request turned away without doing any work: `reason=noClientHeader`, `browser`, `htmlAccept`, `unknownPath`, or `badMethod`. Each carries `remote`, `method`, `path`, and `agent`. |
+| DEBUG | `qwk api rejected` | A request turned away without doing any work: `reason=noClientHeader`, `browser`, `htmlAccept`, `unknownPath`, `badMethod`, or `pathRedirect`. Each carries `remote`, `method`, `path`, and `agent`. |
 
 Failed logins, bad tokens, oversized uploads, and rate-limit trips are all
 recorded at INFO or WARN, so they are visible with the default log level.

--- a/docs/sysop/messages/qwk-api.md
+++ b/docs/sysop/messages/qwk-api.md
@@ -91,7 +91,7 @@ you the full picture of API activity.
 | Level | `msg` | When |
 |-------|-------|------|
 | INFO | `QWK API listening` | Startup: listen address and TLS cert fingerprint. |
-| INFO | `qwk api login` | `outcome=success` / `outcome=fail` / `outcome=badRequest`, with `handle` and `remote`. |
+| INFO | `qwk api login` | `outcome=success` / `outcome=fail`, with `handle` and `remote`. A malformed body logs `outcome=badRequest` with `remote` and `error` but **no** `handle` — on a decode failure that field may be partial or hold the password. |
 | WARN | `qwk api login` | `outcome=rateLimited` — too many login attempts from one IP. |
 | ERROR | `qwk api login: token issue failed` | The server could not mint a token. |
 | INFO | `qwk api auth` | `outcome=noToken` / `outcome=badToken` — a request with a missing, invalid, or expired bearer token. |
@@ -100,7 +100,7 @@ you the full picture of API activity.
 | WARN | `qwk api reply` | `outcome=tooLarge` — an upload over the 16 MiB cap. |
 | ERROR | `qwk api build packet` / `qwk api import rep` | A packet failed to build or import. |
 | WARN | `qwk api server` | Connection-level trouble from Go's HTTP server, e.g. `http: TLS handshake error from ...`. |
-| DEBUG | `qwk api rejected` | A request turned away before any handler: `reason=noClientHeader`, `browser`, `htmlAccept`, `unknownPath`, or `badMethod`. |
+| DEBUG | `qwk api rejected` | A request turned away without doing any work: `reason=noClientHeader`, `browser`, `htmlAccept`, `unknownPath`, or `badMethod`. Each carries `remote`, `method`, `path`, and `agent`. |
 
 Failed logins, bad tokens, oversized uploads, and rate-limit trips are all
 recorded at INFO or WARN, so they are visible with the default log level.

--- a/docs/sysop/messages/qwk-api.md
+++ b/docs/sysop/messages/qwk-api.md
@@ -78,3 +78,35 @@ also send `Authorization: Bearer <token>`.
 Errors are JSON: `{"error": "<code>", "message": "<text>"}`. Rate limits apply
 (login per client IP, packet/reply per user); exceeding them returns `429` with a
 `Retry-After` header.
+
+## What gets logged
+
+Everything the API does goes to the normal BBS log (`data/logs/vision3.log` by
+default, JSON, one record per line) — there is no separate API log file. QWK API
+sessions do **not** appear in Last Callers; that list is for terminal logins.
+
+Every record's `msg` starts with `qwk api`, so `grep '"qwk api'` on the log gives
+you the full picture of API activity.
+
+| Level | `msg` | When |
+|-------|-------|------|
+| INFO | `QWK API listening` | Startup: listen address and TLS cert fingerprint. |
+| INFO | `qwk api login` | `outcome=success` / `outcome=fail` / `outcome=badRequest`, with `handle` and `remote`. |
+| WARN | `qwk api login` | `outcome=rateLimited` — too many login attempts from one IP. |
+| ERROR | `qwk api login: token issue failed` | The server could not mint a token. |
+| INFO | `qwk api auth` | `outcome=noToken` / `outcome=badToken` — a request with a missing, invalid, or expired bearer token. |
+| INFO | `qwk api packet` | A download, with `messages` count (including the `0`/`204` case), or `outcome=rateLimited`. |
+| INFO | `qwk api reply` | An upload, with `posted`/`skipped`/`duplicate`, or `outcome=wrongBBS`, `readError`, or `rateLimited`. |
+| WARN | `qwk api reply` | `outcome=tooLarge` — an upload over the 16 MiB cap. |
+| ERROR | `qwk api build packet` / `qwk api import rep` | A packet failed to build or import. |
+| WARN | `qwk api server` | Connection-level trouble from Go's HTTP server, e.g. `http: TLS handshake error from ...`. |
+| DEBUG | `qwk api rejected` | A request turned away before any handler: `reason=noClientHeader`, `browser`, `htmlAccept`, `unknownPath`, or `badMethod`. |
+
+Failed logins, bad tokens, oversized uploads, and rate-limit trips are all
+recorded at INFO or WARN, so they are visible with the default log level.
+
+Rejected probes are the exception: an open port on the public internet collects
+constant scanner traffic (`/wp-login.php` and friends), and logging every one of
+those at INFO would bury real activity. They are recorded at DEBUG instead — set
+`logging.level` to `"debug"` in `configs/config.json` when you want to see who is
+knocking, then set it back.

--- a/internal/qwkapi/auth.go
+++ b/internal/qwkapi/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
@@ -101,11 +102,15 @@ func (ts *tokenStore) requireBearer(next http.HandlerFunc) http.HandlerFunc {
 		auth := r.Header.Get("Authorization")
 		tok := strings.TrimPrefix(auth, "Bearer ")
 		if tok == auth || tok == "" {
+			slog.Info("qwk api auth", "remote", clientIP(r), "path", r.URL.Path, "outcome", "noToken")
 			writeError(w, http.StatusUnauthorized, "unauthorized", "missing bearer token")
 			return
 		}
 		u, ok := ts.Resolve(tok)
 		if !ok {
+			// Routine after a restart (tokens are in-memory), but also what a
+			// forged or replayed token looks like, so it is always recorded.
+			slog.Info("qwk api auth", "remote", clientIP(r), "path", r.URL.Path, "outcome", "badToken")
 			writeError(w, http.StatusUnauthorized, "unauthorized", "invalid or expired token")
 			return
 		}

--- a/internal/qwkapi/filter.go
+++ b/internal/qwkapi/filter.go
@@ -37,10 +37,12 @@ func clientRejectReason(r *http.Request) string {
 	return ""
 }
 
-// logProbe records a request rejected before it reached a handler. A public
-// port collects constant scanner traffic, so this sits at DEBUG: a sysop turns
-// the log level down to investigate rather than having every probe flood the
-// normal log.
+// logProbe records a request the API turned away without doing any work —
+// filtered by requireClient, aimed at an unknown path, or using the wrong method
+// on a real endpoint. Every such record shares one shape so probe traffic can be
+// correlated. A public port collects constant scanner traffic, so this sits at
+// DEBUG: a sysop turns the log level down to investigate rather than having
+// every probe flood the normal log.
 func logProbe(r *http.Request, reason string) {
 	slog.Debug("qwk api rejected",
 		"remote", clientIP(r), "method", r.Method, "path", r.URL.Path,

--- a/internal/qwkapi/filter.go
+++ b/internal/qwkapi/filter.go
@@ -1,6 +1,7 @@
 package qwkapi
 
 import (
+	"log/slog"
 	"net"
 	"net/http"
 	"strings"
@@ -12,20 +13,38 @@ import (
 // authentication control.
 func requireClient(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if strings.TrimSpace(r.Header.Get("X-V3-Client")) == "" {
-			http.NotFound(w, r)
-			return
-		}
-		if r.Header.Get("Sec-Fetch-Mode") != "" || r.Header.Get("Sec-Fetch-Site") != "" {
-			http.NotFound(w, r)
-			return
-		}
-		if strings.Contains(r.Header.Get("Accept"), "text/html") {
+		if reason := clientRejectReason(r); reason != "" {
+			logProbe(r, reason)
 			http.NotFound(w, r)
 			return
 		}
 		next(w, r)
 	}
+}
+
+// clientRejectReason names why the client filter turned a request away, or ""
+// when the request passes.
+func clientRejectReason(r *http.Request) string {
+	if strings.TrimSpace(r.Header.Get("X-V3-Client")) == "" {
+		return "noClientHeader"
+	}
+	if r.Header.Get("Sec-Fetch-Mode") != "" || r.Header.Get("Sec-Fetch-Site") != "" {
+		return "browser"
+	}
+	if strings.Contains(r.Header.Get("Accept"), "text/html") {
+		return "htmlAccept"
+	}
+	return ""
+}
+
+// logProbe records a request rejected before it reached a handler. A public
+// port collects constant scanner traffic, so this sits at DEBUG: a sysop turns
+// the log level down to investigate rather than having every probe flood the
+// normal log.
+func logProbe(r *http.Request, reason string) {
+	slog.Debug("qwk api rejected",
+		"remote", clientIP(r), "method", r.Method, "path", r.URL.Path,
+		"reason", reason, "agent", r.UserAgent())
 }
 
 // clientIP extracts the remote IP (host part) for rate-limit keying.

--- a/internal/qwkapi/handlers.go
+++ b/internal/qwkapi/handlers.go
@@ -13,7 +13,7 @@ import (
 
 func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		logBadMethod(r)
+		logProbe(r, "badMethod")
 		writeError(w, http.StatusMethodNotAllowed, "method", "POST required")
 		return
 	}
@@ -52,7 +52,7 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handlePacket(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		logBadMethod(r)
+		logProbe(r, "badMethod")
 		writeError(w, http.StatusMethodNotAllowed, "method", "GET required")
 		return
 	}
@@ -98,7 +98,7 @@ func (s *Server) handlePacket(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleReply(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		logBadMethod(r)
+		logProbe(r, "badMethod")
 		writeError(w, http.StatusMethodNotAllowed, "method", "POST required")
 		return
 	}
@@ -145,11 +145,4 @@ func (s *Server) handleReply(w http.ResponseWriter, r *http.Request) {
 	slog.Info("qwk api reply", "handle", u.Handle, "remote", clientIP(r),
 		"posted", res.Posted, "skipped", res.Skipped, "duplicate", res.Duplicate)
 	writeJSON(w, http.StatusOK, replyResponse{Posted: res.Posted, Skipped: res.Skipped, Duplicate: res.Duplicate})
-}
-
-// logBadMethod records a request that reached a real endpoint with the wrong
-// HTTP method — a client bug or a probe, not a normal event.
-func logBadMethod(r *http.Request) {
-	slog.Debug("qwk api rejected",
-		"remote", clientIP(r), "method", r.Method, "path", r.URL.Path, "reason", "badMethod")
 }

--- a/internal/qwkapi/handlers.go
+++ b/internal/qwkapi/handlers.go
@@ -13,17 +13,24 @@ import (
 
 func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
+		logBadMethod(r)
 		writeError(w, http.StatusMethodNotAllowed, "method", "POST required")
 		return
 	}
 	ip := clientIP(r)
 	if !s.loginLimit.allow(ip) {
+		// Repeated login attempts from one address are the brute-force signal a
+		// sysop most wants to see, so this is the one throttle logged at WARN.
+		slog.Warn("qwk api login", "remote", ip, "outcome", "rateLimited")
 		w.Header().Set("Retry-After", "60")
 		writeError(w, http.StatusTooManyRequests, "rate_limited", "too many login attempts")
 		return
 	}
 	var req loginRequest
 	if err := json.NewDecoder(io.LimitReader(r.Body, 4096)).Decode(&req); err != nil {
+		// The handle is not logged here: on a decode failure it may be absent,
+		// partial, or actually be the password field of a malformed body.
+		slog.Info("qwk api login", "remote", ip, "outcome", "badRequest", "error", err)
 		writeError(w, http.StatusBadRequest, "bad_request", "invalid JSON")
 		return
 	}
@@ -45,11 +52,13 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handlePacket(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
+		logBadMethod(r)
 		writeError(w, http.StatusMethodNotAllowed, "method", "GET required")
 		return
 	}
 	u := userFromContext(r.Context())
 	if !s.packetLimit.allow(u.Handle) {
+		slog.Info("qwk api packet", "handle", u.Handle, "remote", clientIP(r), "outcome", "rateLimited")
 		w.Header().Set("Retry-After", "60")
 		writeError(w, http.StatusTooManyRequests, "rate_limited", "slow down")
 		return
@@ -60,6 +69,14 @@ func (s *Server) handlePacket(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		slog.Error("qwk api build packet", "handle", u.Handle, "error", err)
+		writeError(w, http.StatusInternalServerError, "internal", "failed to build packet")
+		return
+	}
+	if res == nil {
+		// A (nil, nil) return would panic on the field reads below. net/http
+		// would recover that, but the client just sees a dropped connection and
+		// the log gets a stack trace instead of a usable record.
+		slog.Error("qwk api build packet", "handle", u.Handle, "error", "service returned no result and no error")
 		writeError(w, http.StatusInternalServerError, "internal", "failed to build packet")
 		return
 	}
@@ -81,21 +98,25 @@ func (s *Server) handlePacket(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleReply(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
+		logBadMethod(r)
 		writeError(w, http.StatusMethodNotAllowed, "method", "POST required")
 		return
 	}
 	u := userFromContext(r.Context())
 	if !s.packetLimit.allow(u.Handle) {
+		slog.Info("qwk api reply", "handle", u.Handle, "remote", clientIP(r), "outcome", "rateLimited")
 		w.Header().Set("Retry-After", "60")
 		writeError(w, http.StatusTooManyRequests, "rate_limited", "slow down")
 		return
 	}
 	data, err := io.ReadAll(io.LimitReader(r.Body, maxREPBytes+1))
 	if err != nil {
+		slog.Info("qwk api reply", "handle", u.Handle, "remote", clientIP(r), "outcome", "readError", "error", err)
 		writeError(w, http.StatusBadRequest, "bad_request", "read error")
 		return
 	}
 	if len(data) > maxREPBytes {
+		slog.Warn("qwk api reply", "handle", u.Handle, "remote", clientIP(r), "outcome", "tooLarge", "limit", maxREPBytes)
 		writeError(w, http.StatusRequestEntityTooLarge, "too_large", "packet exceeds 16 MiB")
 		return
 	}
@@ -114,7 +135,21 @@ func (s *Server) handleReply(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "bad_packet", "could not process packet")
 		return
 	}
+	if res == nil {
+		// As in handlePacket: turn a (nil, nil) service return into a logged
+		// 500 rather than a panic and a dropped connection.
+		slog.Error("qwk api import rep", "handle", u.Handle, "error", "service returned no result and no error")
+		writeError(w, http.StatusInternalServerError, "internal", "could not process packet")
+		return
+	}
 	slog.Info("qwk api reply", "handle", u.Handle, "remote", clientIP(r),
 		"posted", res.Posted, "skipped", res.Skipped, "duplicate", res.Duplicate)
 	writeJSON(w, http.StatusOK, replyResponse{Posted: res.Posted, Skipped: res.Skipped, Duplicate: res.Duplicate})
+}
+
+// logBadMethod records a request that reached a real endpoint with the wrong
+// HTTP method — a client bug or a probe, not a normal event.
+func logBadMethod(r *http.Request) {
+	slog.Debug("qwk api rejected",
+		"remote", clientIP(r), "method", r.Method, "path", r.URL.Path, "reason", "badMethod")
 }

--- a/internal/qwkapi/logging_test.go
+++ b/internal/qwkapi/logging_test.go
@@ -142,6 +142,27 @@ func TestLog_ProbeRejections(t *testing.T) {
 	}
 }
 
+func TestLog_PathRedirect(t *testing.T) {
+	logs := captureLogs(t)
+	h := testServer(t, &fakeSvc{}, true)
+
+	// ServeMux answers unclean paths with a redirect before any registered
+	// handler runs, so these bypass even the "/" catch-all.
+	for _, path := range []string{"/api//qwk/login", "/scan/../..//wp-admin"} {
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, clientReq("GET", path, nil))
+		if rr.Code < 300 || rr.Code > 399 {
+			t.Fatalf("%s status = %d, want a 3xx redirect from the mux", path, rr.Code)
+		}
+		rec := requireRec(t, logs(), map[string]any{
+			"msg": "qwk api rejected", "reason": "pathRedirect", "path": path,
+		})
+		if rec["level"] != "DEBUG" {
+			t.Errorf("%s level = %v, want DEBUG", path, rec["level"])
+		}
+	}
+}
+
 func TestLog_LoginBadJSON(t *testing.T) {
 	logs := captureLogs(t)
 	h := testServer(t, &fakeSvc{}, true)

--- a/internal/qwkapi/logging_test.go
+++ b/internal/qwkapi/logging_test.go
@@ -133,6 +133,12 @@ func TestLog_ProbeRejections(t *testing.T) {
 		if rec["level"] != "DEBUG" {
 			t.Errorf("%v level = %v, want DEBUG", want["reason"], rec["level"])
 		}
+		// Every rejection shares one shape, so probe traffic stays correlatable.
+		for _, field := range []string{"remote", "method", "path", "agent"} {
+			if _, ok := rec[field]; !ok {
+				t.Errorf("%v record missing %q field: %v", want["reason"], field, rec)
+			}
+		}
 	}
 }
 
@@ -192,7 +198,7 @@ func TestLog_ReplyRateLimited(t *testing.T) {
 func TestLog_ServerErrorWriter(t *testing.T) {
 	logs := captureLogs(t)
 
-	line := "http: TLS handshake error from 1.2.3.4:5678: remote error: tls: bad certificate\n"
+	line := "http: TLS handshake error from 1.2.3.4:5678: remote error: tls: bad certificate\r\n"
 	n, err := serverErrorWriter{}.Write([]byte(line))
 	if err != nil || n != len(line) {
 		t.Fatalf("Write = (%d, %v), want (%d, nil)", n, err, len(line))
@@ -201,8 +207,12 @@ func TestLog_ServerErrorWriter(t *testing.T) {
 	if rec["level"] != "WARN" {
 		t.Errorf("level = %v, want WARN", rec["level"])
 	}
-	if got, _ := rec["error"].(string); !strings.Contains(got, "TLS handshake error") || strings.HasSuffix(got, "\n") {
-		t.Errorf("error = %q, want the trimmed handshake line", got)
+	got, _ := rec["error"].(string)
+	if !strings.Contains(got, "TLS handshake error") {
+		t.Errorf("error = %q, want the handshake line", got)
+	}
+	if strings.HasSuffix(got, "\n") || strings.HasSuffix(got, "\r") {
+		t.Errorf("error = %q, want CR and LF trimmed", got)
 	}
 }
 

--- a/internal/qwkapi/logging_test.go
+++ b/internal/qwkapi/logging_test.go
@@ -1,0 +1,252 @@
+package qwkapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/qwkservice"
+)
+
+// captureLogs installs a DEBUG-level JSON logger as slog.Default for the test
+// and returns a func decoding everything logged so far into records.
+func captureLogs(t *testing.T) func() []map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return func() []map[string]any {
+		var recs []map[string]any
+		for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+			if line == "" {
+				continue
+			}
+			var m map[string]any
+			if err := json.Unmarshal([]byte(line), &m); err != nil {
+				t.Fatalf("log line not JSON: %q: %v", line, err)
+			}
+			recs = append(recs, m)
+		}
+		return recs
+	}
+}
+
+// findRec returns the first record whose fields all match want.
+func findRec(recs []map[string]any, want map[string]any) map[string]any {
+	for _, r := range recs {
+		match := true
+		for k, v := range want {
+			if r[k] != v {
+				match = false
+				break
+			}
+		}
+		if match {
+			return r
+		}
+	}
+	return nil
+}
+
+func requireRec(t *testing.T, recs []map[string]any, want map[string]any) map[string]any {
+	t.Helper()
+	got := findRec(recs, want)
+	if got == nil {
+		t.Fatalf("no log record matching %v; got %v", want, recs)
+	}
+	return got
+}
+
+func TestLog_RateLimitedLogin(t *testing.T) {
+	logs := captureLogs(t)
+	h := testServer(t, &fakeSvc{}, false)
+
+	var last int
+	for i := 0; i < 6; i++ { // limiter allows 5 per minute per IP
+		r := clientReq("POST", "/api/qwk/login", []byte(`{"handle":"x","password":"y"}`))
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, r)
+		last = rr.Code
+	}
+	if last != http.StatusTooManyRequests {
+		t.Fatalf("6th login status = %d, want 429", last)
+	}
+	rec := requireRec(t, logs(), map[string]any{"msg": "qwk api login", "outcome": "rateLimited"})
+	if rec["level"] != "WARN" {
+		t.Errorf("level = %v, want WARN", rec["level"])
+	}
+	if rec["remote"] == nil || rec["remote"] == "" {
+		t.Error("rate-limited login logged without a remote address")
+	}
+}
+
+func TestLog_AuthRejections(t *testing.T) {
+	logs := captureLogs(t)
+	h := testServer(t, &fakeSvc{}, true)
+
+	noTok := clientReq("GET", "/api/qwk/packet", nil)
+	h.ServeHTTP(httptest.NewRecorder(), noTok)
+
+	badTok := clientReq("GET", "/api/qwk/packet", nil)
+	badTok.Header.Set("Authorization", "Bearer deadbeef")
+	h.ServeHTTP(httptest.NewRecorder(), badTok)
+
+	recs := logs()
+	requireRec(t, recs, map[string]any{"msg": "qwk api auth", "outcome": "noToken", "path": "/api/qwk/packet"})
+	requireRec(t, recs, map[string]any{"msg": "qwk api auth", "outcome": "badToken", "path": "/api/qwk/packet"})
+}
+
+func TestLog_ProbeRejections(t *testing.T) {
+	logs := captureLogs(t)
+	h := testServer(t, &fakeSvc{}, true)
+
+	noHeader := httptest.NewRequest("POST", "/api/qwk/login", nil)
+	h.ServeHTTP(httptest.NewRecorder(), noHeader)
+
+	browser := clientReq("GET", "/api/qwk/packet", nil)
+	browser.Header.Set("Sec-Fetch-Mode", "navigate")
+	h.ServeHTTP(httptest.NewRecorder(), browser)
+
+	unknown := clientReq("GET", "/wp-login.php", nil)
+	rrUnknown := httptest.NewRecorder()
+	h.ServeHTTP(rrUnknown, unknown)
+	if rrUnknown.Code != http.StatusNotFound {
+		t.Errorf("unknown path status = %d, want 404", rrUnknown.Code)
+	}
+
+	badMethod := clientReq("GET", "/api/qwk/login", nil)
+	h.ServeHTTP(httptest.NewRecorder(), badMethod)
+
+	recs := logs()
+	for _, want := range []map[string]any{
+		{"msg": "qwk api rejected", "reason": "noClientHeader"},
+		{"msg": "qwk api rejected", "reason": "browser"},
+		{"msg": "qwk api rejected", "reason": "unknownPath", "path": "/wp-login.php"},
+		{"msg": "qwk api rejected", "reason": "badMethod", "path": "/api/qwk/login"},
+	} {
+		rec := requireRec(t, recs, want)
+		if rec["level"] != "DEBUG" {
+			t.Errorf("%v level = %v, want DEBUG", want["reason"], rec["level"])
+		}
+	}
+}
+
+func TestLog_LoginBadJSON(t *testing.T) {
+	logs := captureLogs(t)
+	h := testServer(t, &fakeSvc{}, true)
+
+	r := clientReq("POST", "/api/qwk/login", []byte(`{not json`))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, r)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+	rec := requireRec(t, logs(), map[string]any{"msg": "qwk api login", "outcome": "badRequest"})
+	if _, ok := rec["handle"]; ok {
+		t.Error("malformed login body must not log a handle field")
+	}
+}
+
+func TestLog_ReplyTooLarge(t *testing.T) {
+	logs := captureLogs(t)
+	h := testServer(t, &fakeSvc{}, true)
+	tok := login(t, h)
+
+	r := clientReq("POST", "/api/qwk/reply", bytes.Repeat([]byte("x"), maxREPBytes+1))
+	r.Header.Set("Authorization", "Bearer "+tok)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, r)
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", rr.Code)
+	}
+	rec := requireRec(t, logs(), map[string]any{"msg": "qwk api reply", "outcome": "tooLarge", "handle": "felonius"})
+	if rec["level"] != "WARN" {
+		t.Errorf("level = %v, want WARN", rec["level"])
+	}
+}
+
+func TestLog_ReplyRateLimited(t *testing.T) {
+	logs := captureLogs(t)
+	h := testServer(t, &fakeSvc{imp: &qwkservice.ImportResult{}}, true)
+	tok := login(t, h)
+
+	var last int
+	for i := 0; i < 31; i++ { // packet limiter allows 30 per minute per handle
+		r := clientReq("POST", "/api/qwk/reply", []byte("x"))
+		r.Header.Set("Authorization", "Bearer "+tok)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, r)
+		last = rr.Code
+	}
+	if last != http.StatusTooManyRequests {
+		t.Fatalf("31st reply status = %d, want 429", last)
+	}
+	requireRec(t, logs(), map[string]any{"msg": "qwk api reply", "outcome": "rateLimited", "handle": "felonius"})
+}
+
+func TestLog_ServerErrorWriter(t *testing.T) {
+	logs := captureLogs(t)
+
+	line := "http: TLS handshake error from 1.2.3.4:5678: remote error: tls: bad certificate\n"
+	n, err := serverErrorWriter{}.Write([]byte(line))
+	if err != nil || n != len(line) {
+		t.Fatalf("Write = (%d, %v), want (%d, nil)", n, err, len(line))
+	}
+	rec := requireRec(t, logs(), map[string]any{"msg": "qwk api server"})
+	if rec["level"] != "WARN" {
+		t.Errorf("level = %v, want WARN", rec["level"])
+	}
+	if got, _ := rec["error"].(string); !strings.Contains(got, "TLS handshake error") || strings.HasSuffix(got, "\n") {
+		t.Errorf("error = %q, want the trimmed handshake line", got)
+	}
+}
+
+// nilSvc returns (nil, nil) from both service calls — the shape that used to
+// panic in the handlers.
+type nilSvc struct{}
+
+func (nilSvc) BuildPacket(qwkservice.ExportOptions) (*qwkservice.ExportResult, error) {
+	return nil, nil
+}
+func (nilSvc) CommitExport(string, *qwkservice.ExportResult) {}
+func (nilSvc) ImportREP([]byte, qwkservice.ImportOptions) (*qwkservice.ImportResult, error) {
+	return nil, nil
+}
+
+func TestLog_NilServiceResult(t *testing.T) {
+	logs := captureLogs(t)
+	h := testServer(t, nilSvc{}, true)
+	tok := login(t, h)
+
+	pkt := clientReq("GET", "/api/qwk/packet", nil)
+	pkt.Header.Set("Authorization", "Bearer "+tok)
+	rrPkt := httptest.NewRecorder()
+	h.ServeHTTP(rrPkt, pkt)
+	if rrPkt.Code != http.StatusInternalServerError {
+		t.Errorf("packet status = %d, want 500", rrPkt.Code)
+	}
+
+	rep := clientReq("POST", "/api/qwk/reply", []byte("x"))
+	rep.Header.Set("Authorization", "Bearer "+tok)
+	rrRep := httptest.NewRecorder()
+	h.ServeHTTP(rrRep, rep)
+	if rrRep.Code != http.StatusInternalServerError {
+		t.Errorf("reply status = %d, want 500", rrRep.Code)
+	}
+
+	recs := logs()
+	for _, msg := range []string{"qwk api build packet", "qwk api import rep"} {
+		rec := requireRec(t, recs, map[string]any{"msg": msg})
+		if rec["level"] != "ERROR" {
+			t.Errorf("%s level = %v, want ERROR", msg, rec["level"])
+		}
+		if got, _ := rec["error"].(string); !strings.Contains(got, "no result and no error") {
+			t.Errorf("%s error = %q, want the nil-result reason", msg, got)
+		}
+	}
+}

--- a/internal/qwkapi/logging_test.go
+++ b/internal/qwkapi/logging_test.go
@@ -105,40 +105,86 @@ func TestLog_ProbeRejections(t *testing.T) {
 	logs := captureLogs(t)
 	h := testServer(t, &fakeSvc{}, true)
 
-	noHeader := httptest.NewRequest("POST", "/api/qwk/login", nil)
-	h.ServeHTTP(httptest.NewRecorder(), noHeader)
+	// httptest gives every request RemoteAddr 192.0.2.1:1234, so the logged
+	// remote must be the host half of that.
+	const remote = "192.0.2.1"
 
-	browser := clientReq("GET", "/api/qwk/packet", nil)
-	browser.Header.Set("Sec-Fetch-Mode", "navigate")
-	h.ServeHTTP(httptest.NewRecorder(), browser)
-
-	unknown := clientReq("GET", "/wp-login.php", nil)
-	rrUnknown := httptest.NewRecorder()
-	h.ServeHTTP(rrUnknown, unknown)
-	if rrUnknown.Code != http.StatusNotFound {
-		t.Errorf("unknown path status = %d, want 404", rrUnknown.Code)
+	cases := []struct {
+		name   string
+		reason string
+		method string
+		path   string
+		agent  string
+		req    func(agent string) *http.Request
+	}{
+		{
+			name: "no client header", reason: "noClientHeader",
+			method: "POST", path: "/api/qwk/login", agent: "curl/8.5.0",
+			req: func(agent string) *http.Request {
+				r := httptest.NewRequest("POST", "/api/qwk/login", nil) // no X-V3-Client
+				r.Header.Set("User-Agent", agent)
+				return r
+			},
+		},
+		{
+			name: "browser fetch", reason: "browser",
+			method: "GET", path: "/api/qwk/packet", agent: "Mozilla/5.0",
+			req: func(agent string) *http.Request {
+				r := clientReq("GET", "/api/qwk/packet", nil)
+				r.Header.Set("Sec-Fetch-Mode", "navigate")
+				r.Header.Set("User-Agent", agent)
+				return r
+			},
+		},
+		{
+			name: "html accept", reason: "htmlAccept",
+			method: "GET", path: "/api/qwk/packet", agent: "Mozilla/5.0",
+			req: func(agent string) *http.Request {
+				r := clientReq("GET", "/api/qwk/packet", nil)
+				r.Header.Set("Accept", "text/html,application/xhtml+xml")
+				r.Header.Set("User-Agent", agent)
+				return r
+			},
+		},
+		{
+			name: "unknown path", reason: "unknownPath",
+			method: "GET", path: "/wp-login.php", agent: "zgrab/0.x",
+			req: func(agent string) *http.Request {
+				r := clientReq("GET", "/wp-login.php", nil)
+				r.Header.Set("User-Agent", agent)
+				return r
+			},
+		},
+		{
+			name: "wrong method", reason: "badMethod",
+			method: "GET", path: "/api/qwk/login", agent: "vision3-mobile/1.0",
+			req: func(agent string) *http.Request {
+				r := clientReq("GET", "/api/qwk/login", nil) // login is POST-only
+				r.Header.Set("User-Agent", agent)
+				return r
+			},
+		},
 	}
 
-	badMethod := clientReq("GET", "/api/qwk/login", nil)
-	h.ServeHTTP(httptest.NewRecorder(), badMethod)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, tc.req(tc.agent))
 
-	recs := logs()
-	for _, want := range []map[string]any{
-		{"msg": "qwk api rejected", "reason": "noClientHeader"},
-		{"msg": "qwk api rejected", "reason": "browser"},
-		{"msg": "qwk api rejected", "reason": "unknownPath", "path": "/wp-login.php"},
-		{"msg": "qwk api rejected", "reason": "badMethod", "path": "/api/qwk/login"},
-	} {
-		rec := requireRec(t, recs, want)
-		if rec["level"] != "DEBUG" {
-			t.Errorf("%v level = %v, want DEBUG", want["reason"], rec["level"])
-		}
-		// Every rejection shares one shape, so probe traffic stays correlatable.
-		for _, field := range []string{"remote", "method", "path", "agent"} {
-			if _, ok := rec[field]; !ok {
-				t.Errorf("%v record missing %q field: %v", want["reason"], field, rec)
+			// Every field is matched exactly, so a record carrying the right
+			// keys with wrong or empty values still fails.
+			rec := requireRec(t, logs(), map[string]any{
+				"msg":    "qwk api rejected",
+				"reason": tc.reason,
+				"remote": remote,
+				"method": tc.method,
+				"path":   tc.path,
+				"agent":  tc.agent,
+			})
+			if rec["level"] != "DEBUG" {
+				t.Errorf("level = %v, want DEBUG", rec["level"])
 			}
-		}
+		})
 	}
 }
 
@@ -155,7 +201,8 @@ func TestLog_PathRedirect(t *testing.T) {
 			t.Fatalf("%s status = %d, want a 3xx redirect from the mux", path, rr.Code)
 		}
 		rec := requireRec(t, logs(), map[string]any{
-			"msg": "qwk api rejected", "reason": "pathRedirect", "path": path,
+			"msg": "qwk api rejected", "reason": "pathRedirect",
+			"path": path, "method": "GET", "remote": "192.0.2.1",
 		})
 		if rec["level"] != "DEBUG" {
 			t.Errorf("%s level = %v, want DEBUG", path, rec["level"])
@@ -228,12 +275,10 @@ func TestLog_ServerErrorWriter(t *testing.T) {
 	if rec["level"] != "WARN" {
 		t.Errorf("level = %v, want WARN", rec["level"])
 	}
-	got, _ := rec["error"].(string)
-	if !strings.Contains(got, "TLS handshake error") {
-		t.Errorf("error = %q, want the handshake line", got)
-	}
-	if strings.HasSuffix(got, "\n") || strings.HasSuffix(got, "\r") {
-		t.Errorf("error = %q, want CR and LF trimmed", got)
+	// Full equality, so a handler that dropped the detail after the prefix
+	// would fail rather than pass on a substring match.
+	if got, _ := rec["error"].(string); got != strings.TrimRight(line, "\r\n") {
+		t.Errorf("error = %q, want %q", got, strings.TrimRight(line, "\r\n"))
 	}
 }
 

--- a/internal/qwkapi/server.go
+++ b/internal/qwkapi/server.go
@@ -5,8 +5,10 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"log"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -71,6 +73,12 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/qwk/login", requireClient(s.handleLogin))
 	mux.HandleFunc("/api/qwk/packet", requireClient(s.tokens.requireBearer(s.handlePacket)))
 	mux.HandleFunc("/api/qwk/reply", requireClient(s.tokens.requireBearer(s.handleReply)))
+	// Catch-all so requests to unknown paths are visible too; without it the
+	// mux's own 404 would leave scanner traffic entirely unrecorded.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		logProbe(r, "unknownPath")
+		http.NotFound(w, r)
+	})
 	return mux
 }
 
@@ -80,6 +88,10 @@ func (s *Server) Start() error {
 		Addr:      s.deps.Config.ListenAddr(),
 		Handler:   s.Handler(),
 		TLSConfig: &tls.Config{Certificates: []tls.Certificate{s.cert}},
+		// Route net/http's own connection-level errors (TLS handshake failures,
+		// malformed requests) through slog instead of the stdlib log bridge, so
+		// they land in the rolling log as structured records like everything else.
+		ErrorLog: log.New(serverErrorWriter{}, "", 0),
 	}
 	slog.Info("QWK API listening", "addr", s.deps.Config.ListenAddr(), "fingerprint", s.fingerprint)
 	go s.sweepLoop()
@@ -116,4 +128,14 @@ func (s *Server) Shutdown(ctx context.Context) error {
 		return nil
 	}
 	return s.httpSrv.Shutdown(ctx)
+}
+
+// serverErrorWriter adapts http.Server's stdlib logger to slog. Each line net/http
+// writes (e.g. "http: TLS handshake error from 1.2.3.4:5678: ...") becomes one
+// WARN record: these are connection-level problems, not BBS-level failures.
+type serverErrorWriter struct{}
+
+func (serverErrorWriter) Write(p []byte) (int, error) {
+	slog.Warn("qwk api server", "error", strings.TrimRight(string(p), "\n"))
+	return len(p), nil
 }

--- a/internal/qwkapi/server.go
+++ b/internal/qwkapi/server.go
@@ -79,7 +79,35 @@ func (s *Server) Handler() http.Handler {
 		logProbe(r, "unknownPath")
 		http.NotFound(w, r)
 	})
-	return mux
+	return logRedirects(mux)
+}
+
+// logRedirects records the redirects ServeMux issues for unclean paths
+// ("/api//qwk/login", "/a/../b"). The mux answers those itself, before any
+// registered handler runs — including the catch-all above — so without this
+// wrapper they would be the one class of request that reaches the port and
+// leaves no trace at all.
+func logRedirects(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sr := &statusRecorder{ResponseWriter: w}
+		h.ServeHTTP(sr, r)
+		switch sr.status {
+		case http.StatusMovedPermanently, http.StatusTemporaryRedirect, http.StatusPermanentRedirect:
+			logProbe(r, "pathRedirect")
+		}
+	})
+}
+
+// statusRecorder remembers the status code written through it. A handler that
+// never calls WriteHeader leaves status at 0, which no case above matches.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (s *statusRecorder) WriteHeader(code int) {
+	s.status = code
+	s.ResponseWriter.WriteHeader(code)
 }
 
 // Start serves HTTPS until Shutdown is called; blocking.

--- a/internal/qwkapi/server.go
+++ b/internal/qwkapi/server.go
@@ -136,6 +136,6 @@ func (s *Server) Shutdown(ctx context.Context) error {
 type serverErrorWriter struct{}
 
 func (serverErrorWriter) Write(p []byte) (int, error) {
-	slog.Warn("qwk api server", "error", strings.TrimRight(string(p), "\n"))
+	slog.Warn("qwk api server", "error", strings.TrimRight(string(p), "\r\n"))
 	return len(p), nil
 }


### PR DESCRIPTION
## Why

A sysop auditing the QWK API port (`8666`) could only see successful operations and a couple of failure cases. Everything the API rejected — throttled requests, bad tokens, probe traffic, TLS handshake failures — left no trace, so brute-force attempts and scanning were invisible in `data/logs/vision3.log`.

## What changed

Every request that reaches the port now leaves a record. All messages start with `qwk api`, so `grep '"qwk api'` gives the full picture.

| Level | Event |
|---|---|
| WARN | `qwk api login` `outcome=rateLimited` — login throttle trip, per IP (the brute-force signal) |
| INFO | `qwk api login` `outcome=badRequest` — malformed JSON body |
| INFO | `qwk api auth` `outcome=noToken` / `badToken` — missing, forged, or expired bearer |
| INFO | `qwk api packet` / `qwk api reply` `outcome=rateLimited` — per handle |
| INFO | `qwk api reply` `outcome=readError` |
| WARN | `qwk api reply` `outcome=tooLarge` — over the 16 MiB cap |
| WARN | `qwk api server` — connection-level errors (TLS handshake failures) |
| DEBUG | `qwk api rejected` — `noClientHeader` / `browser` / `htmlAccept` / `unknownPath` / `badMethod` |

Supporting changes:

- **`http.Server.ErrorLog` now routes through slog**, so net/http's own connection errors land as structured JSON records instead of going out through the unstructured stdlib log bridge.
- **Added a `/` catch-all to the mux** — the bare `ServeMux` 404 was invisible, so unknown-path scanning left no trace at all.
- **Guarded `(nil, nil)` service returns** in `handlePacket` / `handleReply`. net/http would recover the panic, but the client saw a dropped connection and the log got a stack trace instead of a usable record; now it's a logged ERROR and a clean 500.

## Judgment calls

**Probe traffic sits at DEBUG.** A public port collects constant `/wp-login.php`-style scanning; at INFO that would bury real activity. Sysops flip `logging.level` to `debug` when they want to see who's knocking. Everything security-relevant that got past the client filter — failed logins, bad tokens, throttling, oversized uploads — is at INFO/WARN and visible at the default level.

**The malformed-login path deliberately omits the handle.** On a decode failure the field may be partial or actually hold the password. There's a test asserting no `handle` field is logged there.

QWK API sessions still do not appear in Last Callers — that list is for terminal logins, and this PR does not change that.

## Testing

New `internal/qwkapi/logging_test.go` — 8 tests that capture `slog` output and assert message, level, and fields for each case (rate limits, auth rejections, probes, bad JSON, oversized upload, `serverErrorWriter`, nil-result guards). Full `go test ./...` passes; `go vet` clean.

## Docs

`docs/sysop/messages/qwk-api.md` gains a **What gets logged** section: the full level/message table, where the log lives, the DEBUG note for probe traffic, and a line confirming API sessions are not in Last Callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PwzJUyWT4fbPgRjbx7K9h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured logging for QWK API authentication attempts, rejected probes, invalid requests, rate limits, server errors, and oversized responses.
  * Added debug logging that records why rejected probes were declined.
  * Added logging for unknown paths and HTTPS connection-level errors.

* **Documentation**
  * Documented QWK API log destinations, formats, event categories, severity levels, recorded outcomes, and how to enable debug logging for rejected probes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->