### PR TITLE
fix(menu): expand placeholders inside %%file.ans%% includes

### DIFF
--- a/docs/sysop/menus/menu-system.md
+++ b/docs/sysop/menus/menu-system.md
@@ -362,11 +362,9 @@ Rules:
 - Groups do not nest. An unmatched `|{` is left as visible text rather than
   swallowing the rest of the prompt.
 
-Groups are resolved on the prompt string itself, before `%%file.ans%%` includes
-are expanded — so `|{...|}` works in `PROMPT1`/`PROMPT2` but not inside an
-included ANSI file. This is not specific to groups: **no** `|XX` placeholder
-expands inside an included file, and the markup renders as literal text rather
-than failing loudly. See issue #211.
+`%%file.ans%%` includes are resolved first, so an included file behaves exactly
+like text written inline in the prompt: groups, `|XX` placeholders and `@CODE@`
+AT-codes all work inside one.
 
 The `|{P}` and `|{O}` login position markers share the `|{` prefix but are not
 groups; they are stepped over and pass through untouched.

--- a/internal/menu/executor_display.go
+++ b/internal/menu/executor_display.go
@@ -499,13 +499,11 @@ const maxIncludeRounds = 6
 // It now looks for included files within the MENU SET's ansi directory.
 func (e *MenuExecutor) processFileIncludes(prompt string, depth int) string {
 	if depth >= maxIncludeRounds {
-		slog.Warn("exceeded maximum file inclusion depth, stopping processing", "maxRounds", maxIncludeRounds)
+		slog.Warn("exceeded maximum file inclusion rounds, stopping processing", "maxRounds", maxIncludeRounds)
 		return prompt
 	}
 
-	processedAny := false
 	result := includeTagRe.ReplaceAllStringFunc(prompt, func(match string) string {
-		processedAny = true
 		// match is "%%name.ext%%"; strip the delimiters instead of re-matching.
 		fileName := strings.TrimSuffix(strings.TrimPrefix(match, "%%"), "%%")
 		// Look for included file in MenuSetPath/ansi
@@ -520,7 +518,12 @@ func (e *MenuExecutor) processFileIncludes(prompt string, depth int) string {
 		return string(data)
 	})
 
-	if processedAny {
+	// Recurse on what is left to do, not on what was just done. Recursing
+	// because this round expanded something costs a wasted scan on every
+	// prompt with includes, and worse, a legitimate nest exactly at the cap
+	// would expand its last tag and then recurse once more purely to trip the
+	// limit -- logging "exceeded maximum" about a file set that was fine.
+	if includeTagRe.MatchString(result) {
 		return e.processFileIncludes(result, depth+1)
 	}
 

--- a/internal/menu/executor_display.go
+++ b/internal/menu/executor_display.go
@@ -402,57 +402,12 @@ func (e *MenuExecutor) displayPrompt(terminal *term.Terminal, menu *MenuRecord, 
 		}
 	} // End if currentUser != nil
 
-	// Pull in %%file.ans%% content first, so everything below treats it exactly
-	// like text written inline in the prompt. Includes used to run after
-	// substitution, which meant no |XX placeholder inside an included file was
-	// ever expanded — and since an unrecognised code passes through
-	// ReplacePipeCodes untouched, the markup appeared verbatim on screen with
-	// nothing in the log to explain it.
-	//
-	// Front rather than back for safety as well as simplicity: with includes
-	// resolved before substitution, a placeholder whose *value* happens to
-	// contain "%%something.ans%%" cannot pull in a file. |GL and |UN are
-	// user-settable, so that ordering matters.
-	promptString, err := e.processFileIncludes(promptString, 0)
-	if err != nil {
-		slog.Error("failed processing file includes in prompt", "menu", currentMenuName, "error", err)
-		return err
-	}
-
-	// Drop |{...|} groups whose placeholders are all empty, so decoration around
-	// an unset field (parentheses, a label) goes away with it instead of being
-	// left stranded as "()". Must run before substitution, while the
-	// placeholder tokens are still present to test.
-	promptString = expandOptionalGroups(promptString, placeholders)
-
-	// Replace longer placeholders before shorter ones to avoid prefix collisions (e.g. |CAN vs |CA).
-	replacementPairs := make([]string, 0, len(placeholders)*2)
-	orderedKeys := make([]string, 0, len(placeholders))
-	for key := range placeholders {
-		orderedKeys = append(orderedKeys, key)
-	}
-	sort.SliceStable(orderedKeys, func(i, j int) bool {
-		return len(orderedKeys[i]) > len(orderedKeys[j])
-	})
-	for _, key := range orderedKeys {
-		replacementPairs = append(replacementPairs, key, placeholders[key])
-	}
-	substitutedPrompt := strings.NewReplacer(replacementPairs...).Replace(promptString)
-
-	// Replace @CODE@ AT-codes with width support (@UC@, @UC:5@, @UC##@, @U@, etc.)
-	promptBytes := replaceMenuATCode([]byte(substitutedPrompt), "UC", strconv.Itoa(userManager.GetUserCount()))
-	promptBytes = replaceMenuATCode(promptBytes, "U", strconv.Itoa(e.SessionRegistry.ActiveCount()))
-	substitutedPrompt = string(promptBytes)
-
-	// Includes were resolved above, so @RR@ covers included content here too.
 	rumorLevel := 1 // default MinLevel when no user context
 	if currentUser != nil {
 		rumorLevel = currentUser.AccessLevel
 	}
-	processedPromptBytes := expandRandomRumorATCode([]byte(substitutedPrompt), e.RootConfigPath, rumorLevel)
-
-	// 3. Process pipe codes in the final string (includes/placeholders already processed)
-	rawPromptBytes := ansi.ReplacePipeCodes(processedPromptBytes)
+	rawPromptBytes := e.renderPromptText(promptString, placeholders,
+		userManager.GetUserCount(), e.SessionRegistry.ActiveCount(), rumorLevel)
 
 	// 4. Process character encoding based on outputMode (Reverted to manual loop)
 	var finalBuf bytes.Buffer
@@ -475,7 +430,7 @@ func (e *MenuExecutor) displayPrompt(terminal *term.Terminal, menu *MenuRecord, 
 	}
 
 	// 5. Write the final processed bytes using the terminal's standard Write (Reverted)
-	err = terminalio.WriteProcessedBytes(terminal, finalBuf.Bytes(), outputMode)
+	err := terminalio.WriteProcessedBytes(terminal, finalBuf.Bytes(), outputMode)
 	if err != nil {
 		slog.Error("failed writing processed prompt", "menu", currentMenuName, "error", err)
 		return err
@@ -488,13 +443,59 @@ func (e *MenuExecutor) displayPrompt(terminal *term.Terminal, menu *MenuRecord, 
 // renders don't recompile it on every call and recursion level.
 var includeTagRe = regexp.MustCompile(`%%[a-zA-Z0-9_\-]+\.[a-zA-Z0-9]+%%`)
 
+// renderPromptText turns a raw prompt into the bytes to write, applying every
+// expansion in the order they must happen.
+//
+// Extracted from displayPrompt so the ordering can be tested directly: it is
+// load-bearing and fails quietly when wrong. Includes used to run last, which
+// meant nothing inside an included file was ever expanded and the markup
+// reached the screen verbatim.
+//
+// The order is:
+//
+//  1. %%file.ans%% includes, so included content is treated exactly like text
+//     written inline. First rather than last for safety too: a placeholder
+//     whose value happens to contain an include tag cannot pull in a file,
+//     and |GL and |UN are user-settable.
+//  2. |{...|} optional groups, while the placeholder tokens are still present
+//     to test for emptiness.
+//  3. |XX placeholders, longest first so |CAN is not eaten by |CA.
+//  4. @CODE@ AT-codes.
+//  5. @RR@ random rumor.
+//  6. Pipe colour codes, once everything else has resolved.
+func (e *MenuExecutor) renderPromptText(prompt string, placeholders map[string]string,
+	userCount, activeCount, rumorLevel int) []byte {
+
+	prompt = e.processFileIncludes(prompt, 0)
+	prompt = expandOptionalGroups(prompt, placeholders)
+
+	replacementPairs := make([]string, 0, len(placeholders)*2)
+	orderedKeys := make([]string, 0, len(placeholders))
+	for key := range placeholders {
+		orderedKeys = append(orderedKeys, key)
+	}
+	sort.SliceStable(orderedKeys, func(i, j int) bool {
+		return len(orderedKeys[i]) > len(orderedKeys[j])
+	})
+	for _, key := range orderedKeys {
+		replacementPairs = append(replacementPairs, key, placeholders[key])
+	}
+	prompt = strings.NewReplacer(replacementPairs...).Replace(prompt)
+
+	out := replaceMenuATCode([]byte(prompt), "UC", strconv.Itoa(userCount))
+	out = replaceMenuATCode(out, "U", strconv.Itoa(activeCount))
+	out = expandRandomRumorATCode(out, e.RootConfigPath, rumorLevel)
+
+	return ansi.ReplacePipeCodes(out)
+}
+
 // processFileIncludes recursively replaces %%filename.ans tags with file content.
 // It now looks for included files within the MENU SET's ansi directory.
-func (e *MenuExecutor) processFileIncludes(prompt string, depth int) (string, error) {
+func (e *MenuExecutor) processFileIncludes(prompt string, depth int) string {
 	const maxDepth = 5 // Limit recursion depth
 	if depth > maxDepth {
 		slog.Warn("exceeded maximum file inclusion depth, stopping processing", "maxDepth", maxDepth)
-		return prompt, nil
+		return prompt
 	}
 
 	processedAny := false
@@ -518,5 +519,5 @@ func (e *MenuExecutor) processFileIncludes(prompt string, depth int) (string, er
 		return e.processFileIncludes(result, depth+1)
 	}
 
-	return result, nil
+	return result
 }

--- a/internal/menu/executor_display.go
+++ b/internal/menu/executor_display.go
@@ -486,15 +486,18 @@ func (e *MenuExecutor) renderPromptText(prompt string, placeholders map[string]s
 	return ansi.ReplacePipeCodes(out)
 }
 
+// maxIncludeRounds bounds how many times processFileIncludes will expand.
+//
+// depth counts rounds already completed, so the bound is exclusive: rounds 0
+// through maxIncludeRounds-1 run. Named for what it counts, because "maxDepth"
+// with a `>` test read as one lower than it actually allowed. The value is
+// unchanged from that version -- an include nested this far is already a
+// mistake, and the cap exists to stop a cycle rather than to be a useful limit.
+const maxIncludeRounds = 6
+
 // processFileIncludes recursively replaces %%filename.ans tags with file content.
 // It now looks for included files within the MENU SET's ansi directory.
 func (e *MenuExecutor) processFileIncludes(prompt string, depth int) string {
-	// depth counts rounds already completed, so the bound is exclusive: rounds
-	// 0 through maxIncludeRounds-1 run. Named for what it counts, because
-	// "maxDepth" with a `>` test read as one lower than it actually allowed.
-	// The value is unchanged -- an include nested this far is already a
-	// mistake, and the cap exists to stop a cycle, not to be a useful limit.
-	const maxIncludeRounds = 6
 	if depth >= maxIncludeRounds {
 		slog.Warn("exceeded maximum file inclusion depth, stopping processing", "maxRounds", maxIncludeRounds)
 		return prompt

--- a/internal/menu/executor_display.go
+++ b/internal/menu/executor_display.go
@@ -469,15 +469,12 @@ func (e *MenuExecutor) renderPromptText(prompt string, placeholders map[string]s
 	prompt = e.processFileIncludes(prompt, 0)
 	prompt = expandOptionalGroups(prompt, placeholders)
 
+	// Longest key first, so |CAN is matched before |CA. The ordering is shared
+	// with optional-group scanning rather than repeated here: the two have to
+	// agree on how prefix collisions resolve, and keeping one copy is what
+	// stops them drifting apart.
 	replacementPairs := make([]string, 0, len(placeholders)*2)
-	orderedKeys := make([]string, 0, len(placeholders))
-	for key := range placeholders {
-		orderedKeys = append(orderedKeys, key)
-	}
-	sort.SliceStable(orderedKeys, func(i, j int) bool {
-		return len(orderedKeys[i]) > len(orderedKeys[j])
-	})
-	for _, key := range orderedKeys {
+	for _, key := range placeholderKeysLongestFirst(placeholders) {
 		replacementPairs = append(replacementPairs, key, placeholders[key])
 	}
 	prompt = strings.NewReplacer(replacementPairs...).Replace(prompt)
@@ -492,9 +489,14 @@ func (e *MenuExecutor) renderPromptText(prompt string, placeholders map[string]s
 // processFileIncludes recursively replaces %%filename.ans tags with file content.
 // It now looks for included files within the MENU SET's ansi directory.
 func (e *MenuExecutor) processFileIncludes(prompt string, depth int) string {
-	const maxDepth = 5 // Limit recursion depth
-	if depth > maxDepth {
-		slog.Warn("exceeded maximum file inclusion depth, stopping processing", "maxDepth", maxDepth)
+	// depth counts rounds already completed, so the bound is exclusive: rounds
+	// 0 through maxIncludeRounds-1 run. Named for what it counts, because
+	// "maxDepth" with a `>` test read as one lower than it actually allowed.
+	// The value is unchanged -- an include nested this far is already a
+	// mistake, and the cap exists to stop a cycle, not to be a useful limit.
+	const maxIncludeRounds = 6
+	if depth >= maxIncludeRounds {
+		slog.Warn("exceeded maximum file inclusion depth, stopping processing", "maxRounds", maxIncludeRounds)
 		return prompt
 	}
 

--- a/internal/menu/executor_display.go
+++ b/internal/menu/executor_display.go
@@ -402,6 +402,23 @@ func (e *MenuExecutor) displayPrompt(terminal *term.Terminal, menu *MenuRecord, 
 		}
 	} // End if currentUser != nil
 
+	// Pull in %%file.ans%% content first, so everything below treats it exactly
+	// like text written inline in the prompt. Includes used to run after
+	// substitution, which meant no |XX placeholder inside an included file was
+	// ever expanded — and since an unrecognised code passes through
+	// ReplacePipeCodes untouched, the markup appeared verbatim on screen with
+	// nothing in the log to explain it.
+	//
+	// Front rather than back for safety as well as simplicity: with includes
+	// resolved before substitution, a placeholder whose *value* happens to
+	// contain "%%something.ans%%" cannot pull in a file. |GL and |UN are
+	// user-settable, so that ordering matters.
+	promptString, err := e.processFileIncludes(promptString, 0)
+	if err != nil {
+		slog.Error("failed processing file includes in prompt", "menu", currentMenuName, "error", err)
+		return err
+	}
+
 	// Drop |{...|} groups whose placeholders are all empty, so decoration around
 	// an unset field (parentheses, a label) goes away with it instead of being
 	// left stranded as "()". Must run before substitution, while the
@@ -427,22 +444,12 @@ func (e *MenuExecutor) displayPrompt(terminal *term.Terminal, menu *MenuRecord, 
 	promptBytes = replaceMenuATCode(promptBytes, "U", strconv.Itoa(e.SessionRegistry.ActiveCount()))
 	substitutedPrompt = string(promptBytes)
 
-	processedPrompt, err := e.processFileIncludes(substitutedPrompt, 0) // Pass 'e'
-	if err != nil {
-		slog.Error("failed processing file includes in prompt", "menu", currentMenuName, "error", err)
-
-		// Use RootAssetsPath for global assets if needed, or MenuSetPath for set-specific
-		// pausePrompt := e.LoadedStrings.PauseString // This comes from global strings
-		// ... (rest of pause logic) ...
-		return err // Use original error if includes fail
-	}
-
-	// 2b. Expand @RR@ after file includes so %%file.ans%% content is also processed.
+	// Includes were resolved above, so @RR@ covers included content here too.
 	rumorLevel := 1 // default MinLevel when no user context
 	if currentUser != nil {
 		rumorLevel = currentUser.AccessLevel
 	}
-	processedPromptBytes := expandRandomRumorATCode([]byte(processedPrompt), e.RootConfigPath, rumorLevel)
+	processedPromptBytes := expandRandomRumorATCode([]byte(substitutedPrompt), e.RootConfigPath, rumorLevel)
 
 	// 3. Process pipe codes in the final string (includes/placeholders already processed)
 	rawPromptBytes := ansi.ReplacePipeCodes(processedPromptBytes)

--- a/internal/menu/executor_includes_test.go
+++ b/internal/menu/executor_includes_test.go
@@ -43,10 +43,7 @@ func TestProcessFileIncludes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := e.processFileIncludes(tt.prompt, 0)
-			if err != nil {
-				t.Fatalf("processFileIncludes: %v", err)
-			}
+			got := e.processFileIncludes(tt.prompt, 0)
 			if got != tt.want {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}
@@ -54,10 +51,7 @@ func TestProcessFileIncludes(t *testing.T) {
 	}
 
 	t.Run("self-referential include stops at depth cap", func(t *testing.T) {
-		got, err := e.processFileIncludes("%%loop.ans%%", 0)
-		if err != nil {
-			t.Fatalf("processFileIncludes: %v", err)
-		}
+		got := e.processFileIncludes("%%loop.ans%%", 0)
 		// Must terminate; the unresolved tag from the final depth remains.
 		if !strings.Contains(got, "%%loop.ans%%") {
 			t.Errorf("expected unresolved tag after depth cap, got %q", got)

--- a/internal/menu/prompt_pipeline_test.go
+++ b/internal/menu/prompt_pipeline_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // promptExecutor builds an executor whose menu set contains the given ANSI
@@ -109,5 +110,26 @@ func TestMissingIncludeLeavesTheRestIntact(t *testing.T) {
 
 	if !strings.Contains(got, "Felonius") {
 		t.Errorf("a missing include broke the rest of the prompt: %q", got)
+	}
+}
+
+// The include cap has to stop a cycle rather than recursing until the stack
+// gives out. A file that includes itself is the shape that matters.
+func TestSelfIncludingFileTerminates(t *testing.T) {
+	e := promptExecutor(t, map[string]string{
+		"loop.ans": "x%%loop.ans%%",
+	})
+
+	done := make(chan string, 1)
+	go func() { done <- visibleText(e.renderPromptText("%%loop.ans%%", nil, 0, 0, 1)) }()
+
+	select {
+	case got := <-done:
+		// It stops, and stops having expanded a bounded number of rounds.
+		if strings.Count(got, "x") > 16 {
+			t.Errorf("expanded %d rounds before stopping: %q", strings.Count(got, "x"), got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("a self-including file did not terminate")
 	}
 }

--- a/internal/menu/prompt_pipeline_test.go
+++ b/internal/menu/prompt_pipeline_test.go
@@ -1,0 +1,113 @@
+package menu
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// promptExecutor builds an executor whose menu set contains the given ANSI
+// files, so includes resolve during rendering.
+func promptExecutor(t *testing.T, files map[string]string) *MenuExecutor {
+	t.Helper()
+	root := t.TempDir()
+	ansiDir := filepath.Join(root, "ansi")
+	if err := os.MkdirAll(ansiDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(ansiDir, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	return &MenuExecutor{MenuSetPath: root, RootConfigPath: t.TempDir()}
+}
+
+// visible strips ANSI escapes so assertions read against what appears on screen.
+func visibleText(b []byte) string {
+	return ansiEscapeRe.ReplaceAllString(string(b), "")
+}
+
+// The regression this guards: includes were resolved last, so nothing inside an
+// included file was ever expanded, and the markup reached the screen verbatim.
+func TestIncludedContentIsFullyExpanded(t *testing.T) {
+	e := promptExecutor(t, map[string]string{
+		"inc.ans": "handle=|UH level=|LEVEL users=@UC@|{ note=(|UN)|}",
+	})
+	placeholders := map[string]string{
+		"|UH": "Felonius", "|LEVEL": "255", "|UN": "",
+	}
+
+	got := visibleText(e.renderPromptText("[%%inc.ans%%]", placeholders, 7, 2, 1))
+
+	for _, leaked := range []string{"|UH", "|LEVEL", "@UC@", "|{", "|}"} {
+		if strings.Contains(got, leaked) {
+			t.Errorf("%q reached the output unexpanded: %q", leaked, got)
+		}
+	}
+	for _, want := range []string{"Felonius", "255", "7"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in the rendered prompt, got %q", want, got)
+		}
+	}
+	// The optional group held only an empty value, so it should be gone.
+	if strings.Contains(got, "note=") {
+		t.Errorf("optional group inside the include was not dropped: %q", got)
+	}
+}
+
+// An optional group inside an include keeps its content when the value is set.
+func TestIncludedOptionalGroupKeptWhenPopulated(t *testing.T) {
+	e := promptExecutor(t, map[string]string{"inc.ans": "|{note=(|UN)|}"})
+
+	got := visibleText(e.renderPromptText("%%inc.ans%%",
+		map[string]string{"|UN": "SysOp"}, 0, 0, 1))
+
+	if !strings.Contains(got, "note=(SysOp)") {
+		t.Errorf("populated group inside an include was lost: %q", got)
+	}
+}
+
+// Includes resolve before substitution, so a placeholder whose value happens to
+// look like an include tag cannot pull in a file. |GL and |UN are user-settable,
+// so this is the ordering that keeps that from being reachable.
+func TestPlaceholderValueCannotTriggerAnInclude(t *testing.T) {
+	e := promptExecutor(t, map[string]string{"secret.ans": "SHOULD-NOT-APPEAR"})
+
+	got := visibleText(e.renderPromptText("loc=|GL",
+		map[string]string{"|GL": "%%secret.ans%%"}, 0, 0, 1))
+
+	if strings.Contains(got, "SHOULD-NOT-APPEAR") {
+		t.Errorf("a placeholder value pulled in a file: %q", got)
+	}
+	if !strings.Contains(got, "%%secret.ans%%") {
+		t.Errorf("the value should survive as literal text, got %q", got)
+	}
+}
+
+// Ordering within substitution: a longer placeholder must not be eaten by a
+// shorter one that prefixes it.
+func TestLongerPlaceholdersSubstituteFirst(t *testing.T) {
+	e := promptExecutor(t, nil)
+
+	got := visibleText(e.renderPromptText("|CAN/|CA",
+		map[string]string{"|CA": "SHORT", "|CAN": "LONG"}, 0, 0, 1))
+
+	if got != "LONG/SHORT" {
+		t.Errorf("got %q, want %q", got, "LONG/SHORT")
+	}
+}
+
+// A missing include is skipped rather than failing the prompt, which is why
+// the pipeline has no error to return.
+func TestMissingIncludeLeavesTheRestIntact(t *testing.T) {
+	e := promptExecutor(t, nil)
+
+	got := visibleText(e.renderPromptText("a %%nope.ans%% |UH",
+		map[string]string{"|UH": "Felonius"}, 0, 0, 1))
+
+	if !strings.Contains(got, "Felonius") {
+		t.Errorf("a missing include broke the rest of the prompt: %q", got)
+	}
+}

--- a/internal/menu/prompt_pipeline_test.go
+++ b/internal/menu/prompt_pipeline_test.go
@@ -1,6 +1,9 @@
 package menu
 
 import (
+	"bytes"
+	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -138,5 +141,35 @@ func TestSelfIncludingFileTerminates(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("a self-including file did not terminate")
+	}
+}
+
+// A legitimate chain nested right up to the cap must expand fully and quietly.
+// Recursing because a round did work, rather than because work remains, made
+// the last expansion recurse once more purely to trip the limit -- so a valid
+// menu set logged "exceeded maximum" and looked broken.
+func TestNestingExactlyAtTheCapExpandsWithoutWarning(t *testing.T) {
+	files := map[string]string{}
+	for i := 1; i < maxIncludeRounds; i++ {
+		files[fmt.Sprintf("n%d.ans", i)] = fmt.Sprintf("%%%%n%d.ans%%%%", i+1)
+	}
+	files[fmt.Sprintf("n%d.ans", maxIncludeRounds)] = "BOTTOM"
+	e := promptExecutor(t, files)
+
+	var logged bytes.Buffer
+	restore := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logged, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	defer slog.SetDefault(restore)
+
+	got := visibleText(e.renderPromptText("%%n1.ans%%", nil, 0, 0, 1))
+
+	if !strings.Contains(got, "BOTTOM") {
+		t.Errorf("a chain nested to the cap did not expand fully: %q", got)
+	}
+	if strings.Contains(got, "%%") {
+		t.Errorf("an include tag survived: %q", got)
+	}
+	if strings.Contains(logged.String(), "exceeded maximum") {
+		t.Errorf("a valid nest warned about the cap: %s", logged.String())
 	}
 }

--- a/internal/menu/prompt_pipeline_test.go
+++ b/internal/menu/prompt_pipeline_test.go
@@ -125,9 +125,16 @@ func TestSelfIncludingFileTerminates(t *testing.T) {
 
 	select {
 	case got := <-done:
-		// It stops, and stops having expanded a bounded number of rounds.
-		if strings.Count(got, "x") > 16 {
-			t.Errorf("expanded %d rounds before stopping: %q", strings.Count(got, "x"), got)
+		// Each round appends one "x", so the count is the number of rounds that
+		// ran. Asserting the configured bound exactly, rather than some larger
+		// ceiling, means a regression that expands seven times is caught.
+		if rounds := strings.Count(got, "x"); rounds != maxIncludeRounds {
+			t.Errorf("expanded %d rounds, want exactly %d: %q", rounds, maxIncludeRounds, got)
+		}
+		// The unexpanded tag is left in place rather than silently dropped, so
+		// a menu set that hits the cap shows evidence of it.
+		if !strings.Contains(got, "%%loop.ans%%") {
+			t.Errorf("the tag that hit the cap was dropped rather than left visible: %q", got)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("a self-including file did not terminate")


### PR DESCRIPTION
Closes #211.

Includes were resolved **after** substitution, so nothing inside an included file was ever expanded. And because an unrecognised `|XX` code passes through `ReplacePipeCodes` untouched, the markup appeared verbatim on screen with nothing in the log to explain it.

## Before and after, same include

```text
before  [inc] handle=|UH level=|LEVEL loc=|GL users=@UC@|{ note=(|UN)|}
after   [inc] handle=Felonius level=255 loc=ViSiON/3 users=1
```

Captured live by pointing `MAIN.MNU`'s prompt at an include and running the pre-fix binary against the same file. Every form of markup was leaking to the screen — `|XX` placeholders, the `@UC@` AT-code, and `|{...|}` optional groups.

## The fix, and why front rather than back

Includes now run at the front of the pipeline:

```text
includes → optional groups → |XX substitution → @CODE@ → @RR@ → pipe codes
```

so included content is treated exactly like text written inline in the prompt.

Re-running substitution *after* includes would also have worked, but front is safer. With includes resolved before any value is substituted, a placeholder whose **value** contains `%%something.ans%%` cannot pull in a file. `|GL` and `|UN` are user-settable, so that ordering is not hypothetical — and this removes the possibility rather than relying on values never happening to look like an include tag.

`@RR@` no longer needs its position at the end. It was expanded after includes specifically so included content was covered, which the new order gives it anyway; the comment explaining that is gone with the reason for it.

## Docs

The menu reference stated that groups did not work inside includes, and that no placeholder did. Both are now untrue, so the note is replaced with what the behaviour actually is.

## Testing

`go build ./...` and `go test ./...` clean. Verified live in both directions with an include exercising a placeholder, an AT-code and an optional group — the before/after above is the real render from the same file against the two binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQuYC88yCUrF8isfJdNJyY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Included prompt files now correctly support optional groups, placeholders, pipe codes, and AT-codes.
  * Prompt content remains intact when an included file is missing.
  * Prevented placeholder values from being misinterpreted as file includes.
  * Improved handling of nested file inclusions and overlapping placeholders.
  * Self-referencing included files now terminate safely.

* **Documentation**
  * Updated optional-group documentation to reflect full markup support within included files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->