### PR TITLE
feat(rumors): cap rumor text at 56 characters

### DIFF
--- a/docs/sysop/menus/rumors.md
+++ b/docs/sysop/menus/rumors.md
@@ -45,7 +45,9 @@ Prompts the user through:
 
 1. **Anonymous?** — Only shown if the user's access level meets the configured `AnonymousLevel` threshold. Yes/No lightbar prompt.
 2. **Minimum Level** — Security level required to view this rumor (1–255). Validates input and re-prompts on invalid entries. Defaults to 1 if left blank.
-3. **Enter Rumor** — The rumor text. Empty input aborts.
+3. **Enter Rumor** — The rumor text, up to 56 characters. Input stops accepting keystrokes at the limit, and surrounding whitespace is trimmed. Empty input aborts.
+
+The 56-character limit matches the width of the `@RR|C####...@` field in the stock `MAIN.ANS`, `MSGMENU.ANS`, and `DOORSM.ANS` screens, so a rumor is never clipped when displayed there.
 
 After saving, displays a confirmation message for 1 second.
 

--- a/internal/menu/executor_session.go
+++ b/internal/menu/executor_session.go
@@ -223,18 +223,28 @@ func (e *MenuExecutor) holdScreen(s ssh.Session, terminal *term.Terminal, output
 // readLineFromSessionIH reads a simple command line from the shared session
 // InputHandler so menu input never races with other session readers.
 func readLineFromSessionIH(s ssh.Session, terminal *term.Terminal) (string, error) {
-	return readLineFromSessionIHImpl(s, terminal, false)
+	return readLineFromSessionIHImpl(s, terminal, false, 0)
+}
+
+// readLineFromSessionIHMax reads a simple command line like
+// readLineFromSessionIH, but stops accepting characters once the line holds
+// maxLen runes: further printable or extended keystrokes are dropped without
+// echo, so the caller never sees a value longer than maxLen. A maxLen of 0
+// means unlimited.
+func readLineFromSessionIHMax(s ssh.Session, terminal *term.Terminal, maxLen int) (string, error) {
+	return readLineFromSessionIHImpl(s, terminal, false, maxLen)
 }
 
 // readLineFromSessionIHAllowAbort reads a simple command line like
 // readLineFromSessionIH, but returns errInputAborted when ESC is pressed.
 func readLineFromSessionIHAllowAbort(s ssh.Session, terminal *term.Terminal) (string, error) {
-	return readLineFromSessionIHImpl(s, terminal, true)
+	return readLineFromSessionIHImpl(s, terminal, true, 0)
 }
 
 // readLineFromSessionIHImpl is the shared implementation behind
-// readLineFromSessionIH and readLineFromSessionIHAllowAbort; the two differ
-// only in whether ESC aborts the read.
+// readLineFromSessionIH, readLineFromSessionIHMax and
+// readLineFromSessionIHAllowAbort; they differ only in whether ESC aborts the
+// read and whether the line length is capped (maxLen > 0, counted in runes).
 //
 // Extended keystrokes (byte >= 128) are decoded per the session's output
 // mode via decodeExtendedKey: a CP437 byte is a complete character on its
@@ -243,11 +253,14 @@ func readLineFromSessionIHAllowAbort(s ssh.Session, terminal *term.Terminal) (st
 // reports it complete. Backspace deletes one whole rune (see backspaceRune)
 // rather than one byte, and clears any in-progress utf8Pending sequence
 // without touching line or echoing, since nothing was displayed for it yet.
-func readLineFromSessionIHImpl(s ssh.Session, terminal *term.Terminal, allowAbort bool) (string, error) {
+func readLineFromSessionIHImpl(s ssh.Session, terminal *term.Terminal, allowAbort bool, maxLen int) (string, error) {
 	ih := getSessionIH(s)
 	mode := sessionOutputMode(s)
 	line := make([]byte, 0, 64)
 	var utf8Pending []byte
+	atLimit := func() bool {
+		return maxLen > 0 && utf8.RuneCount(line) >= maxLen
+	}
 
 	for {
 		key, err := ih.ReadKey()
@@ -276,7 +289,12 @@ func readLineFromSessionIHImpl(s ssh.Session, terminal *term.Terminal, allowAbor
 			// comes next.
 			utf8Pending = nil
 		default:
-			if key >= 32 && key < 127 {
+			if atLimit() && ((key >= 32 && key < 127) || (key >= 128 && key <= 255)) {
+				// Line is full: swallow the keystroke silently. Any partial
+				// multi-byte sequence is abandoned too, since its remaining
+				// bytes would otherwise be treated as fresh input.
+				utf8Pending = nil
+			} else if key >= 32 && key < 127 {
 				line = append(line, byte(key))
 				_, _ = terminal.Write([]byte{byte(key)})
 				// A completed ASCII keystroke means any partial multi-byte

--- a/internal/menu/executor_session_test.go
+++ b/internal/menu/executor_session_test.go
@@ -226,3 +226,134 @@ func TestReadLineFromSessionIH_ResyncsAfterStrayLeadByte(t *testing.T) {
 		t.Errorf("line = %q, want %q — the stray lead byte swallowed the next character", got, "日")
 	}
 }
+
+// --- readLineFromSessionIHMax: rune-counted input cap ---
+
+// TestReadLineFromSessionIHMax_ASCIIStopsAtLimit is the basic contract: once
+// the line holds maxLen runes, further printable keystrokes are dropped and
+// not echoed, and Enter still terminates the read normally.
+func TestReadLineFromSessionIHMax_ASCIIStopsAtLimit(t *testing.T) {
+	ts := newTestSession("abcde\r")
+	terminal := newTestTerminal(ts)
+
+	line, err := readLineFromSessionIHMax(ts, terminal, 3)
+	if err != nil {
+		t.Fatalf("readLineFromSessionIHMax: %v", err)
+	}
+	if line != "abc" {
+		t.Errorf("line = %q, want %q", line, "abc")
+	}
+	if out := ts.output(); strings.ContainsAny(out, "de") {
+		t.Errorf("output = %q, dropped keystrokes must not be echoed", out)
+	}
+}
+
+// TestReadLineFromSessionIHMax_BackspaceAfterLimitFreesRoom verifies the
+// limit is a live check on the current line, not a latch: after a dropped
+// keystroke, Backspace still removes a rune and typing resumes into the
+// freed slot.
+func TestReadLineFromSessionIHMax_BackspaceAfterLimitFreesRoom(t *testing.T) {
+	// 'a','b','c' fill the line; 'd' is dropped; Backspace removes 'c';
+	// 'e' is accepted into the freed slot.
+	ts := newTestSession("abcd\x08e\r")
+	terminal := newTestTerminal(ts)
+
+	line, err := readLineFromSessionIHMax(ts, terminal, 3)
+	if err != nil {
+		t.Fatalf("readLineFromSessionIHMax: %v", err)
+	}
+	if line != "abe" {
+		t.Errorf("line = %q, want %q", line, "abe")
+	}
+	if n := strings.Count(ts.output(), "\b \b"); n != 1 {
+		t.Errorf("output contains %d \\b \\b sequences, want exactly 1", n)
+	}
+}
+
+// TestReadLineFromSessionIHMax_CP437CountsRunesNotBytes types three CP437
+// 'é' (0x82) with a cap of 2. Each is stored as a 2-byte UTF-8 rune, so a
+// byte-counted limit would stop after one; a rune-counted one keeps two.
+func TestReadLineFromSessionIHMax_CP437CountsRunesNotBytes(t *testing.T) {
+	ts := newTestSession("\x82\x82\x82\r")
+	SetSessionOutputMode(ts, ansi.OutputModeCP437)
+	terminal := newTestTerminal(ts)
+
+	line, err := readLineFromSessionIHMax(ts, terminal, 2)
+	if err != nil {
+		t.Fatalf("readLineFromSessionIHMax: %v", err)
+	}
+	if line != "éé" {
+		t.Errorf("line = %q, want %q", line, "éé")
+	}
+	if n := utf8.RuneCountInString(line); n != 2 {
+		t.Errorf("line has %d runes, want 2", n)
+	}
+	if n := strings.Count(ts.output(), "\x82"); n != 2 {
+		t.Errorf("output echoed 0x82 %d times, want 2 (third must be dropped)", n)
+	}
+}
+
+// TestReadLineFromSessionIHMax_UTF8RuneCompletesAtLimit drives 'a' then the
+// three bytes of "日" with a cap of 2. The rune starts while there is still
+// room and must be assembled whole, taking the line to exactly maxLen; the
+// following 'b' must then be dropped.
+func TestReadLineFromSessionIHMax_UTF8RuneCompletesAtLimit(t *testing.T) {
+	ts := newTestSession("a\xe6\x97\xa5b\r")
+	SetSessionOutputMode(ts, ansi.OutputModeUTF8)
+	terminal := newTestTerminal(ts)
+
+	line, err := readLineFromSessionIHMax(ts, terminal, 2)
+	if err != nil {
+		t.Fatalf("readLineFromSessionIHMax: %v", err)
+	}
+	if !utf8.ValidString(line) {
+		t.Fatalf("line is not valid UTF-8: %q", line)
+	}
+	if line != "a日" {
+		t.Errorf("line = %q, want %q", line, "a日")
+	}
+	if strings.Contains(ts.output(), "b") {
+		t.Errorf("output = %q, 'b' past the limit must not be echoed", ts.output())
+	}
+}
+
+// TestReadLineFromSessionIHMax_UTF8SequenceAfterLimitFullyDropped sends a
+// complete 2-byte "é" (C3 A9) once the line is already full. Both bytes must
+// be swallowed: the lead byte must not be buffered as pending, and the
+// continuation byte must not survive to corrupt or extend the line.
+func TestReadLineFromSessionIHMax_UTF8SequenceAfterLimitFullyDropped(t *testing.T) {
+	ts := newTestSession("a\xc3\xa9\r")
+	SetSessionOutputMode(ts, ansi.OutputModeUTF8)
+	terminal := newTestTerminal(ts)
+
+	line, err := readLineFromSessionIHMax(ts, terminal, 1)
+	if err != nil {
+		t.Fatalf("readLineFromSessionIHMax: %v", err)
+	}
+	if line != "a" {
+		t.Errorf("line = %q, want %q", line, "a")
+	}
+	if !utf8.ValidString(line) {
+		t.Fatalf("line is not valid UTF-8: %q", line)
+	}
+	if strings.Contains(ts.output(), "\xc3") || strings.Contains(ts.output(), "\xa9") {
+		t.Errorf("output = %q, dropped multi-byte sequence must not be echoed", ts.output())
+	}
+}
+
+// TestReadLineFromSessionIHMax_ZeroMeansUnlimited guards the default used by
+// readLineFromSessionIH and readLineFromSessionIHAllowAbort: maxLen 0 must
+// impose no cap at all.
+func TestReadLineFromSessionIHMax_ZeroMeansUnlimited(t *testing.T) {
+	long := strings.Repeat("x", 200)
+	ts := newTestSession(long + "\r")
+	terminal := newTestTerminal(ts)
+
+	line, err := readLineFromSessionIHMax(ts, terminal, 0)
+	if err != nil {
+		t.Fatalf("readLineFromSessionIHMax: %v", err)
+	}
+	if line != long {
+		t.Errorf("line has %d runes, want 200 (maxLen 0 must be unlimited)", utf8.RuneCountInString(line))
+	}
+}

--- a/internal/menu/rumors_admin.go
+++ b/internal/menu/rumors_admin.go
@@ -104,14 +104,15 @@ func runRumorsAdd(c *cmdCtx, args string) (*user.User, string, error) {
 		enterPrompt = "|09Enter Rumor |08(|15Enter|08/|15Abort|08)|07:\r\n"
 	}
 	wv(terminal, enterPrompt, outputMode)
-	rumorText, err := readLineFromSessionIH(s, terminal)
+	rumorText, err := readLineFromSessionIHMax(s, terminal, rumorMaxLength)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
 			return nil, "LOGOFF", io.EOF
 		}
 		return currentUser, "", nil
 	}
-	if strings.TrimSpace(rumorText) == "" {
+	rumorText = clampRumorText(rumorText)
+	if rumorText == "" {
 		return currentUser, "", nil
 	}
 

--- a/internal/menu/rumors_data.go
+++ b/internal/menu/rumors_data.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 )
 
@@ -32,7 +33,19 @@ type rumorsData struct {
 	NextID int           `json:"next_id"`
 }
 
+// rumorMaxLength is the maximum rumor text length in runes. It matches the
+// width of the @RR|C####...@ field in the stock MAIN/MSGMENU/DOORSM screens,
+// so a rumor never gets clipped when shown there.
+const rumorMaxLength = 56
+
 var rumorsMu sync.Mutex
+
+// clampRumorText trims surrounding whitespace and hard-cuts the text to
+// rumorMaxLength runes. Input entry already stops at the limit; this is the
+// backstop for any path (pasted input, scripts) that bypasses it.
+func clampRumorText(s string) string {
+	return ansi.TruncateRunes(strings.TrimSpace(s), rumorMaxLength, "")
+}
 
 // backfillRumorUserIDs populates UserID for legacy records where UserID == 0
 // by looking up RealUser as a handle. Returns true if any records were updated.

--- a/internal/menu/rumors_data_test.go
+++ b/internal/menu/rumors_data_test.go
@@ -3,6 +3,7 @@ package menu
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -384,4 +385,27 @@ func TestBackfillRumorUserIDs(t *testing.T) {
 			t.Errorf("UserID should remain 0, got %d", rd.Rumors[0].UserID)
 		}
 	})
+}
+
+func TestClampRumorText(t *testing.T) {
+	long := strings.Repeat("x", rumorMaxLength+10)
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"short unchanged", "short rumor", "short rumor"},
+		{"whitespace trimmed", "  padded  ", "padded"},
+		{"exactly max kept", strings.Repeat("a", rumorMaxLength), strings.Repeat("a", rumorMaxLength)},
+		{"over max hard-cut", long, strings.Repeat("x", rumorMaxLength)},
+		{"multibyte counted as runes", strings.Repeat("é", rumorMaxLength+3), strings.Repeat("é", rumorMaxLength)},
+		{"empty stays empty", "   ", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := clampRumorText(tt.in); got != tt.want {
+				t.Errorf("clampRumorText(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Rumor entry now stops accepting keystrokes at 56 characters. The limit matches the width of the `@RR|C####...@` field in the stock `MAIN.ANS`, `MSGMENU.ANS`, and `DOORSM.ANS` screens, so a rumor is never clipped when shown in the random-rumor bar.

## Changes

- **Shared line reader** (`executor_session.go`): `readLineFromSessionIHImpl` gains an optional `maxLen` (in runes, 0 = unlimited). Once the line is full, further printable and extended keystrokes are dropped silently with no echo. Backspace and Enter behave as before. New wrapper `readLineFromSessionIHMax`; existing wrappers are unchanged in behavior.
- **Rumor add flow** (`rumors_admin.go`): reads the text through the capped reader, then runs it through `clampRumorText` as a backstop for any path that bypasses the reader.
- **Constant and clamp** (`rumors_data.go`): `rumorMaxLength = 56` and a rune-safe `clampRumorText` that trims whitespace and hard-cuts at the limit.
- **Docs** (`docs/sysop/menus/rumors.md`): documents the limit and the reason for it.
- **Test** (`rumors_data_test.go`): table-driven coverage for short, trimmed, exact-length, over-length, multibyte, and empty input.

Existing rumors already stored in `data/rumors.json` are not modified on load.

## Verification

- `go build ./...` and `go vet ./internal/menu/` pass.
- All rumor tests and the existing UTF-8 line-reader tests pass, so multibyte handling is unaffected.
- Two unrelated tests in `user_config_test.go` fail in the dev container both with and without this change. They check that a write to a read-only directory is rejected, which does not hold when running as root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXL7xAqJ5Zps8j38UF9rCo

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXL7xAqJ5Zps8j38UF9rCo)_