### PR TITLE
feat(scripting): expose previousLogin to scripts

### DIFF
--- a/docs/sysop/scripting/vpl-scripting.md
+++ b/docs/sysop/scripting/vpl-scripting.md
@@ -360,13 +360,34 @@ Read-only access to the user database. Returns safe fields only — no passwords
 | `filePoints` | number |
 | `validated` | boolean |
 | `lastLogin` | number (Unix timestamp) |
+| `previousLogin` | number (Unix timestamp, `0` if never) |
 | `createdAt` | number (Unix timestamp) |
 
-> **`lastLogin` is the current session, not the caller's previous visit.** It is
-> stamped at authentication, before any script runs, so a script comparing
-> against it to find "what is new since this user was last here" will always
-> come up empty. The user record's `previousLogin` field holds the prior visit
-> but is not yet exposed to scripts — see issue #208.
+#### `lastLogin` vs `previousLogin`
+
+`lastLogin` is **the current session**, not the caller's previous visit. It is
+stamped at authentication, before any script runs, so it always reads as "a
+moment ago".
+
+To ask *"what is new since this user was last here?"* — a custom newscan, a
+bulletin gate, a welcome-back banner — compare against `previousLogin`:
+
+```javascript
+// Right: finds everything posted since the caller was last on.
+var fresh = items.filter(function (i) { return i.postedAt > user.previousLogin; });
+
+// Wrong: lastLogin is this session, so this is always empty.
+var none = items.filter(function (i) { return i.postedAt > user.lastLogin; });
+```
+
+The failure is silent — the second form returns an empty list rather than an
+error — which is what made the same mistake go unnoticed in the BBS itself for
+system news, the rumors newscan, and the `|LCALL` display placeholder.
+
+`previousLogin` is **`0`** for a caller with no previous visit. That is falsy,
+so `if (user.previousLogin)` reads naturally, and it is early enough that a
+`>` comparison treats everything as new — the right answer for a first-time
+caller.
 
 ---
 

