### PR TITLE
fix(editor): preserve spaces when backspacing messages

### DIFF
--- a/internal/editor/fseditor_run_test.go
+++ b/internal/editor/fseditor_run_test.go
@@ -1,6 +1,7 @@
 package editor
 
 import (
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -8,6 +9,29 @@ import (
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/editor/testterm"
 )
+
+func TestRunBackspacePreservesSpaces(t *testing.T) {
+	for _, backspace := range []string{"\x08", "\x7f"} {
+		t.Run(fmt.Sprintf("key_%x", backspace[0]), func(t *testing.T) {
+			for _, initial := range []string{"", "hello w"} {
+				t.Run(fmt.Sprintf("initial_%q", initial), func(t *testing.T) {
+					keys := backspace + "world\x1a"
+					if initial == "" {
+						keys = "hello w" + keys
+					}
+					sess := testterm.NewSession(nil, keys)
+					ed := NewFSEditor(sess, io.Discard, ansi.OutputModeUTF8, 80, 24,
+						"", "", "", "", "", "", nil)
+					ed.LoadContent(initial)
+					content, saved, err := ed.Run()
+					if err != nil || !saved || content != "hello world" {
+						t.Fatalf("Run = (%q,%v,%v), want (%q,true,nil)", content, saved, err, "hello world")
+					}
+				})
+			}
+		})
+	}
+}
 
 // TestRunClosesSelfCreatedInputHandler guards against the "double key press"
 // bug: when NewFSEditor is passed a nil InputHandler it creates its own, and

--- a/internal/editor/wordwrap.go
+++ b/internal/editor/wordwrap.go
@@ -43,7 +43,9 @@ func (ww *WordWrapper) ReflowRange(startLine, cursorLine, cursorCol int) (int, i
 	cursorFound := false
 
 	for i := startLine; i <= endLine; i++ {
-		line := strings.TrimRight(ww.buffer.GetLine(i), " ")
+		// Spaces in the buffer are editable content. Trimming them here would
+		// make a single Backspace delete extra characters and move the cursor.
+		line := ww.buffer.GetLine(i)
 		if i > startLine && collected.Len() > 0 && len(line) > 0 {
 			collected.WriteByte(' ')
 			if !cursorFound {
@@ -88,11 +90,12 @@ func (ww *WordWrapper) ReflowRange(startLine, cursorLine, cursorCol int) (int, i
 			wrapPos = MaxLineLength
 		}
 
-		outputLines = append(outputLines, strings.TrimRight(remaining[:wrapPos], " "))
+		outputLines = append(outputLines, remaining[:wrapPos])
 
-		// Advance past the wrap point and any spaces at the boundary
+		// The soft line break represents one separator space (restored when
+		// collecting above). Preserve any additional spaces on either side.
 		pos += wrapPos
-		for pos < len(text) && text[pos] == ' ' {
+		if pos < len(text) && text[pos] == ' ' {
 			pos++
 		}
 	}

--- a/internal/editor/wordwrap_test.go
+++ b/internal/editor/wordwrap_test.go
@@ -241,6 +241,57 @@ func TestWrapAfterInsert_WrapsLongLine(t *testing.T) {
 
 // --- HandleBackspace Tests ---
 
+func TestHandleBackspace_PreservesSpaces(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		col  int
+		want string
+	}{
+		{"last letter", "hello w", 8, "hello "},
+		{"one of several spaces", "hello   ", 9, "hello  "},
+		{"indentation", "    ", 5, "   "},
+		{"mid-line with trailing spaces", "hello world  ", 6, "hell world  "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mb, ww := setupBuffer([]string{tt.text}, 1)
+			line, col, changed := ww.HandleBackspace(1, tt.col)
+			if !changed || line != 1 || col != tt.col-1 {
+				t.Errorf("Backspace = (%d,%d,%v), want (1,%d,true)", line, col, changed, tt.col-1)
+			}
+			if got := mb.GetLine(1); got != tt.want {
+				t.Errorf("text = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHandleBackspace_PreservesSpacesDuringReflow(t *testing.T) {
+	// Deleting in the first line must preserve spaces on the continuation,
+	// including a run of spaces that straddles the new wrap boundary.
+	prefix := strings.Repeat("a", 75)
+	mb, ww := setupBuffer([]string{prefix + "x", "     tail  "}, 2)
+	line, col, changed := ww.HandleBackspace(1, 77)
+	if !changed || line != 1 || col != 76 {
+		t.Errorf("Backspace = (%d,%d,%v), want (1,76,true)", line, col, changed)
+	}
+	want := prefix + "      tail  " // soft wrap represents one additional space
+	for pass := 0; pass < 2; pass++ {
+		var lines []string
+		for i := 1; i <= mb.GetLineCount(); i++ {
+			lines = append(lines, mb.GetLine(i))
+			if mb.GetLineLength(i) > MaxLineLength {
+				t.Errorf("line %d exceeds wrap width", i)
+			}
+		}
+		if got := strings.Join(lines, " "); got != want {
+			t.Errorf("reflow pass %d: text = %q, want %q", pass, got, want)
+		}
+		ww.ReflowRange(1, line, col)
+	}
+}
+
 func TestHandleBackspace_MidLine(t *testing.T) {
 	// Delete char mid-line, reflow pulls words up
 	mb, ww := setupBuffer([]string{"hello world", "next line"})


### PR DESCRIPTION
Backspace triggered paragraph reflow that trimmed legitimate spaces and moved the cursor too far left: deleting `w` from `hello w` left `hello`. Preserve buffered spaces during reflow and treat only one space at each word-wrap boundary as the soft-break separator.

Regression tests cover trailing spaces, indentation, repeated spaces across wrap boundaries, and composing or editing messages with both Backspace key codes.

Validation passed: `go test ./...`, `go test -race ./...`, `go vet ./...`, and `git diff --check`. Interactive coverage uses scripted editor sessions.

Closes #231.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved spaces when rewrapping text, including multiple spaces around line-wrap boundaries.
  * Fixed backspace editing so spaces, indentation, and mid-line content are retained correctly.
  * Improved consistency when repeatedly reflowing edited text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->