### PR TITLE
feat(users): continue into the session after signup

### DIFF
--- a/cmd/vision3/main.go
+++ b/cmd/vision3/main.go
@@ -1072,7 +1072,7 @@ func sessionHandler(s ssh.Session) {
 			}
 		}
 
-		matrixAction, matrixErr := menuExecutor.RunMatrixScreen(s, terminal, userMgr, int(nodeID), effectiveMode, int(termWidth.Load()), int(termHeight.Load()))
+		matrixAction, matrixUser, matrixErr := menuExecutor.RunMatrixScreen(s, terminal, userMgr, int(nodeID), effectiveMode, int(termWidth.Load()), int(termHeight.Load()))
 		if matrixErr != nil {
 			slog.Error("matrix screen error", "node", nodeID, "error", matrixErr)
 			return
@@ -1080,6 +1080,18 @@ func sessionHandler(s ssh.Session) {
 		if matrixAction == "DISCONNECT" {
 			slog.Info("user selected disconnect from matrix", "node", nodeID)
 			return
+		}
+		// A completed signup hands back the account to continue as, so the
+		// caller is not asked for credentials they set moments ago. The login
+		// loop below is skipped, but everything after it — including the login
+		// sequence — runs exactly as for any other caller.
+		if matrixUser != nil {
+			authenticatedUser = matrixUser
+			bbsSession.Mutex.Lock()
+			bbsSession.User = authenticatedUser
+			bbsSession.Mutex.Unlock()
+			userMgr.MarkUserOnline(authenticatedUser.ID)
+			slog.Info("continuing as newly created user", "node", nodeID, "user", authenticatedUser.Handle)
 		}
 		// matrixAction == "LOGIN" — proceed to normal login loop
 	}

--- a/internal/menu/executor_login_auth.go
+++ b/internal/menu/executor_login_auth.go
@@ -93,7 +93,7 @@ func runAuthenticate(c *cmdCtx, args string) (*user.User, string, error) {
 		}
 		// Carry them into the session rather than making them re-enter the
 		// handle and password they set moments ago.
-		if started := e.continueAsNewUser(userManager, newUser, nodeNumber); started != nil {
+		if started := e.continueAsNewUser(s, userManager, newUser, nodeNumber); started != nil {
 			return started, "", nil
 		}
 		return nil, "", nil // Could not continue: back to the LOGIN screen

--- a/internal/menu/executor_login_auth.go
+++ b/internal/menu/executor_login_auth.go
@@ -84,14 +84,19 @@ func runAuthenticate(c *cmdCtx, args string) (*user.User, string, error) {
 	// Check if user wants to apply as a new user
 	if strings.EqualFold(username, "new") {
 		slog.Info("user typed 'new' in AUTHENTICATE - starting new user application", "node", nodeNumber)
-		newUserErr := e.handleNewUserApplication(s, terminal, userManager, nodeNumber, outputMode, termWidth, termHeight)
+		newUser, newUserErr := e.handleNewUserApplication(s, terminal, userManager, nodeNumber, outputMode, termWidth, termHeight)
 		if newUserErr != nil {
 			if errors.Is(newUserErr, io.EOF) {
 				return nil, "LOGOFF", io.EOF
 			}
 			slog.Error("new user application error", "node", nodeNumber, "error", newUserErr)
 		}
-		return nil, "", nil // Return to LOGIN screen after signup
+		// Carry them into the session rather than making them re-enter the
+		// handle and password they set moments ago.
+		if started := e.continueAsNewUser(userManager, newUser, nodeNumber); started != nil {
+			return started, "", nil
+		}
+		return nil, "", nil // Could not continue: back to the LOGIN screen
 	}
 
 	// Move to Password position, display prompt, and read input securely

--- a/internal/menu/executor_login_prompt.go
+++ b/internal/menu/executor_login_prompt.go
@@ -78,14 +78,17 @@ func (e *MenuExecutor) handleLoginPrompt(s ssh.Session, terminal *term.Terminal,
 	// Check if user wants to apply as a new user
 	if strings.EqualFold(username, "new") {
 		slog.Info("user typed 'new' - starting new user application", "node", nodeNumber)
-		err := e.handleNewUserApplication(s, terminal, userManager, nodeNumber, outputMode, termWidth, termHeight)
+		newUser, err := e.handleNewUserApplication(s, terminal, userManager, nodeNumber, outputMode, termWidth, termHeight)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				return nil, io.EOF
 			}
 			slog.Error("new user application error", "node", nodeNumber, "error", err)
 		}
-		return nil, nil // Return to LOGIN screen after signup
+		if started := e.continueAsNewUser(userManager, newUser, nodeNumber); started != nil {
+			return started, nil
+		}
+		return nil, nil // Could not continue: back to the LOGIN screen
 	}
 
 	// Move to Password position (coordinates are accurate since display is truncated to fit)

--- a/internal/menu/executor_login_prompt.go
+++ b/internal/menu/executor_login_prompt.go
@@ -85,7 +85,7 @@ func (e *MenuExecutor) handleLoginPrompt(s ssh.Session, terminal *term.Terminal,
 			}
 			slog.Error("new user application error", "node", nodeNumber, "error", err)
 		}
-		if started := e.continueAsNewUser(userManager, newUser, nodeNumber); started != nil {
+		if started := e.continueAsNewUser(s, userManager, newUser, nodeNumber); started != nil {
 			return started, nil
 		}
 		return nil, nil // Could not continue: back to the LOGIN screen

--- a/internal/menu/matrix.go
+++ b/internal/menu/matrix.go
@@ -236,7 +236,7 @@ func (e *MenuExecutor) processMatrixAction(
 			}
 			slog.Error("new user application error from matrix", "node", nodeNumber, "error", err)
 		}
-		if started := e.continueAsNewUser(userManager, newUser, nodeNumber); started != nil {
+		if started := e.continueAsNewUser(s, userManager, newUser, nodeNumber); started != nil {
 			return "LOGIN", started, nil
 		}
 		return "MATRIX", nil, nil // Could not continue: back to the matrix

--- a/internal/menu/matrix.go
+++ b/internal/menu/matrix.go
@@ -30,18 +30,18 @@ func (e *MenuExecutor) RunMatrixScreen(
 	outputMode ansi.OutputMode,
 	termWidth int,
 	termHeight int,
-) (string, error) {
+) (string, *user.User, error) {
 	const menuName = "PDMATRIX"
 
 	// Load lightbar options from PDMATRIX.BAR
 	options, err := loadLightbarOptions(menuName, e)
 	if err != nil {
 		slog.Warn("failed to load BAR file, skipping matrix", "node", nodeNumber, "menu", menuName, "error", err)
-		return "LOGIN", nil
+		return "LOGIN", nil, nil
 	}
 	if len(options) == 0 {
 		slog.Warn("no options in BAR file, skipping matrix", "node", nodeNumber, "menu", menuName)
-		return "LOGIN", nil
+		return "LOGIN", nil, nil
 	}
 
 	// Load commands from PDMATRIX.CFG to map hotkeys to actions
@@ -49,7 +49,7 @@ func (e *MenuExecutor) RunMatrixScreen(
 	commands, err := LoadCommands(menuName, cfgPath)
 	if err != nil {
 		slog.Warn("failed to load CFG file, skipping matrix", "node", nodeNumber, "menu", menuName, "error", err)
-		return "LOGIN", nil
+		return "LOGIN", nil, nil
 	}
 
 	// Build hotkey → command map
@@ -64,7 +64,7 @@ func (e *MenuExecutor) RunMatrixScreen(
 	ansBackground, err := ansi.GetAnsiFileContent(ansPath)
 	if err != nil {
 		slog.Warn("failed to load ANS file, skipping matrix", "node", nodeNumber, "menu", menuName, "error", err)
-		return "LOGIN", nil
+		return "LOGIN", nil, nil
 	}
 
 	slog.Info("displaying pre-login matrix screen", "node", nodeNumber, "count", len(options))
@@ -81,7 +81,7 @@ func (e *MenuExecutor) RunMatrixScreen(
 	// Draw the initial screen
 	if err := drawMatrixScreen(terminal, ansBackground, options, selectedIndex, outputMode); err != nil {
 		slog.Error("failed to draw matrix screen", "node", nodeNumber, "error", err)
-		return "LOGIN", nil
+		return "LOGIN", nil, nil
 	}
 
 	// Apply the pre-login idle timeout on the shared InputHandler.
@@ -94,12 +94,12 @@ func (e *MenuExecutor) RunMatrixScreen(
 		if err != nil {
 			if errors.Is(err, editor.ErrIdleTimeout) {
 				e.handleIdleTimeout(terminal, outputMode, nodeNumber, termHeight)
-				return "DISCONNECT", nil
+				return "DISCONNECT", nil, nil
 			}
 			if errors.Is(err, io.EOF) {
-				return "DISCONNECT", io.EOF
+				return "DISCONNECT", nil, io.EOF
 			}
-			return "DISCONNECT", fmt.Errorf("failed reading matrix input: %w", err)
+			return "DISCONNECT", nil, fmt.Errorf("failed reading matrix input: %w", err)
 		}
 
 		newIndex := selectedIndex
@@ -161,12 +161,15 @@ func (e *MenuExecutor) RunMatrixScreen(
 			}
 			slog.Info("matrix selection", "node", nodeNumber, "text", options[selectedIndex].Text, "action", action)
 
-			result, err := e.processMatrixAction(action, s, terminal, userManager, nodeNumber, outputMode, termWidth, termHeight)
+			result, authed, err := e.processMatrixAction(action, s, terminal, userManager, nodeNumber, outputMode, termWidth, termHeight)
 			if err != nil {
-				return result, err
+				return result, authed, err
 			}
-			if result == "LOGIN" || result == "DISCONNECT" {
-				return result, nil
+			// A completed signup can hand back an account to continue as, so
+			// the caller is not sent round to type the credentials they just
+			// chose.
+			if result == "LOGIN" || result == "DISCONNECT" || authed != nil {
+				return result, authed, nil
 			}
 
 			// For actions that return to the matrix (like NEWUSER, CHECKACCESS),
@@ -179,7 +182,7 @@ func (e *MenuExecutor) RunMatrixScreen(
 
 	// Max tries exceeded
 	slog.Info("matrix max tries exceeded, disconnecting", "node", nodeNumber)
-	return "DISCONNECT", nil
+	return "DISCONNECT", nil, nil
 }
 
 // matrixPrintableKey resolves a printable keypress against the matrix options:
@@ -215,38 +218,41 @@ func (e *MenuExecutor) processMatrixAction(
 	outputMode ansi.OutputMode,
 	termWidth int,
 	termHeight int,
-) (string, error) {
+) (string, *user.User, error) {
 	switch action {
 	case "LOGIN":
 		// Show PRELOGON ANSI file before login screen (matches Pascal: Printfile(PRELOGON.x) + HoldScreen)
 		e.showPrelogon(s, terminal, nodeNumber, outputMode, termWidth, termHeight)
-		return "LOGIN", nil
+		return "LOGIN", nil, nil
 
 	case "NEWUSER":
 		// Clear screen immediately when transitioning from matrix to new user flow
 		terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 		terminalio.WriteProcessedBytes(terminal, []byte("\x1b[?25h"), outputMode) // Show cursor
-		err := e.handleNewUserApplication(s, terminal, userManager, nodeNumber, outputMode, termWidth, termHeight)
+		newUser, err := e.handleNewUserApplication(s, terminal, userManager, nodeNumber, outputMode, termWidth, termHeight)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return "DISCONNECT", io.EOF
+				return "DISCONNECT", nil, io.EOF
 			}
 			slog.Error("new user application error from matrix", "node", nodeNumber, "error", err)
 		}
-		return "MATRIX", nil // Return to matrix after signup
+		if started := e.continueAsNewUser(userManager, newUser, nodeNumber); started != nil {
+			return "LOGIN", started, nil
+		}
+		return "MATRIX", nil, nil // Could not continue: back to the matrix
 
 	case "CHECKACCESS":
 		e.handleCheckAccess(s, terminal, userManager, nodeNumber, outputMode)
-		return "MATRIX", nil // Return to matrix after check
+		return "MATRIX", nil, nil // Return to matrix after check
 
 	case "DISCONNECT":
 		terminalio.WriteStringCP437(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.MatrixDisconnecting)), outputMode)
-		return "DISCONNECT", nil
+		return "DISCONNECT", nil, nil
 
 	default:
 		slog.Warn("unknown matrix action", "node", nodeNumber, "action", action)
 		e.showUndefinedMenuInput(terminal, outputMode, nodeNumber)
-		return "MATRIX", nil
+		return "MATRIX", nil, nil
 	}
 }
 

--- a/internal/menu/newuser.go
+++ b/internal/menu/newuser.go
@@ -268,7 +268,15 @@ func (e *MenuExecutor) handleNewUserApplication(
 		pausePrompt = "\r\n|07Press |15[ENTER]|07 to continue... "
 	}
 	terminalio.WriteStringCP437(terminal, ansi.ReplacePipeCodes([]byte("\r\n"+pausePrompt)), outputMode)
-	_, _ = readLineFromSessionIH(s, terminal)
+	if _, pauseErr := readLineFromSessionIH(s, terminal); pauseErr != nil {
+		// The account is created and saved either way, but a caller who has
+		// dropped must not have a session opened for them: the callers' io.EOF
+		// handling has to run before they reach continueAsNewUser.
+		if errors.Is(pauseErr, io.EOF) {
+			return newUser, io.EOF
+		}
+		slog.Warn("error reading the signup pause", "node", nodeNumber, "handle", newUser.Handle, "error", pauseErr)
+	}
 
 	return newUser, nil
 }

--- a/internal/menu/newuser.go
+++ b/internal/menu/newuser.go
@@ -78,7 +78,7 @@ func (e *MenuExecutor) handleNewUserApplication(
 	outputMode ansi.OutputMode,
 	termWidth int,
 	termHeight int,
-) error {
+) (*user.User, error) {
 	slog.Info("starting new user application", "node", nodeNumber)
 
 	// Check if new user registration is allowed
@@ -96,7 +96,7 @@ func (e *MenuExecutor) handleNewUserApplication(
 		}
 		terminalio.WriteStringCP437(terminal, ansi.ReplacePipeCodes([]byte(pausePrompt)), outputMode)
 		_, _ = readLineFromSessionIH(s, terminal)
-		return nil
+		return nil, nil
 	}
 
 	// 1. "Apply for access?" prompt (before showing the ANS screen, matching Pascal flow)
@@ -107,14 +107,14 @@ func (e *MenuExecutor) handleNewUserApplication(
 	applyYes, err := e.PromptYesNo(s, terminal, applyPrompt, outputMode, nodeNumber, termWidth, termHeight, false)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
-			return io.EOF
+			return nil, io.EOF
 		}
 		slog.Error("error during apply prompt", "node", nodeNumber, "error", err)
-		return err
+		return nil, err
 	}
 	if !applyYes {
 		slog.Info("user declined new user application", "node", nodeNumber)
-		return nil
+		return nil, nil
 	}
 
 	// Show blinking underline cursor for form input
@@ -133,10 +133,10 @@ func (e *MenuExecutor) handleNewUserApplication(
 	// 3. Handle/Alias entry
 	handle, err := e.promptForHandle(s, terminal, userManager, nodeNumber, outputMode, termWidth, termHeight)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if handle == "" {
-		return nil // User cancelled
+		return nil, nil // User cancelled
 	}
 
 	// 4. Clear screen, show welcome and user number (matching Pascal: AnsiCls → Welcome → UserNum)
@@ -160,31 +160,31 @@ func (e *MenuExecutor) handleNewUserApplication(
 	// 5. Password creation with confirmation
 	password, err := e.promptForPassword(s, terminal, nodeNumber, outputMode, termWidth, termHeight)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if password == "" {
-		return nil // User cancelled
+		return nil, nil // User cancelled
 	}
 
 	// 6. Real name
 	realName, err := e.promptForRealName(s, terminal, nodeNumber, outputMode, termWidth, termHeight)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if realName == "" {
-		return nil // User cancelled
+		return nil, nil // User cancelled
 	}
 
 	// 7. User Note (optional)
 	userNote, err := e.promptForUserNote(s, terminal, nodeNumber, outputMode, termWidth, termHeight)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// 8. Location
 	location, err := e.promptForLocation(s, terminal, nodeNumber, outputMode, termWidth, termHeight)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// 9. Create account
@@ -199,7 +199,7 @@ func (e *MenuExecutor) handleNewUserApplication(
 		errMsg := e.LoadedStrings.NewUserCreationError
 		terminalio.WriteStringCP437(terminal, ansi.ReplacePipeCodes([]byte(errMsg)), outputMode)
 		time.Sleep(2 * time.Second)
-		return nil
+		return nil, nil
 	}
 
 	// Set the private note with creation date
@@ -270,7 +270,7 @@ func (e *MenuExecutor) handleNewUserApplication(
 	terminalio.WriteStringCP437(terminal, ansi.ReplacePipeCodes([]byte("\r\n"+pausePrompt)), outputMode)
 	_, _ = readLineFromSessionIH(s, terminal)
 
-	return nil
+	return newUser, nil
 }
 
 // displayNewUserScreen loads and displays NEWUSER.ANS.
@@ -685,7 +685,9 @@ func runNewUser(c *cmdCtx, args string) (*user.User, string, error) {
 	termWidth := c.termWidth
 	termHeight := c.termHeight
 
-	err := e.handleNewUserApplication(s, terminal, userManager, nodeNumber, outputMode, termWidth, termHeight)
+	// Invoked from a menu, so the caller is already in a session; the created
+	// account is not this session's user.
+	_, err := e.handleNewUserApplication(s, terminal, userManager, nodeNumber, outputMode, termWidth, termHeight)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
 			return nil, "LOGOFF", io.EOF

--- a/internal/menu/newuser_continue.go
+++ b/internal/menu/newuser_continue.go
@@ -1,0 +1,45 @@
+package menu
+
+import (
+	"log/slog"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+// continueAsNewUser decides whether a caller who has just created an account
+// should be carried straight into a session as that account, and if so does
+// the login bookkeeping for it.
+//
+// Returns nil when they should not be — either no account was created, or its
+// access level is below logonLevel, in which case continuing would only bounce
+// them back out. Validation is deliberately not consulted: it does not gate
+// login, so letting it gate this would reintroduce the confusion #222 fixed.
+//
+// The bookkeeping goes through UserMgr.BeginSession, the same call Authenticate
+// makes once a password verifies. Stamping lastLogin and timesCalled here by
+// hand would work until the two drifted, and a first call that goes unrecorded
+// is exactly the kind of gap that stays invisible.
+func (e *MenuExecutor) continueAsNewUser(userManager *user.UserMgr, newUser *user.User, nodeNumber int) *user.User {
+	if newUser == nil {
+		return nil
+	}
+	if !canLogonAtLevel(e.GetServerConfig(), newUser.AccessLevel) {
+		slog.Info("new account cannot log on yet; returning to the login prompt",
+			"node", nodeNumber, "handle", newUser.Handle, "level", newUser.AccessLevel)
+		return nil
+	}
+
+	started, ok := userManager.BeginSession(newUser.Handle)
+	if !ok {
+		// The account was created a moment ago, so this should not happen;
+		// fall back to a normal login rather than proceeding without the
+		// bookkeeping done.
+		slog.Warn("could not start a session for the new account; falling back to the login prompt",
+			"node", nodeNumber, "handle", newUser.Handle)
+		return nil
+	}
+
+	slog.Info("continuing into the session as the newly created account",
+		"node", nodeNumber, "handle", started.Handle, "level", started.AccessLevel)
+	return started
+}

--- a/internal/menu/newuser_continue.go
+++ b/internal/menu/newuser_continue.go
@@ -3,7 +3,9 @@ package menu
 import (
 	"log/slog"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/logging"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+	"github.com/gliderlabs/ssh"
 )
 
 // continueAsNewUser decides whether a caller who has just created an account
@@ -19,9 +21,22 @@ import (
 // makes once a password verifies. Stamping lastLogin and timesCalled here by
 // hand would work until the two drifted, and a first call that goes unrecorded
 // is exactly the kind of gap that stays invisible.
-func (e *MenuExecutor) continueAsNewUser(userManager *user.UserMgr, newUser *user.User, nodeNumber int) *user.User {
+func (e *MenuExecutor) continueAsNewUser(s ssh.Session, userManager *user.UserMgr, newUser *user.User, nodeNumber int) *user.User {
 	if newUser == nil {
 		return nil
+	}
+	// The login paths check the IP lockout after the "new" branch, which was
+	// harmless while signup could not authenticate anyone. Now that it can,
+	// skipping the check would let a locked-out client register an account and
+	// walk straight in — so it is enforced here, covering every caller.
+	if e.IPLockoutCheck != nil {
+		remoteIP := remoteIPFromSession(s)
+		if locked, until, attempts := e.IPLockoutCheck.IsIPLockedOut(remoteIP); locked {
+			logging.Security("blocked session continuation for a locked IP after signup",
+				"node", nodeNumber, "ip", remoteIP, "handle", newUser.Handle,
+				"locked_until", until.Format("2006-01-02 15:04:05"), "attempts", attempts)
+			return nil
+		}
 	}
 	if !canLogonAtLevel(e.GetServerConfig(), newUser.AccessLevel) {
 		slog.Info("new account cannot log on yet; returning to the login prompt",

--- a/internal/user/begin_session_test.go
+++ b/internal/user/begin_session_test.go
@@ -1,0 +1,84 @@
+package user
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func mgrWithAccount(t *testing.T, u *User) *UserMgr {
+	t.Helper()
+	um := NewUserMgrForTest(u)
+	um.path = filepath.Join(t.TempDir(), "users.json")
+	return um
+}
+
+// A brand-new account has never called before, so its first session must
+// record one call and leave PreviousLogin zero — which is what makes the
+// newscans treat everything as new for a first-time caller.
+func TestBeginSessionRecordsAFirstCall(t *testing.T) {
+	um := mgrWithAccount(t, &User{ID: 1, Handle: "Newbie", AccessLevel: 10})
+
+	got, ok := um.BeginSession("Newbie")
+	if !ok {
+		t.Fatal("BeginSession failed for an account that exists")
+	}
+	if got.TimesCalled != 1 {
+		t.Errorf("TimesCalled = %d, want 1 — the first call went unrecorded", got.TimesCalled)
+	}
+	if got.LastLogin.IsZero() {
+		t.Error("LastLogin was not stamped")
+	}
+	if !got.PreviousLogin.IsZero() {
+		t.Errorf("PreviousLogin = %v, want zero for an account that has never called", got.PreviousLogin)
+	}
+}
+
+// On a later call it behaves exactly as Authenticate always did, rolling the
+// old stamp into PreviousLogin.
+func TestBeginSessionRollsPreviousLogin(t *testing.T) {
+	prior := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	um := mgrWithAccount(t, &User{ID: 1, Handle: "Regular", LastLogin: prior, TimesCalled: 4})
+
+	got, ok := um.BeginSession("Regular")
+	if !ok {
+		t.Fatal("BeginSession failed")
+	}
+	if !got.PreviousLogin.Equal(prior) {
+		t.Errorf("PreviousLogin = %v, want the prior stamp %v", got.PreviousLogin, prior)
+	}
+	if !got.LastLogin.After(prior) {
+		t.Errorf("LastLogin = %v, expected it to advance past %v", got.LastLogin, prior)
+	}
+	if got.TimesCalled != 5 {
+		t.Errorf("TimesCalled = %d, want 5", got.TimesCalled)
+	}
+}
+
+// Authenticate delegates here, so the signup path and the password path record
+// a call identically. This pins that they cannot drift apart.
+func TestAuthenticateAndBeginSessionAgree(t *testing.T) {
+	um := mgrWithAccount(t, &User{ID: 1, Handle: "Same", AccessLevel: 10, TimesCalled: 7})
+
+	got, ok := um.BeginSession("Same")
+	if !ok {
+		t.Fatal("BeginSession failed")
+	}
+	if got.TimesCalled != 8 {
+		t.Errorf("TimesCalled = %d, want 8", got.TimesCalled)
+	}
+
+	um.mu.RLock()
+	stored := *um.users["same"]
+	um.mu.RUnlock()
+	if stored.TimesCalled != got.TimesCalled || !stored.LastLogin.Equal(got.LastLogin) {
+		t.Error("the returned snapshot does not match what was stored")
+	}
+}
+
+func TestBeginSessionUnknownHandle(t *testing.T) {
+	um := mgrWithAccount(t, &User{ID: 1, Handle: "Known"})
+	if _, ok := um.BeginSession("Nobody"); ok {
+		t.Error("BeginSession succeeded for a handle that does not exist")
+	}
+}

--- a/internal/user/begin_session_test.go
+++ b/internal/user/begin_session_test.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"golang.org/x/crypto/bcrypt"
 )
 
 func mgrWithAccount(t *testing.T, u *User) *UserMgr {
@@ -56,23 +58,57 @@ func TestBeginSessionRollsPreviousLogin(t *testing.T) {
 }
 
 // Authenticate delegates here, so the signup path and the password path record
-// a call identically. This pins that they cannot drift apart.
+// a call identically. The point of extracting rather than duplicating was that
+// they cannot drift, so this actually drives both and compares.
 func TestAuthenticateAndBeginSessionAgree(t *testing.T) {
-	um := mgrWithAccount(t, &User{ID: 1, Handle: "Same", AccessLevel: 10, TimesCalled: 7})
+	const pw = "pw123456"
+	hash, err := bcrypt.GenerateFromPassword([]byte(pw), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("bcrypt: %v", err)
+	}
+	prior := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
 
-	got, ok := um.BeginSession("Same")
+	viaAuth := mgrWithAccount(t, &User{
+		ID: 1, Handle: "Same", PasswordHash: string(hash), LastLogin: prior, TimesCalled: 7,
+	})
+	viaBegin := mgrWithAccount(t, &User{
+		ID: 1, Handle: "Same", PasswordHash: string(hash), LastLogin: prior, TimesCalled: 7,
+	})
+
+	a, ok := viaAuth.Authenticate("Same", pw)
+	if !ok {
+		t.Fatal("Authenticate failed")
+	}
+	b, ok := viaBegin.BeginSession("Same")
 	if !ok {
 		t.Fatal("BeginSession failed")
 	}
-	if got.TimesCalled != 8 {
-		t.Errorf("TimesCalled = %d, want 8", got.TimesCalled)
-	}
 
+	if a.TimesCalled != b.TimesCalled {
+		t.Errorf("TimesCalled differs: Authenticate=%d BeginSession=%d", a.TimesCalled, b.TimesCalled)
+	}
+	if !a.PreviousLogin.Equal(b.PreviousLogin) {
+		t.Errorf("PreviousLogin differs: Authenticate=%v BeginSession=%v", a.PreviousLogin, b.PreviousLogin)
+	}
+	if a.LastLogin.IsZero() || b.LastLogin.IsZero() {
+		t.Error("one of the paths did not stamp LastLogin")
+	}
+}
+
+// The deleted-user guard belongs to the shared entry point, not only to
+// Authenticate: a caller reaching BeginSession another way must not be able to
+// open a session on a deleted account.
+func TestBeginSessionDeniesDeletedAccounts(t *testing.T) {
+	um := mgrWithAccount(t, &User{ID: 1, Handle: "Ghost", DeletedUser: true, TimesCalled: 3})
+
+	if _, ok := um.BeginSession("Ghost"); ok {
+		t.Fatal("BeginSession opened a session on a deleted account")
+	}
 	um.mu.RLock()
-	stored := *um.users["same"]
+	stored := *um.users["ghost"]
 	um.mu.RUnlock()
-	if stored.TimesCalled != got.TimesCalled || !stored.LastLogin.Equal(got.LastLogin) {
-		t.Error("the returned snapshot does not match what was stored")
+	if stored.TimesCalled != 3 {
+		t.Errorf("TimesCalled = %d, want 3 — a rejected session must not stamp bookkeeping", stored.TimesCalled)
 	}
 }
 

--- a/internal/user/manager_auth.go
+++ b/internal/user/manager_auth.go
@@ -37,16 +37,31 @@ func (um *UserMgr) Authenticate(handle, password string) (*User, bool) {
 		return nil, false
 	}
 
-	// Authentication successful - update LastLogin and TimesCalled
+	// Password verified; record the call.
+	return um.BeginSession(handle)
+}
+
+// BeginSession stamps the login bookkeeping for a handle and returns a
+// snapshot of the record, without checking any credential.
+//
+// Authenticate calls this once the password verifies. The signup flow calls it
+// directly for an account it has just created, which has no password to
+// re-check — the caller set it moments ago. Both paths must record a call
+// identically, so the bookkeeping lives here rather than being written twice.
+func (um *UserMgr) BeginSession(handle string) (*User, bool) {
+	lowerHandle := strings.ToLower(handle)
+
 	um.mu.Lock()
-	user = um.users[lowerHandle] // Re-fetch under write lock
+	user := um.users[lowerHandle]
 	if user == nil {
 		um.mu.Unlock()
 		return nil, false
 	}
 	// Preserve the prior login stamp before overwriting it; "new since last
 	// login" checks during the login sequence need the previous visit, not
-	// this one.
+	// this one. A brand-new account has a zero LastLogin, so its PreviousLogin
+	// stays zero and everything reads as new — which is correct for a first
+	// call.
 	user.PreviousLogin = user.LastLogin
 	user.LastLogin = time.Now()
 	user.TimesCalled++

--- a/internal/user/manager_auth.go
+++ b/internal/user/manager_auth.go
@@ -57,6 +57,14 @@ func (um *UserMgr) BeginSession(handle string) (*User, bool) {
 		um.mu.Unlock()
 		return nil, false
 	}
+	// Authenticate checks this before verifying the password, but the guard
+	// belongs here too: this is the shared entry point, and any future caller
+	// that reaches it another way must not be able to open a session on a
+	// deleted account or stamp login bookkeeping onto one.
+	if user.DeletedUser {
+		um.mu.Unlock()
+		return nil, false
+	}
 	// Preserve the prior login stamp before overwriting it; "new since last
 	// login" checks during the login sequence need the previous visit, not
 	// this one. A brand-new account has a zero LastLogin, so its PreviousLogin


### PR DESCRIPTION
Closes #227.

A caller who had just chosen a handle and password was returned to the matrix menu and made to type them again. #226 sharpened the oddity by ending signup with *"You can log on now"* — they could, but had to do it themselves.

## What changed

They now continue straight into the session, gated on `canLogonAtLevel`. An account whose level is below `logonLevel` still returns to the matrix, since continuing would only bounce it back out. Validation is deliberately **not** consulted — it does not gate login, and letting it gate this would reintroduce exactly the confusion #222 removed.

The plumbing did not carry the account out of signup, so three returns widened:

| | Was | Now |
| --- | --- | --- |
| `handleNewUserApplication` | `error` | `(*user.User, error)` |
| `processMatrixAction` | `(string, error)` | `(string, *user.User, error)` |
| `RunMatrixScreen` | `(string, error)` | `(string, *user.User, error)` |

`main.go` treats a user coming back from the matrix as authenticated and skips the login loop. Everything *after* that loop — the login sequence included — runs exactly as for any other caller, which was one of the points to settle on the issue. Confirmed by the required-infoform prompt appearing immediately after signup.

The two "type NEW at the login prompt" paths had the same gap and are fixed alongside. Simpler there, since both already return the authenticated user.

## The bookkeeping, which is the part worth care

`lastLogin`, `previousLogin` and `timesCalled` are stamped by `Authenticate`, which this path bypasses entirely — so a first call would have gone unrecorded, silently. I flagged this on the issue as the easy thing to miss.

Rather than repeat the stamping, `Authenticate`'s half is extracted into `UserMgr.BeginSession` and **both paths call it**, so they cannot drift. `Authenticate` now verifies the password and delegates.

## Testing

`go build ./...`, `go vet ./...`, `go test ./...` clean. Four tests on `BeginSession`: a first call recorded with `PreviousLogin` left zero, a later call rolling the stamp, the returned snapshot matching what was stored, and an unknown handle. Existing `Authenticate` tests pass unchanged against the refactor, which is the point of extracting rather than duplicating.

Verified live, both directions:

```text
level 10 (>= logonLevel)  -> lands in the BBS
                             timesCalled=1, lastLogin set, previousLogin zero
level 1  (<  logonLevel)  -> returns to the matrix, timesCalled=0
```

`previousLogin` being zero is what makes the newscans treat everything as new for a first-time caller — the behaviour established in #205 and #214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQuYC88yCUrF8isfJdNJyY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New accounts can now be signed in immediately after completing registration.
  * Successful sessions are automatically started and the user is marked online.
  * Login activity and call counts are recorded consistently for new and returning users.

* **Bug Fixes**
  * Registration and authentication flows now correctly preserve the newly created account through the login process.

* **Tests**
  * Added coverage for session initialization, login history updates, account consistency, and unknown accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->