### PR TITLE
fix(users): lock users.json across processes and write it atomically

### DIFF
--- a/internal/filelock/filelock.go
+++ b/internal/filelock/filelock.go
@@ -1,0 +1,93 @@
+// Package filelock provides an advisory cross-process lock, used to serialise
+// read-modify-write cycles on a shared data file between the BBS and the
+// separate editor binaries.
+//
+// The lock is advisory: it only excludes processes that ask for it. It is not
+// a permission check and does not stop an unrelated program from writing the
+// file underneath us.
+//
+// internal/menu keeps its own lock helpers for single-instance doors. That is
+// a different job -- a reservation held for as long as a door runs, carrying
+// node and pid metadata inside the lock file for diagnosing stale ones -- and
+// folding it in here would mean exposing the file handle just for that. These
+// two are deliberately separate rather than an oversight.
+package filelock
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// DefaultTimeout is a sensible wait for a data-file lock. Holders take the
+// lock across a read-merge-write of a small JSON file, which is milliseconds,
+// so anything approaching this means a wedged or stopped process rather than
+// ordinary contention.
+const DefaultTimeout = 5 * time.Second
+
+// retryInterval is how often a blocked acquire re-tries. The underlying
+// primitives are non-blocking so that Acquire can honour a timeout at all;
+// polling is what buys that. Short enough to be imperceptible, long enough not
+// to spin a core while waiting.
+const retryInterval = 20 * time.Millisecond
+
+// Lock is a held advisory lock. Release it when the critical section ends.
+type Lock struct {
+	f *os.File
+}
+
+// SidecarPath returns the lock file path guarding dataPath.
+//
+// The lock deliberately lives on a sidecar rather than on the data file
+// itself. Writers here update the data file atomically, by writing a temp file
+// and renaming it into place, which replaces the inode. A lock taken on the
+// data file is attached to the open file description behind the *old* inode,
+// so the instant a writer renamed over it the two processes would be holding
+// locks on different objects and both would proceed. The sidecar is never
+// renamed, so every participant contends on the same inode.
+func SidecarPath(dataPath string) string {
+	return dataPath + ".lock"
+}
+
+// Acquire takes an exclusive lock guarding dataPath, waiting up to timeout.
+// A timeout of zero or less tries exactly once.
+//
+// The returned error distinguishes nothing about why the wait failed on
+// purpose: to a caller, "someone else holds it" and "we waited long enough"
+// are the same decision.
+func Acquire(dataPath string, timeout time.Duration) (*Lock, error) {
+	lockPath := SidecarPath(dataPath)
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file %s: %w", lockPath, err)
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		if tryLock(f) {
+			return &Lock{f: f}, nil
+		}
+		if !time.Now().Before(deadline) {
+			_ = f.Close() // not holding the lock; nothing to release
+			return nil, fmt.Errorf("timed out after %s waiting for lock %s", timeout, lockPath)
+		}
+		time.Sleep(retryInterval)
+	}
+}
+
+// Release drops the lock. Safe to call on a nil Lock so callers can defer it
+// next to an acquire whose error they handle by carrying on unlocked.
+//
+// The lock file is deliberately left on disk. Removing it after unlocking
+// opens a race where another process locks the same path between our unlock
+// and our remove, and we then unlink the file they are holding — after which a
+// third process creates a fresh one and two writers believe they hold the same
+// lock. An empty sidecar file costs nothing.
+func (l *Lock) Release() {
+	if l == nil || l.f == nil {
+		return
+	}
+	unlock(l.f)
+	_ = l.f.Close() // lock already dropped above
+	l.f = nil
+}

--- a/internal/filelock/filelock_test.go
+++ b/internal/filelock/filelock_test.go
@@ -1,0 +1,139 @@
+package filelock
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAcquireAndRelease(t *testing.T) {
+	data := filepath.Join(t.TempDir(), "users.json")
+
+	lock, err := Acquire(data, time.Second)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	lock.Release()
+
+	// Releasing frees it for the next taker.
+	again, err := Acquire(data, time.Second)
+	if err != nil {
+		t.Fatalf("Acquire after Release: %v", err)
+	}
+	again.Release()
+}
+
+// flock and LockFileEx are both per open file description, so two independent
+// acquires contend even inside one process. That is what makes this a real
+// exclusion test rather than a check that the code runs.
+func TestSecondAcquireWaitsForTheFirst(t *testing.T) {
+	data := filepath.Join(t.TempDir(), "users.json")
+
+	held, err := Acquire(data, time.Second)
+	if err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+
+	if _, err := Acquire(data, 50*time.Millisecond); err == nil {
+		t.Fatal("second Acquire succeeded while the lock was held")
+	}
+
+	held.Release()
+	second, err := Acquire(data, time.Second)
+	if err != nil {
+		t.Fatalf("Acquire after the holder released: %v", err)
+	}
+	second.Release()
+}
+
+// A blocked acquire has to give up rather than hang, so a wedged editor cannot
+// stall every save on the BBS indefinitely.
+func TestAcquireHonoursItsTimeout(t *testing.T) {
+	data := filepath.Join(t.TempDir(), "users.json")
+
+	held, err := Acquire(data, time.Second)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	defer held.Release()
+
+	start := time.Now()
+	if _, err := Acquire(data, 150*time.Millisecond); err == nil {
+		t.Fatal("expected a timeout error")
+	}
+	waited := time.Since(start)
+	if waited < 150*time.Millisecond {
+		t.Errorf("gave up after %s, before the %s timeout", waited, 150*time.Millisecond)
+	}
+	if waited > 2*time.Second {
+		t.Errorf("waited %s, far longer than the timeout", waited)
+	}
+}
+
+// Release must tolerate a nil receiver so callers can defer it beside an
+// acquire whose failure they handle by continuing unlocked -- which is what
+// the BBS save path does.
+func TestReleaseOnNilLockIsSafe(t *testing.T) {
+	var l *Lock
+	l.Release()
+}
+
+func TestSidecarPathIsNotTheDataFile(t *testing.T) {
+	if got := SidecarPath("/data/users.json"); got != "/data/users.json.lock" {
+		t.Errorf("SidecarPath = %q", got)
+	}
+}
+
+// The lock has to hold across processes; that is its entire purpose, and an
+// in-process test cannot prove it. This re-runs the test binary as a child
+// that takes the lock and holds it, then checks the parent is excluded.
+func TestLockExcludesASeparateProcess(t *testing.T) {
+	if os.Getenv("FILELOCK_CHILD_HOLD") != "" {
+		holdLockForChild()
+		return
+	}
+
+	dir := t.TempDir()
+	data := filepath.Join(dir, "users.json")
+	ready := filepath.Join(dir, "ready")
+
+	cmd := exec.Command(os.Args[0], "-test.run", "TestLockExcludesASeparateProcess")
+	cmd.Env = append(os.Environ(),
+		"FILELOCK_CHILD_HOLD="+data,
+		"FILELOCK_CHILD_READY="+ready,
+	)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	defer func() { _ = cmd.Wait() }()
+
+	// Wait for the child to signal it holds the lock.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if _, err := os.Stat(ready); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("child never signalled that it had the lock")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if _, err := Acquire(data, 200*time.Millisecond); err == nil {
+		t.Error("acquired the lock while another process held it")
+	}
+}
+
+// holdLockForChild runs in the child process: take the lock, say so, hold it
+// briefly, exit.
+func holdLockForChild() {
+	lock, err := Acquire(os.Getenv("FILELOCK_CHILD_HOLD"), 5*time.Second)
+	if err != nil {
+		os.Exit(1)
+	}
+	defer lock.Release()
+	_ = os.WriteFile(os.Getenv("FILELOCK_CHILD_READY"), []byte("held"), 0600)
+	time.Sleep(1500 * time.Millisecond)
+}

