### PR TITLE
fix: matrix hotkeys, global Goodbye key, and FTN wizard dead ends

### DIFF
--- a/docs/sysop/configuration/configuration.md
+++ b/docs/sysop/configuration/configuration.md
@@ -71,6 +71,8 @@ Choosing **System Configuration** (key 1) opens an inner menu with nine numbered
 
 **Node Lookup.** After entering your FTN address, select the *Node Lookup* row and press Enter. The wizard downloads the network's nodelist, finds your node, and fills in your uplink hub's address, hostname, and BinkP port automatically. If your node isn't listed yet (new nodes appear in the next weekly nodelist), the hub is inferred from your net's Host/Hub entries. Networks without a published nodelist URL skip this feature; hub details can always be entered manually.
 
+**Echo Areas.** Selecting the *Echo Areas* row downloads the network's echolist so you can tick the echoes you want. Echo areas are optional: not every network publishes its `.NA` file on the web (some hand it out through the network itself, via AreaFix), and web-hosted lists do go offline. If the download fails, press ESC — everything you entered is still on the form — and save. You get the network, its hub link, the netmail area and an updated `binkd.conf`; echoes can be added later under *Message Areas*, or by re-entering the wizard and choosing the network to edit.
+
 ### ViSiON/3 Networking (V3Net) Sub-menu
 
 | Item | What it edits |

--- a/docs/sysop/menus/menu-system.md
+++ b/docs/sysop/menus/menu-system.md
@@ -202,6 +202,19 @@ Command files are JSON arrays that define what happens when users press keys.
 - `//` - Auto-run once per session
 - `~~` - Auto-run every time menu loads
 - Numbers (`1`, `2`, etc.) - Can be used to select visible commands by index
