### PR TITLE
fix(ftn): make the tearline machine-assigned and add an origin setting

### DIFF
--- a/cmd/v3mail/cmd_ftn.go
+++ b/cmd/v3mail/cmd_ftn.go
@@ -214,10 +214,10 @@ func loadFTNDeps(configDir, dataDir string) (config.FTNConfig, *message.MessageM
 	// Resolve relative FTN paths against BBS root
 	ftnCfg.ResolvePaths(bbsRoot)
 
-	// Build tearlines map for MessageManager
-	tearlines := make(map[string]string)
+	// Build per-network origin line text for MessageManager
+	origins := make(map[string]string)
 	for name, net := range ftnCfg.Networks {
-		tearlines[name] = net.Tearline
+		origins[name] = net.Origin
 	}
 
 	// Load server config for board name
@@ -227,7 +227,7 @@ func loadFTNDeps(configDir, dataDir string) (config.FTNConfig, *message.MessageM
 		boardName = serverCfg.BoardName
 	}
 
-	msgMgr, err := message.NewMessageManager(dataDir, configDir, boardName, tearlines)
+	msgMgr, err := message.NewMessageManager(dataDir, configDir, boardName, origins)
 	if err != nil {
 		return config.FTNConfig{}, nil, nil, fmt.Errorf("init message manager: %w", err)
 	}

--- a/cmd/vision3/main.go
+++ b/cmd/vision3/main.go
@@ -1610,22 +1610,22 @@ func main() {
 		logging.Fatal("failed to load door configuration", "error", err)
 	}
 
-	// Load FTN configuration early so message manager can use per-network tearlines.
+	// Load FTN configuration early so message manager can use per-network origins.
 	ftnConfig, ftnErr := config.LoadFTNConfig(rootConfigPath)
 	if ftnErr != nil {
 		slog.Error("failed to load FTN config, echomail disabled", "error", ftnErr)
 	}
-	networkTearlines := make(map[string]string)
+	networkOrigins := make(map[string]string)
 	if ftnErr == nil {
 		for name, netCfg := range ftnConfig.Networks {
-			if strings.TrimSpace(netCfg.Tearline) == "" {
+			if strings.TrimSpace(netCfg.Origin) == "" {
 				continue
 			}
-			networkTearlines[strings.ToLower(strings.TrimSpace(name))] = netCfg.Tearline
+			networkOrigins[strings.ToLower(strings.TrimSpace(name))] = netCfg.Origin
 		}
 	}
-	if len(networkTearlines) == 0 {
-		networkTearlines = nil
+	if len(networkOrigins) == 0 {
+		networkOrigins = nil
 	}
 
 	// Oneliners are loaded by the runnable; start with an empty list here.
@@ -1640,7 +1640,7 @@ func main() {
 	userMgr.SetNewUserLevel(serverConfig.NewUserLevel)
 
 	// Initialize MessageManager (areas config from configs/, message data from data/)
-	messageMgr, err = message.NewMessageManager(dataPath, rootConfigPath, serverConfig.BoardName, networkTearlines)
+	messageMgr, err = message.NewMessageManager(dataPath, rootConfigPath, serverConfig.BoardName, networkOrigins)
 	if err != nil {
 		logging.Fatal("failed to initialize message manager", "error", err)
 	}

--- a/docs/sysop/configuration/configuration.md
+++ b/docs/sysop/configuration/configuration.md
@@ -63,7 +63,7 @@ Choosing **System Configuration** (key 1) opens an inner menu with nine numbered
 
 | Item | What it edits |
 |------|---------------|
-| Echomail Networks | Global FTN paths (inbound, outbound, temp, bad/dupe tags) and per-network settings (own address, poll interval, tearline) |
+| Echomail Networks | Global FTN paths (inbound, outbound, temp, bad/dupe tags) and per-network settings (own address, poll interval, origin line) |
 | Echomail Links | Per-hub link settings (address, packet/session/AreaFix passwords, flavour) |
 | FTN Setup Wizard | Guided flow: downloads a network's echolist, lets you browse and subscribe to areas, then writes `ftn.json`, `message_areas.json`, and `conferences.json` automatically |
 
@@ -626,7 +626,7 @@ See [Message Areas Guide](messages/message-areas.md) for detailed configuration.
 
 > *Use the [Configuration Editor](#configuration-editor-tui) (key 3 → Echomail Networks / Echomail Links) to manage FTN settings interactively. The JSON structure below is for reference.*
 
-Located in the `configs/` directory. Configures the internal FTN tosser (v3mail) for echomail. Global fields include directory paths (`inbound_path`, `outbound_path`, `binkd_outbound_path`, `temp_path`) and routing tags (`bad_area_tag`, `dupe_area_tag`). Per-network fields include `own_address`, `internal_tosser_enabled`, `poll_interval_seconds`, and `tearline`. Per-link fields include `address`, `packet_password`, `areafix_password`, `name`, and `flavour`.
+Located in the `configs/` directory. Configures the internal FTN tosser (v3mail) for echomail. Global fields include directory paths (`inbound_path`, `outbound_path`, `binkd_outbound_path`, `temp_path`) and routing tags (`bad_area_tag`, `dupe_area_tag`). Per-network fields include `own_address`, `internal_tosser_enabled`, `poll_interval_seconds`, and `origin`. Per-link fields include `address`, `packet_password`, `areafix_password`, `name`, and `flavour`.
 
 See [FTN Echomail Guide](messages/ftn-echomail.md) for setup and full field reference.
 

--- a/docs/sysop/messages/ftn-echomail.md
+++ b/docs/sysop/messages/ftn-echomail.md
@@ -172,7 +172,7 @@ Three behaviours are worth knowing before you rely on it:
   conference, every area tag and every message base path on disk. Add a new
   network instead.
 - **Settings the wizard does not ask about are left alone.** Tosser enable, poll
-  interval and tearline belong to **Echomail Networks**, and an edit here will
+  interval and origin belong to **Echomail Networks**, and an edit here will
   not reset them. Links other than the hub — downstream systems you feed — are
   likewise untouched.
 
@@ -470,7 +470,7 @@ verify the directory paths are correct for your installation:
         "fsxnet": {
             "internal_tosser_enabled": true,
             "own_address": "21:4/158.1",
-            "tearline": "",
+            "origin": "",
             "links": [
                 {
                     "address": "21:4/158",
@@ -627,7 +627,7 @@ read by `v3mail toss`, `v3mail scan`, and `v3mail ftn-pack`.
 | `internal_tosser_enabled` | Set `true` to enable `v3mail` for this network      |
 | `own_address`             | Your FTN address (e.g., `21:4/158.1`)               |
 | `poll_interval_seconds`   | Auto-poll interval; `0` = manual only               |
-| `tearline`                | Optional tearline suffix (empty = use default)      |
+| `origin`                  | Origin line text (empty = board name)               |
 
 **Per-link fields (`networks.<key>.links[]`):**
 
@@ -657,7 +657,7 @@ read by `v3mail toss`, `v3mail scan`, and `v3mail ftn-pack`.
         "fsxnet": {
             "internal_tosser_enabled": true,
             "own_address": "21:4/158.1",
-            "tearline": "",
+            "origin": "",
             "links": [
                 {
                     "address": "21:4/158",

--- a/docs/sysop/messages/jam-echomail.md
+++ b/docs/sysop/messages/jam-echomail.md
@@ -22,16 +22,22 @@ Message type is derived from the area configuration:
 
 Logic lives in `internal/jam/msgtype.go` and is called by `internal/message/manager.go`.
 
-## What Gets Added for Echomail/Netmail
+## What Gets Added for Echomail
 
-When writing echomail/netmail with `WriteMessageExt`, Vision3 automatically appends:
+When writing **echomail** with `WriteMessageExt`, Vision3 automatically adds:
 
-- `AREA:` kludge for echomail
-- `MSGID` (unique serial per base)
+- `AREA:` kludge
+- `MSGID` (unique serial per base), generated when the message has none
 - `PID`/`TID` identifiers
 - Tearline (`--- ViSiON/3 vX.Y.Z/Platform`, assigned by the software)
 - Origin line (`* Origin: ... (address)`)
-- `SEEN-BY` and `PATH` for echomail
+
+`SEEN-BY` and `PATH` are the tosser's job and are not added here.
+
+**Netmail** takes none of the above: `WriteMessageExt` writes an `MSGID`
+subfield only when the message already carries one, and adds no kludges,
+tearline, or origin line. Netmail is point-to-point, so the origin line — which
+identifies a message's source conference-wide — does not apply.
 
 Implementation: `internal/jam/echomail.go`, `internal/jam/format.go`, `internal/jam/msgid.go`.
 

--- a/docs/sysop/messages/jam-echomail.md
+++ b/docs/sysop/messages/jam-echomail.md
@@ -29,7 +29,7 @@ When writing echomail/netmail with `WriteMessageExt`, Vision3 automatically appe
 - `AREA:` kludge for echomail
 - `MSGID` (unique serial per base)
 - `PID`/`TID` identifiers
-- Tearline (`--- Vision3 ...`)
+- Tearline (`--- ViSiON/3 vX.Y.Z/Platform`, assigned by the software)
 - Origin line (`* Origin: ... (address)`)
 - `SEEN-BY` and `PATH` for echomail
 
@@ -40,7 +40,7 @@ Implementation: `internal/jam/echomail.go`, `internal/jam/format.go`, `internal/
 These values come from configuration and are applied during message creation:
 
 - **Origin address**: `configs/message_areas.json` (`origin_addr` per area)
-- **Network tearline**: `configs/ftn.json` (`tearline` per network)
+- **Network origin text**: `configs/ftn.json` (`origin` per network; empty = board name)
 - **BBS name**: `configs/config.json` (`boardName`)
 
 The message manager passes these into the JAM writer.

--- a/docs/sysop/messages/message-areas.md
+++ b/docs/sysop/messages/message-areas.md
@@ -143,7 +143,7 @@ Configure it in `configs/ftn.json` (separate from the main `config.json`):
       "outbound_path": "data/ftn/fsxnet/outbound",
       "temp_path": "data/ftn/fsxnet/temp",
       "poll_interval_seconds": 300,
-      "tearline": "My BBS 1.0",
+      "origin": "My BBS - bbs.example.com",
       "links": [
         {
           "address": "21:1/100",
@@ -172,7 +172,9 @@ Each network key (e.g., `"fsxnet"`) contains:
 - `outbound_path` — Directory for outgoing .PKT files
 - `temp_path` — Temp directory for failed packets
 - `poll_interval_seconds` — How often to scan for packets (0 = manual only)
-- `tearline` — Optional tearline text for new echomail posts (prefix `---` is added unless you include it)
+- `origin` — Optional origin line text for new echomail posts (empty = the board name). The address is appended automatically.
+
+The tearline is not configurable: FTS-0004 reserves it for the software that produced the message, so ViSiON/3 always stamps `--- ViSiON/3 vX.Y.Z/Platform`.
 
 ### Link Configuration
 

--- a/docs/sysop/messages/v3mail.md
+++ b/docs/sysop/messages/v3mail.md
@@ -108,7 +108,7 @@ Per-network fields (`networks.<key>`):
 | `own_address`               | This node's FTN address (zone:net/node.point)                   |
 | `internal_tosser_enabled`   | Set `true` to enable `v3mail` for this network                  |
 | `poll_interval_seconds`     | Auto-poll interval; `0` = manual only                           |
-| `tearline`                  | Custom tearline text (empty = use default)                      |
+| `origin`                    | Origin line text (empty = board name)                           |
 
 Per-link fields (`networks.<key>.links[]`):
 

--- a/docs/sysop/reference/api-reference.md
+++ b/docs/sysop/reference/api-reference.md
@@ -641,7 +641,7 @@ type FTNNetworkConfig struct {
     InternalTosserEnabled bool
     OwnAddress            string
     PollSeconds           int
-    Tearline              string
+    Origin                string
     Links                 []FTNLinkConfig
 }
 

--- a/docs/sysop/v3net/message-areas.md
+++ b/docs/sysop/v3net/message-areas.md
@@ -65,7 +65,7 @@ When a leaf syncs the NAL from the hub, any network areas you are subscribed to 
 V3Net messages in JAM bases look like standard echomail messages with a few additions:
 
 - A `V3NETUUID` kludge line (hidden from users) stores the message's unique identifier for deduplication
-- A tearline (`--- ViSiON/3 x.y.z/platform`) identifies the posting software
+- A tearline (`--- ViSiON/3 vX.Y.Z/Platform`) identifies the posting software
 - An origin line (`* Origin: BBS Name (node_id)`) identifies the posting node
 
 ## Area Proposals

--- a/internal/config/config_ftn.go
+++ b/internal/config/config_ftn.go
@@ -74,7 +74,7 @@ type FTNNetworkConfig struct {
 	InternalTosserEnabled bool            `json:"internal_tosser_enabled"` // Enable internal tosser
 	OwnAddress            string          `json:"own_address"`             // e.g., "21:4/158.1"
 	PollSeconds           int             `json:"poll_interval_seconds"`   // 0 = manual only (v3mail toss/scan)
-	Tearline              string          `json:"tearline,omitempty"`      // Custom tearline text for echomail
+	Origin                string          `json:"origin,omitempty"`        // Origin line text for echomail (empty = board name)
 	Links                 []FTNLinkConfig `json:"links"`
 }
 

--- a/internal/configeditor/fields_ftn.go
+++ b/internal/configeditor/fields_ftn.go
@@ -94,9 +94,9 @@ func (m *Model) fieldsFTNLink() []fieldDef {
 			},
 		},
 		{
-			Label: "Tearline", Help: "Tearline text appended to outgoing messages", Type: ftString, Col: 3, Row: 5, Width: 40,
-			Get: func() string { return netPtr.Tearline },
-			Set: func(val string) error { netPtr.Tearline = val; save(); return nil },
+			Label: "Origin", Help: "Origin line text for outgoing echomail (empty = board name)", Type: ftString, Col: 3, Row: 5, Width: 40,
+			Get: func() string { return netPtr.Origin },
+			Set: func(val string) error { netPtr.Origin = val; save(); return nil },
 		},
 	}
 }

--- a/internal/configeditor/ftn_wizard_edit_test.go
+++ b/internal/configeditor/ftn_wizard_edit_test.go
@@ -22,7 +22,7 @@ func configuredModel() Model {
 						InternalTosserEnabled: true,
 						OwnAddress:            "21:4/158",
 						PollSeconds:           900,
-						Tearline:              "Custom Tearline",
+						Origin:                "Custom Origin Line",
 						Links: []config.FTNLinkConfig{{
 							Address:         "21:1/100",
 							Hostname:        "agency.bbs.nz",
@@ -120,8 +120,8 @@ func TestConfirmFTNWizardEditPreservesUnaskedSettings(t *testing.T) {
 	if net.PollSeconds != 900 {
 		t.Errorf("PollSeconds = %d, want 900 preserved", net.PollSeconds)
 	}
-	if net.Tearline != "Custom Tearline" {
-		t.Errorf("Tearline = %q, want preserved", net.Tearline)
+	if net.Origin != "Custom Origin Line" {
+		t.Errorf("Origin = %q, want preserved", net.Origin)
 	}
 	if !net.InternalTosserEnabled {
 		t.Error("InternalTosserEnabled should be preserved")

--- a/internal/configeditor/ftn_wizard_save.go
+++ b/internal/configeditor/ftn_wizard_save.go
@@ -73,7 +73,7 @@ func (m Model) confirmFTNWizard() (Model, tea.Cmd) {
 
 	if existing, ok := m.configs.FTN.Networks[netKey]; ok && editing {
 		// Keep the settings this wizard does not ask about. Tosser, poll
-		// interval and tearline are all editable under Echomail Networks, and
+		// interval and origin are all editable under Echomail Networks, and
 		// rewriting them with the wizard's create-time defaults would throw
 		// away whatever the sysop set there.
 		existing.OwnAddress = w.ownAddress
@@ -94,8 +94,9 @@ func (m Model) confirmFTNWizard() (Model, tea.Cmd) {
 			InternalTosserEnabled: true,
 			OwnAddress:            w.ownAddress,
 			PollSeconds:           300,
-			Tearline:              "ViSiON/3",
-			Links:                 []config.FTNLinkConfig{link},
+			// Origin left empty: echomail then falls back to the board name.
+			// The tearline is not configurable — the software stamps it.
+			Links: []config.FTNLinkConfig{link},
 		}
 	}
 

--- a/internal/jam/echomail.go
+++ b/internal/jam/echomail.go
@@ -11,7 +11,7 @@ import (
 // origin line. DateProcessed is set to 0 so the tosser knows to export it.
 //
 // For local messages this behaves identically to WriteMessage.
-func (b *Base) WriteMessageExt(msg *Message, msgType MessageType, echoTag, bbsName, tearline string) (int, error) {
+func (b *Base) WriteMessageExt(msg *Message, msgType MessageType, echoTag, originText string) (int, error) {
 	var msgNum int
 	err := b.withFileLock(func() error {
 		b.mu.Lock()
@@ -84,9 +84,9 @@ func (b *Base) WriteMessageExt(msg *Message, msgType MessageType, echoTag, bbsNa
 			hdr.Subfields = append(hdr.Subfields, CreateSubfield(SfldPID, FormatPID()))
 			hdr.Subfields = append(hdr.Subfields, CreateSubfield(SfldFTSKludge, "TID: "+FormatTID()))
 
-			if bbsName != "" && msg.OrigAddr != "" {
-				msg.Text = AddCustomTearline(msg.Text, tearline)
-				msg.Text = AddOriginLine(msg.Text, bbsName, msg.OrigAddr)
+			if originText != "" && msg.OrigAddr != "" {
+				msg.Text = AddTearline(msg.Text)
+				msg.Text = AddOriginLine(msg.Text, originText, msg.OrigAddr)
 			}
 			// SEEN-BY and PATH are NOT added here — that is the tosser's job.
 		} else {

--- a/internal/jam/echomail_test.go
+++ b/internal/jam/echomail_test.go
@@ -15,7 +15,7 @@ func TestWriteMessageExtEchomail(t *testing.T) {
 	msg.Text = "Testing echomail support"
 	msg.OrigAddr = "21:3/110"
 
-	msgNum, err := b.WriteMessageExt(msg, MsgTypeEchomailMsg, "FSX_GEN", "Test BBS", "")
+	msgNum, err := b.WriteMessageExt(msg, MsgTypeEchomailMsg, "FSX_GEN", "Test BBS")
 	if err != nil {
 		t.Fatalf("WriteMessageExt: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestWriteMessageExtLocal(t *testing.T) {
 	msg.Subject = "Local"
 	msg.Text = "Local message"
 
-	msgNum, err := b.WriteMessageExt(msg, MsgTypeLocalMsg, "", "Test BBS", "")
+	msgNum, err := b.WriteMessageExt(msg, MsgTypeLocalMsg, "", "Test BBS")
 	if err != nil {
 		t.Fatalf("WriteMessageExt local: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestWriteMessageExtWithReply(t *testing.T) {
 	orig.Subject = "Original"
 	orig.Text = "Original message"
 	orig.OrigAddr = "1:103/705"
-	b.WriteMessageExt(orig, MsgTypeEchomailMsg, "TEST", "BBS", "")
+	b.WriteMessageExt(orig, MsgTypeEchomailMsg, "TEST", "BBS")
 
 	// Write reply
 	reply := NewMessage()
@@ -148,7 +148,7 @@ func TestWriteMessageExtWithReply(t *testing.T) {
 	reply.OrigAddr = "1:103/705"
 	reply.ReplyID = orig.MsgID // MsgID was set by WriteMessageExt
 
-	_, err := b.WriteMessageExt(reply, MsgTypeEchomailMsg, "TEST", "BBS", "")
+	_, err := b.WriteMessageExt(reply, MsgTypeEchomailMsg, "TEST", "BBS")
 	if err != nil {
 		t.Fatalf("WriteMessageExt reply: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestMSGIDUniqueness(t *testing.T) {
 		msg.Subject = "Test"
 		msg.Text = "Body"
 		msg.OrigAddr = "1:103/705"
-		b.WriteMessageExt(msg, MsgTypeEchomailMsg, "TEST", "BBS", "")
+		b.WriteMessageExt(msg, MsgTypeEchomailMsg, "TEST", "BBS")
 
 		if seen[msg.MsgID] {
 			t.Fatalf("duplicate MSGID at iteration %d: %s", i, msg.MsgID)

--- a/internal/jam/format.go
+++ b/internal/jam/format.go
@@ -3,6 +3,7 @@ package jam
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/version"
 )
@@ -96,8 +97,11 @@ func DefaultTearlineText() string {
 	if maxVersionLength < 0 {
 		maxVersionLength = 0
 	}
-	if len(versionText) > maxVersionLength {
-		versionText = versionText[:maxVersionLength]
+	// Trim whole runes: a build could stamp a non-ASCII version, and cutting
+	// one in half would put invalid UTF-8 on the wire.
+	for len(versionText) > maxVersionLength {
+		_, size := utf8.DecodeLastRuneInString(versionText)
+		versionText = versionText[:len(versionText)-size]
 	}
 	return fmt.Sprintf("%s %s/%s", softwareName, versionText, platform)
 }

--- a/internal/jam/format.go
+++ b/internal/jam/format.go
@@ -2,7 +2,6 @@ package jam
 
 import (
 	"fmt"
-	"runtime"
 	"strings"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/version"
@@ -11,27 +10,20 @@ import (
 // Version is kept for compatibility; use internal/version.Number for new code.
 var Version = version.Number
 
-// AddTearline appends a tearline to the message text.
-// Format: "--- ViSiON/3 0.1.0/darwin"
-func AddTearline(text string) string {
-	return AddCustomTearline(text, "")
-}
+// softwareName is the product name stamped into tearlines and PID/TID kludges.
+const softwareName = "ViSiON/3"
 
-// AddCustomTearline appends a tearline to the message text.
-// If tearline is empty, it uses the default ViSiON/3 tearline.
-// If tearline already starts with "---", it is used as-is.
-func AddCustomTearline(text, tearline string) string {
+// AddTearline appends the software tearline to the message text.
+// Format: "--- ViSiON/3 v0.8.0/macOS"
+//
+// Per FTS-0004 the tearline identifies the software that produced the message
+// and is assigned by that software, not by the sysop. The sysop-configurable
+// line is the origin line; see AddOriginLine.
+func AddTearline(text string) string {
 	if !strings.HasSuffix(text, "\n") {
 		text += "\n"
 	}
-	trimmed := strings.TrimSpace(tearline)
-	if trimmed == "" {
-		trimmed = fmt.Sprintf("ViSiON/3 %s/%s", version.Number, runtime.GOOS)
-	}
-	if strings.HasPrefix(trimmed, "---") {
-		return text + trimmed + "\n"
-	}
-	return text + fmt.Sprintf("--- %s\n", trimmed)
+	return text + fmt.Sprintf("--- %s\n", DefaultTearlineText())
 }
 
 // AddOriginLine appends an origin line to the message text.
@@ -43,9 +35,15 @@ func AddOriginLine(text, systemName, address string) string {
 	return text + fmt.Sprintf(" * Origin: %s (%s)\n", systemName, address)
 }
 
+// DefaultTearlineText returns the tearline body carrying the running
+// version and platform, e.g. "ViSiON/3 v0.8.0/macOS".
+func DefaultTearlineText() string {
+	return fmt.Sprintf("%s %s/%s", softwareName, version.Display(), version.Platform())
+}
+
 // FormatPID returns the PID kludge value.
 func FormatPID() string {
-	return fmt.Sprintf("ViSiON/3 %s/%s", version.Number, runtime.GOOS)
+	return DefaultTearlineText()
 }
 
 // FormatTID returns the TID kludge value.

--- a/internal/jam/format.go
+++ b/internal/jam/format.go
@@ -13,34 +13,66 @@ var Version = version.Number
 // softwareName is the product name stamped into tearlines and PID/TID kludges.
 const softwareName = "ViSiON/3"
 
-// AddTearline appends the software tearline to the message text.
+// maxTearlineLength is the FTS-0004 limit on the text following "--- ".
+const maxTearlineLength = 35
+
+// AddTearline stamps the software tearline onto the message text.
 // Format: "--- ViSiON/3 v0.8.0/macOS"
 //
 // Per FTS-0004 the tearline identifies the software that produced the message
 // and is assigned by that software, not by the sysop. The sysop-configurable
 // line is the origin line; see AddOriginLine.
+//
+// The tearline belongs at the end of the message, directly above the origin
+// line, so any tearline already sitting in that trailing block is replaced
+// rather than duplicated. Only the trailer is rewritten: a "--- " line inside
+// the body — a quoted separator, a list item, an e-mail-style signature cut —
+// is message content and is left exactly where the author put it.
 func AddTearline(text string) string {
-	tearline := fmt.Sprintf("--- %s", DefaultTearlineText())
-	lines := strings.Split(text, "\n")
-	foundTearline := false
-	formattedLines := make([]string, 0, len(lines))
-	for index, line := range lines {
-		if strings.HasPrefix(line, "--- ") {
-			if !foundTearline {
-				formattedLines = append(formattedLines, tearline)
-				foundTearline = true
-			}
-			continue
+	tearline := "--- " + DefaultTearlineText()
+
+	lines := strings.Split(strings.TrimSuffix(text, "\n"), "\n")
+	start := trailerStart(lines)
+
+	out := make([]string, 0, len(lines)+1)
+	out = append(out, lines[:start]...)
+	out = append(out, tearline)
+	for _, line := range lines[start:] {
+		// Tearlines in the trailer are superseded by the one just added;
+		// origin lines and any other trailer content survive.
+		if !isTearlineLine(line) {
+			out = append(out, line)
 		}
-		formattedLines = append(formattedLines, lines[index])
 	}
-	if foundTearline {
-		return strings.Join(formattedLines, "\n")
+
+	return strings.Join(out, "\n") + "\n"
+}
+
+// trailerStart returns the index at which the message's trailing tearline and
+// origin block begins, or len(lines) when the message has no such block. Only
+// an unbroken run of tearline and origin lines at the very end counts, so body
+// text is never mistaken for a trailer.
+func trailerStart(lines []string) int {
+	start := len(lines)
+	for i := len(lines) - 1; i >= 0; i-- {
+		if !isTearlineLine(lines[i]) && !isOriginLine(lines[i]) {
+			break
+		}
+		start = i
 	}
-	if !strings.HasSuffix(text, "\n") {
-		text += "\n"
-	}
-	return text + tearline + "\n"
+	return start
+}
+
+// isTearlineLine reports whether a line is a tearline: "---" alone, or "---"
+// followed by a software identifier.
+func isTearlineLine(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return trimmed == "---" || strings.HasPrefix(trimmed, "--- ")
+}
+
+// isOriginLine reports whether a line is an FTN origin line.
+func isOriginLine(line string) bool {
+	return strings.HasPrefix(strings.TrimSpace(line), "* Origin:")
 }
 
 // AddOriginLine appends an origin line to the message text.
@@ -57,7 +89,13 @@ func AddOriginLine(text, systemName, address string) string {
 func DefaultTearlineText() string {
 	platform := version.Platform()
 	versionText := version.Display()
-	maxVersionLength := 35 - len(softwareName) - len(" //") - len(platform)
+	// FTS-0004 caps the text after "--- " at 35 characters, and version.Number
+	// takes whatever a -ldflags build stamps into it. The separators are the
+	// space and the slash in the format string below.
+	maxVersionLength := maxTearlineLength - len(softwareName) - len(" /") - len(platform)
+	if maxVersionLength < 0 {
+		maxVersionLength = 0
+	}
 	if len(versionText) > maxVersionLength {
 		versionText = versionText[:maxVersionLength]
 	}

--- a/internal/jam/format.go
+++ b/internal/jam/format.go
@@ -20,10 +20,27 @@ const softwareName = "ViSiON/3"
 // and is assigned by that software, not by the sysop. The sysop-configurable
 // line is the origin line; see AddOriginLine.
 func AddTearline(text string) string {
+	tearline := fmt.Sprintf("--- %s", DefaultTearlineText())
+	lines := strings.Split(text, "\n")
+	foundTearline := false
+	formattedLines := make([]string, 0, len(lines))
+	for index, line := range lines {
+		if strings.HasPrefix(line, "--- ") {
+			if !foundTearline {
+				formattedLines = append(formattedLines, tearline)
+				foundTearline = true
+			}
+			continue
+		}
+		formattedLines = append(formattedLines, lines[index])
+	}
+	if foundTearline {
+		return strings.Join(formattedLines, "\n")
+	}
 	if !strings.HasSuffix(text, "\n") {
 		text += "\n"
 	}
-	return text + fmt.Sprintf("--- %s\n", DefaultTearlineText())
+	return text + tearline + "\n"
 }
 
 // AddOriginLine appends an origin line to the message text.
@@ -38,7 +55,13 @@ func AddOriginLine(text, systemName, address string) string {
 // DefaultTearlineText returns the tearline body carrying the running
 // version and platform, e.g. "ViSiON/3 v0.8.0/macOS".
 func DefaultTearlineText() string {
-	return fmt.Sprintf("%s %s/%s", softwareName, version.Display(), version.Platform())
+	platform := version.Platform()
+	versionText := version.Display()
+	maxVersionLength := 35 - len(softwareName) - len(" //") - len(platform)
+	if len(versionText) > maxVersionLength {
+		versionText = versionText[:maxVersionLength]
+	}
+	return fmt.Sprintf("%s %s/%s", softwareName, versionText, platform)
 }
 
 // FormatPID returns the PID kludge value.

--- a/internal/jam/jam_extended_test.go
+++ b/internal/jam/jam_extended_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/version"
 )
@@ -802,6 +803,25 @@ func TestDefaultTearlineTextCapsLongBuildVersion(t *testing.T) {
 	}
 	if !strings.HasPrefix(got, softwareName+" v") {
 		t.Errorf("DefaultTearlineText() = %q, want %q software and version prefix", got, softwareName)
+	}
+	if !strings.HasSuffix(got, "/"+version.Platform()) {
+		t.Errorf("DefaultTearlineText() = %q, want it to end with /%s", got, version.Platform())
+	}
+}
+
+func TestDefaultTearlineTextTruncatesOnRuneBoundaries(t *testing.T) {
+	originalVersion := version.Number
+	// version.Number is whatever -ldflags stamps in, so it is not guaranteed
+	// to be ASCII. Each of these is 3 bytes per rune.
+	version.Number = "1.0.0-" + strings.Repeat("\u00e9\u00e9\u4e16", 12)
+	t.Cleanup(func() { version.Number = originalVersion })
+
+	got := DefaultTearlineText()
+	if !utf8.ValidString(got) {
+		t.Errorf("DefaultTearlineText() = %q is not valid UTF-8", got)
+	}
+	if len(got) > maxTearlineLength {
+		t.Errorf("DefaultTearlineText() = %q is %d bytes, FTS-0004 allows %d", got, len(got), maxTearlineLength)
 	}
 	if !strings.HasSuffix(got, "/"+version.Platform()) {
 		t.Errorf("DefaultTearlineText() = %q, want it to end with /%s", got, version.Platform())

--- a/internal/jam/jam_extended_test.go
+++ b/internal/jam/jam_extended_test.go
@@ -716,6 +716,17 @@ func TestAddTearlineIsAlwaysTheSoftwareStamp(t *testing.T) {
 	}
 }
 
+func TestAddTearlineReplacesExistingTearline(t *testing.T) {
+	text := "Relayed text\n--- " + DefaultTearlineText() + "\n--- Other BBS v1.0\n * Origin: Remote (1:2/3)\n"
+	want := "Relayed text\n--- " + DefaultTearlineText() + "\n * Origin: Remote (1:2/3)\n"
+	if got := AddTearline(text); got != want {
+		t.Errorf("AddTearline() = %q, want %q", got, want)
+	}
+	if got := strings.Count(AddTearline(text), "--- "); got != 1 {
+		t.Errorf("AddTearline() produced %d tearlines, want 1", got)
+	}
+}
+
 func TestDefaultTearlineTextFormat(t *testing.T) {
 	got := DefaultTearlineText()
 	if !strings.Contains(got, version.Display()) {
@@ -727,6 +738,23 @@ func TestDefaultTearlineTextFormat(t *testing.T) {
 	// FTS-0004 caps the text after "--- " at 35 characters.
 	if len(got) > 35 {
 		t.Errorf("DefaultTearlineText() = %q is %d chars, FTS-0004 allows 35", got, len(got))
+	}
+}
+
+func TestDefaultTearlineTextCapsLongBuildVersion(t *testing.T) {
+	originalVersion := version.Number
+	version.Number = "1.2.3-rc.12345678901234567890"
+	t.Cleanup(func() { version.Number = originalVersion })
+
+	got := DefaultTearlineText()
+	if len(got) > 35 {
+		t.Errorf("DefaultTearlineText() = %q is %d bytes, FTS-0004 allows 35", got, len(got))
+	}
+	if !strings.HasPrefix(got, softwareName+" v") {
+		t.Errorf("DefaultTearlineText() = %q, want %q software and version prefix", got, softwareName)
+	}
+	if !strings.HasSuffix(got, "/"+version.Platform()) {
+		t.Errorf("DefaultTearlineText() = %q, want it to end with /%s", got, version.Platform())
 	}
 }
 

--- a/internal/jam/jam_extended_test.go
+++ b/internal/jam/jam_extended_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/version"
 )
 
 // ---------------------------------------------------------------------------
@@ -702,28 +704,29 @@ func TestAddTearline(t *testing.T) {
 	}
 }
 
-func TestAddCustomTearlineEmpty(t *testing.T) {
-	result := AddCustomTearline("Text", "")
-	if !strings.Contains(result, "--- ViSiON/3") {
-		t.Error("empty custom tearline should use default")
+// The tearline is the producing software's identifier (FTS-0004), so it is
+// fixed: no config, no caller, and no sysop can substitute their own text.
+func TestAddTearlineIsAlwaysTheSoftwareStamp(t *testing.T) {
+	want := "--- " + DefaultTearlineText() + "\n"
+	if got := AddTearline("Text"); !strings.HasSuffix(got, want) {
+		t.Errorf("AddTearline() = %q, want suffix %q", got, want)
+	}
+	if strings.Count(AddTearline("Text"), "--- ") != 1 {
+		t.Error("tearline prefix should appear exactly once")
 	}
 }
 
-func TestAddCustomTearlineWithPrefix(t *testing.T) {
-	result := AddCustomTearline("Text", "--- MyTearline")
-	if !strings.Contains(result, "--- MyTearline") {
-		t.Error("tearline starting with --- should be used as-is")
+func TestDefaultTearlineTextFormat(t *testing.T) {
+	got := DefaultTearlineText()
+	if !strings.Contains(got, version.Display()) {
+		t.Errorf("DefaultTearlineText() = %q, want it to contain version %q", got, version.Display())
 	}
-	// Should NOT add an extra "--- " prefix
-	if strings.Contains(result, "--- --- ") {
-		t.Error("should not double the --- prefix")
+	if !strings.HasSuffix(got, "/"+version.Platform()) {
+		t.Errorf("DefaultTearlineText() = %q, want it to end with /%s", got, version.Platform())
 	}
-}
-
-func TestAddCustomTearlineCustom(t *testing.T) {
-	result := AddCustomTearline("Text", "CustomSoft 1.0")
-	if !strings.Contains(result, "--- CustomSoft 1.0") {
-		t.Errorf("expected custom tearline, got %q", result)
+	// FTS-0004 caps the text after "--- " at 35 characters.
+	if len(got) > 35 {
+		t.Errorf("DefaultTearlineText() = %q is %d chars, FTS-0004 allows 35", got, len(got))
 	}
 }
 
@@ -1162,7 +1165,7 @@ func TestWriteMessageExtNetmail(t *testing.T) {
 	msg.OrigAddr = "1:103/705"
 	msg.DestAddr = "1:103/706"
 
-	_, err := b.WriteMessageExt(msg, MsgTypeNetmailMsg, "", "BBS", "")
+	_, err := b.WriteMessageExt(msg, MsgTypeNetmailMsg, "", "BBS")
 	if err != nil {
 		t.Fatalf("WriteMessageExt netmail: %v", err)
 	}
@@ -1180,10 +1183,10 @@ func TestWriteMessageExtNetmail(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// WriteMessageExt: echomail with custom tearline
+// WriteMessageExt: echomail stamps the software tearline
 // ---------------------------------------------------------------------------
 
-func TestWriteMessageExtCustomTearline(t *testing.T) {
+func TestWriteMessageExtTearline(t *testing.T) {
 	b := openExtTestBase(t)
 
 	msg := NewMessage()
@@ -1193,14 +1196,14 @@ func TestWriteMessageExtCustomTearline(t *testing.T) {
 	msg.Text = "Body text"
 	msg.OrigAddr = "1:1/1"
 
-	_, err := b.WriteMessageExt(msg, MsgTypeEchomailMsg, "TEST", "BBS", "MySoft 2.0")
+	_, err := b.WriteMessageExt(msg, MsgTypeEchomailMsg, "TEST", "BBS")
 	if err != nil {
 		t.Fatalf("WriteMessageExt: %v", err)
 	}
 
 	got, _ := b.ReadMessage(1)
-	if !strings.Contains(got.Text, "--- MySoft 2.0") {
-		t.Errorf("custom tearline not found in %q", got.Text)
+	if !strings.Contains(got.Text, "--- "+DefaultTearlineText()) {
+		t.Errorf("software tearline not found in %q", got.Text)
 	}
 }
 
@@ -1220,7 +1223,7 @@ func TestWriteMessageExtSeenByPath(t *testing.T) {
 	msg.SeenBy = "103/705"
 	msg.Path = "103/705"
 
-	b.WriteMessageExt(msg, MsgTypeEchomailMsg, "TEST", "BBS", "")
+	b.WriteMessageExt(msg, MsgTypeEchomailMsg, "TEST", "BBS")
 
 	got, _ := b.ReadMessage(1)
 	if got.SeenBy != "103/705" {
@@ -1538,7 +1541,7 @@ func TestWriteMessageExtKludges(t *testing.T) {
 	msg.Text = "Body"
 	msg.Kludges = []string{"CUSTOM: value1", "CUSTOM: value2"}
 
-	b.WriteMessageExt(msg, MsgTypeLocalMsg, "", "", "")
+	b.WriteMessageExt(msg, MsgTypeLocalMsg, "", "")
 
 	got, _ := b.ReadMessage(1)
 	found := 0
@@ -1724,7 +1727,7 @@ func TestWriteMessageExtPreservesExistingAttributes(t *testing.T) {
 	msg.OrigAddr = "1:1/1"
 	msg.Header = &MessageHeader{Attribute: MsgPrivate}
 
-	b.WriteMessageExt(msg, MsgTypeEchomailMsg, "TEST", "BBS", "")
+	b.WriteMessageExt(msg, MsgTypeEchomailMsg, "TEST", "BBS")
 
 	got, _ := b.ReadMessage(1)
 	if got.Header.Attribute&MsgPrivate == 0 {

--- a/internal/jam/jam_extended_test.go
+++ b/internal/jam/jam_extended_test.go
@@ -727,6 +727,56 @@ func TestAddTearlineReplacesExistingTearline(t *testing.T) {
 	}
 }
 
+// Only the trailing tearline/origin block is rewritten. A "--- " line the
+// author typed in the body is message content: rewriting it would move the
+// tearline above the rest of the message and drop whatever followed.
+func TestAddTearlineLeavesBodyDashLinesAlone(t *testing.T) {
+	stamp := "--- " + DefaultTearlineText() + "\n"
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{
+			name: "dashes used as list markers",
+			text: "Here are my picks:\n--- item one\n--- item two\nThanks!\n",
+			want: "Here are my picks:\n--- item one\n--- item two\nThanks!\n" + stamp,
+		},
+		{
+			name: "signature cut mid-message",
+			text: "See you at the meetup.\n--- \nRobbie, sysop\n",
+			want: "See you at the meetup.\n--- \nRobbie, sysop\n" + stamp,
+		},
+		{
+			name: "no trailing newline",
+			text: "Body",
+			want: "Body\n" + stamp,
+		},
+		{
+			name: "trailing separator is a tearline and is replaced",
+			text: "Bye\n--- \n",
+			want: "Bye\n" + stamp,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AddTearline(tt.text); got != tt.want {
+				t.Errorf("AddTearline(%q) = %q, want %q", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+// The tearline must end up directly above the origin line, which is what the
+// echomail writer appends next.
+func TestAddTearlineSitsAboveOriginLine(t *testing.T) {
+	got := AddOriginLine(AddTearline("Body text.\n"), "My BBS", "21:4/158.1")
+	want := "Body text.\n--- " + DefaultTearlineText() + "\n * Origin: My BBS (21:4/158.1)\n"
+	if got != want {
+		t.Errorf("trailer = %q, want %q", got, want)
+	}
+}
+
 func TestDefaultTearlineTextFormat(t *testing.T) {
 	got := DefaultTearlineText()
 	if !strings.Contains(got, version.Display()) {
@@ -736,8 +786,8 @@ func TestDefaultTearlineTextFormat(t *testing.T) {
 		t.Errorf("DefaultTearlineText() = %q, want it to end with /%s", got, version.Platform())
 	}
 	// FTS-0004 caps the text after "--- " at 35 characters.
-	if len(got) > 35 {
-		t.Errorf("DefaultTearlineText() = %q is %d chars, FTS-0004 allows 35", got, len(got))
+	if len(got) > maxTearlineLength {
+		t.Errorf("DefaultTearlineText() = %q is %d chars, FTS-0004 allows %d", got, len(got), maxTearlineLength)
 	}
 }
 
@@ -747,8 +797,8 @@ func TestDefaultTearlineTextCapsLongBuildVersion(t *testing.T) {
 	t.Cleanup(func() { version.Number = originalVersion })
 
 	got := DefaultTearlineText()
-	if len(got) > 35 {
-		t.Errorf("DefaultTearlineText() = %q is %d bytes, FTS-0004 allows 35", got, len(got))
+	if len(got) > maxTearlineLength {
+		t.Errorf("DefaultTearlineText() = %q is %d bytes, FTS-0004 allows %d", got, len(got), maxTearlineLength)
 	}
 	if !strings.HasPrefix(got, softwareName+" v") {
 		t.Errorf("DefaultTearlineText() = %q, want %q software and version prefix", got, softwareName)

--- a/internal/jam/replyto_test.go
+++ b/internal/jam/replyto_test.go
@@ -62,7 +62,7 @@ func TestWriteMessageExt_PreservesReplyTo(t *testing.T) {
 	msg.From, msg.To, msg.Subject, msg.Text = "u1", "u2", "Re", "reply"
 	msg.ReplyTo = 3
 
-	n, err := b.WriteMessageExt(msg, MsgTypeLocalMsg, "", "Test BBS", "")
+	n, err := b.WriteMessageExt(msg, MsgTypeLocalMsg, "", "Test BBS")
 	if err != nil {
 		t.Fatalf("WriteMessageExt: %v", err)
 	}

--- a/internal/message/manager.go
+++ b/internal/message/manager.go
@@ -54,11 +54,11 @@ type MessageManager struct {
 	// across networks; AddArea/UpdateAreaByID reject same-network duplicates and
 	// the load path warns about any collision it finds in an existing config.
 	areasByEchoTag map[string]*MessageArea
-	boardName      string // BBS name for echomail origin lines
-	// networkTearlines maps network key -> custom tearline text.
-	networkTearlines map[string]string
-	threadIndex      map[int]*threadIndex
-	msgidIndex       map[int]*msgidIndex
+	boardName      string // BBS name, the default echomail origin line text
+	// networkOrigins maps network key -> origin line text, overriding boardName.
+	networkOrigins map[string]string
+	threadIndex    map[int]*threadIndex
+	msgidIndex     map[int]*msgidIndex
 
 	// OnMessagePosted is called after a message is successfully written to a JAM base.
 	// The callback receives the area and the message details. May be nil.
@@ -74,19 +74,21 @@ type MessageManager struct {
 // NewMessageManager creates and initializes a new MessageManager.
 // dataPath is the directory where JAM base files are stored.
 // configPath is the directory containing message_areas.json.
-// boardName is the BBS name used in echomail origin lines.
-// networkTearlines maps network name -> custom tearline text for echomail.
-func NewMessageManager(dataPath, configPath, boardName string, networkTearlines map[string]string) (*MessageManager, error) {
+// boardName is the BBS name used in echomail origin lines by default.
+// networkOrigins maps network name -> origin line text, overriding boardName
+// for areas on that network. The tearline is not configurable: FTS-0004 makes
+// it the producing software's identifier, so jam stamps it.
+func NewMessageManager(dataPath, configPath, boardName string, networkOrigins map[string]string) (*MessageManager, error) {
 	mm := &MessageManager{
-		dataPath:         dataPath,
-		areasPath:        filepath.Join(configPath, messageAreaFile),
-		areasByID:        make(map[int]*MessageArea),
-		areasByTag:       make(map[string]*MessageArea),
-		areasByEchoTag:   make(map[string]*MessageArea),
-		boardName:        boardName,
-		networkTearlines: normalizeNetworkTearlines(networkTearlines),
-		threadIndex:      make(map[int]*threadIndex),
-		msgidIndex:       make(map[int]*msgidIndex),
+		dataPath:       dataPath,
+		areasPath:      filepath.Join(configPath, messageAreaFile),
+		areasByID:      make(map[int]*MessageArea),
+		areasByTag:     make(map[string]*MessageArea),
+		areasByEchoTag: make(map[string]*MessageArea),
+		boardName:      boardName,
+		networkOrigins: normalizeNetworkOrigins(networkOrigins),
+		threadIndex:    make(map[int]*threadIndex),
+		msgidIndex:     make(map[int]*msgidIndex),
 	}
 
 	if err := mm.loadMessageAreas(); err != nil {
@@ -108,17 +110,18 @@ func (mm *MessageManager) DataPath() string {
 	return mm.dataPath
 }
 
-func normalizeNetworkTearlines(input map[string]string) map[string]string {
+func normalizeNetworkOrigins(input map[string]string) map[string]string {
 	if len(input) == 0 {
 		return nil
 	}
 	out := make(map[string]string, len(input))
 	for k, v := range input {
 		key := strings.ToLower(strings.TrimSpace(k))
-		if key == "" {
+		val := strings.TrimSpace(v)
+		if key == "" || val == "" {
 			continue
 		}
-		out[key] = strings.TrimSpace(v)
+		out[key] = val
 	}
 	if len(out) == 0 {
 		return nil
@@ -126,15 +129,16 @@ func normalizeNetworkTearlines(input map[string]string) map[string]string {
 	return out
 }
 
-func (mm *MessageManager) tearlineForNetwork(network string) string {
-	if mm.networkTearlines == nil {
-		return ""
-	}
+// originTextForNetwork returns the origin line text for an area on the given
+// network, falling back to the board name when the network sets none.
+func (mm *MessageManager) originTextForNetwork(network string) string {
 	key := strings.ToLower(strings.TrimSpace(network))
-	if key == "" {
-		return ""
+	if key != "" && mm.networkOrigins != nil {
+		if origin := mm.networkOrigins[key]; origin != "" {
+			return origin
+		}
 	}
-	return mm.networkTearlines[key]
+	return mm.boardName
 }
 
 // Close is a no-op now that bases are opened on-demand.

--- a/internal/message/manager_post.go
+++ b/internal/message/manager_post.go
@@ -72,7 +72,7 @@ func (mm *MessageManager) addMessage(areaID int, from, to, subject, body, replyT
 	var msgNum int
 	if msgType.IsEchomail() || msgType.IsNetmail() {
 		msg.OrigAddr = area.OriginAddr
-		msgNum, err = b.WriteMessageExt(msg, msgType, area.EchoTag, mm.boardName, mm.tearlineForNetwork(area.Network))
+		msgNum, err = b.WriteMessageExt(msg, msgType, area.EchoTag, mm.originTextForNetwork(area.Network))
 	} else {
 		msgNum, err = b.WriteMessage(msg)
 	}

--- a/internal/tosser/import.go
+++ b/internal/tosser/import.go
@@ -473,7 +473,7 @@ func (t *Tosser) tossMessage(msg *ftn.PackedMessage, pktHdr *ftn.PacketHeader) (
 
 	// Write to JAM base with echomail handling
 	msgType := jam.DetermineMessageType(area.AreaType, area.EchoTag)
-	msgNum, err := base.WriteMessageExt(jamMsg, msgType, area.EchoTag, "", "")
+	msgNum, err := base.WriteMessageExt(jamMsg, msgType, area.EchoTag, "")
 	if err != nil {
 		return fmt.Errorf("write to JAM: %w", err)
 	}
@@ -566,7 +566,7 @@ func (t *Tosser) writeMsgToArea(areaTag string, msg *ftn.PackedMessage, pktHdr *
 	}
 
 	msgType := jam.DetermineMessageType(area.AreaType, area.EchoTag)
-	msgNum, err := base.WriteMessageExt(jamMsg, msgType, area.EchoTag, "", "")
+	msgNum, err := base.WriteMessageExt(jamMsg, msgType, area.EchoTag, "")
 	if err != nil {
 		return err
 	}

--- a/internal/tosser/integration_test.go
+++ b/internal/tosser/integration_test.go
@@ -265,7 +265,7 @@ func TestScanExportCreatesPacket(t *testing.T) {
 	// Use the echomail write path so DateProcessed=0 (pending export)
 	area, _ := env.msgMgr.GetAreaByTag("FSX_TEST")
 	msgType := jam.DetermineMessageType(area.AreaType, area.EchoTag)
-	_, err = base.WriteMessageExt(msg, msgType, area.EchoTag, "TestBBS", "")
+	_, err = base.WriteMessageExt(msg, msgType, area.EchoTag, "TestBBS")
 	if err != nil {
 		t.Fatalf("WriteMessageExt: %v", err)
 	}
@@ -310,7 +310,7 @@ func TestHighWaterMarkAdvances(t *testing.T) {
 
 	area, _ := env.msgMgr.GetAreaByTag("FSX_TEST")
 	msgType := jam.DetermineMessageType(area.AreaType, area.EchoTag)
-	base.WriteMessageExt(msg, msgType, area.EchoTag, "TestBBS", "")
+	base.WriteMessageExt(msg, msgType, area.EchoTag, "TestBBS")
 	base.Close()
 
 	tosser, err := New("testnet", env.netCfg, env.globalCfg, env.dupeDB, env.msgMgr)
@@ -680,7 +680,7 @@ func TestScanExportNetmail(t *testing.T) {
 
 	area, _ := env.msgMgr.GetAreaByTag("NETMAIL")
 	msgType := jam.DetermineMessageType(area.AreaType, area.EchoTag)
-	_, err = base.WriteMessageExt(msg, msgType, area.EchoTag, "TestBBS", "")
+	_, err = base.WriteMessageExt(msg, msgType, area.EchoTag, "TestBBS")
 	if err != nil {
 		t.Fatalf("WriteMessageExt: %v", err)
 	}

--- a/internal/v3net/jam_adapter.go
+++ b/internal/v3net/jam_adapter.go
@@ -47,7 +47,7 @@ func (a *JAMAdapter) WriteMessage(msg protocol.Message) (int64, error) {
 // AppendV3NetOrigin appends a tearline and origin line to the message body,
 // matching the FTN convention:
 //
-//	--- ViSiON/3 0.1.0/linux
+//	--- ViSiON/3 v0.8.0/Linux
 //	 * Origin: My Cool BBS (a1b2c3d4e5f6a7b8)
 func AppendV3NetOrigin(body, tearline, origin, nodeID string) string {
 	// Nothing to append if both are empty.

--- a/internal/v3net/protocol/message.go
+++ b/internal/v3net/protocol/message.go
@@ -30,7 +30,7 @@ type Message struct {
 	Subject     string         `json:"subject"`
 	DateUTC     string         `json:"date_utc"`
 	Body        string         `json:"body"`
-	Tearline    string         `json:"tearline,omitempty"` // Software tearline (e.g. "--- ViSiON/3 0.1.0/linux")
+	Tearline    string         `json:"tearline,omitempty"` // Software tearline (e.g. "--- ViSiON/3 v0.8.0/Linux")
 	Origin      string         `json:"origin,omitempty"`   // User-defined origin line (e.g. "My Cool BBS - bbs.example.com")
 	Attributes  uint32         `json:"attributes"`
 	Kludges     map[string]any `json:"kludges"`

--- a/internal/v3net/wire.go
+++ b/internal/v3net/wire.go
@@ -3,7 +3,6 @@ package v3net
 import (
 	"crypto/rand"
 	"fmt"
-	"runtime"
 	"time"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
@@ -38,7 +37,7 @@ func BuildWireMessage(network, areaTag, originNode, originBoard, from, to, subje
 
 // DefaultTearline returns the standard ViSiON/3 software tearline.
 func DefaultTearline() string {
-	return fmt.Sprintf("--- ViSiON/3 %s/%s", version.Number, runtime.GOOS)
+	return fmt.Sprintf("--- ViSiON/3 %s/%s", version.Display(), version.Platform())
 }
 
 func newUUID() string {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,60 @@
 package version
 
+import (
+	"runtime"
+	"strings"
+)
+
 // Number is the global ViSiON/3 version.
 // Set this at build time with:
 // -ldflags "-X github.com/ViSiON-3/vision-3-bbs/internal/version.Number=1.0.0"
 var Number = "0.8.0"
+
+// Display returns the version prefixed with "v", e.g. "v0.8.0". A Number that
+// already carries the prefix (a build stamped from a git tag) is left alone.
+func Display() string {
+	n := strings.TrimSpace(Number)
+	if n == "" {
+		return ""
+	}
+	if n[0] == 'v' || n[0] == 'V' {
+		return n
+	}
+	return "v" + n
+}
+
+// Platform returns a human-readable name for the running operating system,
+// e.g. "macOS" rather than Go's "darwin". Unknown platforms fall back to the
+// raw GOOS value.
+func Platform() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "macOS"
+	case "linux":
+		return "Linux"
+	case "windows":
+		return "Windows"
+	case "freebsd":
+		return "FreeBSD"
+	case "openbsd":
+		return "OpenBSD"
+	case "netbsd":
+		return "NetBSD"
+	case "dragonfly":
+		return "DragonFly"
+	case "solaris":
+		return "Solaris"
+	case "illumos":
+		return "illumos"
+	case "aix":
+		return "AIX"
+	case "android":
+		return "Android"
+	case "ios":
+		return "iOS"
+	case "plan9":
+		return "Plan9"
+	default:
+		return runtime.GOOS
+	}
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,37 @@
+package version
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestDisplay(t *testing.T) {
+	orig := Number
+	t.Cleanup(func() { Number = orig })
+
+	tests := []struct {
+		number string
+		want   string
+	}{
+		{"0.8.0", "v0.8.0"},
+		{"v1.2.3", "v1.2.3"},
+		{" 1.0.0 ", "v1.0.0"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		Number = tt.number
+		if got := Display(); got != tt.want {
+			t.Errorf("Display() with Number=%q = %q, want %q", tt.number, got, tt.want)
+		}
+	}
+}
+
+func TestPlatform(t *testing.T) {
+	got := Platform()
+	if got == "" {
+		t.Fatal("Platform() returned an empty string")
+	}
+	if runtime.GOOS == "darwin" && got != "macOS" {
+		t.Errorf("Platform() on darwin = %q, want %q", got, "macOS")
+	}
+}


### PR DESCRIPTION
## Problem

Posts were printing a version-less tearline:

```
--- ViSiON/3
```

The root cause turned out to be a spec mix-up rather than a formatting bug. FTS-0004 assigns the **tearline** to the software that produced the message and the **origin line** to the sysop. FTN echomail had these inverted:

- `ftn.json` exposed a free-text `tearline` per network, and the config editor offered a 40-wide field for it (wide enough to blow past FTS-0004's 35-char limit).
- The origin line text was *not* configurable at all — `internal/jam/echomail.go` hardcoded the global board name, so every network and area shared one origin.

The FTN wizard wrote a bare `"ViSiON/3"` into that tearline field. That value overrode the built-in stamp, dropping the version. V3Net already did this correctly, which made the contrast clear.

## Changes

**The tearline is no longer configurable by anyone.**

- `jam.AddCustomTearline` is removed; `jam.AddTearline` takes no text argument and always stamps the software identifier.
- `Base.WriteMessageExt` drops its `tearline` parameter — signature is now `(msg, msgType, echoTag, originText)`. No caller can inject one.
- `FTNNetworkConfig.Tearline`, its config-editor field, and the wizard's write of it are all deleted. A leftover `tearline` key in an existing `ftn.json` is ignored on load.

**The origin line becomes the sysop-owned setting.**

- New `FTNNetworkConfig.Origin` (`"origin"` in `ftn.json`), surfaced in the config editor in the slot the tearline field used to occupy.
- `MessageManager` carries `networkOrigins` and resolves per area via `originTextForNetwork()`, falling back to the board name when unset. This closes a gap that existed before this PR: there was previously no origin override at all.

**The stamp itself now reads `--- ViSiON/3 v0.8.0/macOS`.**

- `version.Display()` adds the `v` prefix, without doubling one already present in a `-ldflags`-stamped tag.
- `version.Platform()` maps `GOOS` to a human name (`darwin`→`macOS`, `linux`→`Linux`, the BSDs, …), falling back to raw `GOOS`.
- Both `internal/jam` and `internal/v3net` build from these helpers, so the two tearline paths cannot drift. `FormatPID`/`FormatTID` share the same string.

## Result

```
Body text.\r--- ViSiON/3 v0.8.0/macOS\r * Origin: My BBS - bbs.example.com (21:4/158.1)\r
```

## Notes for review

- **Config compatibility:** removing the struct field means an old `tearline` key is silently ignored rather than erroring. Sysops who typed custom text there lose it — deliberate, since that field should not have existed.
- Added a test asserting the stamp fits FTS-0004's 35-char limit (`ViSiON/3 v0.8.0/macOS` is 21).
- Origin text is per-*network*. Per-*area* origin overrides would be a reasonable follow-up but are out of scope here.
- Docs updated: `configuration.md`, `jam-echomail.md`, `message-areas.md`, `ftn-echomail.md`, `v3mail.md`, `api-reference.md`, `v3net/message-areas.md`.

`gofmt`, `go build ./...`, `go vet ./...`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQuYC88yCUrF8isfJdNJyY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FTN echomail networks now support configurable origin text, using the board name when no origin is provided.
  * Echomail messages now receive standardized software-generated tearlines with the application version and platform.
  * Tearline formatting now preserves message content and correctly places origin lines.

* **Documentation**
  * Updated configuration and messaging guidance for origin text and standardized tearline formatting.
  * Clarified version and platform display conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->