### PR TITLE
fix(news): show System News at login by default

### DIFF
--- a/cmd/vision3/main.go
+++ b/cmd/vision3/main.go
@@ -1668,6 +1668,7 @@ func main() {
 	if err != nil {
 		logging.Fatal("failed to load login sequence configuration", "error", err)
 	}
+	menu.WarnIfNewsUnwired(rootConfigPath, loginSequence)
 
 	// Initialize session registry for who's online tracking
 	sessionRegistry = session.NewSessionRegistry()

--- a/docs/sysop/menus/menu-system.md
+++ b/docs/sysop/menus/menu-system.md
@@ -323,7 +323,7 @@ Dynamic content placeholders in prompts and ANSI files:
 - `|UPLDS` - User's upload count
 - `|DNLDS` - User's download count
 - `|POSTS` - Number of messages the user has posted
-- `|PV` - Number of users pending validation
+- `|PV` - Number of users pending validation. Only populated on the **MAIN** menu and only for users at CoSysOp level or above; it renders as `0` in every other prompt.
 - `|NODE` - Current node number
 - `|MN` - Current menu name
 - `|GL` - Group/Location (from user profile)

--- a/docs/sysop/menus/menu-system.md
+++ b/docs/sysop/menus/menu-system.md
@@ -709,7 +709,7 @@ Functions available via `RUN:` command:
 
 ### News
 
-- `PRINTNEWS` - Display news items new since last login (login sequence use)
+- `PRINTNEWS` - Display news items the user has not seen yet (login sequence use)
 - `LISTNEWS` - Browse all visible news items; user selects to read
 - `EDITNEWS` - SysOp news management: add, delete, edit, list, view (SysOp only)
 

--- a/docs/sysop/menus/menu-system.md
+++ b/docs/sysop/menus/menu-system.md
@@ -303,6 +303,10 @@ ANSI files contain the visual display for menus. They support:
 Dynamic content placeholders in prompts and ANSI files:
 
 - `|UH` - User handle
+- `|ALIAS` - User handle (alias for `|UH`)
+- `|HANDLE` - User handle (alias for `|UH`)
+- `|NAME` - User's real name
+- `|LEVEL` - User's access level
 - `|TL` - Time left (in minutes)
 - `|CA` - Current message area tag
 - `|CAN` - Current message area name (resolved display name)
@@ -315,6 +319,11 @@ Dynamic content placeholders in prompts and ANSI files:
 - `|DATE` - Current date (MM/DD/YY)
 - `|TIME` - Current time (HH:MM)
 - `|CALLS` - User's total calls
+- `|LCALL` - Date of the user's previous call (MM/DD/YY), or `Never` on a first call
+- `|UPLDS` - User's upload count
+- `|DNLDS` - User's download count
+- `|POSTS` - Number of messages the user has posted
+- `|PV` - Number of users pending validation
 - `|NODE` - Current node number
 - `|MN` - Current menu name
 - `|GL` - Group/Location (from user profile)

--- a/docs/sysop/menus/news.md
+++ b/docs/sysop/menus/news.md
@@ -27,11 +27,21 @@ News items are stored in `data/news.json`. Each item has:
 When `PRINTNEWS` is in the login sequence, ViSiON/3 checks each news item against:
 
 1. **Access level** — user's level must be `>= Level` and `<= MaxLevel` (if set)
-2. **Date filter** — item's `When` must be after the user's `lastLogin`, **or** `Always` is `true`
+2. **Already seen** — the item must not already be in the user's seen list, **or** `Always` is `true`
 
 Each qualifying item is displayed using `NEWSHDR.ANS` (header) followed by the body text. The user presses a key after each item to continue. If no qualifying items exist, the login step is silent.
 
-This matches ViSiON/2's `PrintNews(0, True)` call.
+This matches ViSiON/2's `PrintNews(0, True)` call, with one deliberate difference: V2 decided what was new by comparing the item's date to the user's last login. ViSiON/3 instead records which item **IDs** each user has actually been shown, in `seen_news_ids` on the user record.
+
+The date comparison could not work reliably here — the login timestamp is written at authentication, before the login sequence runs — and it also lost items whenever a caller dropped carrier or fast-logged past the news. With ID tracking, an item that was never displayed is still waiting on the next call.
+
+Consequences:
+
+- An item marked `always: false` is shown **exactly once per user**, whenever that user next completes the news step.
+- Reading an item from `RUN:LISTNEWS` also marks it seen, so it will not reappear at the next login.
+- `always: true` items are never recorded and display on every login.
+- Deleting a news item prunes its ID from every user's seen list on their next news step, so the list cannot grow without bound.
+- On a system upgrading to seen-tracking, each user's list is back-filled once from their previous login timestamp, so existing callers are not shown the entire news backlog.
 
 ---
 
@@ -154,13 +164,13 @@ Items are stored newest-first. The file is created automatically when the first 
 
 ## Login Sequence Configuration
 
-To display news at login, add `PRINTNEWS` to `configs/login.json`:
+`PRINTNEWS` ships in the default `configs/login.json` and in the built-in default sequence, so news displays at login out of the box. Installs created before it was added keep their existing `login.json`; add the item by hand:
 
 ```json
 {"command": "PRINTNEWS"}
 ```
 
-`PRINTNEWS` does not support `clear_screen` or `pause_after` — it handles its own display and pausing internally.
+Leave `clear_screen` and `pause_after` off. `NEWSHDR.ANS` begins with `|CL`, so each item already clears the screen, and `PRINTNEWS` pauses after every item itself. Setting `clear_screen` would blank the previous step's output even on logins where there is no news to show.
 
 ---
 

--- a/docs/sysop/menus/news.md
+++ b/docs/sysop/menus/news.md
@@ -202,8 +202,49 @@ Leave `clear_screen` and `pause_after` off. `NEWSHDR.ANS` begins with `|CL`, so 
 
 ---
 
+## Troubleshooting
+
+### News items exist but never appear at login
+
+If the log shows this at startup:
+
+```
+level=WARN msg="system news items exist but will never be displayed at login"
+  items=4 reason="the login sequence has no PRINTNEWS step"
+  fix="add {\"command\": \"PRINTNEWS\"} to configs/login.json"
+```
+
+your `configs/login.json` has no `PRINTNEWS` step. `PRINTNEWS` ships in the
+default login sequence, but setup only copies a template config when the target
+file does not already exist — so a system installed before `PRINTNEWS` was added
+keeps its original `login.json`. Add the step by hand:
+
+```json
+{"command": "PRINTNEWS"}
+```
+
+The warning only appears when there are news items to show, and clears once the
+step is present.
+
+### An item shows for some users but not others
+
+Check the item's `level` and `max_level` against those users' access levels. An
+item with `max_level: 100` is hidden from anyone above level 100 — this is
+intended for new-user notices, and is easy to trip over when testing as SysOp.
+
+### An item will not show again
+
+Once displayed, an `always: false` item is recorded in the user's
+`seen_news_ids` and will not be shown to that user again. To re-show it, either
+set `always: true`, or delete the item and add it back — a new item gets a new
+ID, which no user has seen. See [User Management](users/user-management.md) for
+the user record fields.
+
+---
+
 ## See Also
 
 - [Login Sequence](users/login-sequence.md) — configuring `PRINTNEWS` in `login.json`
 - [Admin Menu](users/admin-menu.md) — `W` key for news management
 - [Pipe Color Codes](menus/menu-system.md#pipe-color-codes) — colors in `NEWSHDR.ANS`
+- [User Management](users/user-management.md) — `seen_news_ids` and `previousLogin` on the user record

--- a/docs/sysop/menus/news.md
+++ b/docs/sysop/menus/news.md
@@ -63,7 +63,7 @@ After reading an item, the list is redisplayed. This matches ViSiON/2's `PrintNe
 
 Opens the news management interface. Requires SysOp access (`isCoSysOpOrAbove`).
 
-```
+```text
 System News Management (N items)
 ──────────────────────────────────────────────────
 [A]dd  [D]el  [E]dit  [L]ist  [V]iew  [Q]uit:
@@ -208,7 +208,7 @@ Leave `clear_screen` and `pause_after` off. `NEWSHDR.ANS` begins with `|CL`, so 
 
 If the log shows this at startup:
 
-```
+```text
 level=WARN msg="system news items exist but will never be displayed at login"
   items=4 reason="the login sequence has no PRINTNEWS step"
   fix="add {\"command\": \"PRINTNEWS\"} to configs/login.json"

--- a/docs/sysop/menus/rumors.md
+++ b/docs/sysop/menus/rumors.md
@@ -80,7 +80,9 @@ Results show the rumor number, text, and author. Case-insensitive matching.
 
 ### Rumors Newscan (`RUN:RUMORSNEWSCAN`)
 
-Clears the screen and displays all rumors posted since the user's last login. Shows rumor number, text, and author for each new rumor.
+Clears the screen and displays all rumors posted since the user's *previous* call. Shows rumor number, text, and author for each new rumor.
+
+The comparison is against `previousLogin`, not `lastLogin` — the latter is stamped at authentication, before the login sequence runs, so it always reads as the current session. Rumors posted since the caller was last on the board are the ones shown.
 
 **Default menu binding:** `N` on the Rumors Menu.
 

--- a/docs/sysop/reference/api-reference.md
+++ b/docs/sysop/reference/api-reference.md
@@ -1045,7 +1045,7 @@ type LoginItem struct {
 | ------------------------- | ------------------------------------------ |
 | `FULL_LOGIN_SEQUENCE`     | Complete login flow                        |
 | `FASTLOGIN`               | Inline fast login menu                     |
-| `PRINTNEWS`               | Display news items the user has not seen   |
+| `PRINTNEWS`               | Display unseen news plus all Always items  |
 | `PENDINGVALIDATIONNOTICE` | SysOp notice for users awaiting validation |
 
 #### System Information

--- a/docs/sysop/reference/api-reference.md
+++ b/docs/sysop/reference/api-reference.md
@@ -1045,7 +1045,7 @@ type LoginItem struct {
 | ------------------------- | ------------------------------------------ |
 | `FULL_LOGIN_SEQUENCE`     | Complete login flow                        |
 | `FASTLOGIN`               | Inline fast login menu                     |
-| `PRINTNEWS`               | Display news since last login              |
+| `PRINTNEWS`               | Display news items the user has not seen   |
 | `PENDINGVALIDATIONNOTICE` | SysOp notice for users awaiting validation |
 
 #### System Information

--- a/docs/sysop/scripting/vpl-scripting.md
+++ b/docs/sysop/scripting/vpl-scripting.md
@@ -362,6 +362,12 @@ Read-only access to the user database. Returns safe fields only — no passwords
 | `lastLogin` | number (Unix timestamp) |
 | `createdAt` | number (Unix timestamp) |
 
+> **`lastLogin` is the current session, not the caller's previous visit.** It is
+> stamped at authentication, before any script runs, so a script comparing
+> against it to find "what is new since this user was last here" will always
+> come up empty. The user record's `previousLogin` field holds the prior visit
+> but is not yet exposed to scripts — see issue #208.
+
 ---
 
 ### v3.data

--- a/docs/sysop/users/login-sequence.md
+++ b/docs/sysop/users/login-sequence.md
@@ -15,7 +15,7 @@ The login sequence provides:
 
 ## Configuration
 
-The login sequence is configured in `configs/login.json`. If the file is missing, a built-in default sequence is used (Last Callers, Oneliners, User Stats) to maintain backward compatibility.
+The login sequence is configured in `configs/login.json`. If the file is missing, a built-in default sequence is used (System News, Last Callers, Oneliners, User Stats).
 
 ### Basic Structure
 
@@ -140,13 +140,21 @@ Place this after `VOTEMANDATORY` so standard voting and NUV both run in the same
 
 ### PRINTNEWS
 
-Displays system news items that are new since the user's last login, or flagged as `always` (shown every login). Items are filtered by the user's access level. Each item is displayed using the `NEWSHDR.ANS` header template, followed by its body text. The user presses a key after each item to continue.
+Displays system news items the user has not seen yet, plus any flagged as `always` (shown every login). Items are filtered by the user's access level. Which items a user has seen is tracked per-item on the user record, so an item is not lost if the caller drops before it is displayed. Each item is displayed using the `NEWSHDR.ANS` header template, followed by its body text. The user presses a key after each item to continue.
 
 ```json
 {"command": "PRINTNEWS"}
 ```
 
-If no new news items exist, this step is silently skipped. See [News](menus/news.md) for details on creating and managing news items.
+If no new news items exist, this step is silently skipped. `NEWSHDR.ANS` starts
+with `|CL`, so each item clears the screen itself — do not set `clear_screen` on
+this item, or the screen is wiped even when there is no news to show.
+
+`PRINTNEWS` is part of the shipped `configs/login.json` and of the built-in
+default sequence. Installs created before it was added still have the old
+`login.json`; add the item by hand to enable news at login.
+
+See [News](menus/news.md) for details on creating and managing news items.
 
 ### WHOISONLINE
 
@@ -175,17 +183,19 @@ In this example, `SYSOP_NEWS.ANS` is only shown to users with access level 200 o
 
 ## Examples
 
-### Default (Legacy-Compatible)
-
-This matches the original hard-coded behavior:
+### Default (Used When `login.json` Is Missing)
 
 ```json
 [
+    {"command": "PRINTNEWS"},
     {"command": "LASTCALLS"},
     {"command": "ONELINERS"},
     {"command": "USERSTATS"}
 ]
 ```
+
+`PRINTNEWS` is silent when the user has no unread news, so this behaves like the
+legacy three-item sequence on a system with no news items.
 
 ### Full-Featured Login
 
@@ -265,7 +275,7 @@ The login sequence is loaded at BBS startup from `configs/login.json` and stored
 - **Missing PRIVMAIL area**: NMAILSCAN silently skips if the area is not configured
 - **User disconnect**: Detected via EOF and properly handled (session ends)
 - **Script errors**: RUNDOOR logs the error but continues with the next item
-- **Missing login.json**: The built-in default sequence (LASTCALLS, ONELINERS, USERSTATS) is used
+- **Missing login.json**: The built-in default sequence (PRINTNEWS, LASTCALLS, ONELINERS, USERSTATS) is used
 
 ## Menu System Integration
 

--- a/docs/sysop/users/user-management.md
+++ b/docs/sysop/users/user-management.md
@@ -20,6 +20,7 @@ Users are stored as a JSON array. Each user account contains:
   "accessLevel": 10,
   "flags": "",
   "lastLogin": "2025-05-01T15:13:20Z",
+  "previousLogin": "2025-04-28T09:02:11Z",
   "timesCalled": 220,
   "lastBulletinRead": "0001-01-01T00:00:00Z",
   "realName": "Felonius",
@@ -77,7 +78,10 @@ Users are stored as a JSON array. Each user account contains:
 #### Statistics
 
 - `timesCalled` - Login count
-- `lastLogin` - Last login timestamp
+- `lastLogin` - Timestamp of the **current** session, written at authentication
+- `previousLogin` - Timestamp of the call before this one; what "new since your last visit" is measured against (see below)
+- `seen_news_ids` - System News item IDs already shown to this user
+- `news_seen_initialized` - Whether `seen_news_ids` has been back-filled yet
 - `lastBulletinRead` - Last time bulletins were read
 - `filePoints` - File area points
 - `numUploads` - Number of file uploads
@@ -350,7 +354,21 @@ function, so an account below 255 cannot promote itself from inside the BBS.
 
 - Usernames are case-insensitive for login
 - Passwords are hashed using bcrypt
-- Login increments `timesCalled` and updates `lastLogin`
+- Login increments `timesCalled`, rolls `lastLogin` into `previousLogin`, and sets `lastLogin` to now
+
+#### `lastLogin` vs `previousLogin`
+
+`lastLogin` is stamped with the current time **at authentication** — before the
+login sequence runs and before the user reaches a menu. For the whole session it
+therefore reads as "a moment ago", not as the caller's previous visit.
+
+Anything answering *"what is new since this user was last here?"* must compare
+against `previousLogin` instead. That includes System News, the rumors newscan,
+the file newscan, and the `|LCALL` display placeholder.
+
+`previousLogin` is absent on an account that has not logged in since the field
+was introduced, and is zero for a first-time caller. Treat a zero value as "no
+previous visit" rather than as the epoch — `|LCALL` renders it as `Never`.
 
 ### Adding Users
 

--- a/internal/config/config_login.go
+++ b/internal/config/config_login.go
@@ -47,9 +47,13 @@ func LoadLoginSequence(configPath string) ([]LoginItem, error) {
 	return items, nil
 }
 
-// defaultLoginSequence returns the built-in default login sequence matching legacy behavior.
+// defaultLoginSequence returns the built-in default login sequence used when
+// login.json is missing: system news first (it clears the screen via
+// NEWSHDR.ANS and is silent when there is nothing new), then the legacy
+// last callers / oneliners / user stats trio.
 func defaultLoginSequence() []LoginItem {
 	return []LoginItem{
+		{Command: "PRINTNEWS"},
 		{Command: "LASTCALLS"},
 		{Command: "ONELINERS"},
 		{Command: "USERSTATS"},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -206,11 +206,14 @@ func TestLoadLoginSequence_MissingFile(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	// Should return default sequence
-	if len(result) != 3 {
-		t.Fatalf("expected default 3-item sequence, got %d", len(result))
+	want := []string{"PRINTNEWS", "LASTCALLS", "ONELINERS", "USERSTATS"}
+	if len(result) != len(want) {
+		t.Fatalf("expected default %d-item sequence, got %d", len(want), len(result))
 	}
-	if result[0].Command != "LASTCALLS" {
-		t.Errorf("expected LASTCALLS as first default item, got %s", result[0].Command)
+	for i, cmd := range want {
+		if result[i].Command != cmd {
+			t.Errorf("default item %d: expected %s, got %s", i, cmd, result[i].Command)
+		}
 	}
 }
 

--- a/internal/menu/display_placeholders_test.go
+++ b/internal/menu/display_placeholders_test.go
@@ -1,0 +1,89 @@
+package menu
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+// defaults mirrors the logged-out seed values displayPrompt builds before
+// applyUserPlaceholders runs.
+func placeholderDefaults() map[string]string {
+	return map[string]string{
+		"|UH":     "Guest",
+		"|ALIAS":  "Guest",
+		"|HANDLE": "Guest",
+		"|LEVEL":  "0",
+		"|NAME":   "Guest User",
+		"|GL":     "",
+		"|UN":     "",
+		"|UPLDS":  "0",
+		"|DNLDS":  "0",
+		"|POSTS":  "0",
+		"|CALLS":  "0",
+		"|LCALL":  "Never",
+	}
+}
+
+func TestApplyUserPlaceholders(t *testing.T) {
+	prev := time.Date(2026, 3, 14, 21, 30, 0, 0, time.UTC)
+	u := &user.User{
+		Handle:         "Felonius",
+		RealName:       "Robbie",
+		AccessLevel:    255,
+		GroupLocation:  "Dallas",
+		PrivateNote:    "sysop",
+		NumUploads:     12,
+		NumDownloads:   34,
+		MessagesPosted: 56,
+		TimesCalled:    78,
+		LastLogin:      time.Date(2026, 9, 4, 9, 0, 0, 0, time.UTC), // this session
+		PreviousLogin:  prev,
+	}
+
+	got := placeholderDefaults()
+	applyUserPlaceholders(got, u)
+
+	want := map[string]string{
+		"|UH":     "Felonius",
+		"|ALIAS":  "Felonius",
+		"|HANDLE": "Felonius",
+		"|LEVEL":  "255",
+		"|NAME":   "Robbie",
+		"|GL":     "Dallas",
+		"|UN":     "sysop",
+		"|UPLDS":  "12",
+		"|DNLDS":  "34",
+		"|POSTS":  "56",
+		"|CALLS":  "78",
+		// The previous visit, not this session's login stamp.
+		"|LCALL": "03/14/26",
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("%s = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestApplyUserPlaceholdersFirstCallShowsNever(t *testing.T) {
+	// A first-time caller: LastLogin is already stamped with this session, but
+	// there is no previous visit to report.
+	u := &user.User{Handle: "Newbie", LastLogin: time.Now()}
+
+	got := placeholderDefaults()
+	applyUserPlaceholders(got, u)
+
+	if got["|LCALL"] != "Never" {
+		t.Errorf("|LCALL = %q, want %q for a first-time caller", got["|LCALL"], "Never")
+	}
+}
+
+func TestApplyUserPlaceholdersNilUserKeepsDefaults(t *testing.T) {
+	got := placeholderDefaults()
+	applyUserPlaceholders(got, nil)
+	if got["|UH"] != "Guest" || got["|LCALL"] != "Never" {
+		t.Errorf("nil user mutated defaults: %v", got)
+	}
+}

--- a/internal/menu/executor_display.go
+++ b/internal/menu/executor_display.go
@@ -255,6 +255,33 @@ func (e *MenuExecutor) deliverPendingPages(terminal *term.Terminal, nodeNumber i
 
 // displayPrompt handles rendering the menu prompt, including file includes and placeholder substitution.
 // Added currentAreaName parameter
+// applyUserPlaceholders fills in the placeholders taken straight off the user
+// record. Callers seed the map with logged-out defaults first; every key set
+// here overwrites one of those defaults, except |LCALL, which is deliberately
+// left at "Never" when there is no previous call to report.
+func applyUserPlaceholders(placeholders map[string]string, u *user.User) {
+	if u == nil {
+		return
+	}
+	placeholders["|UH"] = u.Handle
+	placeholders["|ALIAS"] = u.Handle
+	placeholders["|HANDLE"] = u.Handle
+	placeholders["|LEVEL"] = strconv.Itoa(u.AccessLevel)
+	placeholders["|NAME"] = u.RealName
+	placeholders["|GL"] = u.GroupLocation
+	placeholders["|UN"] = u.PrivateNote
+	placeholders["|UPLDS"] = strconv.Itoa(u.NumUploads)
+	placeholders["|DNLDS"] = strconv.Itoa(u.NumDownloads)
+	placeholders["|POSTS"] = strconv.Itoa(u.MessagesPosted)
+	placeholders["|CALLS"] = strconv.Itoa(u.TimesCalled)
+	// PreviousLogin, not LastLogin: Authenticate() stamps LastLogin with "now"
+	// at the start of the session, so |LCALL would otherwise always read as
+	// today. A first-time caller has no previous visit and keeps "Never".
+	if !u.PreviousLogin.IsZero() {
+		placeholders["|LCALL"] = u.PreviousLogin.Format("01/02/06")
+	}
+}
+
 func (e *MenuExecutor) displayPrompt(terminal *term.Terminal, menu *MenuRecord, currentUser *user.User, userManager *user.UserMgr, nodeNumber int, currentMenuName string, sessionStartTime time.Time, outputMode ansi.OutputMode, currentAreaName string) error {
 	promptParts := make([]string, 0, 2)
 	if strings.TrimSpace(menu.Prompt1) != "" {
@@ -334,18 +361,7 @@ func (e *MenuExecutor) displayPrompt(terminal *term.Terminal, menu *MenuRecord, 
 
 	// Populate user-specific placeholders if logged in
 	if currentUser != nil {
-		placeholders["|UH"] = currentUser.Handle
-		placeholders["|ALIAS"] = currentUser.Handle
-		placeholders["|HANDLE"] = currentUser.Handle
-		placeholders["|LEVEL"] = strconv.Itoa(currentUser.AccessLevel)
-		placeholders["|NAME"] = currentUser.RealName
-		placeholders["|GL"] = currentUser.GroupLocation
-		placeholders["|UN"] = currentUser.PrivateNote
-		placeholders["|UPLDS"] = strconv.Itoa(currentUser.NumUploads)
-		placeholders["|CALLS"] = strconv.Itoa(currentUser.TimesCalled)
-		if !currentUser.LastLogin.IsZero() {
-			placeholders["|LCALL"] = currentUser.LastLogin.Format("01/02/06")
-		}
+		applyUserPlaceholders(placeholders, currentUser)
 
 		// Set |CC/|CCN based on user's current message conference
 		if currentUser.CurrentMsgConferenceTag != "" {

--- a/internal/menu/file_newscan.go
+++ b/internal/menu/file_newscan.go
@@ -36,9 +36,10 @@ func runFileNewscan(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	slog.Info("file newscan", "node", nodeNumber, "handle", currentUser.Handle,
-		"last_login", currentUser.LastLogin.Format(time.RFC3339), "args", args)
+		"since", currentUser.PreviousLogin.Format(time.RFC3339), "args", args)
 
-	since := currentUser.LastLogin
+	// PreviousLogin, not LastLogin: the latter is stamped at authentication.
+	since := currentUser.PreviousLogin
 
 	// Determine which areas to scan
 	var areas []file.FileArea

--- a/internal/menu/file_newscan.go
+++ b/internal/menu/file_newscan.go
@@ -38,8 +38,7 @@ func runFileNewscan(c *cmdCtx, args string) (*user.User, string, error) {
 	slog.Info("file newscan", "node", nodeNumber, "handle", currentUser.Handle,
 		"since", currentUser.PreviousLogin.Format(time.RFC3339), "args", args)
 
-	// PreviousLogin, not LastLogin: the latter is stamped at authentication.
-	since := currentUser.PreviousLogin
+	since := newscanSince(currentUser)
 
 	// Determine which areas to scan
 	var areas []file.FileArea

--- a/internal/menu/news.go
+++ b/internal/menu/news.go
@@ -34,6 +34,12 @@ type NewsItem struct {
 // NewsData holds all news items.
 type NewsData struct {
 	Items []NewsItem `json:"items"`
+	// NextID is the monotonic ID allocator. IDs must never be reused: users
+	// carry seen-state keyed by ID, and handing a deleted item's ID to a new
+	// one would hide the new item from everyone who had seen the old.
+	// Deriving IDs from the live list alone is not enough, because deleting
+	// the highest-numbered item frees its ID again.
+	NextID int `json:"next_id,omitempty"`
 }
 
 var newsMu sync.Mutex
@@ -65,22 +71,36 @@ func saveNewsData(rootConfigPath string, nd *NewsData) error {
 	return os.WriteFile(newsFilePath(rootConfigPath), data, 0644)
 }
 
-// nextNewsID returns an unused ID for a new item. IDs must be unique and
-// stable for the life of an item: per-user "already seen" tracking keys off
-// them, and reusing an ID would silently hide a fresh item.
-func nextNewsID(items []NewsItem) int {
-	max := 0
-	for _, it := range items {
-		if it.ID > max {
-			max = it.ID
+// allocNewsID reserves the next unused ID and advances the allocator. IDs are
+// never reused, including after the highest-numbered item is deleted.
+//
+// The floor is taken from the live items as well as NextID so that news.json
+// files written before NextID existed cannot collide on the first allocation.
+func allocNewsID(nd *NewsData) int {
+	id := nd.NextID
+	for _, it := range nd.Items {
+		if it.ID >= id {
+			id = it.ID + 1
 		}
 	}
-	return max + 1
+	if id < 1 {
+		id = 1
+	}
+	nd.NextID = id + 1
+	return id
 }
 
 // normalizeNewsIDs assigns unique IDs to items missing one (ID <= 0) or
 // sharing one with an earlier item. Earlier entries keep their ID so existing
 // seen-sets stay valid. Reports whether anything changed.
+//
+// Repaired items draw from the monotonic allocator rather than filling the
+// lowest free gap: a gap usually means a deleted item, and reusing its number
+// would hide the repaired item from every user who had seen the original.
+//
+// This is deterministic for a given file, so callers that cannot write (user
+// sessions) may normalize in memory and still agree with what the sysop editor
+// eventually persists.
 func normalizeNewsIDs(nd *NewsData) bool {
 	used := make(map[int]bool, len(nd.Items))
 	changed := false
@@ -90,12 +110,12 @@ func normalizeNewsIDs(nd *NewsData) bool {
 			used[id] = true
 			continue
 		}
-		next := 1
-		for used[next] {
-			next++
+		fresh := allocNewsID(nd)
+		for used[fresh] {
+			fresh = allocNewsID(nd)
 		}
-		nd.Items[i].ID = next
-		used[next] = true
+		nd.Items[i].ID = fresh
+		used[fresh] = true
 		changed = true
 	}
 	return changed
@@ -247,6 +267,11 @@ func runPrintNews(c *cmdCtx, args string) (*user.User, string, error) {
 		slog.Warn("failed to load news data", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
 	}
+	// Repair duplicate or missing IDs in memory. Seen-state is keyed by ID, so
+	// duplicates would collapse several items under one key. This is
+	// deterministic for a given file, so every session agrees; only the sysop
+	// editor writes the repair back to disk.
+	normalizeNewsIDs(nd)
 
 	userLevel := currentUser.AccessLevel
 	seen := newsSeenSet(currentUser, nd.Items)
@@ -332,9 +357,18 @@ func runListNews(c *cmdCtx, args string) (*user.User, string, error) {
 		wv(terminal, "\r\n|04Error loading news.\r\n", outputMode)
 		return currentUser, "", nil
 	}
+	normalizeNewsIDs(nd)
 
 	userLevel := currentUser.AccessLevel
 	seen := newsSeenSet(currentUser, nd.Items)
+	// Reaching the list before ever reaching PRINTNEWS still counts as the
+	// user's first contact with seen-tracking; without the back-fill here the
+	// entire backlog would be tagged [NEW].
+	backfilled := false
+	if !currentUser.NewsSeenInitialized {
+		initNewsSeen(currentUser, nd.Items, seen)
+		backfilled = true
+	}
 	var visible []int
 	for i, item := range nd.Items {
 		if userLevel < item.Level {
@@ -369,7 +403,7 @@ func runListNews(c *cmdCtx, args string) (*user.User, string, error) {
 	// Reading an item here counts as having seen it, so it does not reappear
 	// at the next login.
 	saveSeen := func() {
-		if storeNewsSeen(currentUser, seen) && c.userManager != nil {
+		if (storeNewsSeen(currentUser, seen) || backfilled) && c.userManager != nil {
 			if err := c.userManager.UpdateUser(currentUser); err != nil {
 				slog.Error("failed to save news seen-set", "node", nodeNumber, "handle", currentUser.Handle, "error", err)
 			}

--- a/internal/menu/news.go
+++ b/internal/menu/news.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
 	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 	"golang.org/x/term"
@@ -155,6 +156,36 @@ func initNewsSeen(u *user.User, items []NewsItem, seen map[int]bool) {
 		}
 	}
 	u.NewsSeenInitialized = true
+}
+
+// WarnIfNewsUnwired logs a one-time startup warning when the system has news
+// items to show but no PRINTNEWS step to show them with.
+//
+// PRINTNEWS ships in the default login sequence, but setup only copies a
+// template config when the target file does not already exist, so a system
+// installed before PRINTNEWS was added keeps its old configs/login.json and
+// silently never displays news. There is no config migration framework, and
+// rewriting a sysop-owned file to add the step would not be able to tell
+// "never had it" from "deliberately removed it" — so this only reports.
+func WarnIfNewsUnwired(rootConfigPath string, loginSequence []config.LoginItem) {
+	for _, item := range loginSequence {
+		if strings.EqualFold(item.Command, "PRINTNEWS") {
+			return
+		}
+	}
+
+	newsMu.Lock()
+	nd, err := loadNewsData(rootConfigPath)
+	newsMu.Unlock()
+	if err != nil || len(nd.Items) == 0 {
+		// No news to show, so nothing is being missed.
+		return
+	}
+
+	slog.Warn("system news items exist but will never be displayed at login",
+		"items", len(nd.Items),
+		"reason", "the login sequence has no PRINTNEWS step",
+		"fix", `add {"command": "PRINTNEWS"} to configs/login.json`)
 }
 
 // displayNewsItem renders NEWSHDR.ANS with substitution vars, then the body text.

--- a/internal/menu/news.go
+++ b/internal/menu/news.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -63,6 +64,99 @@ func saveNewsData(rootConfigPath string, nd *NewsData) error {
 	return os.WriteFile(newsFilePath(rootConfigPath), data, 0644)
 }
 
+// nextNewsID returns an unused ID for a new item. IDs must be unique and
+// stable for the life of an item: per-user "already seen" tracking keys off
+// them, and reusing an ID would silently hide a fresh item.
+func nextNewsID(items []NewsItem) int {
+	max := 0
+	for _, it := range items {
+		if it.ID > max {
+			max = it.ID
+		}
+	}
+	return max + 1
+}
+
+// normalizeNewsIDs assigns unique IDs to items missing one (ID <= 0) or
+// sharing one with an earlier item. Earlier entries keep their ID so existing
+// seen-sets stay valid. Reports whether anything changed.
+func normalizeNewsIDs(nd *NewsData) bool {
+	used := make(map[int]bool, len(nd.Items))
+	changed := false
+	for i := range nd.Items {
+		id := nd.Items[i].ID
+		if id > 0 && !used[id] {
+			used[id] = true
+			continue
+		}
+		next := 1
+		for used[next] {
+			next++
+		}
+		nd.Items[i].ID = next
+		used[next] = true
+		changed = true
+	}
+	return changed
+}
+
+// newsSeenSet rebuilds the user's seen-ID set, dropping IDs for items that no
+// longer exist so the list cannot grow without bound as news is deleted.
+func newsSeenSet(u *user.User, items []NewsItem) map[int]bool {
+	live := make(map[int]bool, len(items))
+	for _, it := range items {
+		if it.ID > 0 {
+			live[it.ID] = true
+		}
+	}
+	seen := make(map[int]bool, len(u.SeenNewsIDs))
+	for _, id := range u.SeenNewsIDs {
+		if live[id] {
+			seen[id] = true
+		}
+	}
+	return seen
+}
+
+// storeNewsSeen writes the seen set back to the user in a stable order and
+// reports whether the stored value actually changed.
+func storeNewsSeen(u *user.User, seen map[int]bool) bool {
+	ids := make([]int, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	sort.Ints(ids)
+	if len(ids) == len(u.SeenNewsIDs) {
+		same := true
+		for i, id := range ids {
+			if u.SeenNewsIDs[i] != id {
+				same = false
+				break
+			}
+		}
+		if same {
+			return false
+		}
+	}
+	if len(ids) == 0 {
+		ids = nil
+	}
+	u.SeenNewsIDs = ids
+	return true
+}
+
+// initNewsSeen back-fills the seen set for a user who predates seen-tracking:
+// everything posted on or before their previous visit counts as already read,
+// so upgrading systems do not dump the whole news backlog on the next login.
+func initNewsSeen(u *user.User, items []NewsItem, seen map[int]bool) {
+	for _, it := range items {
+		if it.ID > 0 && !it.Always && !it.When.After(u.PreviousLogin) {
+			seen[it.ID] = true
+		}
+	}
+	u.NewsSeenInitialized = true
+}
+
 // displayNewsItem renders NEWSHDR.ANS with substitution vars, then the body text.
 // Substitution vars (V2-compatible mapping):
 //
@@ -97,8 +191,10 @@ func displayNewsItem(e *MenuExecutor, terminal *term.Terminal, item *NewsItem, i
 	}
 }
 
-// runPrintNews displays news items new since last login (or Always-flagged items).
-// Maps to V2's PrintNews(0, True) called at login.
+// runPrintNews displays news items the user has not seen yet, plus any
+// Always-flagged items. Maps to V2's PrintNews(0, True) called at login,
+// except that "unseen" is tracked per user by item ID instead of by date, so
+// an item is not lost when a login is aborted before it is displayed.
 func runPrintNews(c *cmdCtx, args string) (*user.User, string, error) {
 	e := c.e
 	s := c.s
@@ -121,10 +217,17 @@ func runPrintNews(c *cmdCtx, args string) (*user.User, string, error) {
 		return currentUser, "", nil
 	}
 
-	lastLogin := currentUser.LastLogin
 	userLevel := currentUser.AccessLevel
-	shown := 0
+	seen := newsSeenSet(currentUser, nd.Items)
+	dirty := false
+	if !currentUser.NewsSeenInitialized {
+		// First run for this user: treat the existing backlog as read so an
+		// upgrading system does not dump every old item on the next login.
+		initNewsSeen(currentUser, nd.Items, seen)
+		dirty = true
+	}
 
+	shown := 0
 	for i, item := range nd.Items {
 		if userLevel < item.Level {
 			continue
@@ -132,13 +235,39 @@ func runPrintNews(c *cmdCtx, args string) (*user.User, string, error) {
 		if item.MaxLevel > 0 && userLevel > item.MaxLevel {
 			continue
 		}
-		// V2 logic: show if Always, or newer than last login, or no prior login
-		if !item.Always && !lastLogin.IsZero() && !item.When.After(lastLogin) {
-			continue
+		// Always-items reappear every login and are never marked seen.
+		// Everything else shows exactly once, tracked by ID rather than by
+		// date, so an item survives a dropped connection or a fast login and
+		// is still waiting on the next call.
+		if !item.Always {
+			if item.ID <= 0 {
+				// Untracked item (pre-normalization data): fall back to the
+				// date filter rather than repeating it every single login.
+				if !currentUser.PreviousLogin.IsZero() && !item.When.After(currentUser.PreviousLogin) {
+					continue
+				}
+			} else if seen[item.ID] {
+				continue
+			}
 		}
+
 		displayNewsItem(e, terminal, &nd.Items[i], i+1, outputMode)
 		e.holdScreen(s, terminal, outputMode, termWidth, termHeight)
 		shown++
+
+		if !item.Always && item.ID > 0 {
+			seen[item.ID] = true
+		}
+	}
+
+	if storeNewsSeen(currentUser, seen) {
+		dirty = true
+	}
+	if dirty && c.userManager != nil {
+		if err := c.userManager.UpdateUser(currentUser); err != nil {
+			// Non-fatal: the items simply show again next login.
+			slog.Error("failed to save news seen-set", "node", nodeNumber, "handle", currentUser.Handle, "error", err)
+		}
 	}
 
 	if shown > 0 {
@@ -174,6 +303,7 @@ func runListNews(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	userLevel := currentUser.AccessLevel
+	seen := newsSeenSet(currentUser, nd.Items)
 	var visible []int
 	for i, item := range nd.Items {
 		if userLevel < item.Level {
@@ -196,7 +326,7 @@ func runListNews(c *cmdCtx, args string) (*user.User, string, error) {
 		for rank, idx := range visible {
 			item := nd.Items[idx]
 			newTag := "      "
-			if item.When.After(currentUser.LastLogin) {
+			if !item.Always && item.ID > 0 && !seen[item.ID] {
 				newTag = "|12[NEW]|07"
 			}
 			wv(terminal, fmt.Sprintf("  |11%2d|07. |15%-28s |07%s |11%s\r\n",
@@ -205,12 +335,23 @@ func runListNews(c *cmdCtx, args string) (*user.User, string, error) {
 		wv(terminal, "|08"+strings.Repeat("\xc4", 70)+"\r\n", outputMode)
 	}
 
+	// Reading an item here counts as having seen it, so it does not reappear
+	// at the next login.
+	saveSeen := func() {
+		if storeNewsSeen(currentUser, seen) && c.userManager != nil {
+			if err := c.userManager.UpdateUser(currentUser); err != nil {
+				slog.Error("failed to save news seen-set", "node", nodeNumber, "handle", currentUser.Handle, "error", err)
+			}
+		}
+	}
+
 	showList()
 	for {
 		prompt := fmt.Sprintf("|07Read which item |15[|111-%d|15]|07, or |15ENTER|07 to continue: ", len(visible))
 		wv(terminal, prompt, outputMode)
 		input, err := readLineFromSessionIH(s, terminal)
 		if err != nil || strings.TrimSpace(input) == "" {
+			saveSeen()
 			return currentUser, "", nil
 		}
 		n, nerr := strconv.Atoi(strings.TrimSpace(input))
@@ -220,6 +361,9 @@ func runListNews(c *cmdCtx, args string) (*user.User, string, error) {
 		}
 		idx := visible[n-1]
 		displayNewsItem(e, terminal, &nd.Items[idx], n, outputMode)
+		if item := nd.Items[idx]; !item.Always && item.ID > 0 {
+			seen[item.ID] = true
+		}
 		e.holdScreen(s, terminal, outputMode, termWidth, termHeight)
 		showList()
 	}

--- a/internal/menu/news_edit.go
+++ b/internal/menu/news_edit.go
@@ -160,7 +160,7 @@ func newsAddItem(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 		return
 	}
 	item := NewsItem{
-		ID:       nextNewsID(fresh.Items),
+		ID:       allocNewsID(fresh),
 		Title:    title,
 		From:     from,
 		When:     time.Now(),

--- a/internal/menu/news_edit.go
+++ b/internal/menu/news_edit.go
@@ -36,6 +36,13 @@ func runEditNews(c *cmdCtx, args string) (*user.User, string, error) {
 
 		newsMu.Lock()
 		nd, err := loadNewsData(e.RootConfigPath)
+		if err == nil && normalizeNewsIDs(nd) {
+			// Repair data written before IDs were required to be unique;
+			// best-effort, non-fatal.
+			if saveErr := saveNewsData(e.RootConfigPath, nd); saveErr != nil {
+				slog.Warn("failed to persist normalized news IDs", "error", saveErr)
+			}
+		}
 		newsMu.Unlock()
 		if err != nil {
 			wv(terminal, "\r\n|04Error loading news.\r\n", outputMode)
@@ -153,7 +160,7 @@ func newsAddItem(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 		return
 	}
 	item := NewsItem{
-		ID:       len(fresh.Items) + 1,
+		ID:       nextNewsID(fresh.Items),
 		Title:    title,
 		From:     from,
 		When:     time.Now(),

--- a/internal/menu/news_seen_test.go
+++ b/internal/menu/news_seen_test.go
@@ -14,13 +14,35 @@ import (
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 )
 
-func TestNextNewsIDSurvivesDeletion(t *testing.T) {
-	items := []NewsItem{{ID: 3}, {ID: 1}}
-	if got := nextNewsID(items); got != 4 {
-		t.Fatalf("nextNewsID = %d, want 4 (must not reuse a live ID)", got)
+func TestAllocNewsIDNeverReuses(t *testing.T) {
+	nd := &NewsData{Items: []NewsItem{{ID: 3}, {ID: 1}}}
+	if got := allocNewsID(nd); got != 4 {
+		t.Fatalf("allocNewsID = %d, want 4 (must not reuse a live ID)", got)
 	}
-	if got := nextNewsID(nil); got != 1 {
-		t.Fatalf("nextNewsID(nil) = %d, want 1", got)
+
+	// The regression this exists for: deleting the highest-numbered item must
+	// not free its ID, or a user holding it in their seen-set never sees the
+	// replacement.
+	nd.Items = []NewsItem{{ID: 1}} // sysop deletes 3 (and the just-allocated 4)
+	if got := allocNewsID(nd); got == 3 || got == 4 {
+		t.Fatalf("allocNewsID reused a retired ID: %d", got)
+	}
+
+	empty := &NewsData{}
+	if got := allocNewsID(empty); got != 1 {
+		t.Fatalf("first ID on an empty file = %d, want 1", got)
+	}
+	if got := allocNewsID(empty); got != 2 {
+		t.Fatalf("second ID = %d, want 2", got)
+	}
+}
+
+// A news.json written before NextID existed has no allocator value; the first
+// allocation must still clear every live ID.
+func TestAllocNewsIDLegacyFileWithoutNextID(t *testing.T) {
+	nd := &NewsData{Items: []NewsItem{{ID: 7}, {ID: 2}}} // NextID zero
+	if got := allocNewsID(nd); got != 8 {
+		t.Fatalf("allocNewsID on a legacy file = %d, want 8", got)
 	}
 }
 
@@ -42,6 +64,13 @@ func TestNormalizeNewsIDs(t *testing.T) {
 	// The first holder of an ID keeps it so existing seen-sets stay valid.
 	if nd.Items[0].ID != 2 || nd.Items[3].ID != 5 {
 		t.Fatalf("normalization moved IDs it should have kept: %+v", nd.Items)
+	}
+	// Repaired items must not be given a low free number like 1 or 3: those
+	// gaps usually mean a deleted item whose ID users may still be holding.
+	for _, i := range []int{1, 2} {
+		if nd.Items[i].ID <= 5 {
+			t.Errorf("repaired item %d got recycled ID %d; expected a fresh one above 5", i, nd.Items[i].ID)
+		}
 	}
 	if normalizeNewsIDs(nd) {
 		t.Fatal("normalizeNewsIDs is not idempotent")

--- a/internal/menu/news_seen_test.go
+++ b/internal/menu/news_seen_test.go
@@ -1,9 +1,16 @@
 package menu
 
 import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 )
 
@@ -105,5 +112,74 @@ func TestInitNewsSeenNewUserSeesEverything(t *testing.T) {
 	initNewsSeen(u, []NewsItem{{ID: 1, When: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)}}, seen)
 	if seen[1] {
 		t.Error("first-time caller should not have news marked as already seen")
+	}
+}
+
+// newsWarningFor writes newsItems to a temp system and returns whatever
+// WarnIfNewsUnwired logged for the given login sequence.
+func newsWarningFor(t *testing.T, newsItems []NewsItem, seq []config.LoginItem) string {
+	t.Helper()
+
+	root := t.TempDir()
+	configPath := filepath.Join(root, "configs")
+	dataPath := filepath.Join(root, "data")
+	for _, d := range []string{configPath, dataPath} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	if newsItems != nil {
+		body, err := json.Marshal(NewsData{Items: newsItems})
+		if err != nil {
+			t.Fatalf("marshal news: %v", err)
+		}
+		// newsFilePath resolves to <configPath>/../data/news.json
+		if err := os.WriteFile(filepath.Join(dataPath, "news.json"), body, 0o644); err != nil {
+			t.Fatalf("write news.json: %v", err)
+		}
+	}
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	defer slog.SetDefault(prev)
+
+	WarnIfNewsUnwired(configPath, seq)
+	return buf.String()
+}
+
+func TestWarnIfNewsUnwiredFiresWhenNewsIsStranded(t *testing.T) {
+	got := newsWarningFor(t,
+		[]NewsItem{{ID: 1, Title: "Welcome"}},
+		[]config.LoginItem{{Command: "LASTCALLS"}, {Command: "USERSTATS"}})
+
+	if !strings.Contains(got, "never be displayed at login") {
+		t.Errorf("expected a warning about stranded news, got %q", got)
+	}
+	if !strings.Contains(got, "PRINTNEWS") {
+		t.Errorf("warning should name the fix, got %q", got)
+	}
+}
+
+func TestWarnIfNewsUnwiredSilentWhenWired(t *testing.T) {
+	// Command matching is case-insensitive: LoadLoginSequence upper-cases, but
+	// a hand-edited file read by another path may not have been normalized.
+	for _, cmd := range []string{"PRINTNEWS", "printnews"} {
+		got := newsWarningFor(t,
+			[]NewsItem{{ID: 1, Title: "Welcome"}},
+			[]config.LoginItem{{Command: "LASTCALLS"}, {Command: cmd}})
+		if got != "" {
+			t.Errorf("command %q: expected silence, got %q", cmd, got)
+		}
+	}
+}
+
+func TestWarnIfNewsUnwiredSilentWhenNoNews(t *testing.T) {
+	// Nothing is being missed on a system with no news, wired or not.
+	if got := newsWarningFor(t, nil, []config.LoginItem{{Command: "LASTCALLS"}}); got != "" {
+		t.Errorf("no news.json: expected silence, got %q", got)
+	}
+	if got := newsWarningFor(t, []NewsItem{}, []config.LoginItem{{Command: "LASTCALLS"}}); got != "" {
+		t.Errorf("empty news.json: expected silence, got %q", got)
 	}
 }

--- a/internal/menu/news_seen_test.go
+++ b/internal/menu/news_seen_test.go
@@ -1,0 +1,109 @@
+package menu
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+func TestNextNewsIDSurvivesDeletion(t *testing.T) {
+	items := []NewsItem{{ID: 3}, {ID: 1}}
+	if got := nextNewsID(items); got != 4 {
+		t.Fatalf("nextNewsID = %d, want 4 (must not reuse a live ID)", got)
+	}
+	if got := nextNewsID(nil); got != 1 {
+		t.Fatalf("nextNewsID(nil) = %d, want 1", got)
+	}
+}
+
+func TestNormalizeNewsIDs(t *testing.T) {
+	nd := &NewsData{Items: []NewsItem{{ID: 2}, {ID: 2}, {ID: 0}, {ID: 5}}}
+	if !normalizeNewsIDs(nd) {
+		t.Fatal("expected normalizeNewsIDs to report a change")
+	}
+	seen := map[int]bool{}
+	for _, it := range nd.Items {
+		if it.ID <= 0 {
+			t.Fatalf("item left with non-positive ID: %+v", it)
+		}
+		if seen[it.ID] {
+			t.Fatalf("duplicate ID %d after normalization", it.ID)
+		}
+		seen[it.ID] = true
+	}
+	// The first holder of an ID keeps it so existing seen-sets stay valid.
+	if nd.Items[0].ID != 2 || nd.Items[3].ID != 5 {
+		t.Fatalf("normalization moved IDs it should have kept: %+v", nd.Items)
+	}
+	if normalizeNewsIDs(nd) {
+		t.Fatal("normalizeNewsIDs is not idempotent")
+	}
+}
+
+func TestNewsSeenSetPrunesDeletedItems(t *testing.T) {
+	u := &user.User{SeenNewsIDs: []int{1, 2, 9}}
+	seen := newsSeenSet(u, []NewsItem{{ID: 1}, {ID: 2}})
+	if !seen[1] || !seen[2] {
+		t.Fatal("live IDs dropped from seen set")
+	}
+	if seen[9] {
+		t.Fatal("ID 9 has no live item and should have been pruned")
+	}
+}
+
+func TestStoreNewsSeenReportsChange(t *testing.T) {
+	u := &user.User{}
+	if !storeNewsSeen(u, map[int]bool{2: true, 1: true}) {
+		t.Fatal("expected first store to report a change")
+	}
+	if got := u.SeenNewsIDs; len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Fatalf("SeenNewsIDs = %v, want sorted [1 2]", got)
+	}
+	if storeNewsSeen(u, map[int]bool{1: true, 2: true}) {
+		t.Fatal("storing an identical set should report no change")
+	}
+	if !storeNewsSeen(u, map[int]bool{}) {
+		t.Fatal("clearing the set should report a change")
+	}
+	if u.SeenNewsIDs != nil {
+		t.Fatalf("empty set should store as nil, got %v", u.SeenNewsIDs)
+	}
+}
+
+func TestInitNewsSeenBackfillsOnlyOlderItems(t *testing.T) {
+	prev := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	items := []NewsItem{
+		{ID: 1, When: prev.Add(-24 * time.Hour)}, // before last visit -> seen
+		{ID: 2, When: prev.Add(24 * time.Hour)},  // after last visit  -> unseen
+		{ID: 3, When: prev.Add(-24 * time.Hour), Always: true},
+	}
+
+	u := &user.User{PreviousLogin: prev}
+	seen := map[int]bool{}
+	initNewsSeen(u, items, seen)
+
+	if !u.NewsSeenInitialized {
+		t.Fatal("NewsSeenInitialized not set")
+	}
+	if !seen[1] {
+		t.Error("item posted before the previous visit should be back-filled as seen")
+	}
+	if seen[2] {
+		t.Error("item posted after the previous visit must stay unseen")
+	}
+	if seen[3] {
+		t.Error("always-items are never recorded as seen")
+	}
+}
+
+func TestInitNewsSeenNewUserSeesEverything(t *testing.T) {
+	// A brand-new account has a zero PreviousLogin: nothing is back-filled,
+	// so the full news list is waiting on the first call.
+	u := &user.User{}
+	seen := map[int]bool{}
+	initNewsSeen(u, []NewsItem{{ID: 1, When: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)}}, seen)
+	if seen[1] {
+		t.Error("first-time caller should not have news marked as already seen")
+	}
+}

--- a/internal/menu/newscan_cutoff.go
+++ b/internal/menu/newscan_cutoff.go
@@ -1,0 +1,32 @@
+package menu
+
+import (
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+// newscanSince returns the timestamp that "new since your last visit" is
+// measured from.
+//
+// This is deliberately PreviousLogin and not LastLogin. Authenticate() stamps
+// LastLogin with time.Now() at the start of the session, before the login
+// sequence runs, so comparing against it means "new in the last few seconds"
+// and never matches anything. Every newscan-style feature — system news,
+// rumors, the file newscan — must use this.
+func newscanSince(u *user.User) time.Time {
+	if u == nil {
+		return time.Time{}
+	}
+	return u.PreviousLogin
+}
+
+// isNewSince reports whether something posted at postedAt should count as new
+// for a caller whose last visit was since. A zero cutoff means the user has no
+// previous visit, so everything is new to them.
+func isNewSince(postedAt, since time.Time) bool {
+	if since.IsZero() {
+		return true
+	}
+	return postedAt.After(since)
+}

--- a/internal/menu/newscan_cutoff_test.go
+++ b/internal/menu/newscan_cutoff_test.go
@@ -1,0 +1,87 @@
+package menu
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+// The regression this guards: LastLogin is stamped with now() at
+// authentication, so any newscan comparing against it finds nothing. The
+// cutoff must come from PreviousLogin.
+func TestNewscanSinceUsesPreviousLoginNotLastLogin(t *testing.T) {
+	prev := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	u := &user.User{
+		LastLogin:     time.Now(), // this session, as Authenticate leaves it
+		PreviousLogin: prev,
+	}
+
+	got := newscanSince(u)
+	if !got.Equal(prev) {
+		t.Fatalf("newscanSince = %v, want PreviousLogin %v", got, prev)
+	}
+	if got.Equal(u.LastLogin) {
+		t.Error("newscanSince returned LastLogin; newscans would never find anything")
+	}
+}
+
+func TestNewscanSinceFirstTimeCallerAndNilUser(t *testing.T) {
+	// First call: LastLogin already stamped, but no previous visit.
+	u := &user.User{LastLogin: time.Now()}
+	if got := newscanSince(u); !got.IsZero() {
+		t.Errorf("first-time caller cutoff = %v, want zero", got)
+	}
+	if got := newscanSince(nil); !got.IsZero() {
+		t.Errorf("nil user cutoff = %v, want zero", got)
+	}
+}
+
+func TestIsNewSince(t *testing.T) {
+	cut := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name     string
+		postedAt time.Time
+		since    time.Time
+		want     bool
+	}{
+		{"posted after the last visit is new", cut.Add(time.Hour), cut, true},
+		{"posted before the last visit is not", cut.Add(-time.Hour), cut, false},
+		{"posted exactly at the cutoff is not new", cut, cut, false},
+		{"zero cutoff means everything is new", cut.Add(-9999 * time.Hour), time.Time{}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isNewSince(c.postedAt, c.since); got != c.want {
+				t.Errorf("isNewSince(%v, %v) = %v, want %v", c.postedAt, c.since, got, c.want)
+			}
+		})
+	}
+}
+
+// End-to-end shape of the bug for a rumors/file newscan style filter: with a
+// user as Authenticate leaves them, items posted since the previous visit must
+// still be found.
+func TestNewscanFiltersFindItemsPostedSincePreviousVisit(t *testing.T) {
+	prev := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	u := &user.User{LastLogin: time.Now(), PreviousLogin: prev}
+	since := newscanSince(u)
+
+	posted := []time.Time{
+		prev.Add(-48 * time.Hour), // old
+		prev.Add(-time.Second),    // just before the visit
+		prev.Add(time.Second),     // just after: new
+		prev.Add(24 * time.Hour),  // new
+	}
+
+	found := 0
+	for _, p := range posted {
+		if isNewSince(p, since) {
+			found++
+		}
+	}
+	if found != 2 {
+		t.Errorf("found %d new items, want 2 — the cutoff is wrong", found)
+	}
+}

--- a/internal/menu/rumors.go
+++ b/internal/menu/rumors.go
@@ -169,14 +169,13 @@ func runRumorsNewscan(c *cmdCtx, args string) (*user.User, string, error) {
 
 	wv(terminal, "\r\n|15Rumors Newscan\r\n|08"+strings.Repeat("\xc4", 50)+"\r\n", outputMode)
 
-	// PreviousLogin, not LastLogin: the latter is stamped at authentication.
-	lastLogin := currentUser.PreviousLogin
+	since := newscanSince(currentUser)
 	found := 0
 	for _, r := range rd.Rumors {
 		if userLevel < r.MinLevel {
 			continue
 		}
-		if !r.PostedAt.After(lastLogin) && !lastLogin.IsZero() {
+		if !isNewSince(r.PostedAt, since) {
 			continue
 		}
 		found++

--- a/internal/menu/rumors.go
+++ b/internal/menu/rumors.go
@@ -169,7 +169,8 @@ func runRumorsNewscan(c *cmdCtx, args string) (*user.User, string, error) {
 
 	wv(terminal, "\r\n|15Rumors Newscan\r\n|08"+strings.Repeat("\xc4", 50)+"\r\n", outputMode)
 
-	lastLogin := currentUser.LastLogin
+	// PreviousLogin, not LastLogin: the latter is stamped at authentication.
+	lastLogin := currentUser.PreviousLogin
 	found := 0
 	for _, r := range rd.Rumors {
 		if userLevel < r.MinLevel {

--- a/internal/user/manager_auth.go
+++ b/internal/user/manager_auth.go
@@ -50,6 +50,12 @@ func (um *UserMgr) Authenticate(handle, password string) (*User, bool) {
 	user.PreviousLogin = user.LastLogin
 	user.LastLogin = time.Now()
 	user.TimesCalled++
+	// Snapshot under the same lock that set the fields. Re-reading after the
+	// unlock would let a concurrent login for this handle overwrite
+	// PreviousLogin first, and this session would then measure "new since your
+	// last visit" against the other session's timestamp — hiding news, rumors
+	// and files posted since this caller was actually last on.
+	userCopy := *user
 	um.mu.Unlock()
 
 	// Save outside the write lock to avoid blocking other user operations
@@ -57,10 +63,6 @@ func (um *UserMgr) Authenticate(handle, password string) (*User, bool) {
 		slog.Error("failed to save user data after login", "handle", handle, "error", err)
 	}
 
-	// Return a copy
-	um.mu.RLock()
-	userCopy := *um.users[lowerHandle]
-	um.mu.RUnlock()
 	return &userCopy, true
 }
 

--- a/internal/user/manager_auth.go
+++ b/internal/user/manager_auth.go
@@ -44,6 +44,10 @@ func (um *UserMgr) Authenticate(handle, password string) (*User, bool) {
 		um.mu.Unlock()
 		return nil, false
 	}
+	// Preserve the prior login stamp before overwriting it; "new since last
+	// login" checks during the login sequence need the previous visit, not
+	// this one.
+	user.PreviousLogin = user.LastLogin
 	user.LastLogin = time.Now()
 	user.TimesCalled++
 	um.mu.Unlock()

--- a/internal/user/manager_auth_previouslogin_test.go
+++ b/internal/user/manager_auth_previouslogin_test.go
@@ -1,0 +1,95 @@
+package user
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+func seedAuthUser(t *testing.T, handle, password string, lastLogin time.Time) *UserMgr {
+	t.Helper()
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("bcrypt: %v", err)
+	}
+	um := NewUserMgrForTest(&User{
+		ID:           1,
+		Handle:       handle,
+		PasswordHash: string(hash),
+		LastLogin:    lastLogin,
+	})
+	um.path = t.TempDir()
+	return um
+}
+
+// Authenticate must roll the old LastLogin into PreviousLogin. Everything that
+// asks "what is new since this user was last here?" depends on it — LastLogin
+// itself is overwritten with now() before the login sequence even runs.
+func TestAuthenticateRollsLastLoginIntoPreviousLogin(t *testing.T) {
+	prior := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	um := seedAuthUser(t, "Tester", "pw123456", prior)
+
+	got, ok := um.Authenticate("Tester", "pw123456")
+	if !ok {
+		t.Fatal("authentication failed")
+	}
+	if !got.PreviousLogin.Equal(prior) {
+		t.Errorf("PreviousLogin = %v, want the prior stamp %v", got.PreviousLogin, prior)
+	}
+	if !got.LastLogin.After(prior) {
+		t.Errorf("LastLogin = %v, expected it to advance past %v", got.LastLogin, prior)
+	}
+	// The distinction the whole feature rests on.
+	if got.LastLogin.Equal(got.PreviousLogin) {
+		t.Error("LastLogin and PreviousLogin must not be the same instant")
+	}
+}
+
+// A first-time caller has no prior visit, so PreviousLogin stays zero and
+// callers can treat that as "never here before".
+func TestAuthenticateFirstLoginHasZeroPreviousLogin(t *testing.T) {
+	um := seedAuthUser(t, "Newbie", "pw123456", time.Time{})
+
+	got, ok := um.Authenticate("Newbie", "pw123456")
+	if !ok {
+		t.Fatal("authentication failed")
+	}
+	if !got.PreviousLogin.IsZero() {
+		t.Errorf("PreviousLogin = %v, want zero for a first-time caller", got.PreviousLogin)
+	}
+}
+
+// The returned record is snapshotted under the lock that wrote it. Re-reading
+// after unlocking would let a concurrent login for the same handle overwrite
+// PreviousLogin first, and that session would then measure "new since your
+// last visit" against another session's timestamp.
+func TestAuthenticateSnapshotIsSelfConsistent(t *testing.T) {
+	prior := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	um := seedAuthUser(t, "Racer", "pw123456", prior)
+
+	const n = 8
+	var wg sync.WaitGroup
+	results := make([]*User, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if u, ok := um.Authenticate("Racer", "pw123456"); ok {
+				results[i] = u
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for i, u := range results {
+		if u == nil {
+			t.Fatalf("session %d failed to authenticate", i)
+		}
+		if !u.PreviousLogin.Before(u.LastLogin) {
+			t.Errorf("session %d: PreviousLogin %v is not before its own LastLogin %v",
+				i, u.PreviousLogin, u.LastLogin)
+		}
+	}
+}

--- a/internal/user/user.go
+++ b/internal/user/user.go
@@ -16,14 +16,20 @@ type LoginEvent struct {
 
 // User represents a user account.
 type User struct {
-	ID               int       `json:"id"`           // Added User ID for ACS 'U' check
-	PasswordHash     string    `json:"passwordHash"` // Changed from []byte to string
-	Handle           string    `json:"handle"`
-	LegacyUsername   string    `json:"username,omitempty"` // Migration only: used during load when Handle is absent; cleared on save
-	AccessLevel      int       `json:"accessLevel"`
-	Flags            string    `json:"flags"`                // Added Flags string for ACS 'F' check (e.g., "XYZ")
-	PublicKeys       []string  `json:"publicKeys,omitempty"` // OpenSSH authorized_keys lines authorized for WFC admin
-	LastLogin        time.Time `json:"lastLogin"`
+	ID             int       `json:"id"`           // Added User ID for ACS 'U' check
+	PasswordHash   string    `json:"passwordHash"` // Changed from []byte to string
+	Handle         string    `json:"handle"`
+	LegacyUsername string    `json:"username,omitempty"` // Migration only: used during load when Handle is absent; cleared on save
+	AccessLevel    int       `json:"accessLevel"`
+	Flags          string    `json:"flags"`                // Added Flags string for ACS 'F' check (e.g., "XYZ")
+	PublicKeys     []string  `json:"publicKeys,omitempty"` // OpenSSH authorized_keys lines authorized for WFC admin
+	LastLogin      time.Time `json:"lastLogin"`
+	// PreviousLogin is the LastLogin value from before the current session's
+	// authentication. Authenticate() overwrites LastLogin with time.Now()
+	// before the login sequence runs, so anything asking "what is new since
+	// this user was last here?" (news, rumors, file newscan) must compare
+	// against PreviousLogin, not LastLogin.
+	PreviousLogin    time.Time `json:"previousLogin,omitempty"`
 	TimesCalled      int       `json:"timesCalled"` // Used for E (NumLogons)
 	LastBulletinRead time.Time `json:"lastBulletinRead"`
 	RealName         string    `json:"realName"`
@@ -59,6 +65,10 @@ type User struct {
 	SeenNewscanNetworks    []string `json:"seen_newscan_networks,omitempty"`    // Lowercase network names already offered for newscan auto-join
 	SeenNewscanAreaTags    []string `json:"seen_newscan_area_tags,omitempty"`   // Area tags already offered/added for newscan auto-join
 	NewscanSeenInitialized bool     `json:"newscan_seen_initialized,omitempty"` // Seen-set tracking has been initialized for this user
+
+	// System News tracking
+	SeenNewsIDs         []int `json:"seen_news_ids,omitempty"`         // News item IDs already shown to this user (non-"always" items only)
+	NewsSeenInitialized bool  `json:"news_seen_initialized,omitempty"` // SeenNewsIDs has been back-filled from PreviousLogin
 
 	// Terminal Preferences
 	ScreenWidth       int    `json:"screenWidth,omitempty"`       // Detected/preferred terminal width (default 80)

--- a/templates/configs/login.json
+++ b/templates/configs/login.json
@@ -8,6 +8,9 @@
         "pause_after": true
     },
     {
+        "command": "PRINTNEWS"
+    },
+    {
         "command": "LASTCALLS"
     },
     {


### PR DESCRIPTION
Closes #198.

Sysops could add System News items but they never appeared automatically. Two separate things were missing.

## Wiring

`PRINTNEWS` was already a supported login sequence command, and `LISTNEWS`/`EDITNEWS` were already bound on the MAIN and ADMIN menus — but `PRINTNEWS` was absent from both the shipped `templates/configs/login.json` and the built-in default sequence used when `login.json` is missing. It now runs after `NMAILSCAN`.

`NEWSHDR.ANS` opens with `|CL`, so the item clears the screen itself and must **not** set `clear_screen` — doing so would blank the previous step's output even on logins with no news to show. The docs previously claimed `PRINTNEWS` ignores `clear_screen`/`pause_after`; it does not, so that was corrected too.

## Visibility

Even once wired up, non-`always` items could never display. `Authenticate()` stamps `LastLogin` with `time.Now()` before the login sequence runs, so `item.When.After(lastLogin)` was always false by the time `PRINTNEWS` executed.

The prior stamp is now kept as `User.PreviousLogin`, and the three "new since your last visit" checks use it: news, rumors newscan, and the file newscan.

## Seen tracking

For news the date filter is replaced outright with a per-user seen list (`SeenNewsIDs`). A date comparison also silently lost items whenever a caller dropped carrier or fast-logged past the news; tracking IDs means an item that was never displayed is still waiting on the next call.

- `always: false` items show exactly once per user.
- Reading an item from `RUN:LISTNEWS` marks it seen, and drives the `[NEW]` tag.
- `always: true` items are never recorded and still show every login.
- IDs of deleted items are pruned, so the list cannot grow without bound.
- Existing users are back-filled once from `PreviousLogin`, so upgrading systems do not dump the whole backlog.

Seen tracking needs stable IDs, but `newsAddItem` assigned `len(items)+1`, which collides after a delete (add 3, delete 1, add → duplicate ID). It now assigns `max+1`, and `EDITNEWS` repairs existing data on entry. Items with no usable ID fall back to the old date filter.

Access level and max-level filtering are unchanged.

## Note for existing installs

`configs/login.json` is not overwritten on upgrade, so existing systems still need `{"command": "PRINTNEWS"}` added by hand. This is called out in both docs pages.

## Testing

`go build ./...` and `go test ./...` pass. New unit tests in `internal/menu/news_seen_test.go` cover ID allocation after deletion, ID normalization idempotency, seen-set pruning, change detection on store, and back-fill behavior for both upgrading and first-time callers.

Not manually exercised against a live BBS session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQuYC88yCUrF8isfJdNJyY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Login now displays news before other standard login information.
  - News items are tracked individually, allowing unread items to persist across sessions.
  - `Always` news remains visible, while `LISTNEWS` marks items as seen.
  - Login placeholders now support additional user details, activity counts, and prior-login information.
  - New users and migrated accounts receive appropriate news history.

- **Bug Fixes**
  - New-item detection for news, rumors, and file listings now consistently uses the previous login.

- **Documentation**
  - Updated administrator guidance for news tracking, login configuration, migration behavior, and available placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->