+- `^M` - Matches Enter pressed on an empty prompt (the menu's default command)
+- `##` - Matches any all-numeric input, passing the number to the command as args
+
+### Built-in Shortcuts
+
+Two keys work from every menu without appearing in any `.CFG`:
+
+- `/G` - Hang up immediately, no confirmation
+- `G` - Log off with confirmation and `GOODBYE.ANS`
+
+`G` is a fallback, checked only after every command in the menu has failed to
+match, so a menu that binds `G` to something of its own keeps it — `USERCFG`
+uses it for the custom prompt editor.
 
 ### Command Actions
 

--- a/docs/sysop/menus/menu-system.md
+++ b/docs/sysop/menus/menu-system.md
@@ -207,7 +207,7 @@ Command files are JSON arrays that define what happens when users press keys.
 
 ### Built-in Shortcuts
 
-Two keys work from every menu without appearing in any `.CFG`:
+Two keys work on every standard command menu without appearing in any `.CFG`:
 
 - `/G` - Hang up immediately, no confirmation
 - `G` - Log off with confirmation and `GOODBYE.ANS`
@@ -215,6 +215,11 @@ Two keys work from every menu without appearing in any `.CFG`:
 `G` is a fallback, checked only after every command in the menu has failed to
 match, so a menu that binds `G` to something of its own keeps it — `USERCFG`
 uses it for the custom prompt editor.
+
+Both are matched by the standard menu input loop. The pre-login matrix
+(`PDMATRIX`) reads keys itself and recognises only its own hotkeys, so neither
+shortcut applies there; give it a `DISCONNECT` option instead, as the shipped
+`PDMATRIX.CFG` does.
 
 ### Command Actions
 

--- a/internal/configeditor/colors.go
+++ b/internal/configeditor/colors.go
@@ -124,5 +124,10 @@ var reorderSourceStyle = dosColor(2, 15)
 // --- Separator style ---
 var separatorStyle = dosColor(1, 9)
 
+// listEmptyHintStyle draws the "nothing here yet, press I" line an empty
+// record list shows in place of its first row. Yellow, not the list's own
+// white, so it reads as guidance rather than as a record.
+var listEmptyHintStyle = dosColor(1, 14)
+
 // --- Edit field fill character ---
 const fieldFillChar = '░'

--- a/internal/configeditor/ftn_wizard_no_areas_test.go
+++ b/internal/configeditor/ftn_wizard_no_areas_test.go
@@ -1,0 +1,96 @@
+package configeditor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ftn"
+)
+
+// wizardReadyToSave returns a wizard filled in far enough that only the echo
+// area selection is missing — the state an operator is left in when the
+// echolist download fails.
+func wizardReadyToSave(t *testing.T) Model {
+	t.Helper()
+	m := Model{
+		configPath: t.TempDir(),
+		configs:    &allConfigs{},
+		ftnWizard: &ftnWizardState{
+			zone:            21,
+			networkName:     "fsxNet",
+			ownAddress:      "21:4/158",
+			hubAddress:      "21:1/100",
+			hubHostname:     "agency.bbs.nz",
+			hubPort:         24556,
+			areafixPassword: "afpw",
+			sessionPassword: "sesspw",
+			autoJoinAreas:   true,
+			echolistURL:     "https://example.test/fsxnet.na",
+		},
+	}
+	m.ftnWizardFields = m.fieldsFTNWizard()
+	return m
+}
+
+// TestFTNWizardSavesWithoutEchoAreas covers the dead end reported when the
+// echolist 401s: the wizard used to refuse to save without at least one echo
+// area, so the only way out discarded everything the operator had typed.
+func TestFTNWizardSavesWithoutEchoAreas(t *testing.T) {
+	m := wizardReadyToSave(t)
+
+	result, _ := m.submitFTNWizardForm()
+
+	if _, ok := result.configs.FTN.Networks["fsxnet"]; !ok {
+		t.Fatalf("network was not saved; message: %q", result.message)
+	}
+	if strings.Contains(result.message, "Select at least one echo area") {
+		t.Fatalf("save was refused: %q", result.message)
+	}
+
+	// Netmail still gets its area, and it is the only one.
+	if len(result.configs.MsgAreas) != 1 || result.configs.MsgAreas[0].AreaType != "netmail" {
+		t.Fatalf("want a single netmail area, got %+v", result.configs.MsgAreas)
+	}
+	if !strings.Contains(result.message, "Message Areas") {
+		t.Errorf("message should say where echo areas get added, got %q", result.message)
+	}
+}
+
+// TestFTNWizardAreaBrowserRejectsNonURLEcholist covers the registry entries
+// that record a filename ("metronet.na") rather than a web address: handing
+// one to the HTTP client fails with an opaque scheme error, so the wizard
+// explains where the file actually comes from and stays on the form.
+func TestFTNWizardAreaBrowserRejectsNonURLEcholist(t *testing.T) {
+	m := wizardReadyToSave(t)
+	m.ftnWizard.echolistURL = "metronet.na"
+	m.mode = modeFTNWizardForm
+
+	result, cmd := m.enterFTNAreaBrowser()
+
+	if cmd != nil {
+		t.Error("no download should be started for a bare filename")
+	}
+	if result.mode != modeFTNWizardForm {
+		t.Errorf("mode = %v, want to stay on the wizard form", result.mode)
+	}
+	if !strings.Contains(result.message, "metronet.na") || !strings.Contains(result.message, "AreaFix") {
+		t.Errorf("message should name the file and how to get it, got %q", result.message)
+	}
+}
+
+func TestEcholistIsDownloadable(t *testing.T) {
+	for _, url := range []string{
+		"https://raw.githubusercontent.com/fsxnet/infopack/master/fsxnet.na",
+		"http://example.test/backbone.na",
+		"HTTPS://EXAMPLE.TEST/A.NA",
+	} {
+		if !ftn.EcholistIsDownloadable(url) {
+			t.Errorf("EcholistIsDownloadable(%q) = false, want true", url)
+		}
+	}
+	for _, url := range []string{"", "metronet.na", "DORENET.NA", "ftp://example.test/a.na"} {
+		if ftn.EcholistIsDownloadable(url) {
+			t.Errorf("EcholistIsDownloadable(%q) = true, want false", url)
+		}
+	}
+}

--- a/internal/configeditor/ftn_wizard_save.go
+++ b/internal/configeditor/ftn_wizard_save.go
@@ -206,6 +206,12 @@ func (m Model) confirmFTNWizard() (Model, tea.Cmd) {
 				"%d existing area(s) left in place: remove them under Message Areas. Restart BBS to activate.",
 				netKey, selectedCount, dropped)
 		}
+	} else if selectedCount == 0 {
+		// Saving with no echoes is allowed (the echolist may be unavailable),
+		// so point at where they get added rather than leaving the operator
+		// wondering whether the save was incomplete.
+		m.message = fmt.Sprintf("FTN network %q saved with netmail only — add echo areas under Message Areas "+
+			"or re-run the wizard. Restart BBS to activate.", w.networkName)
 	} else {
 		m.message = fmt.Sprintf("FTN network %q saved — %d area(s) created. Restart BBS to activate.", w.networkName, selectedCount)
 	}

--- a/internal/configeditor/testdata/ftn_area_browser_error.golden
+++ b/internal/configeditor/testdata/ftn_area_browser_error.golden
@@ -4,8 +4,8 @@
 ░░░░┌──────────────────────────────────────────────────────────────────────┐░░░░
 ░░░░│                         Echo Areas — fsxNet                          │░░░░
 ░░░░│ Download failed: connection refused while fetching the echolist fr...│░░░░
