### PR TITLE
docs(users): correct the new-user defaults and state what signup sets

### DIFF
--- a/docs/sysop/configuration/configuration.md
+++ b/docs/sysop/configuration/configuration.md
@@ -446,7 +446,7 @@ built-in defaults and overlays whatever the file provides.
 | `logonLevel` | `10` | `10` | Minimum level required to log in |
 | `anonymousLevel` | `50` | `5` | Minimum level to post anonymously (`0` = disabled) |
 
-See [User Management](../users/user-management.md#system-access-levels) for how
+See [User Management](users/user-management.md#system-access-levels) for how
 these interact, and what happens at signup.
 
 **Default Settings:**

--- a/docs/sysop/configuration/configuration.md
+++ b/docs/sysop/configuration/configuration.md
@@ -428,19 +428,30 @@ General BBS configuration. All settings in this file are managed through the **S
 
 **Access Levels:**
 
-- `sysOpLevel` — Security level for SysOp access (default: `255`)
-- `coSysOpLevel` — Security level for Co-SysOp access (default: `250`)
-- `invisibleLevel` — Level at which a user is invisible in the who's-online list (default: `0`, falls back to `coSysOpLevel`)
-- `newUserLevel` — Level assigned to a brand-new account (default: `1`)
-- `regularUserLevel` — Level for validated/regular users (default: `10`)
-- `logonLevel` — Level granted on successful login (default: `10`)
-- `anonymousLevel` — Level for guest/anonymous access (default: `5`, `0` = disabled)
+Two different sets of values are called "defaults" here, and they differ. The
+**shipped** value is what a normal install gets, since setup copies
+`templates/configs/config.json` into `configs/`. The **fallback** applies only
+when a key is absent from your `config.json` — the loader starts from the
+built-in defaults and overlays whatever the file provides.
+
+| Setting | Shipped | Fallback | Meaning |
+| ------- | ------- | -------- | ------- |
+| `sysOpLevel` | `255` | `255` | SysOp access |
+| `coSysOpLevel` | `250` | `250` | Co-SysOp access |
+| `invisibleLevel` | `250` | `0` | Invisible in who's-online (`0` falls back to `coSysOpLevel`) |
+| `newUserLevel` | `10` | `1` | Assigned to a brand-new account |
+| `regularUserLevel` | `25` | `10` | Assigned when a user is validated |
+| `logonLevel` | `10` | `10` | Minimum level required to log in |
+| `anonymousLevel` | `50` | `5` | Minimum level to post anonymously (`0` = disabled) |
+
+See [User Management](../users/user-management.md#system-access-levels) for how
+these interact, and what happens at signup.
 
 **Default Settings:**
 
-- `allowNewUsers` — Accept new user registrations (default: `true`)
+- `allowNewUsers` — Accept new user registrations (shipped and fallback: `true`)
 - `fileListingMode` — `""` or `"lightbar"` (default) / `"classic"`
-- `deletedUserRetentionDays` — Days to keep soft-deleted user records before `helper users purge` removes them (default: `30`, `-1` = keep forever)
+- `deletedUserRetentionDays` — Days to keep soft-deleted user records before `helper users purge` removes them (shipped: `-1`, keep forever; fallback: `30`)
 
 **IP Blocklist/Allowlist:**
 

--- a/docs/sysop/configuration/configuration.md
+++ b/docs/sysop/configuration/configuration.md
@@ -426,6 +426,8 @@ General BBS configuration. All settings in this file are managed through the **S
 - `sessionIdleTimeoutMinutes` — Idle session cutoff (default: `5`)
 - `transferTimeoutMinutes` — File transfer timeout (default: `10`)
 
+<a id="access-levels"></a>
+
 **Access Levels:**
 
 Two different sets of values are called "defaults" here, and they differ. The
@@ -438,7 +440,7 @@ built-in defaults and overlays whatever the file provides.
 | ------- | ------- | -------- | ------- |
 | `sysOpLevel` | `255` | `255` | SysOp access |
 | `coSysOpLevel` | `250` | `250` | Co-SysOp access |
-| `invisibleLevel` | `250` | `0` | Invisible in who's-online (`0` falls back to `coSysOpLevel`) |
+| `invisibleLevel` | `250` | `0` | Minimum level offered the Invisible Logon prompt, letting the caller keep the session off the Last Callers list (`0` falls back to `coSysOpLevel`) |
 | `newUserLevel` | `10` | `1` | Assigned to a brand-new account |
 | `regularUserLevel` | `25` | `10` | Assigned when a user is validated |
 | `logonLevel` | `10` | `10` | Minimum level required to log in |

--- a/docs/sysop/users/user-management.md
+++ b/docs/sysop/users/user-management.md
@@ -156,12 +156,20 @@ ViSiON/3 uses several key configuration values in `configs/config.json` to contr
 {
   "sysOpLevel": 255,
   "coSysOpLevel": 250,
-  "newUserLevel": 1,
-  "regularUserLevel": 10,
+  "invisibleLevel": 250,
+  "newUserLevel": 10,
+  "regularUserLevel": 25,
   "logonLevel": 10,
-  "anonymousLevel": 5
+  "anonymousLevel": 50
 }
 ```
+
+These are the values in the shipped `templates/configs/config.json`, which
+setup copies into `configs/` — so they are what a normal install runs. If a key
+is missing from your `config.json` the loader falls back to a built-in value
+instead, and several of those differ (`newUserLevel` 1, `regularUserLevel` 10,
+`anonymousLevel` 5). [Configuration](../configuration/configuration.md#access-levels)
+lists both sets side by side.
 
 **Configuration Values:**
 
@@ -171,11 +179,11 @@ ViSiON/3 uses several key configuration values in `configs/config.json` to contr
 
 - **newUserLevel (10)**: The access level assigned to users when they first sign up. This is an *assignment value* — when someone registers a new account, they get this level. Default is 10 (allows immediate login after registration).
 
-- **regularUserLevel (20)**: The access level assigned to users when they are validated by the SysOp. This is an *assignment value* — when you validate a user, their level is upgraded to this value (if they're below it).
+- **regularUserLevel (25)**: The access level assigned to users when they are validated by the SysOp. This is an *assignment value* — when you validate a user, their level is upgraded to this value (if they're below it).
 
 - **logonLevel (10)**: Minimum access level required to log in to the BBS. This is a *threshold check* — users below this level are denied login even if their password is correct. Set to `0` to disable this check.
 
-- **anonymousLevel (5)**: Minimum access level required to post messages/oneliners anonymously. This is a *threshold check* — users at or above this level can choose to post as "Anonymous" instead of their real name. Set to `0` to disable anonymous posting entirely, or `255` to restrict to SysOps only.
+- **anonymousLevel (50)**: Minimum access level required to post messages/oneliners anonymously. This is a *threshold check* — users at or above this level can choose to post as "Anonymous" instead of their real name. Set to `0` to disable anonymous posting entirely, or `255` to restrict to SysOps only.
 
 ### Login Flow and Level Checks
 
@@ -185,6 +193,32 @@ When a user attempts to log in, the system performs two checks in order:
 2. **Meets LogonLevel** → If fails: "Access Denied"
 
 Access control is based solely on the user's **access level**. The `validated` flag is used for administrative purposes but does **not** block login.
+
+### What a New Account Starts With
+
+Every account created through the signup flow starts as:
+
+| Field | Value |
+| ----- | ----- |
+| `accessLevel` | `newUserLevel` — `10` in the shipped config |
+| `validated` | **`false`**, always |
+
+`validated: false` is **not configurable**. It is set unconditionally when the
+account is created (`internal/user/manager_users.go`), so there is no setting
+that makes signups arrive pre-validated. Sysops looking for auto-validation
+will not find a switch for it — the options are:
+
+- **Raise `newUserLevel`** so new accounts can already do what you want without
+  being validated. Access is controlled by level, not by the flag (see below),
+  so this is the setting that actually governs what a new caller can reach.
+- **Validate by hand** afterwards, from `./ue` or the admin menu, which also
+  upgrades the account to `regularUserLevel`.
+- **Turn on New User Voting** (`useNuv`) and let existing users vote newcomers
+  in. Off by default. See [New User Voting](nuv.md).
+
+Note that `accessLevel` and `validated` move independently. Raising a user's
+level does not validate them, so an ACS check written against validation status
+still fails for a high-level unvalidated account.
 
 ### What the `validated` Flag Does
 
@@ -196,33 +230,33 @@ The `validated` flag serves these purposes:
 
 **Key Point:** If you want to prevent new users from logging in until you review them, set `newUserLevel` below `logonLevel` (e.g., `newUserLevel: 1, logonLevel: 10`). Don't rely on the `validated` flag for access control.
 
-**Example with default config (newUserLevel=10, logonLevel=10, regularUserLevel=20):**
+**Example with the shipped config (newUserLevel=10, logonLevel=10, regularUserLevel=25):**
 
-- User registers → Gets AccessLevel: 10, Validated: false
+- User registers → Gets AccessLevel: 10, Validated: **false**
 - User logs in → Passes (level 10 meets logonLevel 10)
 - User has limited access via ACS `s10` restrictions
-- SysOp validates user → AccessLevel upgraded to 20, Validated: true
-- User now has full access via ACS `s20` permissions
+- SysOp validates user → AccessLevel upgraded to 25, Validated: true
+- User now has full access via ACS `s25` permissions
 
 ### Creating Tiered Access Systems
 
 By adjusting `newUserLevel`, `logonLevel`, and `regularUserLevel`, you can create sophisticated multi-tier access systems:
 
-**Simple Configuration (Default - Immediate Login, Tiered Access):**
+**Simple Configuration (what ships — immediate login, tiered access):**
 ```json
 {
   "newUserLevel": 10,
   "logonLevel": 10,
-  "regularUserLevel": 20
+  "regularUserLevel": 25
 }
 ```
 
 - Level 0: Banned (cannot log in)
 - Level 1-9: Locked out (below logonLevel threshold)
-- Level 10-19: New users (can log in with limited access via ACS `s10`)
-- Level 20+: Validated users (full access via ACS `s20`)
+- Level 10-24: New users (can log in with limited access via ACS `s10`)
+- Level 25+: Validated users (full access via ACS `s25`)
 
-**Workflow:** User signs up (level 10) → can log in immediately with limited access → SysOp validates → upgraded to level 20 → full access granted
+**Workflow:** User signs up (level 10) → can log in immediately with limited access → SysOp validates → upgraded to level 25 → full access granted
 
 **Manual Validation Required (Secure - No Auto-Login):**
 ```json

--- a/docs/sysop/users/user-management.md
+++ b/docs/sysop/users/user-management.md
@@ -167,9 +167,10 @@ ViSiON/3 uses several key configuration values in `configs/config.json` to contr
 These are the values in the shipped `templates/configs/config.json`, which
 setup copies into `configs/` — so they are what a normal install runs. If a key
 is missing from your `config.json` the loader falls back to a built-in value
-instead, and several of those differ (`newUserLevel` 1, `regularUserLevel` 10,
-`anonymousLevel` 5). [Configuration](../configuration/configuration.md#access-levels)
-lists both sets side by side.
+instead, and four of these differ that way (`invisibleLevel` 0, `newUserLevel` 1,
+`regularUserLevel` 10, `anonymousLevel` 5).
+[Configuration](../configuration/configuration.md#access-levels) lists both sets
+side by side.
 
 **Configuration Values:**
 

--- a/docs/sysop/users/user-management.md
+++ b/docs/sysop/users/user-management.md
@@ -169,7 +169,7 @@ setup copies into `configs/` — so they are what a normal install runs. If a ke
 is missing from your `config.json` the loader falls back to a built-in value
 instead, and four of these differ that way (`invisibleLevel` 0, `newUserLevel` 1,
 `regularUserLevel` 10, `anonymousLevel` 5).
-[Configuration](../configuration/configuration.md#access-levels) lists both sets
+[Configuration](configuration/configuration.md#access-levels) lists both sets
 side by side.
 
 **Configuration Values:**
@@ -215,7 +215,7 @@ will not find a switch for it — the options are:
 - **Validate by hand** afterwards, from `./ue` or the admin menu, which also
   upgrades the account to `regularUserLevel`.
 - **Turn on New User Voting** (`useNuv`) and let existing users vote newcomers
-  in. Off by default. See [New User Voting](nuv.md).
+  in. Off by default. See [New User Voting](users/nuv.md).
 
 Note that `accessLevel` and `validated` move independently. Raising a user's
 level does not validate them, so an ACS check written against validation status
@@ -255,7 +255,7 @@ By adjusting `newUserLevel`, `logonLevel`, and `regularUserLevel`, you can creat
 - Level 0: Banned (cannot log in)
 - Level 1-9: Locked out (below logonLevel threshold)
 - Level 10-24: New users (can log in with limited access via ACS `s10`)
-- Level 25+: Validated users (full access via ACS `s25`)
+- Level 25+: Users at level 25+ (full access via ACS `s25`)
 
 **Workflow:** User signs up (level 10) → can log in immediately with limited access → SysOp validates → upgraded to level 25 → full access granted
 
@@ -451,7 +451,7 @@ The application can also be invoked from a menu command via `RUN:NEWUSER`.
 8. **Account Creation** — Calls `UserMgr.AddUser()` which:
    - Assigns the next available user ID
    - Hashes the password with bcrypt
-   - Sets `accessLevel` to 1 and `validated` to false
+   - Sets `accessLevel` to `um.newUserLevel` (`newUserLevel` from config, shipped default `10`; falls back to `1` if unset) and `validated` to false
    - Sets `timeLimit` to 60 minutes
    - Saves to `data/users/users.json`
 10. **User Number** — Displays the assigned ID using `yourUserNum`
@@ -486,8 +486,8 @@ Place a `NEWUSER.ANS` file in `menus/v3/ansi/` to display a welcome screen befor
 
 New accounts are created with:
 
-- `validated: false` — user cannot log in until a SysOp sets this to `true`
-- `accessLevel: 1` — minimal access level
+- `validated: false` — set unconditionally; it does **not** block login (see [What the `validated` Flag Does](#what-the-validated-flag-does))
+- `accessLevel: um.newUserLevel` — `10` in the shipped config; falls back to `1` if `newUserLevel` is unset
 - `timeLimit: 60` — 60-minute time limit per call
 
 The SysOp can validate users in-BBS from the Admin Menu (`%` from MAIN → `V`). See [Admin Menu](users/admin-menu.md) for the full key reference.


### PR DESCRIPTION
Closes #204.

The issue asks for the new-user defaults to be documented. Checking them against the source turned up that most of the surrounding numbers were wrong, because **two different things are called "defaults" and the docs mixed them.**

## Two sets of defaults

`templates/configs/config.json` is what a normal install runs — setup copies it into `configs/`. The built-in fallback only applies to keys *absent* from that file: `LoadServerConfig` starts from `defaultConfig` and unmarshals the file over it.

Five settings differ:

| Setting | Shipped | Fallback |
| --- | --- | --- |
| `invisibleLevel` | `250` | `0` |
| `newUserLevel` | `10` | `1` |
| `regularUserLevel` | `25` | `10` |
| `anonymousLevel` | `50` | `5` |
| `deletedUserRetentionDays` | `-1` | `30` |

`configuration.md` documented the **fallback** column throughout — the set almost nobody experiences. It now shows both, labelled.

`user-management.md` was worse: its sample config block showed the fallback values while the prose beside it described different ones, and its `regularUserLevel` figure of **20 matched neither**. Corrected against the shipped config, along with the worked example and the tiering walkthrough that both depended on 20.

The alternative tiering examples are deliberately left alone — they are different configurations offered as options, not claims about defaults.

## The issue's actual ask

A new section states what signup produces:

| Field | Value |
| --- | --- |
| `accessLevel` | `newUserLevel` — `10` shipped |
| `validated` | **`false`**, always |

The part worth spelling out is that **`validated: false` is not configurable** — it is set unconditionally at account creation, so a sysop looking for an auto-validation switch will not find one. The issue notes many sysops want exactly that, so the docs now name the three actual levers: raise `newUserLevel`, validate by hand, or enable New User Voting.

Also notes that level and validation move independently, so raising a level does not satisfy an ACS check written against validation status.

## Verification

Rather than eyeballing, I checked the documented numbers programmatically against the source of truth:

```text
sample block vs shipped config: MATCHES
configuration.md shipped column: MATCHES
stale 'regularUserLevel (20)': gone
stale 'anonymousLevel (5)': gone
stale 'newUserLevel ... (default: `1`)': gone
```

Docs-only change; `go build ./...` and `go test ./...` still clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQuYC88yCUrF8isfJdNJyY