--- a/internal/scripting/users.go
+++ b/internal/scripting/users.go
@@ -1,6 +1,8 @@
 package scripting
 
 import (
+	"time"
+
 	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 	"github.com/dop251/goja"
@@ -71,8 +73,24 @@ func userToJS(vm *goja.Runtime, u *user.User) goja.Value {
 	jsutil.Set(obj, "filePoints", u.FilePoints)
 	jsutil.Set(obj, "validated", u.Validated)
 	jsutil.Set(obj, "lastLogin", u.LastLogin.Unix())
+	jsutil.Set(obj, "previousLogin", unixOrZero(u.PreviousLogin))
 	jsutil.Set(obj, "createdAt", u.CreatedAt.Unix())
 	return obj
+}
+
+// unixOrZero converts a timestamp for JS, mapping the zero time to 0 rather
+// than to time.Time{}.Unix(), which is -62135596800.
+//
+// 0 is the useful value for a caller with no previous visit. It is falsy, so
+// `if (user.previousLogin)` reads naturally, and it is early enough that a
+// script comparing `postedAt > user.previousLogin` treats everything as new —
+// which is the right answer for someone who has never called before. The raw
+// negative would behave the same numerically but is baffling to print or log.
+func unixOrZero(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.Unix()
 }
 
 func intToStr(i int) string {

--- a/internal/scripting/users_previouslogin_test.go
+++ b/internal/scripting/users_previouslogin_test.go
@@ -93,9 +93,16 @@ func TestScriptNewSinceLastVisitWorksWithPreviousLogin(t *testing.T) {
 		prev.Add(-48*time.Hour).Unix(), prev.Add(-time.Hour).Unix(),
 		prev.Add(time.Hour).Unix(), prev.Add(24*time.Hour).Unix())
 
-	res := evalWithUser(t, u, expr).Export().([]interface{})
-	withPrev := toInt(res[0])
-	withLast := toInt(res[1])
+	exported := evalWithUser(t, u, expr).Export()
+	res, ok := exported.([]interface{})
+	if !ok {
+		t.Fatalf("script returned %T (%v), want a two-element array", exported, exported)
+	}
+	if len(res) != 2 {
+		t.Fatalf("script returned %d values, want 2: %v", len(res), res)
+	}
+	withPrev := toInt(t, res[0])
+	withLast := toInt(t, res[1])
 
 	if withPrev != 2 {
 		t.Errorf("using previousLogin found %d new items, want 2", withPrev)
@@ -105,13 +112,17 @@ func TestScriptNewSinceLastVisitWorksWithPreviousLogin(t *testing.T) {
 	}
 }
 
-func toInt(v interface{}) int {
+// toInt converts a value exported from goja, which may arrive as either
+// integer or float depending on how the VM represents the number.
+func toInt(t *testing.T, v interface{}) int {
+	t.Helper()
 	switch n := v.(type) {
 	case int64:
 		return int(n)
 	case float64:
 		return int(n)
 	default:
-		return -1
+		t.Fatalf("expected a number from the script, got %T (%v)", v, v)
+		return 0
 	}
 }

--- a/internal/scripting/users_previouslogin_test.go
+++ b/internal/scripting/users_previouslogin_test.go
@@ -1,0 +1,117 @@
+package scripting
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+	"github.com/dop251/goja"
+)
+
+// evalWithUser exposes u to a script as `u` and returns the expression's value.
+func evalWithUser(t *testing.T, u *user.User, expr string) goja.Value {
+	t.Helper()
+	vm := goja.New()
+	if err := vm.Set("u", userToJS(vm, u)); err != nil {
+		t.Fatalf("set user: %v", err)
+	}
+	v, err := vm.RunString(expr)
+	if err != nil {
+		t.Fatalf("eval %q: %v", expr, err)
+	}
+	return v
+}
+
+func TestUnixOrZeroMapsZeroTimeToZero(t *testing.T) {
+	if got := unixOrZero(time.Time{}); got != 0 {
+		t.Errorf("unixOrZero(zero) = %d, want 0 (not %d)", got, time.Time{}.Unix())
+	}
+	stamp := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	if got := unixOrZero(stamp); got != stamp.Unix() {
+		t.Errorf("unixOrZero(%v) = %d, want %d", stamp, got, stamp.Unix())
+	}
+}
+
+func TestPreviousLoginExposedToScripts(t *testing.T) {
+	prev := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	u := &user.User{
+		Handle:        "Felonius",
+		LastLogin:     time.Date(2026, 9, 6, 9, 0, 0, 0, time.UTC), // this session
+		PreviousLogin: prev,
+	}
+
+	if got := evalWithUser(t, u, "u.previousLogin").ToInteger(); got != prev.Unix() {
+		t.Errorf("u.previousLogin = %d, want %d", got, prev.Unix())
+	}
+	// lastLogin is unchanged: scripts may already depend on it.
+	if got := evalWithUser(t, u, "u.lastLogin").ToInteger(); got != u.LastLogin.Unix() {
+		t.Errorf("u.lastLogin = %d, want %d", got, u.LastLogin.Unix())
+	}
+	// The distinction that makes the field worth having.
+	if evalWithUser(t, u, "u.lastLogin === u.previousLogin").ToBoolean() {
+		t.Error("lastLogin and previousLogin must not be the same value")
+	}
+}
+
+// A first-time caller must not be handed -62135596800.
+func TestFirstTimeCallerPreviousLoginIsZeroAndFalsy(t *testing.T) {
+	u := &user.User{Handle: "Newbie", LastLogin: time.Now()} // PreviousLogin zero
+
+	if got := evalWithUser(t, u, "u.previousLogin").ToInteger(); got != 0 {
+		t.Errorf("u.previousLogin = %d, want 0 for a first-time caller", got)
+	}
+	// Falsy, so `if (user.previousLogin)` reads naturally in a script.
+	if evalWithUser(t, u, "!!u.previousLogin").ToBoolean() {
+		t.Error("previousLogin should be falsy when there is no previous visit")
+	}
+}
+
+// The trap this field exists to fix: a script asking "what is new since this
+// user was last here?" finds nothing when it compares against lastLogin,
+// because that is stamped at authentication before any script runs.
+func TestScriptNewSinceLastVisitWorksWithPreviousLogin(t *testing.T) {
+	prev := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	u := &user.User{
+		Handle:        "Felonius",
+		LastLogin:     time.Date(2026, 9, 6, 9, 0, 0, 0, time.UTC),
+		PreviousLogin: prev,
+	}
+
+	// Four items, two posted since the user was last on.
+	script := `
+		var posted = [
+			%d, %d,   // before the previous visit
+			%d, %d    // after it
+		];
+		function countNewerThan(cut) {
+			return posted.filter(function (p) { return p > cut; }).length;
+		}
+		[countNewerThan(u.previousLogin), countNewerThan(u.lastLogin)];
+	`
+	expr := fmt.Sprintf(script,
+		prev.Add(-48*time.Hour).Unix(), prev.Add(-time.Hour).Unix(),
+		prev.Add(time.Hour).Unix(), prev.Add(24*time.Hour).Unix())
+
+	res := evalWithUser(t, u, expr).Export().([]interface{})
+	withPrev := toInt(res[0])
+	withLast := toInt(res[1])
+
+	if withPrev != 2 {
+		t.Errorf("using previousLogin found %d new items, want 2", withPrev)
+	}
+	if withLast != 0 {
+		t.Errorf("using lastLogin found %d new items, want 0 — that is the trap", withLast)
+	}
+}
+
+func toInt(v interface{}) int {
+	switch n := v.(type) {
+	case int64:
+		return int(n)
+	case float64:
+		return int(n)
+	default:
+		return -1
+	}
+}


### PR DESCRIPTION
Closes #208.

`userToJS` handed scripts `lastLogin` and nothing else time-related. That stamp is written at authentication — before the login sequence and before any script runs — so a script asking *"what is new since this user was last here?"* compares against the current session and silently finds nothing.

It is the same trap that stopped system news displaying (#198), made the rumors and file newscans find nothing, and had `|LCALL` rendering today's date. All fixed in the BBS itself; the scripting bridge was the last place it survived.

## The zero value

A caller with no previous visit reports **`0`**, not `time.Time{}.Unix()` which is `-62135596800`.

Zero is falsy, so `if (user.previousLogin)` reads naturally, and it is early enough that `postedAt > user.previousLogin` treats everything as new — the right answer for a first-time caller. The raw negative behaves identically in a numeric comparison but is baffling to print or log.

## `lastLogin` is deliberately unchanged

It is accurate for what it says, and scripts do depend on it. The shipped `scripts/examples/last10.js` sorts users by `lastLogin` to find the most recent callers — a legitimate use that has nothing to do with the per-user "since your last visit" question. Changing its meaning would break it.

The reference now documents the distinction with both forms side by side, since the failure mode is an empty result rather than an error:

```javascript
// Right: finds everything posted since the caller was last on.
var fresh = items.filter(function (i) { return i.postedAt > user.previousLogin; });

// Wrong: lastLogin is this session, so this is always empty.
var none = items.filter(function (i) { return i.postedAt > user.lastLogin; });
```

## Testing

`go build ./...`, `go vet`, `go test ./...` clean. Four tests run against a real goja VM through `userToJS`, covering the zero-time mapping, both fields being exposed and distinct, a first-time caller getting a falsy `0`, and — the one that matters — a script filtering a list of timestamps, asserting `previousLogin` finds the 2 items posted since the last visit while `lastLogin` finds 0.

That last test fails against the old behaviour, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQuYC88yCUrF8isfJdNJyY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Scripting user objects now include `previousLogin`, a Unix timestamp for the user’s prior visit.
  - First-time users receive `0`, allowing scripts to identify users who have not logged in previously.
  - Scripts can compare `previousLogin` with `lastLogin` to identify content added since a user’s last visit.

- **Documentation**
  - Clarified the difference between `lastLogin` (current session) and `previousLogin` (previous visit).
  - Added examples for accurately scanning newly added content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->