--- a/internal/filelock/filelock_unix.go
+++ b/internal/filelock/filelock_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package filelock
+
+import (
+	"os"
+	"syscall"
+)
+
+// tryLock takes a non-blocking exclusive flock, reporting whether it was
+// acquired. Non-blocking so the caller can impose its own timeout.
+func tryLock(f *os.File) bool {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB) == nil
+}
+
+// unlock drops the flock. The kernel would also drop it on close, but doing it
+// explicitly keeps the release ordering the same on both platforms.
+func unlock(f *os.File) {
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/internal/filelock/filelock_windows.go
+++ b/internal/filelock/filelock_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package filelock
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// tryLock takes a non-blocking exclusive lock via LockFileEx, reporting
+// whether it was acquired. One byte is enough: every participant locks the
+// same range, so the range only has to be consistent, not cover the file.
+func tryLock(f *os.File) bool {
+	ol := new(windows.Overlapped)
+	err := windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		1, 0,
+		ol,
+	)
+	return err == nil
+}
+
+// unlock releases the LockFileEx lock over the same one-byte range.
+func unlock(f *os.File) {
+	ol := new(windows.Overlapped)
+	_ = windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, ol)
+}

--- a/internal/menu/user_config_test.go
+++ b/internal/menu/user_config_test.go
@@ -3,6 +3,7 @@ package menu
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -132,6 +133,12 @@ func TestRunCfgToggle_NilUserReturnsNilWithoutPanic(t *testing.T) {
 // where an atomic write actually fails.
 func breakUserStore(t *testing.T, dir string) {
 	t.Helper()
+	// Windows does not honour a POSIX mode here, so the directory stays
+	// writable and the save under test would succeed. Skipping is honest;
+	// silently passing a test that never exercised the failure path is not.
+	if runtime.GOOS == "windows" {
+		t.Skip("cannot make a directory unwritable with os.Chmod on Windows")
+	}
 	if _, err := os.Stat(filepath.Join(dir, "users.json")); err != nil {
 		t.Fatalf("stat users.json before breaking it: %v", err)
 	}
@@ -142,7 +149,7 @@ func breakUserStore(t *testing.T, dir string) {
 	}
 }
 
-// reloadPersistedUser restores write access to users.json and opens a fresh
+// reloadPersistedUser restores write access to the data directory and opens a fresh
 // *user.UserMgr over the same data directory, so the returned user reflects
 // what genuinely made it to disk. A second GetUser on the ORIGINAL manager
 // would not prove this: UserMgr.UpdateUser writes its in-memory map entry

--- a/internal/menu/user_config_test.go
+++ b/internal/menu/user_config_test.go
@@ -121,15 +121,24 @@ func TestRunCfgToggle_NilUserReturnsNilWithoutPanic(t *testing.T) {
 // os.WriteFile only needs write access to the file itself, not create/rename
 // access to its parent directory. Verified empirically before writing these
 // tests (see the report).
+// breakUserStore makes saving users.json fail, by removing write permission
+// from the directory rather than from the file.
+//
+// The file itself is no longer enough. The BBS writes users.json atomically:
+// a fresh temp file in the same directory, renamed into place. Rename replaces
+// the directory entry and does not need write permission on the file it
+// replaces, so a read-only users.json is happily overwritten. Taking away
+// write permission on the directory blocks creating the temp file, which is
+// where an atomic write actually fails.
 func breakUserStore(t *testing.T, dir string) {
 	t.Helper()
-	usersFile := filepath.Join(dir, "users.json")
-	if _, err := os.Stat(usersFile); err != nil {
+	if _, err := os.Stat(filepath.Join(dir, "users.json")); err != nil {
 		t.Fatalf("stat users.json before breaking it: %v", err)
 	}
-	t.Cleanup(func() { _ = os.Chmod(usersFile, 0o600) })
-	if err := os.Chmod(usersFile, 0o400); err != nil {
-		t.Fatalf("chmod users.json: %v", err)
+	// Restore write permission whatever happens, or t.TempDir cannot clean up.
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod data dir: %v", err)
 	}
 }
 
@@ -143,8 +152,8 @@ func breakUserStore(t *testing.T, dir string) {
 // pre-existing gap in internal/user and tests only what this fix controls.
 func reloadPersistedUser(t *testing.T, dir, handle string) *user.User {
 	t.Helper()
-	if err := os.Chmod(filepath.Join(dir, "users.json"), 0o600); err != nil {
-		t.Fatalf("restore users.json permissions: %v", err)
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("restore data dir permissions: %v", err)
 	}
 	reloaded, err := user.NewUserManager(dir)
 	if err != nil {

--- a/internal/user/atomic_write.go
+++ b/internal/user/atomic_write.go
@@ -1,0 +1,65 @@
+package user
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// writeFileAtomic writes data to path by way of a temp file in the same
+// directory, then renames it into place.
+//
+// os.WriteFile truncates the target and then writes, so a crash — or a full
+// disk — between the two leaves a truncated or half-written users.json, and
+// the accounts that did not make it are simply gone. Rename is atomic on both
+// unix and Windows, so a reader sees either the whole old file or the whole
+// new one and never a partial write.
+//
+// The temp file has to live in the destination directory: rename is only
+// atomic within a filesystem, and os.TempDir may well be on another one.
+//
+// ./ue has written this way since it was built (internal/usereditor/fileio.go);
+// this brings the BBS into line with it.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp file in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+
+	// Any failure from here on leaves the original untouched; clean up the
+	// temp file so a run of failed saves does not litter the data directory.
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		cleanup()
+		return fmt.Errorf("write temp file %s: %w", tmpPath, err)
+	}
+	// Flush to the device before the rename. Without this the rename can reach
+	// disk while the contents have not, and a crash in that window leaves a
+	// correctly-named file full of zeroes — worse than the truncation this is
+	// meant to prevent, because it looks intact.
+	if err := tmp.Sync(); err != nil {
+		cleanup()
+		return fmt.Errorf("sync temp file %s: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close temp file %s: %w", tmpPath, err)
+	}
+	// CreateTemp makes the file 0600; set the caller's mode explicitly so the
+	// result does not depend on that default.
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("chmod temp file %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename %s to %s: %w", tmpPath, path, err)
+	}
+	return nil
+}

--- a/internal/user/external_edit.go
+++ b/internal/user/external_edit.go
@@ -3,6 +3,7 @@ package user
 import (
 	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 )
@@ -188,4 +189,30 @@ func (um *UserMgr) mergeExternalEdits() {
 			um.nextUserID = u.ID + 1
 		}
 	}
+}
+
+// FingerprintFile returns a short content fingerprint of path, or "" when the
+// file cannot be read. Two calls returning the same non-empty value mean the
+// contents are identical.
+//
+// Exported for ./ue, which needs the same notion of "has this changed
+// underneath me" as the BBS. Sharing the definition matters: the editor
+// originally compared modification times, which cannot see a write that lands
+// in the same clock tick as the one it recorded, and the two processes
+// disagreeing about whether a file had changed is precisely how an edit gets
+// silently overwritten.
+func FingerprintFile(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return FingerprintBytes(data)
+}
+
+// FingerprintBytes returns the fingerprint of content already in hand, so a
+// caller that has just read or written the bytes need not read them back --
+// and cannot accidentally fingerprint a different write that landed in
+// between.
+func FingerprintBytes(data []byte) string {
+	return fmt.Sprintf("%d-%x", len(data), sha256.Sum256(data))
 }

--- a/internal/user/manager_persist.go
+++ b/internal/user/manager_persist.go
@@ -4,14 +4,45 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/filelock"
 )
 
 // saveUsersLocked performs the actual saving without acquiring locks.
 // Uses um.path (which should point to data/users.json)
 func (um *UserMgr) saveUsersLocked() error { // Receiver uses renamed type
+	// The lock sidecar lives beside users.json, so the directory has to exist
+	// before the acquire. On a fresh install it does not yet, and taking the
+	// lock first would fail and drop the very first save back to unlocked.
+	dir := filepath.Dir(um.path)
+	if err := os.MkdirAll(dir, 0750); err != nil { // Use 0750 for permissions
+		return fmt.Errorf("failed to create directory %s: %w", dir, err)
+	}
+
+	// Hold the cross-process lock across the whole read-merge-write cycle.
+	//
+	// Detecting an external edit and then folding it in is only safe if no one
+	// writes between the two. ./ue takes this same lock around its own
+	// check-and-save, so the sequence below cannot interleave with it and
+	// overwrite an edit made after our fingerprint check -- the narrow window
+	// left open by the merge itself.
+	//
+	// If the lock cannot be taken we save anyway rather than lose the
+	// session's data. That returns us to the pre-lock behaviour, which is a
+	// small race, and is much better than dropping the write outright. It is
+	// logged because a persistent failure here means the editor is wedged or
+	// the data directory is not writable.
+	lock, lockErr := filelock.Acquire(um.path, filelock.DefaultTimeout)
+	if lockErr != nil {
+		slog.Warn("saving users without the cross-process lock; a concurrent ./ue write could be overwritten",
+			"path", um.path, "error", lockErr)
+	}
+	defer lock.Release() // nil-safe: no-op when the acquire above failed
+
 	// This rewrites the whole file from memory, so anything a separate process
 	// wrote since we last read it would be lost. Fold those edits in first.
 	// ./ue is the one that does this, when a sysop changes a level or
@@ -38,17 +69,10 @@ func (um *UserMgr) saveUsersLocked() error { // Receiver uses renamed type
 		return fmt.Errorf("failed to marshal users slice: %w", err)
 	}
 
-	// Ensure the directory exists before writing the file
-	dir := filepath.Dir(um.path)
-	if err := os.MkdirAll(dir, 0750); err != nil { // Use 0750 for permissions
-		return fmt.Errorf("failed to create directory %s: %w", dir, err)
-	}
-
-	// NOTE: os.WriteFile truncates and rewrites in place. It is NOT atomic --
-	// a crash mid-write can leave a truncated users.json. Callers rely on this
-	// being the single writer under um.mu; making it crash-safe would need a
-	// write-to-temp-then-rename.
-	if err = os.WriteFile(um.path, data, 0600); err != nil {
+	// Written temp-file-then-rename, so a crash mid-write cannot leave a
+	// truncated users.json: readers see the whole old file or the whole new
+	// one. See writeFileAtomic.
+	if err = writeFileAtomic(um.path, data, 0600); err != nil {
 		return fmt.Errorf("failed to write users file %s: %w", um.path, err) // Include path in error
 	}
 	// Record what we just wrote, so the next save does not mistake our own

--- a/internal/user/persist_lock_test.go
+++ b/internal/user/persist_lock_test.go
@@ -1,0 +1,173 @@
+package user
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/filelock"
+)
+
+// mgrAt builds a manager backed by a users.json at the given path, already
+// written out so the fingerprint starts in step with the file.
+func mgrAt(t *testing.T, path string, u *User) *UserMgr {
+	t.Helper()
+	um := NewUserMgrForTest(u)
+	um.path = path
+	if err := um.SaveUsers(); err != nil {
+		t.Fatalf("seed SaveUsers: %v", err)
+	}
+	return um
+}
+
+// A save must wait for whoever holds the lock rather than charging through the
+// read-merge-write while ./ue is midway through its own.
+func TestSaveWaitsForTheCrossProcessLock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "users.json")
+	um := mgrAt(t, path, &User{ID: 1, Handle: "Alice", AccessLevel: 10})
+
+	lock, err := filelock.Acquire(path, time.Second)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+
+	released := make(chan struct{})
+	go func() {
+		time.Sleep(120 * time.Millisecond)
+		lock.Release()
+		close(released)
+	}()
+
+	start := time.Now()
+	if err := um.SaveUsers(); err != nil {
+		t.Fatalf("SaveUsers: %v", err)
+	}
+	<-released
+	if waited := time.Since(start); waited < 100*time.Millisecond {
+		t.Errorf("save completed in %s without waiting for the lock holder", waited)
+	}
+}
+
+// The whole point of the lock: an edit written by another process after our
+// fingerprint check but before our write must not be lost. Holding the lock
+// while making that edit forces the save to see it.
+func TestSaveDoesNotClobberAnEditMadeUnderTheLock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "users.json")
+	um := mgrAt(t, path, &User{ID: 1, Handle: "Alice", AccessLevel: 10})
+
+	lock, err := filelock.Acquire(path, time.Second)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	// Stand in for ./ue: promote Alice on disk while holding the lock.
+	writeUsersJSON(t, path, []*User{{ID: 1, Handle: "Alice", AccessLevel: 255}})
+
+	done := make(chan error, 1)
+	go func() { done <- um.SaveUsers() }()
+
+	time.Sleep(80 * time.Millisecond) // let the save block on the lock
+	lock.Release()
+
+	if err := <-done; err != nil {
+		t.Fatalf("SaveUsers: %v", err)
+	}
+
+	onDisk := readUsersJSON(t, path)
+	if len(onDisk) != 1 || onDisk[0].AccessLevel != 255 {
+		t.Errorf("the external promotion was overwritten: %+v", onDisk)
+	}
+}
+
+// A crash or a concurrent reader must never see a half-written users.json.
+// os.WriteFile truncates and then writes, so a reader landing in that window
+// sees an empty or partial file; a rename cannot be observed partway through.
+// Reading continuously across many saves is what tells the two apart.
+func TestSaveIsNeverObservedPartiallyWritten(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "users.json")
+	um := mgrAt(t, path, &User{ID: 1, Handle: "Alice", AccessLevel: 10})
+
+	stop := make(chan struct{})
+	bad := make(chan string, 1)
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				continue // the file is only ever replaced, never absent for long
+			}
+			var out []*User
+			if err := json.Unmarshal(data, &out); err != nil {
+				select {
+				case bad <- "reader saw a partially written file: " + err.Error():
+				default:
+				}
+				return
+			}
+			if len(out) == 0 {
+				select {
+				case bad <- "reader saw an empty user list mid-save":
+				default:
+				}
+				return
+			}
+		}
+	}()
+
+	for i := range 200 {
+		um.mu.Lock()
+		um.users["alice"].AccessLevel = i % 256
+		um.mu.Unlock()
+		if err := um.SaveUsers(); err != nil {
+			close(stop)
+			t.Fatalf("SaveUsers: %v", err)
+		}
+	}
+	close(stop)
+
+	select {
+	case msg := <-bad:
+		t.Error(msg)
+	default:
+	}
+
+	// No temp files left behind; the lock sidecar is expected to stay.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		switch e.Name() {
+		case "users.json", "users.json.lock":
+		default:
+			t.Errorf("leftover file after save: %s", e.Name())
+		}
+	}
+}
+
+func writeUsersJSON(t *testing.T, path string, users []*User) {
+	t.Helper()
+	data, err := json.MarshalIndent(users, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func readUsersJSON(t *testing.T, path string) []*User {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var out []*User
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return out
+}

--- a/internal/usereditor/fileio.go
+++ b/internal/usereditor/fileio.go
@@ -136,6 +136,14 @@ func writeUsers(path string, users []*user.User) (string, error) {
 		_ = os.Remove(tmpPath) // cleanup on error path
 		return "", fmt.Errorf("close temp file: %w", err)
 	}
+	// Set the mode explicitly. os.CreateTemp asks for 0600 but the umask still
+	// applies, so a restrictive one can leave the file unreadable -- and rename
+	// carries that mode onto users.json, after which the BBS and this editor
+	// both fail to load it. The BBS-side writer does the same.
+	if err := os.Chmod(tmpPath, 0600); err != nil {
+		_ = os.Remove(tmpPath) // cleanup on error path
+		return "", fmt.Errorf("chmod temp file: %w", err)
+	}
 
 	if err := os.Rename(tmpPath, path); err != nil {
 		_ = os.Remove(tmpPath) // cleanup on error path

--- a/internal/usereditor/fileio.go
+++ b/internal/usereditor/fileio.go
@@ -2,33 +2,38 @@ package usereditor
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
-	"time"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/filelock"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 	"github.com/google/uuid"
 )
 
-// LoadUsers reads users.json and returns the user slice plus the file's mtime.
-func LoadUsers(path string) ([]*user.User, time.Time, error) {
-	info, err := os.Stat(path)
-	if err != nil {
-		return nil, time.Time{}, fmt.Errorf("stat %s: %w", path, err)
-	}
-	mtime := info.ModTime()
+// ErrFileChanged reports that users.json was written by someone else -- in
+// practice a running BBS -- since this editor loaded it. Saving anyway would
+// discard whatever they wrote, so the caller has to decide.
+var ErrFileChanged = errors.New("users.json was modified externally since it was loaded")
 
+// LoadUsers reads users.json and returns the user slice plus a fingerprint of
+// the bytes it parsed, for detecting a later external write.
+func LoadUsers(path string) ([]*user.User, string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, time.Time{}, fmt.Errorf("read %s: %w", path, err)
+		return nil, "", fmt.Errorf("read %s: %w", path, err)
 	}
+	// Fingerprint what we actually read, not a separate stat: taking the two
+	// from one set of bytes means they cannot disagree about which version of
+	// the file this is.
+	fingerprint := user.FingerprintBytes(data)
 	data = user.StripUTF8BOM(data)
 
 	var users []*user.User
 	if err := json.Unmarshal(data, &users); err != nil {
-		return nil, time.Time{}, fmt.Errorf("unmarshal %s: %w", path, err)
+		return nil, "", fmt.Errorf("unmarshal %s: %w", path, err)
 	}
 
 	// Sort by ID for consistent display
@@ -36,22 +41,65 @@ func LoadUsers(path string) ([]*user.User, time.Time, error) {
 		return users[i].ID < users[j].ID
 	})
 
-	return users, mtime, nil
+	return users, fingerprint, nil
 }
 
-// CheckFileChanged compares the current mtime of the file against a stored mtime.
-// Returns true if the file was modified externally.
-func CheckFileChanged(path string, storedMtime time.Time) bool {
-	info, err := os.Stat(path)
-	if err != nil {
-		return false // If we can't stat, assume unchanged
+// CheckFileChanged reports whether the file differs from the fingerprint taken
+// when it was loaded.
+//
+// This compares contents rather than modification time. mtime resolution
+// varies by filesystem, so a BBS write landing in the same tick as our load
+// reads as unchanged and the next save silently overwrites it -- the exact
+// loss this guard exists to prevent.
+//
+// An unreadable file reports unchanged: there is nothing there to overwrite,
+// and refusing to save would strand the sysop's edits with no way out.
+func CheckFileChanged(path string, storedFingerprint string) bool {
+	current := user.FingerprintFile(path)
+	if current == "" {
+		return false
 	}
-	return !info.ModTime().Equal(storedMtime)
+	return current != storedFingerprint
 }
 
-// SaveUsers writes the user slice to disk atomically (temp file + rename).
-// Returns the new file mtime after writing.
-func SaveUsers(path string, users []*user.User) (time.Time, error) {
+// SaveUsers writes the user slice to disk atomically, taking the cross-process
+// lock for the duration. Returns the fingerprint of what was written.
+//
+// This is the unconditional write. Callers that loaded the file earlier and
+// could be overwriting someone else's work should use SaveUsersChecked.
+func SaveUsers(path string, users []*user.User) (string, error) {
+	lock, err := filelock.Acquire(path, filelock.DefaultTimeout)
+	if err != nil {
+		return "", fmt.Errorf("could not lock %s for writing: %w", path, err)
+	}
+	defer lock.Release()
+	return writeUsers(path, users)
+}
+
+// SaveUsersChecked writes the user slice only if the file still matches the
+// fingerprint it was loaded at, returning ErrFileChanged when it does not.
+// Passing force writes regardless, discarding the other writer's changes.
+//
+// The check and the write happen under one lock. Checking and then writing as
+// two separate steps leaves a window for the BBS to save in between, and the
+// write that follows would destroy it -- the same data loss the check is
+// there to catch, just through a narrower gap.
+func SaveUsersChecked(path string, users []*user.User, loadedFingerprint string, force bool) (string, error) {
+	lock, err := filelock.Acquire(path, filelock.DefaultTimeout)
+	if err != nil {
+		return "", fmt.Errorf("could not lock %s for writing: %w", path, err)
+	}
+	defer lock.Release()
+
+	if !force && CheckFileChanged(path, loadedFingerprint) {
+		return "", ErrFileChanged
+	}
+	return writeUsers(path, users)
+}
+
+// writeUsers marshals and atomically replaces the file. The caller must hold
+// the lock.
+func writeUsers(path string, users []*user.User) (string, error) {
 	// Sort by ID before saving for consistent output
 	sorted := make([]*user.User, len(users))
 	copy(sorted, users)
@@ -61,39 +109,42 @@ func SaveUsers(path string, users []*user.User) (time.Time, error) {
 
 	data, err := json.MarshalIndent(sorted, "", "  ")
 	if err != nil {
-		return time.Time{}, fmt.Errorf("marshal users: %w", err)
+		return "", fmt.Errorf("marshal users: %w", err)
 	}
 
 	// Atomic write: write to temp file, then rename
 	dir := filepath.Dir(path)
 	tmpFile, err := os.CreateTemp(dir, "users-*.json.tmp")
 	if err != nil {
-		return time.Time{}, fmt.Errorf("create temp file: %w", err)
+		return "", fmt.Errorf("create temp file: %w", err)
 	}
 	tmpPath := tmpFile.Name()
 
 	if _, err := tmpFile.Write(data); err != nil {
 		_ = tmpFile.Close()    // cleanup on error path
 		_ = os.Remove(tmpPath) // cleanup on error path
-		return time.Time{}, fmt.Errorf("write temp file: %w", err)
+		return "", fmt.Errorf("write temp file: %w", err)
+	}
+	// Flush before the rename so a crash cannot leave a correctly-named file
+	// of zeroes, which looks intact and is worse than an obvious truncation.
+	if err := tmpFile.Sync(); err != nil {
+		_ = tmpFile.Close()    // cleanup on error path
+		_ = os.Remove(tmpPath) // cleanup on error path
+		return "", fmt.Errorf("sync temp file: %w", err)
 	}
 	if err := tmpFile.Close(); err != nil {
 		_ = os.Remove(tmpPath) // cleanup on error path
-		return time.Time{}, fmt.Errorf("close temp file: %w", err)
+		return "", fmt.Errorf("close temp file: %w", err)
 	}
 
 	if err := os.Rename(tmpPath, path); err != nil {
 		_ = os.Remove(tmpPath) // cleanup on error path
-		return time.Time{}, fmt.Errorf("rename temp to %s: %w", path, err)
+		return "", fmt.Errorf("rename temp to %s: %w", path, err)
 	}
 
-	// Get the new mtime
-	info, err := os.Stat(path)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("stat after save: %w", err)
-	}
-
-	return info.ModTime(), nil
+	// Fingerprint the bytes just written rather than re-reading: identical
+	// content, and it cannot pick up a write that landed in between.
+	return user.FingerprintBytes(data), nil
 }
 
 // CloneUser creates a deep copy of a user record.

--- a/internal/usereditor/fileio.go
+++ b/internal/usereditor/fileio.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -52,14 +53,22 @@ func LoadUsers(path string) ([]*user.User, string, error) {
 // reads as unchanged and the next save silently overwrites it -- the exact
 // loss this guard exists to prevent.
 //
-// An unreadable file reports unchanged: there is nothing there to overwrite,
+// A file that is not there reports unchanged: there is nothing to overwrite,
 // and refusing to save would strand the sysop's edits with no way out.
+//
+// A file that exists but cannot be read reports changed, which is the opposite
+// call and deliberately so. Its contents are unknown, the save that follows
+// would replace them, and "unknown" is not a reason to assume "ours". Better to
+// raise the overwrite prompt and let the sysop decide than to quietly destroy
+// whatever was in a file we could not open.
 func CheckFileChanged(path string, storedFingerprint string) bool {
-	current := user.FingerprintFile(path)
-	if current == "" {
+	if current := user.FingerprintFile(path); current != "" {
+		return current != storedFingerprint
+	}
+	if _, err := os.Stat(path); errors.Is(err, fs.ErrNotExist) {
 		return false
 	}
-	return current != storedFingerprint
+	return true
 }
 
 // SaveUsers writes the user slice to disk atomically, taking the cross-process

--- a/internal/usereditor/fileio_test.go
+++ b/internal/usereditor/fileio_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -204,5 +205,55 @@ func TestSaveUsers_AtomicNoTempLeftBehind(t *testing.T) {
 		if filepath.Ext(e.Name()) == ".tmp" || filepath.Base(e.Name()) != "users.json" {
 			t.Errorf("unexpected leftover file after atomic save: %s", e.Name())
 		}
+	}
+}
+
+// A users.json that exists but cannot be read is not the same as one that is
+// gone. Its contents are unknown and a save would replace them, so it has to
+// raise the prompt rather than be assumed unchanged and quietly overwritten.
+func TestCheckFileChangedTreatsUnreadableAsChanged(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; permission bits do not prevent reads")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod cannot make a file unreadable on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "users.json")
+	fp, err := SaveUsers(path, []*user.User{{ID: 1, Handle: "A"}})
+	if err != nil {
+		t.Fatalf("SaveUsers: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	if !CheckFileChanged(path, fp) {
+		t.Error("an unreadable users.json reported unchanged; the next save would overwrite it blind")
+	}
+}
+
+// And a guarded save over one refuses rather than writing.
+func TestSaveUsersCheckedRefusesOverAnUnreadableFile(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; permission bits do not prevent reads")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod cannot make a file unreadable on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "users.json")
+	fp, err := SaveUsers(path, []*user.User{{ID: 1, Handle: "A"}})
+	if err != nil {
+		t.Fatalf("SaveUsers: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	if _, err := SaveUsersChecked(path, []*user.User{{ID: 1, Handle: "B"}}, fp, false); !errors.Is(err, ErrFileChanged) {
+		t.Errorf("guarded save error = %v, want ErrFileChanged", err)
 	}
 }

--- a/internal/usereditor/fileio_test.go
+++ b/internal/usereditor/fileio_test.go
@@ -1,6 +1,7 @@
 package usereditor
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -53,21 +54,93 @@ func TestLoadUsers_MissingFile(t *testing.T) {
 func TestCheckFileChanged(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "users.json")
-	mtime, err := SaveUsers(path, []*user.User{{ID: 1, Handle: "A"}})
+	fp, err := SaveUsers(path, []*user.User{{ID: 1, Handle: "A"}})
 	if err != nil {
 		t.Fatalf("SaveUsers: %v", err)
 	}
 
-	if CheckFileChanged(path, mtime) {
+	if CheckFileChanged(path, fp) {
 		t.Error("file should be unchanged immediately after save")
 	}
-	// A clearly different stored mtime must read as changed.
-	if !CheckFileChanged(path, mtime.Add(-time.Hour)) {
-		t.Error("expected changed=true for a stale stored mtime")
+	// A fingerprint from different content must read as changed.
+	if !CheckFileChanged(path, "0-deadbeef") {
+		t.Error("expected changed=true for a stale stored fingerprint")
 	}
-	// Missing file is treated as unchanged (can't stat).
-	if CheckFileChanged(filepath.Join(dir, "gone.json"), mtime) {
+	// Missing file is treated as unchanged: there is nothing to overwrite.
+	if CheckFileChanged(filepath.Join(dir, "gone.json"), fp) {
 		t.Error("missing file should report unchanged")
+	}
+}
+
+// The editor compared modification times before, which cannot distinguish two
+// writes inside one filesystem tick. Content comparison can, and a BBS write
+// landing in the same tick as our load is exactly the case that used to be
+// missed and silently overwritten.
+func TestCheckFileChangedDetectsASameTickWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "users.json")
+
+	fp, err := SaveUsers(path, []*user.User{{ID: 1, Handle: "A", AccessLevel: 10}})
+	if err != nil {
+		t.Fatalf("SaveUsers: %v", err)
+	}
+	// Stand in for the BBS writing immediately afterwards, forcing the same
+	// mtime so only the content differs.
+	if _, err := SaveUsers(path, []*user.User{{ID: 1, Handle: "A", AccessLevel: 255}}); err != nil {
+		t.Fatalf("second SaveUsers: %v", err)
+	}
+	stamp := time.Now()
+	if err := os.Chtimes(path, stamp, stamp); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	if !CheckFileChanged(path, fp) {
+		t.Error("a same-tick external write went undetected; the next save would overwrite it")
+	}
+}
+
+// SaveUsersChecked is the guarded write: it refuses when the file moved, and
+// force is what the "overwrite?" prompt turns into.
+func TestSaveUsersCheckedRefusesAndForces(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "users.json")
+
+	loadedFP, err := SaveUsers(path, []*user.User{{ID: 1, Handle: "A", AccessLevel: 10}})
+	if err != nil {
+		t.Fatalf("SaveUsers: %v", err)
+	}
+	// Someone else writes after we loaded.
+	if _, err := SaveUsers(path, []*user.User{{ID: 1, Handle: "A", AccessLevel: 99}}); err != nil {
+		t.Fatalf("external SaveUsers: %v", err)
+	}
+
+	mine := []*user.User{{ID: 1, Handle: "A", AccessLevel: 20}}
+	if _, err := SaveUsersChecked(path, mine, loadedFP, false); !errors.Is(err, ErrFileChanged) {
+		t.Fatalf("guarded save error = %v, want ErrFileChanged", err)
+	}
+	// The refusal must not have written anything.
+	after, _, err := LoadUsers(path)
+	if err != nil {
+		t.Fatalf("LoadUsers: %v", err)
+	}
+	if after[0].AccessLevel != 99 {
+		t.Errorf("a refused save still wrote: level = %d, want 99", after[0].AccessLevel)
+	}
+
+	// Forcing goes through and reports a fingerprint matching what landed.
+	newFP, err := SaveUsersChecked(path, mine, loadedFP, true)
+	if err != nil {
+		t.Fatalf("forced save: %v", err)
+	}
+	if CheckFileChanged(path, newFP) {
+		t.Error("fingerprint returned by a forced save does not match the file it wrote")
+	}
+	forced, _, err := LoadUsers(path)
+	if err != nil {
+		t.Fatalf("LoadUsers after force: %v", err)
+	}
+	if forced[0].AccessLevel != 20 {
+		t.Errorf("forced save did not take: level = %d, want 20", forced[0].AccessLevel)
 	}
 }
 
@@ -122,6 +195,12 @@ func TestSaveUsers_AtomicNoTempLeftBehind(t *testing.T) {
 	}
 	entries, _ := os.ReadDir(dir)
 	for _, e := range entries {
+		// The lock sidecar is meant to stay. Deleting it after unlocking races
+		// with another process taking the same path, so it is left in place;
+		// see filelock.Release.
+		if e.Name() == "users.json.lock" {
+			continue
+		}
 		if filepath.Ext(e.Name()) == ".tmp" || filepath.Base(e.Name()) != "users.json" {
 			t.Errorf("unexpected leftover file after atomic save: %s", e.Name())
 		}

--- a/internal/usereditor/model.go
+++ b/internal/usereditor/model.go
@@ -1,6 +1,7 @@
 package usereditor
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -55,8 +56,8 @@ type Model struct {
 	users         []*user.User // All users (sorted by ID)
 	origUsers     []*user.User // Snapshot at load time (for dirty tracking)
 	filePath      string
-	dataDir       string    // Root data directory (parent of users/, infoforms/, etc.)
-	fileMtime     time.Time // mtime at load for optimistic concurrency
+	dataDir       string // Root data directory (parent of users/, infoforms/, etc.)
+	fileFP        string // content fingerprint at load, for optimistic concurrency
 	dirty         bool
 	retentionDays int // Deleted user retention days from config (-1 = never purge)
 
@@ -103,7 +104,7 @@ type Model struct {
 // New creates a new user editor model.
 // dataDir is the root data directory (e.g., "data/") containing users/, infoforms/, etc.
 func New(filePath string, dataDir ...string) (Model, error) {
-	users, mtime, err := LoadUsers(filePath)
+	users, fingerprint, err := LoadUsers(filePath)
 	if err != nil {
 		return Model{}, fmt.Errorf("loading users: %w", err)
 	}
@@ -180,7 +181,7 @@ func New(filePath string, dataDir ...string) (Model, error) {
 		origUsers:     origUsers,
 		filePath:      filePath,
 		dataDir:       dd,
-		fileMtime:     mtime,
+		fileFP:        fingerprint,
 		retentionDays: retDays,
 		cursor:        0,
 		listType:      1,
@@ -1041,7 +1042,7 @@ func (m Model) executeConfirm() (tea.Model, tea.Cmd) {
 
 	case modeExitConfirm:
 		// Save and quit
-		m.saveAllToDisk()
+		m.saveAllToDisk(false)
 		return m, tea.Quit
 
 	case modeExitClean:
@@ -1049,18 +1050,21 @@ func (m Model) executeConfirm() (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 
 	case modeSaveConfirm:
-		m.saveAllToDisk()
+		m.saveAllToDisk(false)
 		return m, tea.Quit
 
 	case modeFileChanged:
-		// Force overwrite
-		m.saveAllToDisk()
+		// The sysop has been shown the warning and chosen to overwrite, so this
+		// save skips the changed-file check. Passing false here would re-run
+		// the very check that raised this prompt, fail it again, and drop the
+		// edits without saving or warning a second time.
+		m.saveAllToDisk(true)
 		m.mode = modeList
 		return m, nil
 
 	case modeSaveOnLeave:
 		// Save to disk and return to list
-		m.saveAllToDisk()
+		m.saveAllToDisk(false)
 		// Only go to list if saveAllToDisk didn't switch to modeFileChanged
 		if m.mode == modeSaveOnLeave {
 			m.mode = modeList
@@ -1217,25 +1221,30 @@ func (m *Model) saveCurrentUser() {
 	// Dirty flag is already set by field edits
 }
 
-func (m *Model) saveAllToDisk() {
+// saveAllToDisk writes the edited users out, refusing if the file changed
+// underneath us since it was loaded. Pass force to overwrite anyway, which is
+// what the "modified externally" prompt does when the sysop confirms.
+//
+// The check and the write happen inside SaveUsersChecked, under one
+// cross-process lock. Doing them here as two calls would leave a window for a
+// running BBS to save in between, and this write would then destroy it.
+func (m *Model) saveAllToDisk(force bool) {
 	if !m.dirty {
 		return
 	}
 
-	// Check for external modification
-	if CheckFileChanged(m.filePath, m.fileMtime) {
+	newFP, err := SaveUsersChecked(m.filePath, m.users, m.fileFP, force)
+	if errors.Is(err, ErrFileChanged) {
 		m.mode = modeFileChanged
 		m.confirmYes = false
 		m.message = "File modified externally! Overwrite?"
 		return
 	}
-
-	newMtime, err := SaveUsers(m.filePath, m.users)
 	if err != nil {
 		m.message = fmt.Sprintf("SAVE ERROR: %v", err)
 		return
 	}
-	m.fileMtime = newMtime
+	m.fileFP = newFP
 	m.dirty = false
 	m.message = "Saved successfully"
 

--- a/internal/usereditor/model.go
+++ b/internal/usereditor/model.go
@@ -58,6 +58,7 @@ type Model struct {
 	filePath      string
 	dataDir       string // Root data directory (parent of users/, infoforms/, etc.)
 	fileFP        string // content fingerprint at load, for optimistic concurrency
+	quitAfterSave bool   // an exit raised the overwrite prompt; quit once it is answered
 	dirty         bool
 	retentionDays int // Deleted user retention days from config (-1 = never purge)
 
@@ -1040,17 +1041,16 @@ func (m Model) executeConfirm() (tea.Model, tea.Cmd) {
 		m.mode = modeList
 		return m, nil
 
-	case modeExitConfirm:
-		// Save and quit
+	case modeExitConfirm, modeSaveConfirm:
+		// Quitting only once the save has actually landed. Returning tea.Quit
+		// unconditionally drops the sysop back to the shell over the top of the
+		// "modified externally" prompt, so it can never be answered, and over a
+		// save error, so it is never read -- losing the edits either way.
 		m.saveAllToDisk(false)
-		return m, tea.Quit
+		return m.afterSaveOnExit()
 
 	case modeExitClean:
 		// No unsaved changes, just quit
-		return m, tea.Quit
-
-	case modeSaveConfirm:
-		m.saveAllToDisk(false)
 		return m, tea.Quit
 
 	case modeFileChanged:
@@ -1060,6 +1060,13 @@ func (m Model) executeConfirm() (tea.Model, tea.Cmd) {
 		// edits without saving or warning a second time.
 		m.saveAllToDisk(true)
 		m.mode = modeList
+		// If the prompt interrupted an exit, finish the exit now that it has
+		// been answered, rather than stranding the sysop back in the list.
+		if m.quitAfterSave && !m.dirty {
+			m.quitAfterSave = false
+			return m, tea.Quit
+		}
+		m.quitAfterSave = false
 		return m, nil
 
 	case modeSaveOnLeave:
@@ -1228,6 +1235,27 @@ func (m *Model) saveCurrentUser() {
 // The check and the write happen inside SaveUsersChecked, under one
 // cross-process lock. Doing them here as two calls would leave a window for a
 // running BBS to save in between, and this write would then destroy it.
+// afterSaveOnExit decides what happens once a save made on the way out has
+// run: quit if it landed, otherwise stay so the sysop can see why not.
+//
+// A conflict leaves mode at modeFileChanged and the prompt is rendered;
+// answering it quits, because quitAfterSave is still set. Any other failure
+// leaves the editor in the list with the error message showing, still dirty,
+// so the work is recoverable rather than gone.
+func (m Model) afterSaveOnExit() (tea.Model, tea.Cmd) {
+	if !m.dirty {
+		m.quitAfterSave = false
+		return m, tea.Quit
+	}
+	if m.mode == modeFileChanged {
+		m.quitAfterSave = true // answered in the modeFileChanged branch
+		return m, nil
+	}
+	m.quitAfterSave = false
+	m.mode = modeList
+	return m, nil
+}
+
 func (m *Model) saveAllToDisk(force bool) {
 	if !m.dirty {
 		return

--- a/internal/usereditor/save_force_test.go
+++ b/internal/usereditor/save_force_test.go
@@ -160,3 +160,78 @@ func TestConfirmingTheOverwritePromptWrites(t *testing.T) {
 		t.Errorf("mode = %v after confirming, want modeList", got.mode)
 	}
 }
+
+// Quitting with unsaved edits while the BBS has written underneath must not
+// drop the sysop back to the shell over the top of the overwrite prompt. The
+// prompt has to be answerable, and answering it has to finish the exit.
+func TestExitConfirmStaysOpenOnAConflictThenQuits(t *testing.T) {
+	m, path := editorOver(t, &user.User{ID: 1, Handle: "Alice", AccessLevel: 10})
+
+	if _, err := SaveUsers(path, []*user.User{{ID: 1, Handle: "Alice", AccessLevel: 99}}); err != nil {
+		t.Fatalf("external SaveUsers: %v", err)
+	}
+
+	m.users[0].AccessLevel = 42
+	m.dirty = true
+	m.mode = modeExitConfirm
+
+	updated, cmd := m.executeConfirm()
+	got, ok := updated.(Model)
+	if !ok {
+		t.Fatalf("executeConfirm returned %T, want Model", updated)
+	}
+	if cmd != nil {
+		t.Error("the editor quit over the top of the overwrite prompt, losing the edits")
+	}
+	if got.mode != modeFileChanged {
+		t.Fatalf("mode = %v, want modeFileChanged so the prompt is shown", got.mode)
+	}
+	if !got.dirty {
+		t.Error("edits were marked saved even though the save was refused")
+	}
+
+	// The sysop answers "overwrite".
+	final, cmd2 := got.executeConfirm()
+	fin, ok := final.(Model)
+	if !ok {
+		t.Fatalf("executeConfirm returned %T, want Model", final)
+	}
+	if cmd2 == nil {
+		t.Error("answering the prompt did not finish the exit that raised it")
+	}
+	if fin.dirty {
+		t.Error("still dirty after the forced save")
+	}
+	onDisk, _, err := LoadUsers(path)
+	if err != nil {
+		t.Fatalf("LoadUsers: %v", err)
+	}
+	if onDisk[0].AccessLevel != 42 {
+		t.Errorf("the exit-time overwrite never reached disk: level = %d, want 42", onDisk[0].AccessLevel)
+	}
+}
+
+// An ordinary quit with no conflict still quits, and saves on the way.
+func TestExitConfirmQuitsWhenTheSaveLands(t *testing.T) {
+	m, path := editorOver(t, &user.User{ID: 1, Handle: "Alice", AccessLevel: 10})
+
+	m.users[0].AccessLevel = 42
+	m.dirty = true
+	m.mode = modeExitConfirm
+
+	updated, cmd := m.executeConfirm()
+	got := updated.(Model)
+	if cmd == nil {
+		t.Error("a clean save on exit did not quit")
+	}
+	if got.dirty {
+		t.Error("still dirty after a successful save")
+	}
+	onDisk, _, err := LoadUsers(path)
+	if err != nil {
+		t.Fatalf("LoadUsers: %v", err)
+	}
+	if onDisk[0].AccessLevel != 42 {
+		t.Errorf("level on disk = %d, want 42", onDisk[0].AccessLevel)
+	}
+}

--- a/internal/usereditor/save_force_test.go
+++ b/internal/usereditor/save_force_test.go
@@ -1,0 +1,162 @@
+package usereditor
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+// editorOver builds a Model over a users.json seeded with the given records.
+func editorOver(t *testing.T, users ...*user.User) (Model, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "users.json")
+	if _, err := SaveUsers(path, users); err != nil {
+		t.Fatalf("seed SaveUsers: %v", err)
+	}
+	m, err := New(path)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return m, path
+}
+
+// An unguarded save writes, and leaves the model in step with the file so an
+// immediate second save is not mistaken for a conflict.
+func TestSaveAllToDiskWritesAndResyncs(t *testing.T) {
+	m, path := editorOver(t, &user.User{ID: 1, Handle: "Alice", AccessLevel: 10})
+
+	m.users[0].AccessLevel = 42
+	m.dirty = true
+	m.saveAllToDisk(false)
+
+	if m.dirty {
+		t.Errorf("still dirty after a successful save; message = %q", m.message)
+	}
+	if m.mode == modeFileChanged {
+		t.Fatalf("a save with no external write raised a conflict: %q", m.message)
+	}
+	got, _, err := LoadUsers(path)
+	if err != nil {
+		t.Fatalf("LoadUsers: %v", err)
+	}
+	if got[0].AccessLevel != 42 {
+		t.Errorf("level on disk = %d, want 42", got[0].AccessLevel)
+	}
+}
+
+// When the BBS writes underneath the editor, an ordinary save must stop and
+// ask rather than overwrite.
+func TestSaveAllToDiskRaisesTheConflictPrompt(t *testing.T) {
+	m, path := editorOver(t, &user.User{ID: 1, Handle: "Alice", AccessLevel: 10})
+
+	// The BBS saves while the sysop is editing.
+	if _, err := SaveUsers(path, []*user.User{{ID: 1, Handle: "Alice", AccessLevel: 99}}); err != nil {
+		t.Fatalf("external SaveUsers: %v", err)
+	}
+
+	m.users[0].AccessLevel = 42
+	m.dirty = true
+	m.saveAllToDisk(false)
+
+	if m.mode != modeFileChanged {
+		t.Errorf("mode = %v, want modeFileChanged so the sysop is asked", m.mode)
+	}
+	got, _, err := LoadUsers(path)
+	if err != nil {
+		t.Fatalf("LoadUsers: %v", err)
+	}
+	if got[0].AccessLevel != 99 {
+		t.Errorf("the refused save still wrote: level = %d, want 99", got[0].AccessLevel)
+	}
+}
+
+// The regression this pins: confirming "overwrite?" used to call the same
+// guarded save, which re-ran the check that raised the prompt, failed it again
+// and returned without writing. The sysop was sent back to the list with their
+// edits silently dropped, and no second warning.
+func TestForcedSaveAfterAConflictActuallyWrites(t *testing.T) {
+	m, path := editorOver(t, &user.User{ID: 1, Handle: "Alice", AccessLevel: 10})
+
+	if _, err := SaveUsers(path, []*user.User{{ID: 1, Handle: "Alice", AccessLevel: 99}}); err != nil {
+		t.Fatalf("external SaveUsers: %v", err)
+	}
+
+	m.users[0].AccessLevel = 42
+	m.dirty = true
+	m.saveAllToDisk(false) // raises the prompt
+	if m.mode != modeFileChanged {
+		t.Fatalf("expected the conflict prompt first, got mode %v", m.mode)
+	}
+
+	m.saveAllToDisk(true) // the sysop confirms "overwrite"
+	m.mode = modeList     // executeConfirm does this; saveAllToDisk does not
+
+	if m.dirty {
+		t.Errorf("still dirty after confirming the overwrite; message = %q", m.message)
+	}
+	got, _, err := LoadUsers(path)
+	if err != nil {
+		t.Fatalf("LoadUsers: %v", err)
+	}
+	if got[0].AccessLevel != 42 {
+		t.Errorf("confirmed overwrite did not reach disk: level = %d, want 42", got[0].AccessLevel)
+	}
+
+	// And the model must be back in step with the file it just wrote, or the
+	// very next save would re-raise a conflict against its own write.
+	m.users[0].AccessLevel = 7
+	m.dirty = true
+	m.saveAllToDisk(false)
+	if m.mode == modeFileChanged {
+		t.Fatal("a save straight after a forced one re-raised the conflict; the fingerprint was not resynced")
+	}
+	after, _, err := LoadUsers(path)
+	if err != nil {
+		t.Fatalf("LoadUsers: %v", err)
+	}
+	if after[0].AccessLevel != 7 {
+		t.Errorf("the save after the forced one did not land: level = %d, want 7", after[0].AccessLevel)
+	}
+}
+
+// Driving the confirm handler itself, which is where the defect lived: it
+// called the guarded save, so answering "yes" to "overwrite?" re-ran the check
+// that raised the prompt, failed it again, and returned to the list having
+// written nothing and warned no second time.
+func TestConfirmingTheOverwritePromptWrites(t *testing.T) {
+	m, path := editorOver(t, &user.User{ID: 1, Handle: "Alice", AccessLevel: 10})
+
+	// The BBS writes while the sysop is editing.
+	if _, err := SaveUsers(path, []*user.User{{ID: 1, Handle: "Alice", AccessLevel: 99}}); err != nil {
+		t.Fatalf("external SaveUsers: %v", err)
+	}
+
+	m.users[0].AccessLevel = 42
+	m.dirty = true
+	m.saveAllToDisk(false)
+	if m.mode != modeFileChanged {
+		t.Fatalf("expected the overwrite prompt, got mode %v", m.mode)
+	}
+
+	// The sysop selects "yes" on the prompt.
+	updated, _ := m.executeConfirm()
+	got, ok := updated.(Model)
+	if !ok {
+		t.Fatalf("executeConfirm returned %T, want Model", updated)
+	}
+
+	onDisk, _, err := LoadUsers(path)
+	if err != nil {
+		t.Fatalf("LoadUsers: %v", err)
+	}
+	if onDisk[0].AccessLevel != 42 {
+		t.Errorf("confirming the overwrite wrote nothing: level on disk = %d, want 42", onDisk[0].AccessLevel)
+	}
+	if got.dirty {
+		t.Error("still dirty after confirming the overwrite, so the edits were never saved")
+	}
+	if got.mode != modeList {
+		t.Errorf("mode = %v after confirming, want modeList", got.mode)
+	}
+}


### PR DESCRIPTION
Closes #216.

## The race

The BBS folds in `./ue`'s edits before rewriting `users.json`, but nothing holds the file between the check and the write:

1. fingerprint the file, see it changed
2. read it and merge the sysop's fields in
3. write the whole map back

An editor write landing between 1 and 3 is destroyed — the same loss the merge exists to prevent, through a narrower window.

## What this does

**`internal/filelock`** — the advisory lock both processes take. `flock` on unix, `LockFileEx` on Windows, lifted from the door-lock helpers that were already a duplicated pair.

The lock sits on a `users.json.lock` **sidecar**, not on `users.json`. Writers replace the file by rename, which swaps the inode, so a lock on the data file would leave two processes holding locks on different objects the moment either saved. The sidecar is never renamed — and never deleted, since unlinking after unlock races with the next process to take the same path.

**BBS** — holds the lock across the whole read-merge-write. If it cannot be taken in five seconds it saves anyway and logs: that is the pre-lock behaviour, and a small race beats dropping a session's data.

**Atomic writes** — `os.WriteFile` truncates then writes, so a crash between the two leaves a truncated `users.json`. Saves now go temp-file → sync → rename. `./ue` has always written this way.

## Two `./ue` defects this surfaced

**Its changed-file check used mtime**, which cannot see a BBS write in the same filesystem tick as the load. Both processes now share one content-based definition via `user.FingerprintBytes`.

**Confirming "File modified externally! Overwrite?" wrote nothing.** The handler called the same *guarded* save, which re-ran the check that raised the prompt, failed it again and returned — sending the sysop back to the list with their edits silently dropped and no second warning. Check and write now happen together under one lock, with an explicit `force`.

## Two consequences worth knowing

- `users.json` is now `0600` on **every** save rather than only at creation. That is what the code always asked for and is right for a file of password hashes, but it tightens permissions on existing installs.
- A read-only `users.json` no longer makes a save fail — rename needs write permission on the *directory*. `breakUserStore` in the menu tests moves accordingly, to where an atomic write actually fails.

## Verification

Live against the local BBS, with `./ue`'s protocol driven from a **separate python process using `flock(2)` directly**, so what was tested is the on-disk convention rather than this package talking to itself:

- lock held past the timeout → the BBS logged the documented fallback twice, five seconds apart, proving it really waits
- lock held a realistic 200ms → login clean, no warning, external demotion survived
- `./ue` loads and renders the merged record

Every test was checked against the unfixed code rather than trusted for passing:

```
--- FAIL: TestSaveIsNeverObservedPartiallyWritten
    reader saw a partially written file: unexpected end of JSON input
--- FAIL: TestConfirmingTheOverwritePromptWrites
    confirming the overwrite wrote nothing: level on disk = 99, want 42
```

Cross-process exclusion is tested by re-executing the test binary as a child that holds the lock — an in-process test could not prove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQuYC88yCUrF8isfJdNJyY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Detects external changes to user data before saving, even when changes occur rapidly.
  - Prompts for confirmation before overwriting externally modified data, with an option to force the save.
  - Coordinates saves across processes to reduce conflicts between simultaneous edits.

- **Bug Fixes**
  - User data is now saved atomically, preventing empty or partially written files.
  - Successful saves refresh file-change tracking and preserve edits made during concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->