### PR TITLE
fix(menu): print the running version, not one baked into strings.json

### DIFF
--- a/docs/sysop/advanced/string-editor.md
+++ b/docs/sysop/advanced/string-editor.md
@@ -148,7 +148,7 @@ different from `|XX` placeholder codes: a placeholder can be moved or removed fr
 verb must stay, and the **number and order of verbs must not change**. The editor's description line
 names the verbs a string expects, for example:
 
-```
+```text
 Exec: Version String    Version string format (%s=version)
 ```
 

--- a/docs/sysop/advanced/string-editor.md
+++ b/docs/sysop/advanced/string-editor.md
@@ -141,6 +141,24 @@ Runtime placeholder codes like `|MN` (menu name), `|TL` (time left), `|CB` (curr
 
 Keys prefixed with `_` (e.g., `_extra3`) are reserved placeholders and cannot be edited.
 
+### Format verbs
+
+Some strings carry `%s` / `%d` **format verbs**, which the BBS fills in at runtime. These are
+different from `|XX` placeholder codes: a placeholder can be moved or removed freely, but a format
+verb must stay, and the **number and order of verbs must not change**. The editor's description line
+names the verbs a string expects, for example:
+
+```
+Exec: Version String    Version string format (%s=version)
+```
+
+Removing or adding a verb does not fail — it prints `%!d(MISSING)` or `%!(EXTRA int=3)` into the
+middle of the message the user sees. If you want a literal percent sign in one of these strings,
+write it as `%%`.
+
+`execVersionString` is the exception that repairs itself: with no `%s` it prints unchanged and logs
+why, rather than showing a mangled banner.
+
 When saving, the editor writes keys in sorted order and omits internal `_`-prefixed keys, producing clean deterministic output.
 
 ## String Descriptions

--- a/internal/menu/executor_runnables.go
+++ b/internal/menu/executor_runnables.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
-	"github.com/ViSiON-3/vision-3-bbs/internal/version"
 )
 
 func runPlaceholderCommand(c *cmdCtx, args string) (*user.User, string, error) {
@@ -202,11 +201,7 @@ func runShowVersion(c *cmdCtx, args string) (*user.User, string, error) {
 
 	slog.Debug("running showversion", "node", nodeNumber)
 
-	versionTemplate := e.LoadedStrings.ExecVersionString
-	versionString := versionTemplate
-	if strings.Contains(versionTemplate, "%s") {
-		versionString = fmt.Sprintf(versionTemplate, version.Number)
-	}
+	versionString := renderVersionString(upgradeVersionTemplate(e.LoadedStrings.ExecVersionString))
 
 	// Display the version
 	terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode) // Optional: Clear screen

--- a/internal/menu/version_string.go
+++ b/internal/menu/version_string.go
@@ -1,0 +1,96 @@
+package menu
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/version"
+)
+
+// renderVersionString fills the sysop's version template with the running
+// version.
+//
+// The template lives in strings.json so a sysop can brand the line, and marks
+// where the version goes with a single %s. The value comes from
+// internal/version, which is what release builds stamp -- writing the number
+// into strings.json instead is how it came to advertise v0.1.0 (Pre-Alpha) from
+// a 0.8.2 build, since nothing updates a config file on upgrade.
+//
+// A template carrying anything other than exactly one verb is printed as-is
+// rather than fed to Sprintf. Sprintf with the wrong arity does not fail, it
+// renders %!s(MISSING) or (EXTRA ...) into the middle of the sysop's banner,
+// which is worse than leaving their text alone and saying why in the log.
+func renderVersionString(template string) string {
+	total, strVerbs := formatVerbCounts(template)
+	switch {
+	case total == 1 && strVerbs == 1:
+		return fmt.Sprintf(template, version.Display())
+	case total == 0:
+		slog.Warn("execVersionString has no %s, so the version cannot be shown; add one where the version should appear",
+			"template", template, "version", version.Display())
+	default:
+		slog.Warn("execVersionString must contain exactly one %s and nothing else; printing it unchanged to avoid a malformed banner",
+			"verbs", total, "stringVerbs", strVerbs, "template", template)
+	}
+	return template
+}
+
+// formatVerbCounts reports how many format verbs a template holds and how many
+// of those are %s.
+//
+// Both numbers are needed. Counting verbs alone is not enough to know Sprintf
+// is safe: a banner ending "100% Go" has one verb by that measure, but the verb
+// is %<space> and filling it renders %!(string=v0.8.2) into the output. Only a
+// template whose single verb is %s can be filled.
+//
+// An escaped %% is a literal percent sign, not a verb, and a trailing % has no
+// verb character after it.
+func formatVerbCounts(template string) (total, stringVerbs int) {
+	for i := 0; i < len(template); i++ {
+		if template[i] != '%' {
+			continue
+		}
+		if i+1 >= len(template) {
+			break // a trailing % is not a verb
+		}
+		if template[i+1] == '%' {
+			i++ // escaped percent, consume both
+			continue
+		}
+		total++
+		if template[i+1] == 's' {
+			stringVerbs++
+		}
+		i++
+	}
+	return total, stringVerbs
+}
+
+// defaultVersionTemplate is the shipped banner. Kept here beside the renderer
+// so the two stay in step.
+const defaultVersionTemplate = "|15ViSiON/3 Go Edition - %s|07"
+
+// supersededVersionTemplates are banners previously shipped with the version
+// baked in. An install still carrying one has never been edited by its sysop,
+// so replacing it restores a correct version without overwriting anyone's
+// customisation. Add to this list rather than editing it when the default
+// changes again.
+var supersededVersionTemplates = []string{
+	"|15ViSiON/3 Go Edition - v0.1.0 (Pre-Alpha)|07",
+}
+
+// upgradeVersionTemplate returns the template to use, replacing a superseded
+// shipped default with the current one and leaving anything else untouched.
+func upgradeVersionTemplate(configured string) string {
+	trimmed := strings.TrimSpace(configured)
+	if trimmed == "" {
+		return defaultVersionTemplate
+	}
+	for _, old := range supersededVersionTemplates {
+		if trimmed == old {
+			return defaultVersionTemplate
+		}
+	}
+	return configured
+}

--- a/internal/menu/version_string.go
+++ b/internal/menu/version_string.go
@@ -83,12 +83,21 @@ var supersededVersionTemplates = []string{
 // upgradeVersionTemplate returns the template to use, replacing a superseded
 // shipped default with the current one and leaving anything else untouched.
 func upgradeVersionTemplate(configured string) string {
-	trimmed := strings.TrimSpace(configured)
-	if trimmed == "" {
+	// Nothing configured at all: the command would print a blank line, so fall
+	// back rather than show the sysop nothing.
+	if strings.TrimSpace(configured) == "" {
 		return defaultVersionTemplate
 	}
+	// Match exactly, without trimming. Whitespace is not incidental in a banner
+	// -- leading spaces indent it on screen -- so a value that differs from a
+	// shipped default by so much as a space is an edit, and edits are the
+	// sysop's. Trimming here would quietly overwrite one.
+	//
+	// The cost is that such a sysop keeps a banner with the old version baked
+	// in. They are not left guessing: it has no %s, so renderVersionString logs
+	// exactly why no version appears and what to add.
 	for _, old := range supersededVersionTemplates {
-		if trimmed == old {
+		if configured == old {
 			return defaultVersionTemplate
 		}
 	}

--- a/internal/menu/version_string_test.go
+++ b/internal/menu/version_string_test.go
@@ -110,3 +110,30 @@ func TestFormatVerbCounts(t *testing.T) {
 		}
 	}
 }
+
+// Whitespace is not incidental in a banner: leading spaces indent it on screen.
+// A value differing from a shipped default by only whitespace is therefore an
+// edit, and must not be overwritten by the upgrade.
+func TestSupersededMatchIsExactNotTrimmed(t *testing.T) {
+	for _, old := range supersededVersionTemplates {
+		for _, edited := range []string{"  " + old, old + "  ", "\t" + old} {
+			if got := upgradeVersionTemplate(edited); got != edited {
+				t.Errorf("an indented banner was overwritten:\n  had  %q\n  got  %q", edited, got)
+			}
+		}
+	}
+}
+
+// And such a sysop is told why no version shows, rather than left guessing.
+func TestAnEditedStaleBannerStillWarns(t *testing.T) {
+	edited := "  " + supersededVersionTemplates[0]
+
+	got := renderVersionString(upgradeVersionTemplate(edited))
+
+	if got != edited {
+		t.Errorf("the sysop's banner was altered: %q", got)
+	}
+	if strings.Contains(got, "%!") {
+		t.Errorf("Sprintf noise rendered into an unfillable banner: %q", got)
+	}
+}

--- a/internal/menu/version_string_test.go
+++ b/internal/menu/version_string_test.go
@@ -1,0 +1,112 @@
+package menu
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/version"
+)
+
+// The bug: the version was written into strings.json, and nothing rewrites a
+// config file on upgrade, so a 0.8.2 build advertised v0.1.0 (Pre-Alpha).
+func TestVersionStringReportsTheRunningVersion(t *testing.T) {
+	got := renderVersionString(upgradeVersionTemplate(defaultVersionTemplate))
+
+	if !strings.Contains(got, version.Display()) {
+		t.Errorf("banner %q does not contain the running version %q", got, version.Display())
+	}
+	if strings.Contains(got, "%s") {
+		t.Errorf("the verb was left unexpanded: %q", got)
+	}
+}
+
+// An install carrying the old baked-in banner has never been edited, so it is
+// upgraded rather than left advertising a version that is years out of date.
+func TestSupersededTemplateIsUpgraded(t *testing.T) {
+	for _, old := range supersededVersionTemplates {
+		got := renderVersionString(upgradeVersionTemplate(old))
+
+		if strings.Contains(got, "v0.1.0") || strings.Contains(got, "Pre-Alpha") {
+			t.Errorf("the stale banner survived: %q", got)
+		}
+		if !strings.Contains(got, version.Display()) {
+			t.Errorf("banner %q does not contain the running version %q", got, version.Display())
+		}
+	}
+}
+
+// A sysop's own banner is theirs. Upgrading must not overwrite it, even though
+// the shipped default changed.
+func TestCustomTemplateIsLeftAlone(t *testing.T) {
+	custom := "|13The Dungeon |08:: |15%s|07"
+
+	got := renderVersionString(upgradeVersionTemplate(custom))
+
+	if !strings.Contains(got, "The Dungeon") {
+		t.Errorf("a customised banner was overwritten: %q", got)
+	}
+	if !strings.Contains(got, version.Display()) {
+		t.Errorf("banner %q does not contain the running version", got)
+	}
+}
+
+// An empty value falls back to the shipped default rather than printing
+// nothing at all.
+func TestEmptyTemplateFallsBackToTheDefault(t *testing.T) {
+	got := renderVersionString(upgradeVersionTemplate("   "))
+
+	if !strings.Contains(got, version.Display()) {
+		t.Errorf("an empty template printed %q, with no version", got)
+	}
+}
+
+// Sprintf with the wrong arity does not fail, it renders %!s(MISSING) into the
+// middle of the banner. A template that cannot be filled is printed as-is.
+func TestMalformedTemplatesNeverRenderSprintfNoise(t *testing.T) {
+	for _, tmpl := range []string{
+		"|15No verb here at all|07",
+		"|15Two %s verbs %s|07",
+		"|15Trailing percent %|07",
+		"|15Escaped 100%% and one %s|07",
+		"|15100% Go|07",
+		"|15Percent at the end %|07",
+	} {
+		got := renderVersionString(tmpl)
+
+		for _, noise := range []string{"%!", "(MISSING)", "(EXTRA"} {
+			if strings.Contains(got, noise) {
+				t.Errorf("template %q rendered Sprintf noise: %q", tmpl, got)
+			}
+		}
+	}
+}
+
+// formatVerbCounts has to see past %%, which renders as a literal percent and
+// is not a verb, and has to tell %s from any other verb: "100% Go" carries one
+// verb by a naive count, but it is %<space> and filling it mangles the banner.
+func TestFormatVerbCounts(t *testing.T) {
+	cases := []struct {
+		template   string
+		total, str int
+	}{
+		{"", 0, 0},
+		{"no verbs", 0, 0},
+		{"%s", 1, 1},
+		{"%d and %s", 2, 1},
+		{"100%% pure", 0, 0},
+		{"100%% pure %s", 1, 1},
+		{"%%%s", 1, 1},
+		{"trailing %", 0, 0},
+		{"%%", 0, 0},
+		// The case that caught a bug here: the verb is %<space>, not %s.
+		{"100% Go", 1, 0},
+		{"|15Trailing percent %|07", 1, 0},
+	}
+	for _, c := range cases {
+		total, str := formatVerbCounts(c.template)
+		if total != c.total || str != c.str {
+			t.Errorf("formatVerbCounts(%q) = (%d, %d), want (%d, %d)",
+				c.template, total, str, c.total, c.str)
+		}
+	}
+}

--- a/templates/configs/strings.json
+++ b/templates/configs/strings.json
@@ -394,7 +394,7 @@
   "execRunCommandNotFound": "\r\n|01Internal command '%s' not found.|07\r\n",
   "execRunDoorError": "\r\n|01Error running door '%s': %v|07\r\n",
   "execLoginCriticalError": "\r\n|01CRITICAL ERROR: Login screen configuration invalid (Missing P/O).|07\r\n",
-  "execVersionString": "|15ViSiON/3 Go Edition - v0.1.0 (Pre-Alpha)|07",
+  "execVersionString": "|15ViSiON/3 Go Edition - %s|07",
   "termSizeNewDetectedPrompt": "\r\n|03New terminal size detected: |15%dx%d|07 (saved: |08%dx%d|07).\r\nUse it?",
   "termSizeUpdateDefaultsPrompt": "|03Update your defaults to this size?|07",
   "invisibleLogonPrompt": "|03Add this login to Last Caller List?|07"


### PR DESCRIPTION
Closes #229.

## The bug

Reproduced live before touching anything — a 0.8.2 build advertising:

```
ViSiON/3 Go Edition - v0.1.0 (Pre-Alpha)
```

The version was written into the shipped `strings.json`, and nothing rewrites a config file on upgrade, so every install has carried that line since whenever it was true.

The runnable already knew how to fill a `%s` from `internal/version` (what release builds stamp). The shipped default simply had no `%s`, so the substitution never fired. The string editor's own metadata has described the key as `Version string format (%s=version)` the whole time — **the contract was right, the data didn't follow it**.

## The fix

The default now carries the verb. An install still holding a previously shipped banner is upgraded, since carrying one unchanged means no sysop ever edited it; anything else is left alone, because a customised banner is theirs. Superseded defaults are listed explicitly rather than matched loosely, so that stays true next time the default changes.

A template that can't be filled prints as-is with a warning naming the problem. `Sprintf` doesn't fail on wrong arity — it renders `%!s(MISSING)` into the middle of the sysop's banner, which is worse than leaving their text alone.

## A bug in my own guard

Writing that guard turned up a bug in it. Counting format verbs isn't enough: a banner ending `100% Go` has one verb by that measure, and it's `%<space>`. My first version still fed it to Sprintf:

```
"|15Trailing percent %!|(string=v0.8.2)07"
```

Caught by the test I'd just written. Only a template whose single verb is `%s` gets filled now.

## Verified live

All three states, against the local BBS:

| install state | `^` prints |
|---|---|
| still on the old baked-in banner | `ViSiON/3 Go Edition - v0.8.2` |
| customised (`The Dungeon :: %s`) | `The Dungeon :: v0.8.2` |
| no verb (`100% Go, no verb here`) | printed unchanged, warning logged |

The warning is specific enough to act on:

```
execVersionString must contain exactly one %s and nothing else; printing it
unchanged to avoid a malformed banner  verbs=1 stringVerbs=0
```

## Swept for the same bug class elsewhere

`go vet` can't check `fmt.Sprintf(e.LoadedStrings.X, ...)` because the format string isn't constant — which is how this class slips through, and it has bitten twice now. Scanned all 86 `strings.json` values passed to Sprintf against their shipped defaults: **no arity mismatches**. `badUDRatio` and friends contain a literal `%` but are never formatted, so they're fine.

## Docs

`docs/sysop/advanced/string-editor.md` covered `|XX` placeholders but never mentioned that some strings carry format verbs whose count and order must be preserved — the thing most likely to break a string edited in the TUI. Added a short section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQuYC88yCUrF8isfJdNJyY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Version banners now support a configurable `%s` placeholder for displaying the running version.
  - Empty or outdated default templates automatically fall back to the current format, while customized banners are preserved.
  - Invalid templates remain visible without exposing formatting-system error messages.

- **Documentation**
  - Added guidance for supported format verbs, ordering requirements, escaped percent signs, formatting failures, and automatic version-string repair.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->