### PR TITLE
fix(news): word-wrap news bodies instead of letting the terminal split words

### DIFF
--- a/internal/menu/news.go
+++ b/internal/menu/news.go
@@ -213,7 +213,7 @@ func WarnIfNewsUnwired(rootConfigPath string, loginSequence []config.LoginItem) 
 //
 //	^NM = item number   ^TI = title    ^FR = from/author
 //	^DT = date          ^TM = time     ^LV = min level   ^MX = max level
-func displayNewsItem(e *MenuExecutor, terminal *term.Terminal, item *NewsItem, idx int, outputMode ansi.OutputMode) {
+func displayNewsItem(e *MenuExecutor, terminal *term.Terminal, item *NewsItem, idx int, outputMode ansi.OutputMode, termWidth int) {
 	ansiPath := filepath.Join(e.MenuSetPath, "ansi", "NEWSHDR.ANS")
 	if raw, err := os.ReadFile(ansiPath); err == nil {
 		maxStr := strconv.Itoa(item.MaxLevel)
@@ -236,10 +236,48 @@ func displayNewsItem(e *MenuExecutor, terminal *term.Terminal, item *NewsItem, i
 			strings.Repeat("\xc4", 70)), outputMode)
 	}
 	if item.Body != "" {
-		for _, line := range strings.Split(item.Body, "\n") {
-			wv(terminal, strings.TrimRight(line, "\r")+"\r\n", outputMode)
+		// Word-wrap to the terminal, the same way the message reader renders a
+		// message body. Without this the terminal hard-wraps at its own margin
+		// and breaks words mid-word.
+		//
+		// Pipe codes are converted to ANSI *before* wrapping, matching the
+		// reader. wrapAnsiString measures width with ANSI escapes stripped but
+		// knows nothing about pipe codes, so wrapping first would count "|04"
+		// as three visible columns and break lines far too early.
+		//
+		// wrapAnsiString leaves ANSI art alone, so a sysop who pastes art into
+		// an item still gets it positioned correctly.
+		body := ansi.ReplacePipeCodes([]byte(normalizeNewsBody(item.Body)))
+		for _, line := range wrapAnsiString(string(body), newsBodyWidth(termWidth)) {
+			// Already pipe-converted, so write straight through rather than
+			// running it past ReplacePipeCodes a second time.
+			terminalio.WriteProcessedBytes(terminal, []byte(line+"\r\n"), outputMode)
 		}
 	}
+}
+
+// normalizeNewsBody converts stored CRLF line endings to LF so wrapping sees
+// clean lines; a stray CR would otherwise count toward the visible width.
+func normalizeNewsBody(body string) string {
+	return strings.ReplaceAll(body, "\r\n", "\n")
+}
+
+// newsBodyWidth is the column budget for a wrapped news line.
+//
+// One column short of the terminal, because the body is written as a sequence
+// of lines each ending in CRLF: a line filling the full width would trigger the
+// terminal's own auto-wrap and the CRLF would then land on the next row,
+// showing up as a blank line between every wrapped line. The same reservation
+// is made elsewhere for sequentially written output.
+//
+// Falls back to 79 when the width is unknown, rather than to "do not wrap":
+// 80 columns is the safe assumption for a BBS, and no wrapping is what
+// produced broken words in the first place.
+func newsBodyWidth(termWidth int) int {
+	if termWidth <= 1 {
+		return 79
+	}
+	return termWidth - 1
 }
 
 // runPrintNews displays news items the user has not seen yet, plus any
@@ -307,7 +345,7 @@ func runPrintNews(c *cmdCtx, args string) (*user.User, string, error) {
 			}
 		}
 
-		displayNewsItem(e, terminal, &nd.Items[i], i+1, outputMode)
+		displayNewsItem(e, terminal, &nd.Items[i], i+1, outputMode, termWidth)
 		e.holdScreen(s, terminal, outputMode, termWidth, termHeight)
 		shown++
 
@@ -425,7 +463,7 @@ func runListNews(c *cmdCtx, args string) (*user.User, string, error) {
 			continue
 		}
 		idx := visible[n-1]
-		displayNewsItem(e, terminal, &nd.Items[idx], n, outputMode)
+		displayNewsItem(e, terminal, &nd.Items[idx], n, outputMode, termWidth)
 		if item := nd.Items[idx]; !item.Always && item.ID > 0 {
 			seen[item.ID] = true
 		}

