### PR TITLE
docs(sysop): cover the behaviour changes from #177, #178 and #179

### DIFF
--- a/docs/sysop/how-to-guides/keeping-binaries-updated.md
+++ b/docs/sysop/how-to-guides/keeping-binaries-updated.md
@@ -89,10 +89,14 @@ cp menus/v3/cfg/SOMEMENU.CFG   /opt/vision3/menus/v3/cfg/
 cp menus/v3/bar/SOMEMENU.BAR   /opt/vision3/menus/v3/bar/
 ```
 
-A screen's files travel together — the `.ANS` art, its `.BAR` lightbar
-coordinates and its `.CFG` key bindings all have to agree, so copying one and not
-the others can leave you worse off than before. If you have customised a file,
-diff it against the repo's version rather than overwriting it.
+A screen's files travel together — a fix may span the `.ANS` art, its `.BAR`
+lightbar coordinates and its `.CFG` key bindings, so copy whatever the release
+changed as a set; taking one file and not the others can leave you worse off
+than before. (For most menus the three must agree outright; menus that read
+their own keys in Go, like the Sponsor Menu, keep only a subset in their `.CFG`
+— see [the menu system guide](menus/menu-system.md#keeping-the-bar-file-and-the-art-in-step).)
+If you have customised a file, diff it against the repo's version rather than
+overwriting it.
 
 This does not apply if you run Vision/3 directly out of the git checkout, or if
 you bind-mount the repo's `menus/` as `docker-compose.yml` does — there `git pull`

--- a/docs/sysop/how-to-guides/keeping-binaries-updated.md
+++ b/docs/sysop/how-to-guides/keeping-binaries-updated.md
@@ -67,6 +67,37 @@ done
 
 Your `configs/`, `data/`, `menus/`, and `bin/` directories remain untouched — only the Go binaries are replaced.
 
+### Menu and art fixes are not picked up automatically
+
+That last point cuts both ways. Because `menus/` is never overwritten, a release
+that fixes a menu screen, a lightbar layout or a command binding **will not reach
+your board from `git pull` alone** — you rebuild, restart, and the old screen is
+still there with nothing to indicate anything was missed. `dev-setup.sh` copies
+`menus/` only when the target has none, and says "Menus directory already exists,
+skipping" otherwise.
+
+After pulling, check whether the release touched anything under `menus/` and copy
+those files across by hand:
+
+```bash
+# from your repo checkout, see what changed since the version you were on
+git diff --stat <your-old-tag>..HEAD -- menus/
+
+# copy an individual fixed file into your instance
+cp menus/v3/ansi/SOMEMENU.ANS  /opt/vision3/menus/v3/ansi/
+cp menus/v3/cfg/SOMEMENU.CFG   /opt/vision3/menus/v3/cfg/
+cp menus/v3/bar/SOMEMENU.BAR   /opt/vision3/menus/v3/bar/
+```
+
+A screen's files travel together — the `.ANS` art, its `.BAR` lightbar
+coordinates and its `.CFG` key bindings all have to agree, so copying one and not
+the others can leave you worse off than before. If you have customised a file,
+diff it against the repo's version rather than overwriting it.
+
+This does not apply if you run Vision/3 directly out of the git checkout, or if
+you bind-mount the repo's `menus/` as `docker-compose.yml` does — there `git pull`
+is enough.
+
 ---
 
 ## Running Multiple Instances

--- a/docs/sysop/menus/menu-system.md
+++ b/docs/sysop/menus/menu-system.md
@@ -607,6 +607,41 @@ Enable cursor-driven selection by creating a `.BAR` file:
 
 Format: X,Y,HighlightColor,NormalColor,Hotkey,Unused,DisplayText
 
+#### Keeping the BAR file and the art in step
+
+`X` and `Y` are absolute screen coordinates, 1-based, written straight out as a
+cursor-position sequence. Nothing checks them against the art underneath, so if
+you move an option in the `.ANS` and forget the `.BAR`, the highlight bar keeps
+painting at the old spot — you get the option drawn twice, once by the art and
+once by the lightbar, a few rows apart. Whenever you edit a lightbar screen's
+art, re-check the coordinates in its `.BAR`.
+
+The hotkeys are the other half of the same problem. A key printed in the art has
+to exist in that menu's `.CFG`, or pressing it does nothing and the screen is
+lying to the user. Menus that read their own keys in Go, such as the Sponsor
+Menu, are the exception — there the art is the accurate record and the `.CFG`
+lists only a subset.
+
+#### Full-screen art and short terminals
+
+Art that fills all 80 columns of its **last** row will scroll the screen on a
+terminal exactly that tall. The character in the bottom-right corner wraps the
+cursor onto a row that does not exist, the display scrolls up by one, and every
+absolute coordinate in your `.BAR` is then off by a row relative to the art.
+
+This bites on 24-row terminals in particular — SyncTERM with its status line
+showing is the common case — while looking perfect at 25 rows. Leave the last
+row one column short:
+
+- A full-screen piece should be **at most 24 rows**, with the final row ending
+  at **column 79 or earlier**.
+- Every other full-screen screen in the shipped menu set follows this; it is
+  worth matching.
+
+A test in the repo (`TestMenuArtFitsStandardHeights`) checks this for shipped art
+that has a matching `.BAR`, since that is the art where a scroll actually breaks
+something.
+
 ## Built-in Functions
 
 Functions available via `RUN:` command:

--- a/docs/sysop/messages/ftn-echomail.md
+++ b/docs/sysop/messages/ftn-echomail.md
@@ -158,8 +158,8 @@ echo list with the areas you already carry ticked, so you can add more without
 re-picking the ones you have.
 
 Saving an edit updates `configs/ftn.json`, the hub's `node` line in
-`binkd.conf`, and the network's poll event, and creates a message area for any
-newly ticked echo.
+`data/ftn/binkd.conf`, and the network's poll event, and creates a message area
+for any newly ticked echo.
 
 Three behaviours are worth knowing before you rely on it:
 

--- a/docs/sysop/messages/ftn-echomail.md
+++ b/docs/sysop/messages/ftn-echomail.md
@@ -87,7 +87,34 @@ manual steps below. Launch it with:
 ./config
 ```
 
