### PR TITLE
fix(ftn): retire unused network poll interval setting

### DIFF
--- a/cmd/helper/main.go
+++ b/cmd/helper/main.go
@@ -727,9 +727,6 @@ func cmdFTNSetup(args []string) {
 	if ftn.TempPath == "" {
 		ftn.TempPath = "data/ftn/temp_in"
 	}
-	if netCfg.PollSeconds == 0 {
-		netCfg.PollSeconds = 300
-	}
 
 	if existingLinkIdx < 0 {
 		// Add link if not already present; echo area routing is managed via Message Areas.

--- a/docs/sysop/advanced/event-scheduler.md
+++ b/docs/sysop/advanced/event-scheduler.md
@@ -179,6 +179,13 @@ cd /home/bbs/git/vision3
 
 ### FTN Mail Polling (Binkd)
 
+**Events** is where you configure scheduled FTN hub polling. The FTN wizard
+creates an enabled `echomail_poll_<network>` event with a `*/15 * * * *` schedule.
+Edit that event's schedule for a different cadence or polling window, or disable
+it to stop scheduled hub polls. The former **Poll Seconds** field in Echomail
+Networks did not control hub polling and has been removed; legacy
+`poll_interval_seconds` values in `ftn.json` are ignored.
+
 > **Note:** If the integrated binkd mailer is enabled (Server Setup → Binkd
 > Mailer), the scan/toss/ftn-pack scheduler events above **should be
 > disabled**. The integrated mailer already runs its own export loop against

--- a/docs/sysop/configuration/configuration.md
+++ b/docs/sysop/configuration/configuration.md
@@ -63,7 +63,7 @@ Choosing **System Configuration** (key 1) opens an inner menu with nine numbered
 
 | Item | What it edits |
 |------|---------------|
-| Echomail Networks | Global FTN paths (inbound, outbound, temp, bad/dupe tags) and per-network settings (own address, poll interval, origin line) |
+| Echomail Networks | Global FTN paths (inbound, outbound, temp, bad/dupe tags) and per-network settings (own address, tosser enable, origin line); hub polling is configured under Events |
 | Echomail Links | Per-hub link settings (address, packet/session/AreaFix passwords, flavour) |
 | FTN Setup Wizard | Guided flow: downloads a network's echolist, lets you browse and subscribe to areas, then writes `ftn.json`, `message_areas.json`, and `conferences.json` automatically |
 
@@ -641,7 +641,11 @@ See [Message Areas Guide](messages/message-areas.md) for detailed configuration.
 
 > *Use the [Configuration Editor](#configuration-editor-tui) (key 3 → Echomail Networks / Echomail Links) to manage FTN settings interactively. The JSON structure below is for reference.*
 
-Located in the `configs/` directory. Configures the internal FTN tosser (v3mail) for echomail. Global fields include directory paths (`inbound_path`, `outbound_path`, `binkd_outbound_path`, `temp_path`) and routing tags (`bad_area_tag`, `dupe_area_tag`). Per-network fields include `own_address`, `internal_tosser_enabled`, `poll_interval_seconds`, and `origin`. Per-link fields include `address`, `packet_password`, `areafix_password`, `name`, and `flavour`.
+Located in the `configs/` directory. Configures the internal FTN tosser (v3mail) for echomail. Global fields include directory paths (`inbound_path`, `outbound_path`, `binkd_outbound_path`, `temp_path`) and routing tags (`bad_area_tag`, `dupe_area_tag`). Per-network fields include `own_address`, `internal_tosser_enabled`, and `origin`. Per-link fields include `address`, `packet_password`, `areafix_password`, `name`, and `flavour`.
+
+Hub polling is configured under **Events** in `configs/events.json`; edit the
+`echomail_poll_<network>` event's cron schedule. The former per-network
+`poll_interval_seconds` field is obsolete and ignored when loading older configs.
 
 See [FTN Echomail Guide](messages/ftn-echomail.md) for setup and full field reference.
 

--- a/docs/sysop/messages/ftn-echomail.md
+++ b/docs/sysop/messages/ftn-echomail.md
@@ -171,10 +171,10 @@ Three behaviours are worth knowing before you rely on it:
 - **The network name cannot be changed.** Renaming would have to migrate the
   conference, every area tag and every message base path on disk. Add a new
   network instead.
-- **Settings the wizard does not ask about are left alone.** Tosser enable, poll
-  interval and origin belong to **Echomail Networks**, and an edit here will
-  not reset them. Links other than the hub — downstream systems you feed — are
-  likewise untouched.
+- **Settings the wizard does not ask about are left alone.** Tosser enable and
+  origin belong to **Echomail Networks**; hub poll schedules belong to **Events**.
+  An edit here will not reset them. Links other than the hub — downstream
+  systems you feed — are likewise untouched.
 
 Changing **Your Address** also restamps the origin address on every message area
 belonging to that network, so outbound mail matches the new address.
@@ -626,8 +626,20 @@ read by `v3mail toss`, `v3mail scan`, and `v3mail ftn-pack`.
 | ------------------------- | --------------------------------------------------- |
 | `internal_tosser_enabled` | Set `true` to enable `v3mail` for this network      |
 | `own_address`             | Your FTN address (e.g., `21:4/158.1`)               |
-| `poll_interval_seconds`   | Auto-poll interval; `0` = manual only               |
 | `origin`                  | Origin line text (empty = board name)               |
+
+Hub polling is controlled by the per-network `echomail_poll_<network>` event
+under **Events**. The wizard creates it with a 15-minute cron schedule; edit
+that schedule to change when the hub is contacted, or disable the event to
+stop scheduled hub polls. See
+[FTN mail polling](../advanced/event-scheduler.md#ftn-mail-polling-binkd).
+
+The former **Poll Seconds** setting (`poll_interval_seconds`) was unused by the
+BBS and has been removed. Older `ftn.json` files still load; that field is ignored
+and omitted the next time the configuration is saved. Existing event schedules
+are unaffected. Inbound processing still runs through binkd's receive hook, and
+the integrated mailer's `binkd.export_interval_seconds` still controls outbound
+scan/pack frequency; neither is a hub poll schedule.
 
 **Per-link fields (`networks.<key>.links[]`):**
 

--- a/docs/sysop/messages/message-areas.md
+++ b/docs/sysop/messages/message-areas.md
@@ -135,20 +135,22 @@ Configure it in `configs/ftn.json` (separate from the main `config.json`):
 ```json
 {
   "dupe_db_path": "data/ftn/dupes.json",
+  "inbound_path": "data/ftn/in",
+  "outbound_path": "data/ftn/temp_out",
+  "binkd_outbound_path": "data/ftn/out",
+  "temp_path": "data/ftn/temp_in",
   "networks": {
     "fsxnet": {
-      "enabled": true,
+      "internal_tosser_enabled": true,
       "own_address": "21:3/110",
-      "inbound_path": "data/ftn/fsxnet/inbound",
-      "outbound_path": "data/ftn/fsxnet/outbound",
-      "temp_path": "data/ftn/fsxnet/temp",
       "origin": "My BBS - bbs.example.com",
       "links": [
         {
           "address": "21:1/100",
-          "password": "secret",
+          "packet_password": "secret",
           "name": "FSXNet Hub",
-          "echo_areas": ["FSX_GEN", "FSX_BOT", "FSX_MYS"]
+          "hostname": "hub.example.com",
+          "port": 24554
         }
       ]
     }
@@ -165,12 +167,12 @@ Configure it in `configs/ftn.json` (separate from the main `config.json`):
 
 Each network key (e.g., `"fsxnet"`) contains:
 
-- `enabled` — Set to `true` to activate the tosser for this network
+- `internal_tosser_enabled` — Set to `true` to enable `v3mail` processing for this network
 - `own_address` — Your FTN address on this network (e.g., `"21:3/110"`)
-- `inbound_path` — Directory for incoming .PKT files
-- `outbound_path` — Directory for outgoing .PKT files
-- `temp_path` — Temp directory for failed packets
 - `origin` — Optional origin line text for new echomail posts (empty = the board name). The address is appended automatically.
+
+The inbound, outbound, binkd outbound, and temporary paths are top-level
+settings because they are shared by all configured networks.
 
 Configure hub polling under **Events**; the FTN wizard creates an
 `echomail_poll_<network>` event with a cron schedule. See
@@ -183,9 +185,16 @@ The tearline is not configurable: FTS-0004 reserves it for the software that pro
 Each link defines a connected FTN node:
 
 - `address` — Node's FTN address
-- `password` — Packet password (shared secret)
+- `packet_password` — Packet password (shared secret)
+- `session_password` — Optional BinkP session password
+- `areafix_password` — Optional AreaFix password
 - `name` — Human-readable label
-- `echo_areas` — List of echo tags to route to this link (use `"*"` for all)
+- `hostname` — Hub hostname used to generate the binkd node configuration
+- `port` — Hub BinkP port (defaults to 24554)
+
+Echo area routing is configured through `message_areas.json`: set each area's
+`network` field to the network key and use the area editor to manage the
+subscriptions. It is not stored on individual links.
 
 ### Message Area Network Field
 

--- a/docs/sysop/messages/message-areas.md
+++ b/docs/sysop/messages/message-areas.md
@@ -142,7 +142,6 @@ Configure it in `configs/ftn.json` (separate from the main `config.json`):
       "inbound_path": "data/ftn/fsxnet/inbound",
       "outbound_path": "data/ftn/fsxnet/outbound",
       "temp_path": "data/ftn/fsxnet/temp",
-      "poll_interval_seconds": 300,
       "origin": "My BBS - bbs.example.com",
       "links": [
         {
@@ -171,8 +170,11 @@ Each network key (e.g., `"fsxnet"`) contains:
 - `inbound_path` — Directory for incoming .PKT files
 - `outbound_path` — Directory for outgoing .PKT files
 - `temp_path` — Temp directory for failed packets
-- `poll_interval_seconds` — How often to scan for packets (0 = manual only)
 - `origin` — Optional origin line text for new echomail posts (empty = the board name). The address is appended automatically.
+
+Configure hub polling under **Events**; the FTN wizard creates an
+`echomail_poll_<network>` event with a cron schedule. See
+[FTN mail polling](../advanced/event-scheduler.md#ftn-mail-polling-binkd).
 
 The tearline is not configurable: FTS-0004 reserves it for the software that produced the message, so ViSiON/3 always stamps `--- ViSiON/3 vX.Y.Z/Platform`.
 

--- a/docs/sysop/messages/v3mail.md
+++ b/docs/sysop/messages/v3mail.md
@@ -107,8 +107,12 @@ Per-network fields (`networks.<key>`):
 | --------------------------- | --------------------------------------------------------------- |
 | `own_address`               | This node's FTN address (zone:net/node.point)                   |
 | `internal_tosser_enabled`   | Set `true` to enable `v3mail` for this network                  |
-| `poll_interval_seconds`     | Auto-poll interval; `0` = manual only                           |
 | `origin`                    | Origin line text (empty = board name)                           |
+
+Hub polling is scheduled through **Events**, using the per-network
+`echomail_poll_<network>` event created by the FTN wizard. See
+[FTN mail polling](../advanced/event-scheduler.md#ftn-mail-polling-binkd).
+The obsolete `poll_interval_seconds` field is ignored when loading older configs.
 
 Per-link fields (`networks.<key>.links[]`):
 

--- a/docs/sysop/reference/api-reference.md
+++ b/docs/sysop/reference/api-reference.md
@@ -354,7 +354,6 @@ type DupeDB struct { /* Message ID duplicate tracker */ }
 func New(networkName string, cfg networkConfig, globalCfg config.FTNConfig,
     dupeDB *DupeDB, msgMgr *message.MessageManager) *Tosser
 func NewDupeDBFromPath(dupeDBPath string) (*DupeDB, error)
-func (t *Tosser) Start(ctx context.Context)
 func (t *Tosser) RunOnce() TossResult
 func (t *Tosser) ProcessInbound() error
 func (t *Tosser) ScanAndExport() error
@@ -640,7 +639,6 @@ type FTNConfig struct {
 type FTNNetworkConfig struct {
     InternalTosserEnabled bool
     OwnAddress            string
-    PollSeconds           int
     Origin                string
     Links                 []FTNLinkConfig
 }

--- a/internal/config/config_ftn.go
+++ b/internal/config/config_ftn.go
@@ -73,7 +73,6 @@ func (c *FTNLinkConfig) UnmarshalJSON(data []byte) error {
 type FTNNetworkConfig struct {
 	InternalTosserEnabled bool            `json:"internal_tosser_enabled"` // Enable internal tosser
 	OwnAddress            string          `json:"own_address"`             // e.g., "21:4/158.1"
-	PollSeconds           int             `json:"poll_interval_seconds"`   // 0 = manual only (v3mail toss/scan)
 	Origin                string          `json:"origin,omitempty"`        // Origin line text for echomail (empty = board name)
 	Links                 []FTNLinkConfig `json:"links"`
 }

--- a/internal/config/config_ftn_legacy_test.go
+++ b/internal/config/config_ftn_legacy_test.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadFTNConfig_LegacyPollInterval verifies old configs still load after
+// retiring the unused per-network timer, without changing mailer settings.
+func TestLoadFTNConfig_LegacyPollInterval(t *testing.T) {
+	const legacy = `{
+		"binkd": {"enabled": true, "export_interval_seconds": 600},
+		"networks": {
+			"fsxnet": {
+				"internal_tosser_enabled": true,
+				"own_address": "21:4/158",
+				"poll_interval_seconds": 900,
+				"origin": "My BBS",
+				"links": [{"address": "21:1/100", "hostname": "hub.example"}]
+			}
+		}
+	}`
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ftn.json"), []byte(legacy), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadFTNConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	net := cfg.Networks["fsxnet"]
+	if !net.InternalTosserEnabled || net.OwnAddress != "21:4/158" || net.Origin != "My BBS" {
+		t.Fatalf("network settings changed: %+v", net)
+	}
+	if len(net.Links) != 1 || net.Links[0].Address != "21:1/100" || net.Links[0].Hostname != "hub.example" {
+		t.Fatalf("hub link changed: %+v", net.Links)
+	}
+	if !cfg.Binkd.Enabled || cfg.Binkd.ExportSecs != 600 {
+		t.Fatalf("integrated mailer settings changed: %+v", cfg.Binkd)
+	}
+	saved, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(saved, []byte(`"poll_interval_seconds"`)) {
+		t.Error("saved config still contains the obsolete poll interval")
+	}
+}

--- a/internal/configeditor/fields_ftn.go
+++ b/internal/configeditor/fields_ftn.go
@@ -126,20 +126,7 @@ func (m *Model) fieldsFTNLink() []fieldDef {
 			Set: func(val string) error { netPtr.InternalTosserEnabled = uitext.YNToBool(val); save(); return nil },
 		},
 		{
-			Label: "Poll Seconds", Help: "Seconds between inbound directory polls", Type: ftInteger, Col: 3, Row: 4, Width: 6, Min: 0, Max: 999999,
-			Get: func() string { return strconv.Itoa(netPtr.PollSeconds) },
-			Set: func(val string) error {
-				n, err := strconv.Atoi(val)
-				if err != nil {
-					return err
-				}
-				netPtr.PollSeconds = n
-				save()
-				return nil
-			},
-		},
-		{
-			Label: "Origin", Help: "Origin line text for outgoing echomail (empty = board name)", Type: ftString, Col: 3, Row: 5, Width: 40,
+			Label: "Origin", Help: "Origin line text for outgoing echomail (empty = board name)", Type: ftString, Col: 3, Row: 4, Width: 40,
 			Get: func() string { return netPtr.Origin },
 			Set: func(val string) error { netPtr.Origin = val; save(); return nil },
 		},

--- a/internal/configeditor/ftn_wizard_edit_test.go
+++ b/internal/configeditor/ftn_wizard_edit_test.go
@@ -21,7 +21,6 @@ func configuredModel() Model {
 					"fsxnet": {
 						InternalTosserEnabled: true,
 						OwnAddress:            "21:4/158",
-						PollSeconds:           900,
 						Origin:                "Custom Origin Line",
 						Links: []config.FTNLinkConfig{{
 							Address:         "21:1/100",
@@ -117,9 +116,6 @@ func TestConfirmFTNWizardEditPreservesUnaskedSettings(t *testing.T) {
 	m, _ = m.confirmFTNWizard()
 
 	net := m.configs.FTN.Networks["fsxnet"]
-	if net.PollSeconds != 900 {
-		t.Errorf("PollSeconds = %d, want 900 preserved", net.PollSeconds)
-	}
 	if net.Origin != "Custom Origin Line" {
 		t.Errorf("Origin = %q, want preserved", net.Origin)
 	}

--- a/internal/configeditor/ftn_wizard_save.go
+++ b/internal/configeditor/ftn_wizard_save.go
@@ -72,8 +72,8 @@ func (m Model) confirmFTNWizard() (Model, tea.Cmd) {
 	}
 
 	if existing, ok := m.configs.FTN.Networks[netKey]; ok && editing {
-		// Keep the settings this wizard does not ask about. Tosser, poll
-		// interval and origin are all editable under Echomail Networks, and
+		// Keep the settings this wizard does not ask about. Tosser enable
+		// and origin are editable under Echomail Networks, and
 		// rewriting them with the wizard's create-time defaults would throw
 		// away whatever the sysop set there.
 		existing.OwnAddress = w.ownAddress
@@ -93,7 +93,6 @@ func (m Model) confirmFTNWizard() (Model, tea.Cmd) {
 		m.configs.FTN.Networks[netKey] = config.FTNNetworkConfig{
 			InternalTosserEnabled: true,
 			OwnAddress:            w.ownAddress,
-			PollSeconds:           300,
 			// Origin left empty: echomail then falls back to the board name.
 			// The tearline is not configurable — the software stamps it.
 			Links: []config.FTNLinkConfig{link},

--- a/internal/configeditor/view_ftn_wizard_picker.go
+++ b/internal/configeditor/view_ftn_wizard_picker.go
@@ -85,7 +85,7 @@ func (m Model) viewFTNWizardPicker() string {
 			tosser = "on"
 		}
 		lb.row(editInfoValueStyle.Render(padRight(
-			fmt.Sprintf("  Tosser: %s   Poll: %ds", tosser, net.PollSeconds), boxW)))
+			fmt.Sprintf("  Tosser: %s   Hub polling: see Events", tosser), boxW)))
 	}
 
 	lb.bottomBorder()

--- a/internal/tosser/runner.go
+++ b/internal/tosser/runner.go
@@ -1,49 +1,5 @@
 package tosser
 
-import (
-	"context"
-	"log/slog"
-	"time"
-)
-
-// Start begins the tosser background polling loop.
-// It runs import+export cycles at the configured interval.
-// Call cancel on the context to stop.
-func (t *Tosser) Start(ctx context.Context) {
-	if t.config.PollSeconds <= 0 {
-		slog.Info("polling disabled, use RunOnce for manual toss", "network", t.networkName)
-		return
-	}
-
-	interval := time.Duration(t.config.PollSeconds) * time.Second
-	slog.Info("tosser started", "network", t.networkName, "interval", interval)
-
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			slog.Info("tosser stopping", "network", t.networkName)
-			// Save dupe DB on shutdown
-			if err := t.dupeDB.Save(); err != nil {
-				slog.Warn("failed to save dupe DB on shutdown", "network", t.networkName, "error", err)
-			}
-			return
-		case <-ticker.C:
-			result := t.RunOnce()
-			if result.PacketsProcessed > 0 || result.MessagesExported > 0 {
-				slog.Info("toss cycle complete", "network", t.networkName, "imported", result.MessagesImported, "exported", result.MessagesExported, "dupes", result.DupesSkipped, "packets", result.PacketsProcessed)
-			}
-			if len(result.Errors) > 0 {
-				for _, e := range result.Errors {
-					slog.Error("toss cycle error", "network", t.networkName, "msg", e)
-				}
-			}
-		}
-	}
-}
-
 // RunOnce performs a single import+export cycle.
 func (t *Tosser) RunOnce() TossResult {
 	importResult := t.ProcessInbound()


### PR DESCRIPTION
The Echomail Networks editor exposed a Poll Seconds setting that only fed an unused tosser loop. Changing it had no effect on BBS mail flow, while scheduled hub polls already used Events. Remove the obsolete field, setup defaults, and unused loop, and direct sysops to the per-network event's cron schedule.

Older `ftn.json` files still load: `poll_interval_seconds` is ignored and omitted on the next save. Existing event schedules, binkd's inbound receive hook, and the integrated mailer's outbound export interval retain their behavior. Updated the configuration and mail-flow documentation and added a compatibility test for legacy configs.

Validation passed: `go test ./...`, `go test -race ./...`, `go vet ./...`, and `git diff --check`.

Closes #213.
