### PR TITLE
fix(netmail): address replies to the sender's FTN address

### DIFF
--- a/internal/jam/jam_extended_test.go
+++ b/internal/jam/jam_extended_test.go
@@ -896,6 +896,47 @@ func TestMessageTypeMethods(t *testing.T) {
 	}
 }
 
+// Netmail is private mail: WriteMessageExt must stamp MSG_PRIVATE on it
+// whatever the caller passes, so tossed inbound mail and locally written mail
+// are both marked. Echomail is public and must not be.
+func TestWriteMessageExtMarksNetmailPrivate(t *testing.T) {
+	b, _ := openCovTestBase(t)
+
+	msg := NewMessage()
+	msg.From = "Remote User"
+	msg.To = "Local Sysop"
+	msg.Subject = "Private Note"
+	msg.Text = "Secret content"
+	n, err := b.WriteMessageExt(msg, MsgTypeNetmailMsg, "", "")
+	if err != nil {
+		t.Fatalf("WriteMessageExt: %v", err)
+	}
+	got, err := b.ReadMessage(n)
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	if !got.IsPrivate() {
+		t.Errorf("netmail attribute = 0x%08x, want MsgPrivate set", got.GetAttribute())
+	}
+
+	echo := NewMessage()
+	echo.From = "Remote User"
+	echo.To = "All"
+	echo.Subject = "Public Note"
+	echo.Text = "Open content"
+	en, err := b.WriteMessageExt(echo, MsgTypeEchomailMsg, "TESTAREA", "")
+	if err != nil {
+		t.Fatalf("WriteMessageExt echomail: %v", err)
+	}
+	gotEcho, err := b.ReadMessage(en)
+	if err != nil {
+		t.Fatalf("ReadMessage echomail: %v", err)
+	}
+	if gotEcho.IsPrivate() {
+		t.Error("echomail must not be marked private")
+	}
+}
+
 func TestGetJAMAttribute(t *testing.T) {
 	tests := []struct {
 		mt   MessageType
@@ -903,7 +944,7 @@ func TestGetJAMAttribute(t *testing.T) {
 	}{
 		{MsgTypeLocalMsg, MsgLocal | MsgTypeLocal},
 		{MsgTypeEchomailMsg, MsgLocal | MsgTypeEcho},
-		{MsgTypeNetmailMsg, MsgLocal | MsgTypeNet},
+		{MsgTypeNetmailMsg, MsgLocal | MsgTypeNet | MsgPrivate},
 	}
 	for _, tt := range tests {
 		got := tt.mt.GetJAMAttribute()

--- a/internal/jam/msgtype.go
+++ b/internal/jam/msgtype.go
@@ -21,12 +21,18 @@ func (mt MessageType) IsNetmail() bool { return mt == MsgTypeNetmailMsg }
 func (mt MessageType) IsLocal() bool { return mt == MsgTypeLocalMsg }
 
 // GetJAMAttribute returns the JAM attribute flags for this message type.
+//
+// Netmail carries MsgPrivate: it is mail addressed to one person, private by
+// definition, and the tosser stamps MSGPRIVATE on every netmail it packs. Every
+// netmail reaches a base through WriteMessageExt, so setting the flag here
+// covers inbound tossed mail and locally written mail alike, without each
+// caller having to remember.
 func (mt MessageType) GetJAMAttribute() uint32 {
 	switch mt {
 	case MsgTypeEchomailMsg:
 		return MsgLocal | MsgTypeEcho
 	case MsgTypeNetmailMsg:
-		return MsgLocal | MsgTypeNet
+		return MsgLocal | MsgTypeNet | MsgPrivate
 	default:
 		return MsgLocal | MsgTypeLocal
 	}

--- a/internal/menu/message_reader_nav.go
+++ b/internal/menu/message_reader_nav.go
@@ -18,6 +18,35 @@ import (
 	"golang.org/x/term"
 )
 
+// replyAddressee returns who a reply to msg goes to: name for display in the
+// editor header, and to for the message's To field.
+//
+// Netmail is delivered by FTN address, not by name. AddReply splits
+// "user@zone:net/node" into the To and destination-address fields, and a To
+// with no address leaves the JAM message without a DADDRESS subfield, so the
+// tosser has nothing to address the outbound packet with — the reply is
+// written but can never be delivered. Every other area type replies to the
+// bare name.
+//
+// The addressee is normally the parent's author, at the address the message
+// came from. Netmail the user sent themselves is the exception: its origin is
+// this system, so the reply follows the parent to its addressee instead of
+// looping back here.
+func replyAddressee(area *message.MessageArea, msg *message.DisplayMessage) (name, to string) {
+	if area == nil || area.AreaType != "netmail" {
+		return msg.From, msg.From
+	}
+
+	name, addr := msg.From, msg.OrigAddr
+	if msg.DestAddr != "" && area.OriginAddr != "" && addr == area.OriginAddr {
+		name, addr = msg.To, msg.DestAddr
+	}
+	if addr == "" {
+		return name, name // unaddressable, but the reply is still worth keeping
+	}
+	return name, fmt.Sprintf("%s@%s", name, addr)
+}
+
 // handleReply manages the reply flow matching Pascal's reply handling.
 func handleReply(e *MenuExecutor, s ssh.Session, ih *editor.InputHandler, terminal *term.Terminal,
 	userManager *user.UserMgr, currentUser *user.User, nodeNumber int,
@@ -42,6 +71,11 @@ func handleReply(e *MenuExecutor, s ssh.Session, ih *editor.InputHandler, termin
 
 	terminalio.WriteProcessedBytes(terminal, []byte(e.LoadedStrings.MsgLaunchingEditor), outputMode)
 
+	// Work out who the reply is addressed to before opening the editor, so the
+	// header shows the reply's own addressee rather than the parent's.
+	replyArea, _ := e.MessageMgr.GetAreaByID(currentAreaID)
+	replyName, replyTo := replyAddressee(replyArea, currentMsg)
+
 	// Start with empty editor - user will use /Q command to quote if desired
 	// Pass message metadata for quoting (from, title, date, time, isAnon, lines)
 	replyNextMsg := *totalMsgCount + 1
@@ -50,7 +84,7 @@ func handleReply(e *MenuExecutor, s ssh.Session, ih *editor.InputHandler, termin
 		NextMsgNum: replyNextMsg,
 		ConfArea:   fmt.Sprintf("%s > %s", confName, areaName),
 	}
-	replyBody, saved, editErr := editor.RunEditorWithMetadata("", s, s, outputMode, newSubject, currentMsg.To, currentUser.Handle, false,
+	replyBody, saved, editErr := editor.RunEditorWithMetadata("", s, s, outputMode, newSubject, replyName, currentUser.Handle, false,
 		currentMsg.From, currentMsg.Subject, quoteDate, quoteTime, false, quoteLines, ih, replyCtx)
 	if editErr != nil {
 		slog.Error("editor failed", "node", nodeNumber, "error", editErr)
@@ -75,10 +109,10 @@ func handleReply(e *MenuExecutor, s ssh.Session, ih *editor.InputHandler, termin
 	replyMsgID := currentMsg.MsgID
 	var err error
 	if currentMsg.IsPrivate {
-		_, err = e.MessageMgr.AddPrivateReply(currentAreaID, currentUser.Handle, currentMsg.From,
+		_, err = e.MessageMgr.AddPrivateReply(currentAreaID, currentUser.Handle, replyTo,
 			newSubject, replyBody, replyMsgID, currentMsg.MsgNum)
 	} else {
-		_, err = e.MessageMgr.AddReply(currentAreaID, currentUser.Handle, currentMsg.From,
+		_, err = e.MessageMgr.AddReply(currentAreaID, currentUser.Handle, replyTo,
 			newSubject, replyBody, replyMsgID, currentMsg.MsgNum)
 	}
 	if err != nil {

--- a/internal/menu/message_reader_reply_test.go
+++ b/internal/menu/message_reader_reply_test.go
@@ -1,0 +1,77 @@
+package menu
+
+import (
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/message"
+)
+
+func TestReplyAddressee(t *testing.T) {
+	netmail := &message.MessageArea{AreaType: "netmail", OriginAddr: "21:4/158"}
+
+	tests := []struct {
+		desc     string
+		area     *message.MessageArea
+		msg      *message.DisplayMessage
+		wantName string
+		wantTo   string
+	}{
+		{
+			desc:     "local area replies to the bare name",
+			area:     &message.MessageArea{AreaType: "local"},
+			msg:      &message.DisplayMessage{From: "Bob", To: "Alice"},
+			wantName: "Bob",
+			wantTo:   "Bob",
+		},
+		{
+			desc:     "echomail keeps the name even though it has an origin",
+			area:     &message.MessageArea{AreaType: "echomail", OriginAddr: "21:4/158"},
+			msg:      &message.DisplayMessage{From: "Bob", To: "All", OrigAddr: "21:1/100"},
+			wantName: "Bob",
+			wantTo:   "Bob",
+		},
+		{
+			desc:     "inbound netmail is addressed back to its sender",
+			area:     netmail,
+			msg:      &message.DisplayMessage{From: "Bob", To: "Alice", OrigAddr: "21:1/100", DestAddr: "21:4/158"},
+			wantName: "Bob",
+			wantTo:   "Bob@21:1/100",
+		},
+		{
+			desc:     "a point sender keeps its point number",
+			area:     netmail,
+			msg:      &message.DisplayMessage{From: "Bob", To: "Alice", OrigAddr: "21:1/100.5", DestAddr: "21:4/158"},
+			wantName: "Bob",
+			wantTo:   "Bob@21:1/100.5",
+		},
+		{
+			desc:     "a reply to netmail we sent follows the parent's addressee",
+			area:     netmail,
+			msg:      &message.DisplayMessage{From: "Alice", To: "Bob", OrigAddr: "21:4/158", DestAddr: "21:1/100"},
+			wantName: "Bob",
+			wantTo:   "Bob@21:1/100",
+		},
+		{
+			desc:     "netmail with no origin address falls back to the name",
+			area:     netmail,
+			msg:      &message.DisplayMessage{From: "Bob", To: "Alice"},
+			wantName: "Bob",
+			wantTo:   "Bob",
+		},
+		{
+			desc:     "a missing area is treated as non-netmail",
+			area:     nil,
+			msg:      &message.DisplayMessage{From: "Bob", To: "Alice", OrigAddr: "21:1/100"},
+			wantName: "Bob",
+			wantTo:   "Bob",
+		},
+	}
+
+	for _, tt := range tests {
+		name, to := replyAddressee(tt.area, tt.msg)
+		if name != tt.wantName || to != tt.wantTo {
+			t.Errorf("%s: replyAddressee = (%q, %q), want (%q, %q)",
+				tt.desc, name, to, tt.wantName, tt.wantTo)
+		}
+	}
+}

--- a/internal/message/manager_netmail_test.go
+++ b/internal/message/manager_netmail_test.go
@@ -87,3 +87,25 @@ func TestAddPrivateReply_NetmailKeepsDestAddr(t *testing.T) {
 		t.Errorf("ReplyToNum = %d, want %d", reply.ReplyToNum, parent)
 	}
 }
+
+// Netmail written through the public (non-private) entry point still has to be
+// private: inbound mail arrives without the flag, so a reply to it takes the
+// AddReply path, and the reply is mail to one person all the same.
+func TestAddMessage_NetmailIsPrivate(t *testing.T) {
+	mm := newNetmailTestManager(t)
+
+	num, err := mm.AddMessage(1, "Alice", "Bob@21:1/100", "Re: Hello", "hi back", "")
+	if err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+	msg, err := mm.GetMessage(1, num)
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if !msg.IsPrivate {
+		t.Error("netmail must be stored private")
+	}
+	if msg.DestAddr != "21:1/100" {
+		t.Errorf("DestAddr = %q, want %q", msg.DestAddr, "21:1/100")
+	}
+}

--- a/internal/message/manager_netmail_test.go
+++ b/internal/message/manager_netmail_test.go
@@ -89,8 +89,9 @@ func TestAddPrivateReply_NetmailKeepsDestAddr(t *testing.T) {
 }
 
 // Netmail written through the public (non-private) entry point still has to be
-// private: inbound mail arrives without the flag, so a reply to it takes the
-// AddReply path, and the reply is mail to one person all the same.
+// private. Composing netmail from the menu takes that path, and so does a reply
+// to any netmail already in a base from before netmail was stored private.
+// Either way the result is mail to one person.
 func TestAddMessage_NetmailIsPrivate(t *testing.T) {
 	mm := newNetmailTestManager(t)
 

--- a/internal/message/manager_netmail_test.go
+++ b/internal/message/manager_netmail_test.go
@@ -1,6 +1,10 @@
 package message
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestSplitNetmailTo(t *testing.T) {
 	tests := []struct {
@@ -25,5 +29,61 @@ func TestSplitNetmailTo(t *testing.T) {
 			t.Errorf("splitNetmailTo(%q) = (%q, %q), want (%q, %q)",
 				tt.input, name, addr, tt.wantName, tt.wantAddr)
 		}
+	}
+}
+
+// newNetmailTestManager builds a manager with a single netmail area addressed
+// as 21:4/158.
+func newNetmailTestManager(t *testing.T) *MessageManager {
+	t.Helper()
+	tmp := t.TempDir()
+	cfg := filepath.Join(tmp, "config")
+	if err := os.MkdirAll(cfg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	areas := `[{"id":1,"tag":"NETMAIL","name":"Netmail","base_path":"netmail",
+	            "area_type":"netmail","origin_addr":"21:4/158","network":"fsxnet"}]`
+	if err := os.WriteFile(filepath.Join(cfg, "message_areas.json"), []byte(areas), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mm, err := NewMessageManager(tmp, cfg, "TestBBS", nil)
+	if err != nil {
+		t.Fatalf("NewMessageManager: %v", err)
+	}
+	return mm
+}
+
+// A netmail reply has to carry the addressee's FTN address: without a
+// DestAddr the JAM message has no DADDRESS subfield and the tosser cannot
+// address the outbound packet. The sender's point must survive too, since the
+// tosser writes it as the TOPT control paragraph.
+func TestAddPrivateReply_NetmailKeepsDestAddr(t *testing.T) {
+	mm := newNetmailTestManager(t)
+
+	parent, err := mm.AddPrivateMessage(1, "Bob", "Alice@21:1/100.5", "Hello", "hi", "")
+	if err != nil {
+		t.Fatalf("AddPrivateMessage: %v", err)
+	}
+
+	num, err := mm.AddPrivateReply(1, "Alice", "Bob@21:1/100.5", "Re: Hello", "hi back", "", parent)
+	if err != nil {
+		t.Fatalf("AddPrivateReply: %v", err)
+	}
+
+	reply, err := mm.GetMessage(1, num)
+	if err != nil {
+		t.Fatalf("GetMessage: %v", err)
+	}
+	if reply.To != "Bob" {
+		t.Errorf("To = %q, want %q", reply.To, "Bob")
+	}
+	if reply.DestAddr != "21:1/100.5" {
+		t.Errorf("DestAddr = %q, want %q", reply.DestAddr, "21:1/100.5")
+	}
+	if reply.OrigAddr != "21:4/158" {
+		t.Errorf("OrigAddr = %q, want %q", reply.OrigAddr, "21:4/158")
+	}
+	if reply.ReplyToNum != parent {
+		t.Errorf("ReplyToNum = %d, want %d", reply.ReplyToNum, parent)
 	}
 }

--- a/internal/tosser/integration_test.go
+++ b/internal/tosser/integration_test.go
@@ -454,6 +454,11 @@ func TestTossNetmail(t *testing.T) {
 	if msg.From != "Remote User" {
 		t.Errorf("netmail From: got %q, want %q", msg.From, "Remote User")
 	}
+	// Netmail is mail to one person: it has to land private, or the reader
+	// treats it as a public post and replies to it lose the private flag.
+	if !msg.IsPrivate() {
+		t.Error("inbound netmail must be stored private")
+	}
 }
 
 // TestTossBadArea verifies that a message for an unknown area is routed to the bad area.


### PR DESCRIPTION
Fixes #194.

Two related netmail defects: replies had no destination address, and netmail wasn't stored private.

## 1. Replies carry no destination address

The reader passed the parent's `From` — a bare display name — as the reply's `To`; `splitNetmailTo` found no `@`, `DestAddr` was never set, `WriteMessageExt` wrote no `DADDRESS` subfield, and the tosser had nothing to address the outbound packet with. The reply was written but could never be delivered.

`replyAddressee` (in `internal/menu/message_reader_nav.go`) now works out the reply's addressee up front and returns both a display name and the `To` value:

- **Netmail** → `From@OrigAddr`, the form `splitNetmailTo` already parses. The point survives into `DestAddr`, and `createOutboundNetmailPacket` already writes `INTL` from it and `TOPT` when the point is non-zero — so the `INTL`/`TOPT` question raised in the issue needed no code change, only a `DestAddr` to read.
- **Netmail the user sent themselves** (parent's `OrigAddr` == the area's own address) → the reply follows the parent to its addressee (`To@DestAddr`) instead of looping back to this system.
- **No usable address** → falls back to the bare name, so the reply is still written.
- **Every other area type** → unchanged, replies to the bare name.

Also fixed in the same lines: the editor header was passed `currentMsg.To`, the *parent's* recipient, so composing a reply showed the wrong addressee. It now gets the reply's own addressee.

## 2. Netmail wasn't stored private

Inbound netmail was tossed in without `MSG_PRIVATE`, so mail addressed to one person read as a public post — no `P` marker in the list, and replies took the non-private `AddReply` path and inherited the same omission.

Netmail is private by definition, and the tosser already stamps `MSGPRIVATE` on everything it packs. Every netmail reaches a base through `WriteMessageExt`, so `GetJAMAttribute` is the one place that covers inbound tossed mail and locally written mail alike. Echomail and local messages are unchanged.

Checked before flipping it: nothing gates visibility on the flag outside the PRIVMAIL area, whose filter also requires `To` to match the reader, so netmail areas gain the `P` marker without hiding anything. QWK export gates on the conference, not the flag, so it just reports `Private` correctly now. Existing messages keep the attribute they were written with — only the reply path read it, and both reply paths now produce private netmail regardless.

## Tests

- `TestReplyAddressee` — local, echomail, inbound netmail, point sender, self-sent netmail, no-address, nil-area.
- `TestAddPrivateReply_NetmailKeepsDestAddr` — posts a real netmail reply through `MessageManager` and asserts the round trip splits `Bob@21:1/100.5` into `To=Bob` / `DestAddr=21:1/100.5` with the point intact.
- `TestWriteMessageExtMarksNetmailPrivate` — netmail round-trips private, echomail does not.
- `TestTossNetmail` — asserts inbound tossed netmail lands private.
- `TestAddMessage_NetmailIsPrivate` — netmail written through the public entry point is still private.

Each new assertion was confirmed to fail against the unfixed code. `go vet ./...` and the full suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQuYC88yCUrF8isfJdNJyY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Netmail replies now target the original recipient when replying to self-sent messages.
  * Replies preserve the correct originating address and recipient details.
  * Replies without a valid address remain unaddressed rather than using an incorrect destination.
  * Netmail messages are now correctly recognized and stored as private.
  * Reply handling consistently uses the appropriate addressee across message types.

* **Tests**
  * Added coverage for reply addressing and netmail privacy classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->