-then go to **Echomail Networking → FTN Setup Wizard**. The wizard walks you through:
+then go to **Echomail Networking → FTN Setup Wizard**.
+
+On a system with no networks configured yet the wizard opens straight on a blank
+form. Once you have set one up, it opens on a picker instead, listing what you
+already carry alongside **Add a new network**:
+
+```text
+┌──────────────────────────────────────────────────────────────────────┐
+│                           FTN Setup Wizard                           │
+│  Network         Your Address      Hub                               │
+│──────────────────────────────────────────────────────────────────────│
+│+ Add a new network...                                                │
+│  fsxnet          21:4/158          agency.bbs.nz:24554               │
+│──────────────────────────────────────────────────────────────────────│
+│  fsxnet — address 21:4/158                                           │
+│  Hub: 21:1/100 at agency.bbs.nz:24554                                │
+│  Areas: 2 echos + netmail                                            │
+│  Tosser: on   Poll: 900s                                             │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+Choosing **Add a new network** runs the walkthrough below. Choosing a configured
+network loads it for editing — see [Editing a configured
+network](#editing-a-configured-network).
+
+### Adding a network
+
+The wizard walks you through:
 
 1. **Pick a network** — choose from a built-in registry of known FTN networks
    (fsxNet, FidoNet, etc.). Selecting one pre-fills the hub address, hostname,
@@ -121,6 +148,38 @@ then initialize the message bases and test the connection (see
 
 For networks **not** in the registry — or to understand exactly what the wizard
 configures — follow the manual steps below.
+
+### Editing a configured network
+
+Selecting an existing network from the picker loads its address, hub details and
+AreaFix / session / packet passwords into the same form, so you can see what was
+originally set up and change it. Opening **Echo Areas** downloads the current
+echo list with the areas you already carry ticked, so you can add more without
+re-picking the ones you have.
+
+Saving an edit updates `configs/ftn.json`, the hub's `node` line in
+`binkd.conf`, and the network's poll event, and creates a message area for any
+newly ticked echo.
+
+Three behaviours are worth knowing before you rely on it:
+
+- **Unticking an echo area does not delete it.** That area is a message base
+  holding real mail, and the wizard will not remove one as a side effect of
+  saving a form. The area stays and keeps tossing; the save message tells you
+  how many were left in place. To actually retire one, remove it under **Message
+  Areas** — and send an AreaFix unsubscribe to your hub so it stops sending it.
+- **The network name cannot be changed.** Renaming would have to migrate the
+  conference, every area tag and every message base path on disk. Add a new
+  network instead.
+- **Settings the wizard does not ask about are left alone.** Tosser enable, poll
+  interval and tearline belong to **Echomail Networks**, and an edit here will
+  not reset them. Links other than the hub — downstream systems you feed — are
+  likewise untouched.
+
+Changing **Your Address** also restamps the origin address on every message area
+belonging to that network, so outbound mail matches the new address.
+
+As with adding, **restart the BBS** after saving.
 
 ## Prerequisites
 

--- a/docs/sysop/users/admin-menu.md
+++ b/docs/sysop/users/admin-menu.md
@@ -4,13 +4,23 @@ The Admin Menu provides in-BBS access to user management functions without leavi
 
 ## Accessing the Admin Menu
 
-From the **Main Menu**, press `X`. You are taken to the Admin Menu (`ADMIN.MNU`), which presents a prompt:
+From the **Main Menu**, press `%` — the key the Main Menu screen advertises to
+SysOps as `(%) Sysop Menu`. `X` and `/SYSOP` do the same thing. You are taken to
+the Admin Menu (`ADMIN.MNU`), which presents a prompt:
 
 ```text
 [hh:mm] Admin Menu -> _
 ```
 
 > **Access control:** The Admin Menu requires `S255` ACS — only the primary SysOp account (user #1 or any user at `sysOpLevel`) can enter it.
+
+> **Nothing happens when you press it?** Check your access level first — the
+> option is drawn only for level 255 and the key only works at that level, so on
+> a level-10 account there is nothing to see and nothing to press. Run `./ue`,
+> find your account and set **Access Level** to `255`. Some older installs — and
+> any Docker install created before this was corrected — ended up with a
+> level-10 SysOp account this way; see
+> [Default User](users/user-management.md#default-user).
 
 ---
 

--- a/docs/sysop/users/admin-menu.md
+++ b/docs/sysop/users/admin-menu.md
@@ -1,6 +1,6 @@
 # Admin Menu
 
-The Admin Menu provides in-BBS access to user management functions without leaving the BBS or editing JSON files directly. It is accessible only to SysOps (access level ≥ `sysOpLevel`).
+The Admin Menu provides in-BBS access to user management functions without leaving the BBS or editing JSON files directly. It is accessible only to SysOps — access level **255**, see [Why 255 and not `sysOpLevel`](#why-255-and-not-sysoplevel) below.
 
 ## Accessing the Admin Menu
 
@@ -12,7 +12,22 @@ the Admin Menu (`ADMIN.MNU`), which presents a prompt:
 [hh:mm] Admin Menu -> _
 ```
 
