### PR TITLE
fix(gate): keep challenge gate art border aligned after token substitution

### DIFF
--- a/docs/sysop/configuration/security.md
+++ b/docs/sysop/configuration/security.md
@@ -109,6 +109,13 @@ correctly-pluralized noun ("time" for a count of 1, "times" otherwise), so
 custom art always reflects the current configuration and renders grammatically
 correct prompts instead of hardcoding values that can drift out of sync.
 
+Because the substituted text is rarely the same width as the tokens it
+replaces, a line that ends in a box border (any trailing run of frame
+characters, such as `|`, separated from the text by a space) is re-padded in
+the gap before that border, so framed art stays square whatever the configured
+key and press count render as. Lines that simply end in words — the built-in
+fallback prompt, for example — are left exactly as substituted.
+
 ### Connection-Rate Limiter
 
 The connection-rate limiter closes a gap the existing

--- a/internal/menu/challenge_gate_helpers.go
+++ b/internal/menu/challenge_gate_helpers.go
@@ -158,13 +158,17 @@ func substituteGateTokens(prompt []byte, keyDisplay string, presses int) []byte 
 // trailing run is only treated as a border when it is made purely of frame
 // characters (no letters or digits) and a space separates it from the text, so
 // a plain sentence line — the built-in fallback prompt, for instance — is