--- a/internal/menu/news.go
+++ b/internal/menu/news.go
@@ -214,8 +214,14 @@ func WarnIfNewsUnwired(rootConfigPath string, loginSequence []config.LoginItem) 
 //	^NM = item number   ^TI = title    ^FR = from/author
 //	^DT = date          ^TM = time     ^LV = min level   ^MX = max level
 func displayNewsItem(e *MenuExecutor, terminal *term.Terminal, item *NewsItem, idx int, outputMode ansi.OutputMode, termWidth int) {
+	// Width of the header frame the body should line up under. Measured from
+	// the header actually rendered, so a customized NEWSHDR.ANS or a different
+	// menu set stays self-consistent instead of being hard-coded to 78.
+	headerWidth := newsFallbackHeaderWidth
+
 	ansiPath := filepath.Join(e.MenuSetPath, "ansi", "NEWSHDR.ANS")
 	if raw, err := os.ReadFile(ansiPath); err == nil {
+		headerWidth = headerTemplateWidth(string(raw))
 		maxStr := strconv.Itoa(item.MaxLevel)
 		if item.MaxLevel <= 0 {
 			maxStr = "All"
@@ -233,7 +239,7 @@ func displayNewsItem(e *MenuExecutor, terminal *term.Terminal, item *NewsItem, i
 		// Fallback plain header if NEWSHDR.ANS is missing
 		wv(terminal, fmt.Sprintf("\r\n|15News #%d: |11%s\r\n|07From: |11%s |07  Date: |11%s\r\n|08%s\r\n",
 			idx, item.Title, item.From, item.When.Format("01/02/2006"),
-			strings.Repeat("\xc4", 70)), outputMode)
+			strings.Repeat("\xc4", newsFallbackHeaderWidth)), outputMode)
 	}
 	if item.Body != "" {
 		// Word-wrap to the terminal, the same way the message reader renders a
@@ -247,7 +253,7 @@ func displayNewsItem(e *MenuExecutor, terminal *term.Terminal, item *NewsItem, i
 		//
 		// wrapAnsiString leaves ANSI art alone, so a sysop who pastes art into
 		// an item still gets it positioned correctly.
-		width := newsBodyWidth(termWidth)
+		width := newsBodyWidth(headerWidth, termWidth)
 		body := string(ansi.ReplacePipeCodes([]byte(normalizeNewsBody(item.Body))))
 		lines := wrapAnsiString(body, width)
 		// wrapAnsiString breaks on spaces, so a token with no break opportunity
@@ -274,7 +280,12 @@ func normalizeNewsBody(body string) string {
 	return strings.ReplaceAll(body, "\r\n", "\n")
 }
 
-// newsBodyWidth is the column budget for a wrapped news line.
+// newsFallbackHeaderWidth is the rule width of the built-in plain header used
+// when NEWSHDR.ANS is missing, and the assumed frame width when a header
+// cannot be measured.
+const newsFallbackHeaderWidth = 70
+
+// newsTerminalBudget is the widest a body line may be on this terminal.
 //
 // One column short of the terminal, because the body is written as a sequence
 // of lines each ending in CRLF: a line filling the full width would trigger the
@@ -285,11 +296,39 @@ func normalizeNewsBody(body string) string {
 // Falls back to 79 when the width is unknown, rather than to "do not wrap":
 // 80 columns is the safe assumption for a BBS, and no wrapping is what
 // produced broken words in the first place.
-func newsBodyWidth(termWidth int) int {
+func newsTerminalBudget(termWidth int) int {
 	if termWidth <= 1 {
 		return 79
 	}
 	return termWidth - 1
+}
+
+// newsBodyWidth is the column budget for a wrapped news line: the header's
+// frame width, so the text lines up under the rules NEWSHDR.ANS draws rather
+// than running past them, but never wider than the terminal can show.
+func newsBodyWidth(headerWidth, termWidth int) int {
+	budget := newsTerminalBudget(termWidth)
+	if headerWidth > 0 && headerWidth < budget {
+		return headerWidth
+	}
+	return budget
+}
+
+// headerTemplateWidth is the visible width of the widest line in a header
+// template — in practice the horizontal rules, which define the frame.
+//
+// Measured on the template before substitution: that is the width the header
+// was designed to, and it keeps the body budget stable from item to item
+// instead of drifting with the length of a title or author name.
+func headerTemplateWidth(tmpl string) int {
+	converted := string(ansi.ReplacePipeCodes([]byte(strings.ReplaceAll(tmpl, "\r\n", "\n"))))
+	widest := 0
+	for _, line := range strings.Split(converted, "\n") {
+		if w := visibleWidth(line); w > widest {
+			widest = w
+		}
+	}
+	return widest
 }
 
 // runPrintNews displays news items the user has not seen yet, plus any

--- a/internal/menu/news.go
+++ b/internal/menu/news.go
@@ -247,8 +247,20 @@ func displayNewsItem(e *MenuExecutor, terminal *term.Terminal, item *NewsItem, i
 		//
 		// wrapAnsiString leaves ANSI art alone, so a sysop who pastes art into
 		// an item still gets it positioned correctly.
-		body := ansi.ReplacePipeCodes([]byte(normalizeNewsBody(item.Body)))
-		for _, line := range wrapAnsiString(string(body), newsBodyWidth(termWidth)) {
+		width := newsBodyWidth(termWidth)
+		body := string(ansi.ReplacePipeCodes([]byte(normalizeNewsBody(item.Body))))
+		lines := wrapAnsiString(body, width)
+		// wrapAnsiString breaks on spaces, so a token with no break opportunity
+		// (a long URL, a path) comes back oversized; break those explicitly
+		// rather than leaving the client terminal to chop them mid-token.
+		//
+		// Not for ANSI art: wrapAnsiString leaves art rows alone because they
+		// are positioned absolutely, and hard-breaking a full-width row would
+		// push everything below it down a line and wreck the picture.
+		if !containsAnsiArt(body) {
+			lines = breakOversizedLines(lines, width)
+		}
+		for _, line := range lines {
 			// Already pipe-converted, so write straight through rather than
 			// running it past ReplacePipeCodes a second time.
 			terminalio.WriteProcessedBytes(terminal, []byte(line+"\r\n"), outputMode)

--- a/internal/menu/news_edit.go
+++ b/internal/menu/news_edit.go
@@ -76,7 +76,7 @@ func runEditNews(c *cmdCtx, args string) (*user.User, string, error) {
 		default:
 			n, nerr := strconv.Atoi(cmd)
 			if nerr == nil && n >= 1 && n <= len(nd.Items) {
-				displayNewsItem(e, terminal, &nd.Items[n-1], n, outputMode)
+				displayNewsItem(e, terminal, &nd.Items[n-1], n, outputMode, termWidth)
 				e.holdScreen(s, terminal, outputMode, termWidth, termHeight)
 			}
 		}
@@ -358,11 +358,11 @@ func newsViewItem(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 	}
 	if n == 0 {
 		for i := range nd.Items {
-			displayNewsItem(e, terminal, &nd.Items[i], i+1, outputMode)
+			displayNewsItem(e, terminal, &nd.Items[i], i+1, outputMode, termWidth)
 			e.holdScreen(s, terminal, outputMode, termWidth, termHeight)
 		}
 	} else if n >= 1 && n <= len(nd.Items) {
-		displayNewsItem(e, terminal, &nd.Items[n-1], n, outputMode)
+		displayNewsItem(e, terminal, &nd.Items[n-1], n, outputMode, termWidth)
 		e.holdScreen(s, terminal, outputMode, termWidth, termHeight)
 	}
 }

--- a/internal/menu/news_linebreak.go
+++ b/internal/menu/news_linebreak.go
@@ -1,0 +1,99 @@
+package menu
+
+import "strings"
+
+// breakOversizedLines splits any line wider than width into chunks that fit.
+//
+// wrapAnsiString breaks on spaces, so a single token with no break opportunity
+// — a long URL, a path, a run of dashes — is emitted unchanged and overflows.
+// Left alone the client terminal wraps it at its own margin, which is the very
+// mid-token splitting the wrapping exists to prevent, and which lands at the
+// terminal's width rather than ours (re-introducing the trailing-column
+// auto-wrap this code otherwise avoids).
+//
+// An over-long token has to break somewhere; doing it here makes the break
+// deterministic and keeps every emitted line inside the budget.
+//
+// ANSI escape sequences are copied through without counting toward the width
+// and are never split across a chunk boundary.
+func breakOversizedLines(lines []string, width int) []string {
+	if width <= 0 {
+		return lines
+	}
+
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if visibleWidth(line) <= width {
+			out = append(out, line)
+			continue
+		}
+		out = append(out, hardBreak(line, width)...)
+	}
+	return out
+}
+
+// hardBreak cuts s into chunks of at most width visible columns.
+func hardBreak(s string, width int) []string {
+	var (
+		chunks  []string
+		b       strings.Builder
+		visible int
+	)
+	runes := []rune(s)
+
+	for i := 0; i < len(runes); {
+		if n := ansiEscapeLen(runes[i:]); n > 0 {
+			// Zero-width: emit with the current chunk, do not count or split.
+			b.WriteString(string(runes[i : i+n]))
+			i += n
+			continue
+		}
+		if visible == width {
+			chunks = append(chunks, b.String())
+			b.Reset()
+			visible = 0
+		}
+		b.WriteRune(runes[i])
+		visible++
+		i++
+	}
+	if b.Len() > 0 {
+		chunks = append(chunks, b.String())
+	}
+	return chunks
+}
+
+// ansiEscapeLen returns the rune length of the CSI escape sequence at the start
+// of r, or 0 if r does not begin with one. Handles ESC [ params... final-byte,
+// which is the form ReplacePipeCodes emits.
+func ansiEscapeLen(r []rune) int {
+	if len(r) < 2 || r[0] != 0x1b || r[1] != '[' {
+		return 0
+	}
+	for i := 2; i < len(r); i++ {
+		c := r[i]
+		if (c >= '0' && c <= '9') || c == ';' || c == '?' {
+			continue
+		}
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') {
+			return i + 1 // include the final byte
+		}
+		return 0 // malformed; treat as literal text
+	}
+	return 0 // unterminated
+}
+
+// visibleWidth is the on-screen column count of s, ignoring ANSI escapes.
+func visibleWidth(s string) int {
+	runes := []rune(s)
+	n := 0
+	for i := 0; i < len(runes); {
+		if l := ansiEscapeLen(runes[i:]); l > 0 {
+			i += l
+			continue
+		}
+		n++
+		i++
+	}
+	return n
+}

--- a/internal/menu/news_wrap_test.go
+++ b/internal/menu/news_wrap_test.go
@@ -1,0 +1,167 @@
+package menu
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+)
+
+var reWrapEsc = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+// visibleCols is the on-screen width of an already-pipe-converted line.
+func visibleCols(s string) int { return len(reWrapEsc.ReplaceAllString(s, "")) }
+
+// wrapNewsBodyForTest mirrors what displayNewsItem does to a body.
+func wrapNewsBodyForTest(body string, termWidth int) []string {
+	converted := ansi.ReplacePipeCodes([]byte(normalizeNewsBody(body)))
+	return wrapAnsiString(string(converted), newsBodyWidth(termWidth))
+}
+
+func TestNewsBodyWidthReservesAColumn(t *testing.T) {
+	cases := []struct{ term, want int }{
+		{80, 79}, // the common case: one column short of the margin
+		{132, 131},
+		{40, 39},
+		{0, 79},  // width unknown -> assume 80 columns, still wrap
+		{1, 79},  // degenerate
+		{-5, 79}, // degenerate
+	}
+	for _, c := range cases {
+		if got := newsBodyWidth(c.term); got != c.want {
+			t.Errorf("newsBodyWidth(%d) = %d, want %d", c.term, got, c.want)
+		}
+	}
+}
+
+func TestNormalizeNewsBodyStripsCR(t *testing.T) {
+	got := normalizeNewsBody("one\r\ntwo\r\nthree")
+	if strings.Contains(got, "\r") {
+		t.Errorf("carriage returns survived normalization: %q", got)
+	}
+	if want := "one\ntwo\nthree"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// The reported bug: a long paragraph was written out raw, so the terminal
+// hard-wrapped it at its own margin and split words down the middle.
+func TestNewsBodyWrapsOnWordBoundaries(t *testing.T) {
+	body := "The quick brown fox jumps over the lazy dog while the " +
+		"enterprising aardvark contemplates its considerable misfortune " +
+		"in the general vicinity of the woodpile."
+
+	width := newsBodyWidth(80)
+	lines := wrapAnsiString(normalizeNewsBody(body), width)
+
+	if len(lines) < 2 {
+		t.Fatalf("expected the paragraph to wrap onto several lines, got %d", len(lines))
+	}
+	for i, ln := range lines {
+		if len(ln) > width {
+			t.Errorf("line %d is %d cols, over the %d budget: %q", i, len(ln), width, ln)
+		}
+	}
+
+	// Nothing may be lost or invented: the words must round-trip exactly.
+	if got, want := strings.Join(strings.Fields(strings.Join(lines, " ")), " "),
+		strings.Join(strings.Fields(body), " "); got != want {
+		t.Errorf("wrapping altered the text:\n got  %q\n want %q", got, want)
+	}
+
+	// And no line may start or end mid-word, i.e. every line is whole words.
+	for i, ln := range lines {
+		for _, w := range strings.Fields(ln) {
+			if !strings.Contains(body, w) {
+				t.Errorf("line %d contains %q, which is not a word from the body", i, w)
+			}
+		}
+	}
+}
+
+// Explicit newlines the sysop typed are paragraph breaks and must survive.
+func TestNewsBodyPreservesAuthoredLineBreaks(t *testing.T) {
+	body := "First paragraph.\n\nSecond paragraph."
+	lines := wrapAnsiString(normalizeNewsBody(body), newsBodyWidth(80))
+
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines (para, blank, para), got %d: %q", len(lines), lines)
+	}
+	if lines[1] != "" {
+		t.Errorf("blank separator line was lost: %q", lines)
+	}
+}
+
+// A sysop who pastes ANSI art into an item must not have it reflowed, since
+// art relies on absolute positioning.
+func TestNewsBodyLeavesAnsiArtAlone(t *testing.T) {
+	art := "\x1b[5;10Hsome art\n\x1b[6;10Hmore art"
+	lines := wrapAnsiString(normalizeNewsBody(art), newsBodyWidth(80))
+	if len(lines) != 2 {
+		t.Fatalf("art should split on newlines only, got %d lines: %q", len(lines), lines)
+	}
+}
+
+// News bodies support pipe colour codes (wv runs them through
+// ReplacePipeCodes). Wrapping must therefore measure *visible* columns:
+// converting after wrapping would count "|04" as three columns and break
+// lines far too early.
+func TestNewsBodyWrapsOnVisibleWidthNotPipeCodeBytes(t *testing.T) {
+	// 12 coloured words: 95 raw bytes but only 59 visible columns, so it fits
+	// on one 79-column line and must not be split.
+	words := make([]string, 0, 12)
+	for i := 0; i < 12; i++ {
+		words = append(words, "|1"+string(rune('0'+i%6))+"word")
+	}
+	body := strings.Join(words, " ")
+
+	if len(body) <= newsBodyWidth(80) {
+		t.Fatalf("test body is only %d raw bytes; it must exceed the budget to be meaningful", len(body))
+	}
+
+	lines := wrapNewsBodyForTest(body, 80)
+	if len(lines) != 1 {
+		t.Errorf("body is %d visible columns and should fit on one line, got %d lines",
+			visibleCols(string(ansi.ReplacePipeCodes([]byte(body)))), len(lines))
+	}
+	for i, ln := range lines {
+		if got := visibleCols(ln); got > newsBodyWidth(80) {
+			t.Errorf("line %d is %d visible columns, over the %d budget", i, got, newsBodyWidth(80))
+		}
+	}
+}
+
+// Colour codes must survive wrapping, not be stripped or mangled.
+func TestNewsBodyWrappingPreservesColour(t *testing.T) {
+	body := "|10Hello |12world"
+	lines := wrapNewsBodyForTest(body, 80)
+	joined := strings.Join(lines, "")
+
+	if strings.Contains(joined, "|10") || strings.Contains(joined, "|12") {
+		t.Errorf("pipe codes were not converted to ANSI: %q", joined)
+	}
+	if !strings.Contains(joined, "\x1b[") {
+		t.Errorf("no ANSI escape in output; colour was lost: %q", joined)
+	}
+	if !strings.Contains(joined, "Hello") || !strings.Contains(joined, "world") {
+		t.Errorf("text lost during wrapping: %q", joined)
+	}
+}
+
+// A long coloured paragraph still wraps, and every line stays within the
+// visible budget.
+func TestNewsBodyLongColouredParagraphWrapsWithinBudget(t *testing.T) {
+	body := strings.TrimSpace(strings.Repeat("|15colourful |07prose about aardvarks ", 12))
+	width := newsBodyWidth(80)
+
+	lines := wrapNewsBodyForTest(body, 80)
+	if len(lines) < 3 {
+		t.Fatalf("expected the paragraph to wrap onto several lines, got %d", len(lines))
+	}
+	for i, ln := range lines {
+		if got := visibleCols(ln); got > width {
+			t.Errorf("line %d is %d visible columns, over the %d budget: %q", i, got, width, ln)
+		}
+	}
+}

--- a/internal/menu/news_wrap_test.go
+++ b/internal/menu/news_wrap_test.go
@@ -16,10 +16,14 @@ func visibleCols(s string) int { return len(reWrapEsc.ReplaceAllString(s, "")) }
 // wrapNewsBodyForTest mirrors what displayNewsItem does to a body.
 func wrapNewsBodyForTest(body string, termWidth int) []string {
 	converted := ansi.ReplacePipeCodes([]byte(normalizeNewsBody(body)))
-	return wrapAnsiString(string(converted), newsBodyWidth(termWidth))
+	return wrapAnsiString(string(converted), newsBodyWidth(shippedHeaderWidth, termWidth))
 }
 
-func TestNewsBodyWidthReservesAColumn(t *testing.T) {
+// shippedHeaderWidth is the rule width of the NEWSHDR.ANS that ships in
+// menus/v3, which the body now aligns to.
+const shippedHeaderWidth = 78
+
+func TestNewsTerminalBudgetReservesAColumn(t *testing.T) {
 	cases := []struct{ term, want int }{
 		{80, 79}, // the common case: one column short of the margin
 		{132, 131},
@@ -29,9 +33,52 @@ func TestNewsBodyWidthReservesAColumn(t *testing.T) {
 		{-5, 79}, // degenerate
 	}
 	for _, c := range cases {
-		if got := newsBodyWidth(c.term); got != c.want {
-			t.Errorf("newsBodyWidth(%d) = %d, want %d", c.term, got, c.want)
+		if got := newsTerminalBudget(c.term); got != c.want {
+			t.Errorf("newsTerminalBudget(%d) = %d, want %d", c.term, got, c.want)
 		}
+	}
+}
+
+// The body lines up under the header's rules rather than running past them,
+// but never exceeds what the terminal can show.
+func TestNewsBodyWidthAlignsToHeader(t *testing.T) {
+	cases := []struct {
+		name               string
+		header, term, want int
+	}{
+		{"shipped NEWSHDR on an 80-col terminal", 78, 80, 78},
+		{"narrow terminal wins over a wide header", 78, 40, 39},
+		{"wide header clamped to the terminal", 200, 80, 79},
+		{"header exactly at the terminal budget", 79, 80, 79},
+		{"plain fallback header", newsFallbackHeaderWidth, 80, 70},
+		{"unmeasurable header falls back to the terminal", 0, 80, 79},
+		{"unknown terminal still wraps", 78, 0, 78},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := newsBodyWidth(c.header, c.term); got != c.want {
+				t.Errorf("newsBodyWidth(header=%d, term=%d) = %d, want %d",
+					c.header, c.term, got, c.want)
+			}
+		})
+	}
+}
+
+// The width must come from the header the sysop actually has, so a customized
+// NEWSHDR.ANS stays self-consistent.
+func TestHeaderTemplateWidthMeasuresTheRules(t *testing.T) {
+	// Mirrors the shipped NEWSHDR.ANS shape: pipe-coded rules plus short
+	// substitution lines. Pipe codes must not count toward the width.
+	tmpl := "|CL|08" + strings.Repeat("\xc4", 78) + "\r\n" +
+		"|15 News #^NM|15: |11^TI\r\n" +
+		"|08" + strings.Repeat("\xc4", 78) + "\r\n"
+
+	if got := headerTemplateWidth(tmpl); got != 78 {
+		t.Errorf("headerTemplateWidth = %d, want 78 (the rule width)", got)
+	}
+
+	if got := headerTemplateWidth(""); got != 0 {
+		t.Errorf("empty template width = %d, want 0", got)
 	}
 }
 
@@ -52,7 +99,7 @@ func TestNewsBodyWrapsOnWordBoundaries(t *testing.T) {
 		"enterprising aardvark contemplates its considerable misfortune " +
 		"in the general vicinity of the woodpile."
 
-	width := newsBodyWidth(80)
+	width := newsBodyWidth(shippedHeaderWidth, 80)
 	lines := wrapAnsiString(normalizeNewsBody(body), width)
 
 	if len(lines) < 2 {
@@ -83,7 +130,7 @@ func TestNewsBodyWrapsOnWordBoundaries(t *testing.T) {
 // Explicit newlines the sysop typed are paragraph breaks and must survive.
 func TestNewsBodyPreservesAuthoredLineBreaks(t *testing.T) {
 	body := "First paragraph.\n\nSecond paragraph."
-	lines := wrapAnsiString(normalizeNewsBody(body), newsBodyWidth(80))
+	lines := wrapAnsiString(normalizeNewsBody(body), newsBodyWidth(shippedHeaderWidth, 80))
 
 	if len(lines) != 3 {
 		t.Fatalf("expected 3 lines (para, blank, para), got %d: %q", len(lines), lines)
@@ -97,7 +144,7 @@ func TestNewsBodyPreservesAuthoredLineBreaks(t *testing.T) {
 // art relies on absolute positioning.
 func TestNewsBodyLeavesAnsiArtAlone(t *testing.T) {
 	art := "\x1b[5;10Hsome art\n\x1b[6;10Hmore art"
-	lines := wrapAnsiString(normalizeNewsBody(art), newsBodyWidth(80))
+	lines := wrapAnsiString(normalizeNewsBody(art), newsBodyWidth(shippedHeaderWidth, 80))
 	if len(lines) != 2 {
 		t.Fatalf("art should split on newlines only, got %d lines: %q", len(lines), lines)
 	}
@@ -116,7 +163,7 @@ func TestNewsBodyWrapsOnVisibleWidthNotPipeCodeBytes(t *testing.T) {
 	}
 	body := strings.Join(words, " ")
 
-	if len(body) <= newsBodyWidth(80) {
+	if len(body) <= newsBodyWidth(shippedHeaderWidth, 80) {
 		t.Fatalf("test body is only %d raw bytes; it must exceed the budget to be meaningful", len(body))
 	}
 
@@ -126,8 +173,8 @@ func TestNewsBodyWrapsOnVisibleWidthNotPipeCodeBytes(t *testing.T) {
 			visibleCols(string(ansi.ReplacePipeCodes([]byte(body)))), len(lines))
 	}
 	for i, ln := range lines {
-		if got := visibleCols(ln); got > newsBodyWidth(80) {
-			t.Errorf("line %d is %d visible columns, over the %d budget", i, got, newsBodyWidth(80))
+		if got := visibleCols(ln); got > newsBodyWidth(shippedHeaderWidth, 80) {
+			t.Errorf("line %d is %d visible columns, over the %d budget", i, got, newsBodyWidth(shippedHeaderWidth, 80))
 		}
 	}
 }
@@ -153,7 +200,7 @@ func TestNewsBodyWrappingPreservesColour(t *testing.T) {
 // visible budget.
 func TestNewsBodyLongColouredParagraphWrapsWithinBudget(t *testing.T) {
 	body := strings.TrimSpace(strings.Repeat("|15colourful |07prose about aardvarks ", 12))
-	width := newsBodyWidth(80)
+	width := newsBodyWidth(shippedHeaderWidth, 80)
 
 	lines := wrapNewsBodyForTest(body, 80)
 	if len(lines) < 3 {
@@ -171,11 +218,11 @@ func TestNewsBodyLongColouredParagraphWrapsWithinBudget(t *testing.T) {
 // splitting this wrapping exists to prevent. Every emitted line must fit.
 func TestNewsBodyBreaksOversizedTokens(t *testing.T) {
 	url := "https://example.com/downloads/" + strings.Repeat("abcdefghij", 10) + "/file.zip"
-	if len(url) <= newsBodyWidth(80) {
+	if len(url) <= newsBodyWidth(shippedHeaderWidth, 80) {
 		t.Fatalf("test URL is only %d cols; it must exceed the budget", len(url))
 	}
 	body := "Grab it from " + url + " today."
-	width := newsBodyWidth(80)
+	width := newsBodyWidth(shippedHeaderWidth, 80)
 
 	lines := breakOversizedLines(wrapNewsBodyForTest(body, 80), width)
 
@@ -261,12 +308,12 @@ func TestNewsBodyArtIsExemptFromHardBreaking(t *testing.T) {
 		t.Fatal("fixture is not detected as ANSI art; the exemption would not apply")
 	}
 
-	lines := wrapAnsiString(art, newsBodyWidth(80))
+	lines := wrapAnsiString(art, newsBodyWidth(shippedHeaderWidth, 80))
 	if len(lines) != 2 {
 		t.Fatalf("art should stay 2 rows, got %d", len(lines))
 	}
 	// Demonstrates why the gate exists: breaking would double the row count.
-	if broken := breakOversizedLines(lines, newsBodyWidth(80)); len(broken) == len(lines) {
+	if broken := breakOversizedLines(lines, newsBodyWidth(shippedHeaderWidth, 80)); len(broken) == len(lines) {
 		t.Skip("break pass no longer splits these rows; gate may be redundant")
 	}
 }

--- a/internal/menu/news_wrap_test.go
+++ b/internal/menu/news_wrap_test.go
@@ -165,3 +165,108 @@ func TestNewsBodyLongColouredParagraphWrapsWithinBudget(t *testing.T) {
 		}
 	}
 }
+
+// wrapAnsiString breaks on spaces only, so a token with no break opportunity
+// comes back oversized and the client terminal chops it — the exact mid-word
+// splitting this wrapping exists to prevent. Every emitted line must fit.
+func TestNewsBodyBreaksOversizedTokens(t *testing.T) {
+	url := "https://example.com/downloads/" + strings.Repeat("abcdefghij", 10) + "/file.zip"
+	if len(url) <= newsBodyWidth(80) {
+		t.Fatalf("test URL is only %d cols; it must exceed the budget", len(url))
+	}
+	body := "Grab it from " + url + " today."
+	width := newsBodyWidth(80)
+
+	lines := breakOversizedLines(wrapNewsBodyForTest(body, 80), width)
+
+	for i, ln := range lines {
+		if got := visibleCols(ln); got > width {
+			t.Errorf("line %d is %d visible columns, over the %d budget: %q", i, got, width, ln)
+		}
+	}
+
+	// The URL must survive intact once the line breaks are removed.
+	if joined := strings.Join(lines, ""); !strings.Contains(strings.ReplaceAll(joined, " ", ""),
+		strings.ReplaceAll(url, " ", "")) {
+		t.Errorf("URL was corrupted by breaking; not found in reassembled output")
+	}
+}
+
+func TestBreakOversizedLinesKeepsShortLinesUntouched(t *testing.T) {
+	in := []string{"short", "also short", ""}
+	got := breakOversizedLines(in, 79)
+	if len(got) != len(in) {
+		t.Fatalf("short lines were altered: %q", got)
+	}
+	for i := range in {
+		if got[i] != in[i] {
+			t.Errorf("line %d changed from %q to %q", i, in[i], got[i])
+		}
+	}
+}
+
+// Breaking must never split an ANSI escape sequence, and escapes must not
+// count toward the column budget.
+func TestBreakOversizedLinesIsAnsiAware(t *testing.T) {
+	// 100 visible columns, with a colour change every 10.
+	var b strings.Builder
+	for i := 0; i < 10; i++ {
+		b.WriteString("\x1b[1;3" + string(rune('0'+i%8)) + "m")
+		b.WriteString(strings.Repeat("x", 10))
+	}
+	line := b.String()
+	if visibleCols(line) != 100 {
+		t.Fatalf("fixture is %d visible cols, expected 100", visibleCols(line))
+	}
+
+	got := breakOversizedLines([]string{line}, 40)
+
+	for i, ln := range got {
+		if w := visibleCols(ln); w > 40 {
+			t.Errorf("chunk %d is %d visible columns, over 40", i, w)
+		}
+		// A split escape would leave a bare ESC or an unterminated CSI.
+		if strings.Contains(ln, "\x1b") && !reWrapEsc.MatchString(ln) {
+			t.Errorf("chunk %d contains a broken escape sequence: %q", i, ln)
+		}
+	}
+
+	// No visible character may be lost.
+	total := 0
+	for _, ln := range got {
+		total += visibleCols(ln)
+	}
+	if total != 100 {
+		t.Errorf("visible columns after breaking = %d, want 100", total)
+	}
+}
+
+func TestBreakOversizedLinesInvalidWidthIsANoOp(t *testing.T) {
+	in := []string{strings.Repeat("x", 200)}
+	for _, w := range []int{0, -1} {
+		got := breakOversizedLines(in, w)
+		if len(got) != 1 || got[0] != in[0] {
+			t.Errorf("width %d should be a no-op, got %q", w, got)
+		}
+	}
+}
+
+// Art rows are positioned absolutely, so hard-breaking a full-width row would
+// push everything below it down a line. displayNewsItem skips the break pass
+// for art; this pins the detection that gate relies on.
+func TestNewsBodyArtIsExemptFromHardBreaking(t *testing.T) {
+	art := "\x1b[5;1H" + strings.Repeat("\xB0", 80) + "\n\x1b[6;1H" + strings.Repeat("\xB1", 80)
+
+	if !containsAnsiArt(art) {
+		t.Fatal("fixture is not detected as ANSI art; the exemption would not apply")
+	}
+
+	lines := wrapAnsiString(art, newsBodyWidth(80))
+	if len(lines) != 2 {
+		t.Fatalf("art should stay 2 rows, got %d", len(lines))
+	}
+	// Demonstrates why the gate exists: breaking would double the row count.
+	if broken := breakOversizedLines(lines, newsBodyWidth(80)); len(broken) == len(lines) {
+		t.Skip("break pass no longer splits these rows; gate may be redundant")
+	}
+}


### PR DESCRIPTION
`displayNewsItem` wrote each stored body line straight to the terminal with no wrapping:

```go
for _, line := range strings.Split(item.Body, "\n") {
    wv(terminal, strings.TrimRight(line, "\r")+"\r\n", outputMode)
}
```

So anything longer than the screen was hard-wrapped by the terminal at its own margin — mid-word. The message reader has always wrapped properly (`message_reader.go:254`); news simply never did.

## Before / after, same body, same terminal

A 392-character single-line body, captured live over telnet:

**Before** — one line, terminal chops it wherever it lands:
```text
[392] This is a deliberately long paragraph written as one single line with no embedded newlines whatsoever, so that the only thing that can possibly break it across the screen is either our word wrapping or the terminal's own hard margin, and incorporating extraordinarily lengthy vocabulary such as counterrevolutionary and incomprehensibilities to make any mid-word breakage obvious at a glance.
```

**After** — wrapped on word boundaries, every line within budget:
```text
[ 72] This is a deliberately long paragraph written as one single line with no
[ 79] embedded newlines whatsoever, so that the only thing that can possibly break it
[ 72] across the screen is either our word wrapping or the terminal's own hard
[ 68] margin, and incorporating extraordinarily lengthy vocabulary such as
[ 76] counterrevolutionary and incomprehensibilities to make any mid-word breakage
[ 20] obvious at a glance.
```

## Two details the naive version gets wrong

**Pipe codes must be converted before wrapping.** News bodies support colour — `wv` runs them through `ReplacePipeCodes` — so this is a live path, not a theoretical one. `wrapAnsiString` measures width with ANSI escapes stripped but knows nothing about pipe codes, so wrapping the raw body counts `|04` as three visible columns. Demonstrated: a body of **59 visible columns** was being split into **49 + 9**. Converting first (exactly what the reader does at `message_reader.go:234`) fixes it, and the wrapped lines are then written straight through rather than pipe-processed a second time.

**Width is one column short of the terminal.** The body is written as a sequence of CRLF-terminated lines, so a line filling the full width triggers the terminal's own auto-wrap and pushes the CRLF onto the next row — a blank line between every wrapped line. The codebase already reserves this column elsewhere for sequentially written output (`message_reader_subst.go:240`, `v3net_areas.go:173`). The reader can use the full width because it renders into a cursor-addressed region instead.

When the width is unknown this falls back to 79 rather than to "do not wrap" — no wrapping is the original bug.

## Scope

`termWidth` is threaded through `displayNewsItem` to its six call sites, all of which already had it in scope. ANSI art is untouched: `wrapAnsiString` detects cursor positioning and splits on newlines only, so a sysop pasting art into an item still gets it positioned rather than reflowed.

## Testing

`go build ./...`, `go vet`, `go test ./...` all clean. Nine unit tests cover the width budget, CRLF normalization, word-boundary wrapping with exact round-trip of the text, preservation of authored paragraph breaks, ANSI-art passthrough, visible-column measurement with pipe codes, and colour survival.

Verified live against a real BBS for both the plain long paragraph above and a colour-coded one — wraps on visible columns, ANSI escapes intact in the raw stream, no literal pipe codes leaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQuYC88yCUrF8isfJdNJyY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved news display wrapping to fit the available terminal and header width.
  - Split oversized unbroken text, including long URLs, within the visible-width limit.
  - Preserved colors and ANSI formatting while wrapping news content.
  - Kept ANSI artwork layout intact during rendering.
  - Normalized line endings and retained intentional blank lines.
  - Reduced unwanted terminal auto-wrapping artifacts, including for colored and long news content.
  - Improved consistency across news viewing and editing screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->