-> **Access control:** The Admin Menu requires `S255` ACS — only the primary SysOp account (user #1 or any user at `sysOpLevel`) can enter it.
+> **Access control:** The Admin Menu requires `S255` ACS — only an account at level 255 can enter it.
+
+### Why 255 and not `sysOpLevel`
+
+`config.json` has a `sysOpLevel` setting, and it is tempting to assume the menus
+follow it. They do not. An ACS condition like `S255` is a literal comparison
+against the user's access level, so every gate in the shipped menu set — all 24
+of them, `ADMIN.MNU` included — requires 255 no matter what `sysOpLevel` says.
+
+`sysOpLevel` governs Go-side checks instead, such as whether the pending-user
+validation notice appears on the Main Menu.
+
+So if you lower `sysOpLevel` expecting to hand a co-sysop the Admin Menu,
+nothing will change. To actually move the gate, edit the ACS strings themselves:
+`ACS` in `menus/v3/mnu/ADMIN.MNU`, and the `%`, `X` and `/SYSOP` entries in
+`menus/v3/cfg/MAIN.CFG`.
 
 > **Nothing happens when you press it?** Check your access level first — the
 > option is drawn only for level 255 and the key only works at that level, so on

--- a/docs/sysop/users/user-management.md
+++ b/docs/sysop/users/user-management.md
@@ -329,10 +329,12 @@ The system creates a default user on first run:
 **Important**: Change this password immediately! It is published here and in the
 README, and it belongs to a full SysOp account.
 
-The level is 255 because this is the only account a fresh install has.
-Everything a SysOp needs is gated behind `S255`, and raising an account's level
-is itself an [Admin Menu](users/admin-menu.md) function — so an account below
-that level cannot promote itself from inside the BBS.
+The level is 255 because this is the only account a fresh install has. Every
+gate in the shipped menu set is the literal ACS `S255` — not the configurable
+`sysOpLevel`, which drives Go-side checks only (see
+[Why 255 and not `sysOpLevel`](users/admin-menu.md#why-255-and-not-sysoplevel)) —
+and raising an account's level is itself an [Admin Menu](users/admin-menu.md)
+function, so an account below 255 cannot promote itself from inside the BBS.
 
 > **SysOp account stuck at level 10?** Some older installs, and any Docker
 > install created before this was corrected, ended up there because the fallback

--- a/docs/sysop/users/user-management.md
+++ b/docs/sysop/users/user-management.md
@@ -6,28 +6,7 @@ Use the [User Editor](users/user-editor.md) (`./ue`) to manage user accounts int
 
 ## User Database
 
-User data is stored in `data/users/users.json`. The system automatically creates this file with a default user on first run.
-
-### Default User
-
-The bootstrap account is `felonius` / `password`, created at **access level 255**
-so it can reach the [Admin Menu](users/admin-menu.md) and validate other users.
-Everything a SysOp needs is gated behind `S255`, and raising an account's level
-is itself an Admin Menu function, so a first account below that level cannot
-promote itself from inside the BBS.
-
-> **Change the password immediately.** It is published here and in the README,
-> and it now belongs to a full SysOp account.
-
-Some older installs — and any Docker install created before this was corrected —
-ended up with `felonius` at level **10** instead, because the fallback that
-creates `users.json` at startup disagreed with the one in `setup.sh`. If your
-SysOp account cannot open the Admin Menu, that is why. Fix it with the
-[User Editor](users/user-editor.md):
-
-```bash
-./ue          # select the account, set Access Level to 255, save
-```
+User data is stored in `data/users/users.json`. The system automatically creates this file with a default user on first run. See [Default User](#default-user) for its credentials and access level.
 
 ## User Structure
 
@@ -344,10 +323,26 @@ The system creates a default user on first run:
 
 - Username: `felonius`
 - Password: `password`
-- Access Level: 10
+- Access Level: 255 (SysOp)
 - Validated: true
 
-**Important**: Change this password immediately!
+**Important**: Change this password immediately! It is published here and in the
+README, and it belongs to a full SysOp account.
+
+The level is 255 because this is the only account a fresh install has.
+Everything a SysOp needs is gated behind `S255`, and raising an account's level
+is itself an [Admin Menu](users/admin-menu.md) function — so an account below
+that level cannot promote itself from inside the BBS.
+
+> **SysOp account stuck at level 10?** Some older installs, and any Docker
+> install created before this was corrected, ended up there because the fallback
+> that writes `users.json` at startup disagreed with the one in `setup.sh`. If
+> your account cannot open the Admin Menu, that is why. Fix it with the
+> [User Editor](users/user-editor.md):
+>
+> ```bash
+> ./ue          # select the account, set Access Level to 255, save
+> ```
 
 ### User Authentication
 

--- a/docs/sysop/users/user-management.md
+++ b/docs/sysop/users/user-management.md
@@ -8,6 +8,27 @@ Use the [User Editor](users/user-editor.md) (`./ue`) to manage user accounts int
 
 User data is stored in `data/users/users.json`. The system automatically creates this file with a default user on first run.
 
+### Default User
+
+The bootstrap account is `felonius` / `password`, created at **access level 255**
+so it can reach the [Admin Menu](users/admin-menu.md) and validate other users.
+Everything a SysOp needs is gated behind `S255`, and raising an account's level
+is itself an Admin Menu function, so a first account below that level cannot
+promote itself from inside the BBS.
+
+> **Change the password immediately.** It is published here and in the README,
+> and it now belongs to a full SysOp account.
+
+Some older installs — and any Docker install created before this was corrected —
+ended up with `felonius` at level **10** instead, because the fallback that
+creates `users.json` at startup disagreed with the one in `setup.sh`. If your
+SysOp account cannot open the Admin Menu, that is why. Fix it with the
+[User Editor](users/user-editor.md):
+
+```bash
+./ue          # select the account, set Access Level to 255, save
+```
+
 ## User Structure
 
 Users are stored as a JSON array. Each user account contains:
@@ -419,7 +440,7 @@ New accounts are created with:
 - `accessLevel: 1` — minimal access level
 - `timeLimit: 60` — 60-minute time limit per call
 
-The SysOp can validate users in-BBS from the Admin Menu (`X` from MAIN → `V`). See [Admin Menu](users/admin-menu.md) for the full key reference.
+The SysOp can validate users in-BBS from the Admin Menu (`%` from MAIN → `V`). See [Admin Menu](users/admin-menu.md) for the full key reference.
 
 SysOp accounts also receive an automatic notification on MAIN menu entry when there are pending unvalidated users.
 
@@ -587,7 +608,7 @@ Since passwords are hashed, you cannot recover them. To reset: run `./ue`, selec
 
 ### Validating New Users
 
-**Recommended:** use the in-BBS Admin Menu (`X` from MAIN → `V`) to validate pending accounts. The screen shows all unvalidated users with a detail panel; press `H` to toggle validation status, then `S` to save. See [Admin Menu](users/admin-menu.md) for all key bindings.
+**Recommended:** use the in-BBS Admin Menu (`%` from MAIN → `V`) to validate pending accounts. The screen shows all unvalidated users with a detail panel; press `H` to toggle validation status, then `S` to save. See [Admin Menu](users/admin-menu.md) for all key bindings.
 
 **Alternative:** use `./ue`, select the user, and toggle the Validated field to `Y` and set Access Level to 10.
 
@@ -598,7 +619,7 @@ The ban feature sets a user's access level to 0 and marks them as unvalidated, p
 #### How to Ban a User
 
 **Option 1: From Admin User Browser**
-1. Press `X` from MAIN menu to enter Admin menu
+1. Press `%` from MAIN menu to enter Admin menu
 2. Press `E` to run Edit Users (Admin List Users)
 3. Navigate to the user you want to ban
 4. Press `0` to toggle ban status (bans if not banned, or unbans if already banned)
@@ -632,7 +653,7 @@ The soft-delete feature marks users as deleted without removing their data. This
 #### How to Delete a User
 
 **Option 1: From Admin User Browser**
-1. Press `X` from MAIN menu to enter Admin menu
+1. Press `%` from MAIN menu to enter Admin menu
 2. Press `E` to run Edit Users (Admin List Users)
 3. Navigate to the user you want to delete
 4. Press `9` to toggle deletion (marks for delete if not deleted, or undeletes if already deleted)

--- a/internal/menu/menu_art_hotkeys_test.go
+++ b/internal/menu/menu_art_hotkeys_test.go
@@ -28,8 +28,11 @@ var knownUnboundHotkeys = map[string]map[string]string{
 		"B": "sample Synchronet door in the shipped art; doors are site-specific and sysops bind their own",
 		"C": "sample Synchronet door in the shipped art; doors are site-specific and sysops bind their own",
 	},
+	// SPONSORM reads its own keys in runSponsorMenu rather than dispatching
+	// through its CFG, so the CFG lists only a subset and the art is the
+	// accurate record. P (reorder areas) is implemented and works.
 	"SPONSORM": {
-		"P": "'Re-Order Sub-Boards' is advertised but not implemented; see issue #176",
+		"P": "handled directly in runSponsorMenu, not dispatched via SPONSORM.CFG",
 	},
 }
 


### PR DESCRIPTION
Docs follow-up to the three #176 fixes. Also corrects a claim I got wrong during that work.

## `users/admin-menu.md`

Said to press `X`. That works, but it isn't what the Main Menu screen advertises — it shows `(%) Sysop Menu` to level-255 accounts, and `%` is what a sysop actually reaches for. All three keys (`%`, `X`, `/SYSOP`) are now documented, plus a note for the exact situation that produced #176: on a level-10 account nothing happens, because the option is only *drawn* at 255 and only *accepted* at 255.

## `users/user-management.md`

New **Default User** section: the bootstrap account is `felonius`/`password` at level 255, everything a sysop needs is gated behind `S255`, and raising a level is itself an admin function — so an account below that can't promote itself from inside the BBS. Records that some older installs (and Docker installs made before the fix) landed at level 10, and how to recover with `./ue`. Four stale "press `X` from MAIN" references updated to `%`.

## `how-to-guides/keeping-binaries-updated.md`

This one is the most useful of the set. The doc told sysops their `menus/` directory survives an upgrade untouched — as reassurance. It's true, and it's also a trap: **a release that fixes a menu screen never reaches the board from `git pull` alone**, and nothing indicates anything was missed. You rebuild, restart, and the old broken screen is still there.

Now documented, with how to find what changed under `menus/` and copy it across, a warning that a screen's `.ANS`, `.BAR` and `.CFG` travel together (copying one and not the others can leave you worse off), and the exemptions — running from the checkout, or bind-mounting `menus/` as `docker-compose.yml` does.

This is exactly what bit the #176 reporter on item 1.

## `messages/ftn-echomail.md`

Documents the wizard's picker and edit mode from #179, including the three behaviours a sysop needs to know before relying on it: unticking an area doesn't delete it (and needs an AreaFix unsubscribe to genuinely retire), the network name is fixed, and settings owned by Echomail Networks aren't reset.

## `menus/menu-system.md`

Authoring guidance for the two failure modes behind #177 and #178:

- **BAR coordinates are absolute and nothing checks them against the art.** Move an option in the `.ANS` without updating the `.BAR` and the option gets drawn twice, a few rows apart — the #177 symptom.
- **Art filling all 80 columns of its last row scrolls a terminal exactly that tall.** Invisible at 25 rows, breaks every BAR coordinate at 24. Guidance: at most 24 rows, last row ending at column 79 or earlier.

## Correction

I recorded `SPONSORM`'s `[P] Re-Order Sub-Boards` as "advertised but not implemented" — in the #178 test exemption, in the #178 PR description, and to the reporter on #176. **That was wrong.** It *is* implemented: `runSponsorMenu` reads its own keys instead of dispatching through `SPONSORM.CFG`, so the CFG lists only a subset and the art is the accurate record. I found this while checking whether the docs advertised `P` — they document it in detail, which prompted me to verify rather than assume my earlier note was right.

The test exemption now states the real reason, and `menu-system.md` notes self-dispatching menus as the exception to the art/CFG rule. I'll correct the record on #176 too.

No behaviour change; `go build`, `go vet`, `gofmt` and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for updating symlinked installations while preserving custom menus and artwork.
  * Documented menu artwork, lightbar alignment, hotkey configuration, and terminal-size considerations.
  * Expanded FTN network setup instructions, including editing networks and applying configuration changes.
  * Clarified Admin Menu access requirements, entry points, account levels, and recovery steps.
  * Updated user-management guidance for default credentials, password changes, and account administration.
* **Tests**
  * Updated menu documentation to reflect the implemented sponsor-menu hotkey behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->