### PR TITLE
Display messages in newest-first order in message list

### DIFF
--- a/internal/menu/message_list_state.go
+++ b/internal/menu/message_list_state.go
@@ -91,10 +91,11 @@ func buildMessageList(msgMgr *message.MessageManager, areaID int, username strin
 		lastRead = 0 // Default to all unread
 	}
 
-	// Build list of message entries
+	// Build list of message entries, newest first (descending message number)
+	// so the most recent posts appear at the top of the list.
 	entries := make([]MessageListEntry, 0, totalCount)
 
-	for msgNum := 1; msgNum <= totalCount; msgNum++ {
+	for msgNum := totalCount; msgNum >= 1; msgNum-- {
 		msg, err := msgMgr.GetMessage(areaID, msgNum)
 		if err != nil {
 			// Skip deleted or unreadable messages

--- a/internal/menu/message_list_test.go
+++ b/internal/menu/message_list_test.go
@@ -149,20 +149,21 @@ func TestBuildMessageList_CountOrderingAndLastRead(t *testing.T) {
 		t.Fatalf("len(entries) = %d, want 3", len(entries))
 	}
 
-	// Ascending by message number, matching post order.
-	wantSubjects := []string{"first", "second", "third"}
+	// Newest first: descending by message number, reverse of post order.
+	wantSubjects := []string{"third", "second", "first"}
 	for i, e := range entries {
-		if e.MsgNum != i+1 {
-			t.Errorf("entries[%d].MsgNum = %d, want %d", i, e.MsgNum, i+1)
+		wantNum := len(entries) - i
+		if e.MsgNum != wantNum {
+			t.Errorf("entries[%d].MsgNum = %d, want %d", i, e.MsgNum, wantNum)
 		}
 		if e.Subject != wantSubjects[i] {
 			t.Errorf("entries[%d].Subject = %q, want %q", i, e.Subject, wantSubjects[i])
 		}
 	}
-	if !entries[0].IsRead || !entries[1].IsRead {
+	if !entries[1].IsRead || !entries[2].IsRead {
 		t.Error("messages 1 and 2 should be read (msgNum <= lastRead)")
 	}
-	if entries[2].IsRead {
+	if entries[0].IsRead {
 		t.Error("message 3 should be unread (msgNum > lastRead)")
 	}
 }


### PR DESCRIPTION
## Summary
Changed the message list display order from oldest-first (ascending by message number) to newest-first (descending by message number), so the most recent posts appear at the top of the list.

## Key Changes
- Modified `buildMessageList()` in `message_list_state.go` to iterate through messages in reverse order (from `totalCount` down to 1 instead of 1 to `totalCount`)
- Updated test expectations in `TestBuildMessageList_CountOrderingAndLastRead` to verify the new descending order
- Adjusted read/unread status assertions in the test to account for the reversed message positions

## Implementation Details
- The loop now builds the message list with newest messages first, which is a common UX pattern for message boards and discussion forums
- The read/unread status logic remains unchanged; messages are still correctly marked based on the `lastRead` threshold, but their positions in the list are now reversed
- All message metadata (MsgNum, Subject, IsRead) is preserved; only the ordering has changed

https://claude.ai/code/session_01HbmrLjfwH5xXWGgq6KCevQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Message lists now display the newest messages first.
  * Read and unread status indicators remain accurate with the updated ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->