-// returned untouched rather than gaining a gap mid-sentence.
+// returned untouched rather than gaining a gap mid-sentence. Color codes are
+// not text: escape sequences trailing the border (a closing reset, say) or
+// colouring it are skipped when looking for the border.
 func realignBorder(line []byte, delta int) []byte {
 	body := line
 	for len(body) > 0 && (body[len(body)-1] == '\n' || body[len(body)-1] == '\r') {
 		body = body[:len(body)-1]
 	}
-	eol := line[len(body):]
+	tail := trimGateTail(body) // trailing escape sequences and spaces, kept as-is
+	suffix := line[len(body)-len(tail):]
+	body = body[:len(body)-len(tail)]
 
 	border := len(body)
 	for border > 0 && !isGateSpace(body[border-1]) {
@@ -193,25 +197,52 @@ func realignBorder(line []byte, delta int) []byte {
 		out = out[:len(out)+pad]
 	}
 	out = append(out, body[border:]...)
-	out = append(out, eol...)
+	out = append(out, suffix...)
 	return out
 }
 
 func isGateSpace(b byte) bool { return b == ' ' || b == '\t' }
 
+// trimGateTail returns the run of escape sequences and spaces at the end of
+// body — everything past the last visible character — so border detection can
+// look at the border itself rather than at a trailing reset code.
+func trimGateTail(body []byte) []byte {
+	end := len(body)
+	for end > 0 {
+		if isGateSpace(body[end-1]) {
+			end--
+			continue
+		}
+		esc := bytes.LastIndexByte(body[:end], 0x1B)
+		if esc < 0 || esc+escapeSeqLen(body[esc:end]) != end {
+			break
+		}
+		end = esc
+	}
+	return body[end:]
+}
+
 // isGateBorder reports whether run is a frame decoration rather than words:
 // no ASCII letters or digits, and no sentence punctuation, which keeps text
-// ending in "." or "!" from being mistaken for a border.
+// ending in "." or "!" from being mistaken for a border. Escape sequences
+// within the run (a color set on the border) are ignored.
 func isGateBorder(run []byte) bool {
-	for _, b := range run {
+	visible := 0
+	for i := 0; i < len(run); i++ {
+		b := run[i]
+		if b == 0x1B {
+			i += escapeSeqLen(run[i:]) - 1 // -1: the loop's i++ passes the last byte
+			continue
+		}
 		switch {
 		case b >= 'a' && b <= 'z', b >= 'A' && b <= 'Z', b >= '0' && b <= '9':
 			return false
 		case b == '.' || b == ',' || b == '!' || b == '?' || b == ';' || b == '\'' || b == '"':
 			return false
 		}
+		visible++
 	}
-	return len(run) > 0
+	return visible > 0
 }
 
 // challengeInput is the subset of editor.InputHandler the loop needs.

--- a/internal/menu/challenge_gate_helpers.go
+++ b/internal/menu/challenge_gate_helpers.go
@@ -126,15 +126,92 @@ func substituteCountdown(prompt []byte, seconds, width int) []byte {
 // respectively. This allows custom gate art (and the built-in fallback) to
 // render the configured challenge key and required press count without
 // drifting from config. Any "##" countdown field is left untouched.
+//
+// Substitution is done line by line so a line whose width changed can be
+// re-padded against a trailing box border (see realignBorder), keeping framed
+// art square no matter how wide the configured key and press count render.
 func substituteGateTokens(prompt []byte, keyDisplay string, presses int) []byte {
-	out := bytes.ReplaceAll(prompt, []byte("{KEY}"), []byte(keyDisplay))
-	out = bytes.ReplaceAll(out, []byte("{PRESSES}"), []byte(strconv.Itoa(presses)))
 	timesWord := "times"
 	if presses == 1 {
 		timesWord = "time"
 	}
-	out = bytes.ReplaceAll(out, []byte("{TIMES}"), []byte(timesWord))
+	lines := bytes.SplitAfter(prompt, []byte("\n"))
+	for i, line := range lines {
+		out := bytes.ReplaceAll(line, []byte("{KEY}"), []byte(keyDisplay))
+		out = bytes.ReplaceAll(out, []byte("{PRESSES}"), []byte(strconv.Itoa(presses)))
+		out = bytes.ReplaceAll(out, []byte("{TIMES}"), []byte(timesWord))
+		if len(out) != len(line) {
+			out = realignBorder(out, len(line)-len(out))
+		}
+		lines[i] = out
+	}
+	return bytes.Join(lines, nil)
+}
+
+// realignBorder restores a substituted line to its original width by adding
+// (delta > 0) or absorbing (delta < 0) spaces in the gap in front of the
+// line's trailing border decoration, so art like
+//
+//	| Press {KEY} {PRESSES} {TIMES} if you're not a bot. |
+//
+// keeps its right-hand border in the same column after the tokens shrink. The
+// trailing run is only treated as a border when it is made purely of frame
+// characters (no letters or digits) and a space separates it from the text, so
+// a plain sentence line — the built-in fallback prompt, for instance — is
+// returned untouched rather than gaining a gap mid-sentence.
+func realignBorder(line []byte, delta int) []byte {
+	body := line
+	for len(body) > 0 && (body[len(body)-1] == '\n' || body[len(body)-1] == '\r') {
+		body = body[:len(body)-1]
+	}
+	eol := line[len(body):]
+
+	border := len(body)
+	for border > 0 && !isGateSpace(body[border-1]) {
+		border--
+	}
+	if border == len(body) || border == 0 || !isGateBorder(body[border:]) {
+		return line // no trailing border to align against
+	}
+	gap := border
+	for gap > 0 && isGateSpace(body[gap-1]) {
+		gap--
+	}
+
+	pad := delta
+	if pad < 0 {
+		if avail := border - gap; -pad > avail {
+			pad = -avail // line outgrew its gap; close it up as far as it goes
+		}
+	}
+
+	out := make([]byte, 0, len(line)+pad)
+	out = append(out, body[:border]...)
+	if pad > 0 {
+		out = append(out, bytes.Repeat([]byte{' '}, pad)...)
+	} else {
+		out = out[:len(out)+pad]
+	}
+	out = append(out, body[border:]...)
+	out = append(out, eol...)
 	return out
+}
+
+func isGateSpace(b byte) bool { return b == ' ' || b == '\t' }
+
+// isGateBorder reports whether run is a frame decoration rather than words:
+// no ASCII letters or digits, and no sentence punctuation, which keeps text
+// ending in "." or "!" from being mistaken for a border.
+func isGateBorder(run []byte) bool {
+	for _, b := range run {
+		switch {
+		case b >= 'a' && b <= 'z', b >= 'A' && b <= 'Z', b >= '0' && b <= '9':
+			return false
+		case b == '.' || b == ',' || b == '!' || b == '?' || b == ';' || b == '\'' || b == '"':
+			return false
+		}
+	}
+	return len(run) > 0
 }
 
 // challengeInput is the subset of editor.InputHandler the loop needs.

--- a/internal/menu/challenge_gate_helpers_test.go
+++ b/internal/menu/challenge_gate_helpers_test.go
@@ -114,6 +114,29 @@ func TestSubstituteGateTokens(t *testing.T) {
 		t.Errorf("substituteGateTokens with no tokens = %q, want unchanged %q", got, noTokens)
 	}
 
+	// Boxed art keeps its right border in the same column: the line is
+	// re-padded in the gap before the border when the tokens shrink...
+	boxed := []byte(" | Press {KEY} {PRESSES} {TIMES} if you're not a bot. |\r\n")
+	got = string(substituteGateTokens(boxed, "ESC", 2))
+	want := " | Press ESC 2 times if you're not a bot.             |\r\n"
+	if got != want {
+		t.Errorf("substituteGateTokens boxed art: got %q, want %q", got, want)
+	}
+
+	// ...and the gap is absorbed when they grow past the original width.
+	got = string(substituteGateTokens(boxed, "PRESS-THE-ESCAPE-KEY", 10))
+	want = " | Press PRESS-THE-ESCAPE-KEY 10 times if you're not a bot.|\r\n"
+	if got != want {
+		t.Errorf("substituteGateTokens wide key: got %q, want %q", got, want)
+	}
+
+	// A plain sentence has no border to align against, so it is not padded.
+	sentence := []byte(" Press {KEY} {PRESSES} {TIMES} if you're not a bot.\r\n")
+	got = string(substituteGateTokens(sentence, "ESC", 2))
+	if got != " Press ESC 2 times if you're not a bot.\r\n" {
+		t.Errorf("substituteGateTokens sentence: got %q", got)
+	}
+
 	// Test with countdown field (## should remain unchanged)
 	withCountdown := []byte(" Press {KEY} {PRESSES} {TIMES}. You have ## seconds.")
 	got = string(substituteGateTokens(withCountdown, "ESC", 2))

--- a/internal/menu/challenge_gate_helpers_test.go
+++ b/internal/menu/challenge_gate_helpers_test.go
@@ -130,6 +130,22 @@ func TestSubstituteGateTokens(t *testing.T) {
 		t.Errorf("substituteGateTokens wide key: got %q, want %q", got, want)
 	}
 
+	// A trailing reset code after the border does not hide the border.
+	reset := []byte(" | Press {KEY} {PRESSES} {TIMES} if you're not a bot. |\x1b[0m\r\n")
+	got = string(substituteGateTokens(reset, "ESC", 2))
+	want = " | Press ESC 2 times if you're not a bot.             |\x1b[0m\r\n"
+	if got != want {
+		t.Errorf("substituteGateTokens with trailing reset: got %q, want %q", got, want)
+	}
+
+	// Neither does a color code on the border itself.
+	colored := []byte(" | Press {KEY} {PRESSES} {TIMES} if you're not a bot. \x1b[36m|\r\n")
+	got = string(substituteGateTokens(colored, "ESC", 2))
+	want = " | Press ESC 2 times if you're not a bot.             \x1b[36m|\r\n"
+	if got != want {
+		t.Errorf("substituteGateTokens with colored border: got %q, want %q", got, want)
+	}
+
 	// A plain sentence has no border to align against, so it is not padded.
 	sentence := []byte(" Press {KEY} {PRESSES} {TIMES} if you're not a bot.\r\n")
 	got = string(substituteGateTokens(sentence, "ESC", 2))


### PR DESCRIPTION
## Problem

On connect, the bot-check frame broke on the prompt line:

```
 +/--------------------------------------------------/+
 | Press ESC 2 times if you're not a bot. |
 | You have 14 seconds.                               |
 +/--------------------------------------------------/+
```

`BOTCHECK.ASC` reserves 23 columns for `{KEY} {PRESSES} {TIMES}`, but the substituted text (`ESC 2 times`) is 11 wide, pulling the right border 12 columns left.

## Fix

`substituteGateTokens` now works line by line and, when a line's width changes, re-pads it in the gap before a trailing box border (`realignBorder`). A trailing run only counts as a border when it is pure frame characters — no letters, digits, or sentence punctuation — so plain sentence lines such as the built-in fallback prompt are left exactly as substituted. If the configured key and press count render wider than the tokens, the gap is absorbed instead.

Rendered from the real art file:

```
 +/--------------------------------------------------/+
 | Press ESC 2 times if you're not a bot.             |
 | You have 20 seconds.                               |
 +/--------------------------------------------------/+
```

Verified the same for `*` / 1 press and for an over-long key (border holds, gap closes up).

## Tests

Added cases to `TestSubstituteGateTokens` for boxed art, the over-wide key, and the unpadded sentence line. `go test ./internal/menu/` and `go vet ./internal/menu/` pass.

Docs updated in `docs/sysop/configuration/security.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQuYC88yCUrF8isfJdNJyY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Challenge Gate prompt substitutions so framed artwork remains properly aligned when replacement values change line widths.
  - Preserved spacing, trailing spaces, line endings, and colored border alignment.
  - Ensured ordinary sentence lines, including fallback prompts, remain unchanged.
  - Improved handling of prompts containing terminal color formatting.

- **Documentation**
  - Updated security documentation to explain alignment behavior for framed artwork and unframed text after prompt substitution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->