-░░░░│                                                                      │░░░░
-░░░░│                                                                      │░░░░
+░░░░│  ESC keeps what you entered — you can save the network now           │░░░░
+░░░░│  and add echo areas later under Message Areas.                       │░░░░
 ░░░░│                                                                      │░░░░
 ░░░░│                                                                      │░░░░
 ░░░░│                                                                      │░░░░

--- a/internal/configeditor/update_ftn_area_browser.go
+++ b/internal/configeditor/update_ftn_area_browser.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ftn"
 )
 
 // ftnAreaBrowserListVisible is the number of rows visible in the FTN area browser.
@@ -79,7 +81,7 @@ func (m Model) updateFTNAreaBrowser(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		default:
 			key := strings.ToUpper(msg.String())
-			if key == "R" && m.ftnWizard.echolistURL != "" {
+			if key == "R" && ftn.EcholistIsDownloadable(m.ftnWizard.echolistURL) {
 				m.ftnAreaBrowserLoading = true
 				m.ftnAreaBrowserError = ""
 				m.mode = modeFTNAreaDownloading

--- a/internal/configeditor/update_ftn_wizard.go
+++ b/internal/configeditor/update_ftn_wizard.go
@@ -422,13 +422,17 @@ func (m *Model) applyFTNWizardFieldValue(f fieldDef) error {
 }
 
 // submitFTNWizardForm validates the form and triggers save.
+//
+// Echo areas are deliberately not required. The echolist is a convenience —
+// several networks have no downloadable one at all, and the hosted ones do go
+// offline — so demanding at least one area turned a failed download into a
+// dead end where the only way out of the wizard discarded everything typed so
+// far. The network, its hub link, the netmail area and binkd.conf are all
+// worth saving on their own; echoes can be added later by re-entering the
+// wizard or by hand under Message Areas.
 func (m Model) submitFTNWizardForm() (Model, tea.Cmd) {
 	if err := m.validateFTNWizard(); err != nil {
 		m.message = err.Error()
-		return m, nil
-	}
-	if m.ftnWizard.selectedAreaCount() == 0 {
-		m.message = "Select at least one echo area"
 		return m, nil
 	}
 	return m.confirmFTNWizard()
@@ -450,10 +454,14 @@ func (m Model) enterFTNAreaBrowser() (Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Need an echolist URL.
+	// Need an echolist URL we can actually fetch.
 	url := w.echolistURL
 	if url == "" {
-		m.message = "No echolist URL available for this network"
+		m.message = "No echolist for this network — save now and add echo areas under Message Areas"
+		return m, nil
+	}
+	if !ftn.EcholistIsDownloadable(url) {
+		m.message = fmt.Sprintf("%s comes from your hub, not the web — request it via AreaFix, then add areas under Message Areas", url)
 		return m, nil
 	}
 

--- a/internal/configeditor/view_ftn_area_browser.go
+++ b/internal/configeditor/view_ftn_area_browser.go
@@ -22,8 +22,16 @@ func (m Model) viewFTNAreaBrowser() string {
 	}
 
 	if m.ftnAreaBrowserError != "" && total == 0 {
-		return lb.statusScreen(lb.errorRow(m.ftnAreaBrowserError),
-			ftnAreaBrowserListVisible, 2, "R - Retry  |  ESC - Back")
+		// A failed download is not a dead end: say so here, because the
+		// wizard form behind this screen still holds everything typed so
+		// far and saving no longer needs a single echo area.
+		lb.row(lb.errorRow(m.ftnAreaBrowserError))
+		lb.row(menuItemStyle.Render(padRight("  ESC keeps what you entered — you can save the network now", boxW)))
+		lb.row(menuItemStyle.Render(padRight("  and add echo areas later under Message Areas.", boxW)))
+		lb.emptyRows(ftnAreaBrowserListVisible - 1)
+		lb.bottomBorder()
+		lb.bgRows(lb.bottomPad + 2)
+		return lb.finish("R - Retry  |  ESC - Back")
 	}
 
 	lb.colHeader(fmt.Sprintf("   %-4s %-16s %s", " ", "Tag", "Description"))

--- a/internal/configeditor/view_list.go
+++ b/internal/configeditor/view_list.go
@@ -81,9 +81,14 @@ func (m Model) viewRecordList() string {
 
 		var rowContent string
 		if idx < 0 || idx >= total {
-			if i == 0 && total == 0 && m.recordType == "v3nethub" {
-				hint := " Only operators running their own hub/network will have entries here."
-				rowContent = menuItemStyle.Render(padRight(hint, boxW))
+			// An empty list is otherwise a blank box, leaving the only way
+			// forward buried in the help bar at the foot of the screen.
+			if i == 0 && total == 0 {
+				if hint := m.emptyRecordListHint(); hint != "" {
+					rowContent = listEmptyHintStyle.Render(padRight(" "+hint, boxW))
+				} else {
+					rowContent = menuItemStyle.Render(strings.Repeat(" ", boxW))
+				}
 			} else {
 				rowContent = menuItemStyle.Render(strings.Repeat(" ", boxW))
 			}
@@ -161,6 +166,26 @@ func (m Model) viewRecordList() string {
 	b.WriteString(helpBarStyle.Render(helpText))
 
 	return b.String()
+}
+
+// emptyRecordListHint returns the line shown in place of the first list row
+// when a record list has nothing in it, telling the operator what the empty
+// box means and which key fills it. Returns "" for record types that need no
+// explanation.
+func (m Model) emptyRecordListHint() string {
+	switch m.recordType {
+	case "v3nethub":
+		return "Only operators running their own hub/network will have entries here."
+	case "ftn":
+		return "No networks yet — press I to add one (FTN setup wizard)."
+	case "ftnlink":
+		return "No links yet — press I to add this network's uplink."
+	case "v3netleaf":
+		return "No subscriptions yet — press I for the wizard, or B to browse the registry."
+	case "msgarea", "filearea", "conference", "door", "event", "protocol", "archiver", "login":
+		return "Nothing configured yet — press I to insert the first entry."
+	}
+	return ""
 }
 
 // recordTypeTitle returns a human-readable title for the current record type.

--- a/internal/ftn/echolist.go
+++ b/internal/ftn/echolist.go
@@ -83,6 +83,17 @@ func CleanEcholist(areas []EchoArea, excludeTags []string, titlePrefix string) [
 	return result
 }
 
+// EcholistIsDownloadable reports whether a registry echolist_url is something
+// the wizard can actually fetch. Several networks hand their .NA file out over
+// the network itself rather than the web, and the registry records only that
+// filename (for example "metronet.na"). Passing one of those to an HTTP client
+// fails with an opaque "unsupported protocol scheme" error, so callers check
+// here first and explain where the file really comes from instead.
+func EcholistIsDownloadable(url string) bool {
+	lower := strings.ToLower(strings.TrimSpace(url))
+	return strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://")
+}
+
 // DownloadEcholist fetches an echolist from a URL, parses it, and returns
 // the areas. The request is bounded by the given context.
 func DownloadEcholist(ctx context.Context, url string) ([]EchoArea, error) {

--- a/internal/ftn/registry.go
+++ b/internal/ftn/registry.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 //go:embed registry.json
@@ -35,13 +36,28 @@ type RegistryNetwork struct {
 	AreaManager      string   `json:"area_manager,omitempty"`
 }
 
+// normalizeRegistry trims the fields that get handed to a URL parser. Both
+// registries are hand-maintained JSON — the embedded one ported from an ini
+// file that indents some values, the override one edited by the sysop — so a
+// stray space is easy to introduce. Untrimmed it survives
+// EcholistIsDownloadable (which trims) and then fails in url.Parse, where a
+// leading space makes "https:" a relative path segment; a whitespace-only
+// value would likewise read as "configured" rather than "absent".
+func normalizeRegistry(networks []RegistryNetwork) []RegistryNetwork {
+	for i := range networks {
+		networks[i].EcholistURL = strings.TrimSpace(networks[i].EcholistURL)
+		networks[i].NodelistURL = strings.TrimSpace(networks[i].NodelistURL)
+	}
+	return networks
+}
+
 // LoadRegistry returns the embedded FTN network registry.
 func LoadRegistry() ([]RegistryNetwork, error) {
 	var networks []RegistryNetwork
 	if err := json.Unmarshal(registryJSON, &networks); err != nil {
 		return nil, fmt.Errorf("parsing embedded FTN registry: %w", err)
 	}
-	return networks, nil
+	return normalizeRegistry(networks), nil
 }
 
 // LoadOverrideRegistry loads an optional sysop-provided ftn_networks.json
@@ -59,5 +75,5 @@ func LoadOverrideRegistry(configPath string) ([]RegistryNetwork, error) {
 	if err := json.Unmarshal(data, &networks); err != nil {
 		return nil, fmt.Errorf("parsing ftn_networks.json: %w", err)
 	}
-	return networks, nil
+	return normalizeRegistry(networks), nil
 }

--- a/internal/ftn/registry.json
+++ b/internal/ftn/registry.json
@@ -8,7 +8,7 @@
     "coordinator_email": "nandre@net229.org",
     "coordinator_ftn": "1:229/426",
     "dns_suffix": "binkp.net",
-    "echolist_url": "http://web.synchro.net/files/FidoNet/ECHOLIST/BACKBONE.NA",
+    "echolist_url": "http://ambrosia60.spdns.eu/53f8ee03/drv_q/div13/backbone/BACKBONE.NA",
     "nodelist_url": "https://nodelist.fidonet.cc/download/latest"
   },
   {
@@ -19,14 +19,14 @@
     "coordinator_email": "wd@skynet.be",
     "coordinator_ftn": "2:292/854",
     "dns_suffix": "binkp.net",
-    "echolist_url": "http://web.synchro.net/files/FidoNet/ECHOLIST/BACKBONE.NA",
+    "echolist_url": "http://ambrosia60.spdns.eu/53f8ee03/drv_q/div13/backbone/BACKBONE.NA",
     "nodelist_url": "https://nodelist.fidonet.cc/download/latest"
   },
   {
     "zone": 3,
     "name": "FidoNet",
     "description": "Australasia",
-    "echolist_url": "http://web.synchro.net/files/FidoNet/ECHOLIST/BACKBONE.NA",
+    "echolist_url": "http://ambrosia60.spdns.eu/53f8ee03/drv_q/div13/backbone/BACKBONE.NA",
     "nodelist_url": "https://nodelist.fidonet.cc/download/latest"
   },
   {
@@ -38,7 +38,7 @@
     "coordinator_email": "ragnarok@docksud.com.ar",
     "coordinator_ftn": "4:902/26",
     "dns_suffix": "binkp.net",
-    "echolist_url": "http://web.synchro.net/files/FidoNet/ECHOLIST/BACKBONE.NA",
+    "echolist_url": "http://ambrosia60.spdns.eu/53f8ee03/drv_q/div13/backbone/BACKBONE.NA",
     "nodelist_url": "https://nodelist.fidonet.cc/download/latest"
   },
   {

--- a/internal/ftn/registry.json
+++ b/internal/ftn/registry.json
@@ -308,5 +308,19 @@
     "echolist_url": "tqwnet.na",
     "nodelist_url": "https://www.erb.pw/tqwinfo.zip",
     "areatag_prefix": "TQW_"
+  },
+  {
+    "zone": 3323,
+    "name": "CheeseNet",
+    "description": "ch3323 - the network that never sleeps",
+    "info_url": "https://futureland.today/cheesenet/",
+    "pack_url": "https://futureland.today/cheesenet/cheesenet.zip",
+    "coordinator": "Hm Derdoc",
+    "coordinator_email": "hm.derdoc@futureland.today",
+    "hub_address": "3323:1/100",
+    "hub_hostname": "futureland.today",
+    "echolist_url": "https://futureland.today/cheesenet/pack/CHEESENET.NA",
+    "areatag_prefix": "CHEESE_",
+    "handles_allowed": true
   }
 ]

--- a/internal/ftn/registry_test.go
+++ b/internal/ftn/registry_test.go
@@ -2,6 +2,10 @@ package ftn
 
 import (
 	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -93,5 +97,56 @@ func TestEmbeddedRegistryFsxNetHasNodelistURL(t *testing.T) {
 	}
 	if !found {
 		t.Error("fsxNet registry entry not found")
+	}
+}
+
+func TestLoadOverrideRegistryTrimsURLs(t *testing.T) {
+	// A sysop hand-editing ftn_networks.json can easily leave a stray space.
+	// Untrimmed it passes EcholistIsDownloadable (which trims) and then fails
+	// in url.Parse, and a whitespace-only value reads as "configured" instead
+	// of "absent", sending the wizard down the wrong message branch.
+	dir := t.TempDir()
+	body := `[{"zone": 21, "name": "fsxNet",
+	  "echolist_url": "  https://example.test/fsxnet.na  ",
+	  "nodelist_url": "\thttps://example.test/fsxnet.zip\n"},
+	 {"zone": 25, "name": "Blank", "echolist_url": "   "}]`
+	if err := os.WriteFile(filepath.Join(dir, "ftn_networks.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	networks, err := LoadOverrideRegistry(dir)
+	if err != nil {
+		t.Fatalf("LoadOverrideRegistry() error: %v", err)
+	}
+	if len(networks) != 2 {
+		t.Fatalf("got %d networks, want 2", len(networks))
+	}
+
+	if got := networks[0].EcholistURL; got != "https://example.test/fsxnet.na" {
+		t.Errorf("EcholistURL = %q, want it trimmed", got)
+	}
+	if got := networks[0].NodelistURL; got != "https://example.test/fsxnet.zip" {
+		t.Errorf("NodelistURL = %q, want it trimmed", got)
+	}
+	if _, err := http.NewRequest(http.MethodGet, networks[0].EcholistURL, nil); err != nil {
+		t.Errorf("trimmed URL should build a request: %v", err)
+	}
+	if got := networks[1].EcholistURL; got != "" {
+		t.Errorf("whitespace-only EcholistURL = %q, want empty so it reads as absent", got)
+	}
+}
+
+func TestEmbeddedRegistryURLsAreTrimmed(t *testing.T) {
+	networks, err := LoadRegistry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range networks {
+		if n.EcholistURL != strings.TrimSpace(n.EcholistURL) {
+			t.Errorf("%s zone %d: echolist_url has surrounding whitespace: %q", n.Name, n.Zone, n.EcholistURL)
+		}
+		if n.NodelistURL != strings.TrimSpace(n.NodelistURL) {
+			t.Errorf("%s zone %d: nodelist_url has surrounding whitespace: %q", n.Name, n.Zone, n.NodelistURL)
+		}
 	}
 }

--- a/internal/menu/executor_run_input.go
+++ b/internal/menu/executor_run_input.go
@@ -217,9 +217,11 @@ func (st *runLoopState) readStandardInput(menuRec *MenuRecord) (input string, ac
 // only side effect is debug logging.
 //
 // Special cases: "/G" is the global hangup shortcut (matches unconditionally,
-// no ACS check); "^M" matches Enter with no input (classic BBS default
-// command); "##" matches any all-numeric input (classic BBS numeric
-// wildcard), appending the entered number to the command as args.
+// no ACS check); "G" is the global confirmed-logoff shortcut, applied only
+// after every menu command has failed to match so a menu that binds G itself
+// keeps it; "^M" matches Enter with no input (classic BBS default command);
+// "##" matches any all-numeric input (classic BBS numeric wildcard),
+// appending the entered number to the command as args.
 //
 // hasAccess takes both the command's ACS string and its Keys string (rather
 // than just the ACS string) so that the closure Run constructs — which has
@@ -288,6 +290,18 @@ func matchCommand(commands []CommandRecord, userInput string, hasAccess func(acs
 				break // Break outer command loop
 			}
 		}
+	}
+
+	// Classic BBS convention: G is Goodbye from anywhere. Only menus that
+	// happen to list it get it otherwise, so on the ones that don't (the
+	// email, QWK and sysop menus among them) the only way out was the /G
+	// hangup. Running last means a menu's own G still wins — USERCFG binds
+	// it to the custom-prompt editor — because this is reached only when
+	// nothing in the menu matched.
+	if !matched && userInput == "G" {
+		nextAction = "RUN:MAINLOGOFF"
+		matched = true
+		slog.Debug("matched global G shortcut to confirmed logoff")
 	}
 
 	return nextAction, matchedNodeActivity, matched

--- a/internal/menu/executor_run_input_test.go
+++ b/internal/menu/executor_run_input_test.go
@@ -92,3 +92,33 @@ func TestMatchCommandHasAccessReceivesKeys(t *testing.T) {
 		t.Fatalf("hasAccess called with (%q, %q), want (\"s10\", \"Q W\")", gotACS, gotKeys)
 	}
 }
+
+func TestMatchCommandGlobalGoodbye(t *testing.T) {
+	allow := func(string, string) bool { return true }
+
+	// A menu that lists no G (the email, QWK and sysop menus) still logs off
+	// on G, instead of leaving /G as the only way out.
+	cmds := []CommandRecord{
+		{Keys: "S", Command: "RUN:SENDPRIVMAIL"},
+		{Keys: "Q", Command: "GOTO:MAIN"},
+	}
+	action, _, matched := matchCommand(cmds, "G", allow)
+	if !matched || action != "RUN:MAINLOGOFF" {
+		t.Fatalf("got (%q, %v), want (RUN:MAINLOGOFF, true)", action, matched)
+	}
+
+	// A menu that binds G itself keeps it: the fallback only runs when
+	// nothing in the menu matched.
+	own := []CommandRecord{
+		{Keys: "G", Command: "RUN:CFG_CUSTOMPROMPT", NodeActivity: "User Settings"},
+	}
+	action, nodeActivity, matched := matchCommand(own, "G", allow)
+	if !matched || action != "RUN:CFG_CUSTOMPROMPT" || nodeActivity != "User Settings" {
+		t.Fatalf("got (%q, %q, %v), want (RUN:CFG_CUSTOMPROMPT, User Settings, true)", action, nodeActivity, matched)
+	}
+
+	// The fallback is exact: it must not swallow other input starting with G.
+	if _, _, m := matchCommand(cmds, "GO", allow); m {
+		t.Fatal("GO should not match the global goodbye shortcut")
+	}
+}

--- a/internal/menu/matrix.go
+++ b/internal/menu/matrix.go
@@ -132,32 +132,15 @@ func (e *MenuExecutor) RunMatrixScreen(
 			if key < 32 || key > 126 {
 				continue // ignore non-printable / special keys
 			}
-			r := rune(key)
-
-			// Direct selection by number
-			if r >= '1' && r <= '9' {
-				numIndex := int(r - '1')
-				if numIndex < len(options) {
-					selectedIndex = numIndex
-					_ = drawMatrixOptions(terminal, options, selectedIndex, outputMode) // best-effort redraw
-					selectionMade = true
-				}
-				break
-			}
-
-			// Check for hotkey match (explicit HotKey field from BAR file)
-			keyStr := strings.ToUpper(string(r))
-			matchedHotkey := false
-			for i, opt := range options {
-				if keyStr == opt.HotKey {
-					selectedIndex = i
-					_ = drawMatrixOptions(terminal, options, selectedIndex, outputMode) // best-effort redraw
-					selectionMade = true
-					matchedHotkey = true
-					break
-				}
-			}
-			if !matchedHotkey {
+			// The move has to go through newIndex: the shared "did the
+			// highlight move?" block below copies newIndex back over
+			// selectedIndex, so assigning selectedIndex here would be
+			// undone and every hotkey press would act on whatever was
+			// already highlighted instead of what was typed.
+			if idx, ok := matrixPrintableKey(rune(key), options); ok {
+				newIndex = idx
+				selectionMade = true
+			} else {
 				e.showUndefinedMenuInput(terminal, outputMode, nodeNumber)
 				_ = drawMatrixScreen(terminal, ansBackground, options, selectedIndex, outputMode) // best-effort redraw
 			}
@@ -197,6 +180,29 @@ func (e *MenuExecutor) RunMatrixScreen(
 	// Max tries exceeded
 	slog.Info("matrix max tries exceeded, disconnecting", "node", nodeNumber)
 	return "DISCONNECT", nil
+}
+
+// matrixPrintableKey resolves a printable keypress against the matrix options:
+// 1-9 pick by position, anything else matches the HotKey column of the .BAR
+// file (case-insensitively). It returns the option index to select and false
+// if the key matches nothing, in which case the caller reports undefined
+// input.
+func matrixPrintableKey(r rune, options []LightbarOption) (int, bool) {
+	if r >= '1' && r <= '9' {
+		idx := int(r - '1')
+		if idx < len(options) {
+			return idx, true
+		}
+		return 0, false
+	}
+
+	keyStr := strings.ToUpper(string(r))
+	for i, opt := range options {
+		if keyStr == opt.HotKey {
+			return i, true
+		}
+	}
+	return 0, false
 }
 
 // processMatrixAction handles the selected matrix menu action.

--- a/internal/menu/matrix_test.go
+++ b/internal/menu/matrix_test.go
@@ -1,0 +1,43 @@
+package menu
+
+import "testing"
+
+func matrixTestOptions() []LightbarOption {
+	// Mirrors the shipped PDMATRIX.BAR ordering.
+	return []LightbarOption{
+		{HotKey: "J", Text: "Journey onward."},
+		{HotKey: "C", Text: "Create an account."},
+		{HotKey: "A", Text: "Check your access."},
+		{HotKey: "D", Text: "Disconnect."},
+	}
+}
+
+func TestMatrixPrintableKey(t *testing.T) {
+	options := matrixTestOptions()
+
+	// Hotkeys pick their own option. Regression guard: the matrix used to
+	// hand every hotkey press back to whatever was already highlighted, so
+	// C ("Create an account") logged the caller in instead of starting the
+	// new user application, and there was no way to sign up at all.
+	for _, tc := range []struct {
+		key  rune
+		want int
+	}{
+		{'J', 0}, {'C', 1}, {'A', 2}, {'D', 3},
+		{'c', 1}, // lower case matches too
+		{'1', 0}, {'2', 1}, {'3', 2}, {'4', 3},
+	} {
+		got, ok := matrixPrintableKey(tc.key, options)
+		if !ok || got != tc.want {
+			t.Errorf("matrixPrintableKey(%q) = (%d, %v), want (%d, true)", tc.key, got, ok, tc.want)
+		}
+	}
+
+	// Keys that match nothing, and digits past the end of the list, are
+	// reported as unmatched rather than selecting option 0.
+	for _, key := range []rune{'Z', '5', '9', '!'} {
+		if got, ok := matrixPrintableKey(key, options); ok {
+			t.Errorf("matrixPrintableKey(%q) = (%d, true), want no match", key, got)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #190.

## 1. Cannot create a new user (the big one)

Pressing **C** — "Create an account" — on the pre-login matrix logged you into the login prompt instead. You then typed the handle you wanted to register, and got **"Login incorrect."** There was no way to sign up at all.

Every printable key in `RunMatrixScreen` assigned `selectedIndex` directly, and then the shared "did the highlight move?" block below the switch copied the untouched `newIndex` back over it:

```go
if idx, ok := hotkeyMatch(...); ok {
    selectedIndex = i        // C -> index 1
    selectionMade = true
}
...
if newIndex != selectedIndex {
    selectedIndex = newIndex // ...and back to 0
}
```

So every hotkey and every 1-9 shortcut acted on whatever was already highlighted — option 1, `LOGIN`, on a fresh screen. Only arrow keys + Enter worked. Selection now moves through `newIndex`, and the key-to-option lookup is extracted as `matrixPrintableKey` so it can be tested.

Verified against a live instance over telnet: `C` and `2` now start the signup, the account is created, and it logs in.

## 2. G doesn't quit from several screens

`/G` is hardcoded as a global hangup in `matchCommand`; plain `G` was only ever a per-menu `.CFG` entry, and `EMAILM`, `QWKM`, `SPONSORM` and `ADMIN` never listed it. `G` is now a global confirmed-logoff (`RUN:MAINLOGOFF`), matched **after** every command in the menu has failed — so `USERCFG`, which binds `G` to the custom prompt editor, keeps it. Being in code rather than in the menu files, this reaches existing installs, whose `menus/` directory is never overwritten on upgrade.

## 3. FTN wizard: the 401, and losing your work

The wizard refused to save without at least one echo area, so a failed echolist download left the operator with no exit that kept the form. Echo areas are optional now — the network, its hub link, the netmail area and `binkd.conf` are all worth saving on their own, and echoes can be added later under *Message Areas* or by re-entering the wizard in edit mode. The failure screen says so instead of looking like a dead end.

Two things made that failure the default:

- **FidoNet's `echolist_url` was dead.** `web.synchro.net` stopped serving files anonymously and answers `401 Unauthorized` (`WWW-Authenticate: Basic realm="Vertrauen"`). All four FidoNet zone entries now point at a mirror that still serves `BACKBONE.NA`. The registry is embedded, so this ships to existing installs.
- **A dozen entries aren't URLs at all.** MetroNet, SFNet, DoRENET, Agoranet, C=Net, DevNet, MusicNet, Whisper, iLink, Micronet, Zer0net, HobbyNet and tqwNet record a *filename* (`metronet.na`), because those networks distribute the `.NA` through the network itself. Handing one to an HTTP client produced an opaque "unsupported protocol scheme" error; `ftn.EcholistIsDownloadable` now recognises them and the wizard says to request the file from the hub via AreaFix.

## 4. CheeseNet added to the registry

Zone 3323, carried upstream in Synchronet's `init-fidonet.ini` — the file this registry was ported from — but missing here. It is one of the few networks whose echolist is genuinely web-hosted, so the wizard can download and browse its areas. Echolist, info and pack URLs all verified live, and the echolist parses as `BACKBONE.NA` with the `CHEESE_` prefix the entry declares.

## 5. Blank config-editor screens

An empty record list rendered as an empty box, with the only way forward (`I - Insert`) buried in the help bar at the foot of the screen. Empty lists now show a line saying what they are and which key fills them, in yellow rather than the list's own white:

```
┌──────────────────────────────────────────────────────────────────────┐
│                          Echomail Networks                           │
│  Network                 Own Address                  Tosser         │
│──────────────────────────────────────────────────────────────────────│
│ No networks yet — press I to add one (FTN setup wizard).             │
```

## Testing

- New unit tests: `matrixPrintableKey` (hotkeys, digits, lower case, no-match), the global `G` fallback and its precedence, saving the wizard with no echo areas, and the non-URL echolist path.
- Manual end-to-end over telnet against a `dev-setup.sh` instance: matrix signup, login as the new account, `G` on the email and sysop menus, and `G` still editing the custom prompt on `USERCFG`.
- `go build ./...` and `go test ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQuYC88yCUrF8isfJdNJyY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FTN Setup Wizard now supports saving networks without echo areas, with guidance for adding them later.
  * Added validation and clearer handling for downloadable echolist URLs and failed downloads.
  * Added CheeseNet zone configuration and updated FidoNet echolist information.
  * Added global `G` logoff behavior and improved matrix-menu keyboard selection.

* **Bug Fixes**
  * Improved empty-list guidance and FTN error messages while preserving entered configuration.

* **Documentation**
  * Documented FTN wizard behavior and additional menu shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->