### PR TITLE
ci: run the test suite on Windows (#235)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,9 @@
 menus/v3/templates/* binary
 menus/v3/ansi/* binary
 
-# Golden files are captured terminal screens: every row is padded to the full
-# width, so trailing whitespace is content rather than a mistake. Exempt them
-# from the whitespace checks so `git diff --check` stays useful elsewhere.
-*.golden -whitespace
+# Golden files are captured terminal screens compared byte for byte. Every row
+# is padded to the full width, so trailing whitespace is content rather than a
+# mistake; and the line endings are content too, so they must survive a
+# checkout on Windows unconverted. Without -text, a runner with autocrlf turns
+# every LF into CRLF and the comparisons fail on Windows alone.
+*.golden -text -whitespace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,17 @@ jobs:
         with:
           only-new-issues: true
 
+  # Windows is a released platform (README: "Windows x86_64 Released") but had
+  # no test execution at all, so five windows-tagged files shipped without ever
+  # being run -- including internal/filelock, whose whole purpose is excluding
+  # a second process. A lock that silently fails to exclude is worse than none,
+  # because the callers now assume it works. See issue #235.
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -47,6 +56,10 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      # vet on Linux never analyses the windows-tagged files, since the build
+      # constraints exclude them; this is their first vet coverage.
+      - name: go vet
+        run: go vet ./...
       - name: go test
         run: go test ./...
       - name: go test -race

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      # vet on Linux never analyses the windows-tagged files, since the build
-      # constraints exclude them; this is their first vet coverage.
+      # Windows only: the lint job already vets on Linux, and a Linux vet never
+      # analyses the windows-tagged files anyway, since the build constraints
+      # exclude them. This is their first vet coverage.
       - name: go vet
+        if: matrix.os == 'windows-latest'
         run: go vet ./...
       - name: go test
         run: go test ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,25 +38,19 @@ jobs:
         with:
           only-new-issues: true
 
-  # Windows is a released platform (README: "Windows x86_64 Released") but had
-  # no test execution at all, so five windows-tagged files shipped without ever
-  # being run -- including internal/filelock, whose whole purpose is excluding
-  # a second process. A lock that silently fails to exclude is worse than none,
-  # because the callers now assume it works. See issue #235.
+  # Windows is a released platform (README: "Windows x86_64 Released") and now
+  # gates like Linux does. It went untested for a long time, and turning it on
+  # found four product bugs at once: FTN mail could not start there at all
+  # (#248), a concurrent read made every users.json save fail (#249), a path
+  # ending in "/" gained a second separator, and ziplab held its own source
+  # file open while renaming over it. None was visible from a Linux run, a
+  # GOOS=windows build, or vet. See #235.
   test:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    # Windows reports but does not gate, for now. Turning it on surfaced
-    # failures in 11 packages: two product bugs (#248 binkd's executable check
-    # uses unix permission bits; #249 os.Rename fails while another handle is
-    # open) and a set of test assumptions that do not hold there (#250).
-    # Blocking on those would stop every unrelated PR, and excluding the
-    # packages would hide the bugs. Drop this line once #248, #249 and #250
-    # are closed -- #250 tracks that.
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    # Windows reports but does not gate, for now. Turning it on surfaced
+    # failures in 11 packages: two product bugs (#248 binkd's executable check
+    # uses unix permission bits; #249 os.Rename fails while another handle is
+    # open) and a set of test assumptions that do not hold there (#250).
+    # Blocking on those would stop every unrelated PR, and excluding the
+    # packages would hide the bugs. Drop this line once #248, #249 and #250
+    # are closed -- #250 tracks that.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -1,0 +1,91 @@
+// Package atomicfile replaces a file in one step, so a reader sees either the
+// whole old contents or the whole new ones and never a partial write.
+//
+// The write half is the familiar temp-file-then-rename dance, which several
+// packages had each grown their own copy of. The replace half is the part that
+// needed a home: os.Rename is not the whole story on Windows, where the call
+// fails outright while any other handle to the destination is open.
+package atomicfile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Retry budget for a rename blocked by another handle. Only the Windows
+// implementation waits, but the values live here so the shared test can state
+// how long it has to hold a file for the retry to be under test at all.
+//
+// A reader holds a file only for as long as it takes to read it, so the block
+// is brief. Half a second is far longer than any read of a config or user file,
+// and still short enough that a genuine permission problem surfaces promptly
+// rather than hanging a save.
+const (
+	replaceAttempts = 20
+	replacePause    = 25 * time.Millisecond
+)
+
+// Replace moves src onto dst, replacing dst if it exists.
+//
+// On unix this is os.Rename. On Windows it retries briefly, because a rename
+// there fails while another process holds the destination open -- see the
+// commentary in replace_windows.go.
+func Replace(src, dst string) error {
+	return replace(src, dst)
+}
+
+// WriteFile writes data to path by way of a temp file in the same directory,
+// then replaces path with it.
+//
+// os.WriteFile truncates the target and then writes, so a crash -- or a full
+// disk -- between the two leaves a truncated file, and whatever did not make it
+// is simply gone.
+//
+// The temp file has to live in the destination directory: a rename is only
+// atomic within a filesystem, and os.TempDir may well be on another one.
+func WriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp file in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+
+	// Any failure from here on leaves the original untouched; clean up the
+	// temp file so a run of failed saves does not litter the directory.
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		cleanup()
+		return fmt.Errorf("write temp file %s: %w", tmpPath, err)
+	}
+	// Flush to the device before the rename. Without this the rename can reach
+	// disk while the contents have not, and a crash in that window leaves a
+	// correctly-named file full of zeroes -- worse than the truncation this is
+	// meant to prevent, because it looks intact.
+	if err := tmp.Sync(); err != nil {
+		cleanup()
+		return fmt.Errorf("sync temp file %s: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close temp file %s: %w", tmpPath, err)
+	}
+	// CreateTemp makes the file 0600; set the caller's mode explicitly so the
+	// result does not depend on that default. Windows has no mode bits to set,
+	// and Chmod there only toggles the read-only attribute, which is harmless.
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("chmod temp file %s: %w", tmpPath, err)
+	}
+	if err := Replace(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename %s to %s: %w", tmpPath, path, err)
+	}
+	return nil
+}

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -1,0 +1,213 @@
+package atomicfile
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestWriteFileReplacesContents covers the ordinary case.
+func TestWriteFileReplacesContents(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "data.json")
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteFile(path, []byte("new"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new" {
+		t.Errorf("contents = %q, want %q", got, "new")
+	}
+}
+
+// TestWriteFileCreatesMissingFile covers first write.
+func TestWriteFileCreatesMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fresh.json")
+	if err := WriteFile(path, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("contents = %q", got)
+	}
+}
+
+// TestWriteFileLeavesNoTempBehind checks the directory is not littered, on
+// success or on failure.
+func TestWriteFileLeavesNoTempBehind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data.json")
+	if err := WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "data.json" {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("directory holds %v, want just data.json", names)
+	}
+}
+
+// TestWriteFileIsNeverObservedPartiallyWritten is the property the package
+// exists for, and the one that fails on Windows without the retry in
+// replace_windows.go: a reader polling the file while it is rewritten must
+// always see complete, valid contents, and the writer must never fail because
+// a reader happened to have it open.
+func TestWriteFileIsNeverObservedPartiallyWritten(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "users.json")
+
+	payload := func(n int) []byte {
+		b, err := json.Marshal(map[string]any{"n": n, "pad": bytes.Repeat([]byte("x"), 4096)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return b
+	}
+	if err := WriteFile(path, payload(0), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stop := make(chan struct{})
+	bad := make(chan string, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				continue // only ever replaced, never absent for long
+			}
+			var out map[string]any
+			if err := json.Unmarshal(data, &out); err != nil {
+				select {
+				case bad <- "reader saw a partially written file: " + err.Error():
+				default:
+				}
+				return
+			}
+		}
+	}()
+
+	for i := 1; i <= 200; i++ {
+		if err := WriteFile(path, payload(i), 0o600); err != nil {
+			close(stop)
+			wg.Wait()
+			t.Fatalf("write %d failed while a reader had the file open: %v", i, err)
+		}
+	}
+	close(stop)
+	wg.Wait()
+
+	select {
+	case msg := <-bad:
+		t.Error(msg)
+	default:
+	}
+}
+
+// TestReplaceOverExistingFile covers Replace on its own.
+func TestReplaceOverExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	if err := os.WriteFile(src, []byte("new"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := Replace(src, dst); err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new" {
+		t.Errorf("dst = %q, want %q", got, "new")
+	}
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Error("src still exists after Replace")
+	}
+}
+
+// TestReplaceWhileDestinationIsOpen is the Windows case stated directly: a
+// rename over a file someone else holds open is refused there, and Replace has
+// to wait them out.
+//
+// The hold has to outlast at least one retry interval, or the test passes
+// whether or not Replace retries at all -- releasing the handle immediately
+// lets even a single attempt succeed. Holding for several intervals means a
+// non-retrying Replace fails here on Windows.
+//
+// On unix an open handle never blocks a rename, so this passes trivially.
+func TestReplaceWhileDestinationIsOpen(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	if err := os.WriteFile(src, []byte("new"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := os.Open(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Hold it well past a single retry interval, but comfortably inside the
+	// total budget so Replace still has attempts left when it is released.
+	hold := 4 * replacePause
+	released := make(chan struct{})
+	go func() {
+		time.Sleep(hold)
+		_ = f.Close()
+		close(released)
+	}()
+
+	start := time.Now()
+	err = Replace(src, dst)
+	<-released
+
+	if err != nil {
+		t.Fatalf("Replace failed while the destination was briefly open (GOOS=%s): %v",
+			runtime.GOOS, err)
+	}
+	if got, err := os.ReadFile(dst); err != nil || string(got) != "new" {
+		t.Errorf("dst = %q (err %v), want %q", got, err, "new")
+	}
+	// On Windows the call cannot have succeeded before the handle went away,
+	// which is the retry doing its job. Elsewhere it should not have waited.
+	waited := time.Since(start)
+	if runtime.GOOS == "windows" && waited < hold {
+		t.Errorf("Replace returned after %v, before the handle was released at %v; "+
+			"it cannot have been blocked, so this test is not exercising the retry",
+			waited, hold)
+	}
+}

--- a/internal/atomicfile/replace_unix.go
+++ b/internal/atomicfile/replace_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package atomicfile
+
+import "os"
+
+// replace is a plain rename. On unix an open handle does not block one: the
+// directory entry is swapped and any reader keeps the inode it already opened.
+func replace(src, dst string) error {
+	return os.Rename(src, dst)
+}

--- a/internal/atomicfile/replace_windows.go
+++ b/internal/atomicfile/replace_windows.go
@@ -1,0 +1,54 @@
+//go:build windows
+
+package atomicfile
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// replace renames src onto dst, retrying while another handle blocks it.
+//
+// Windows refuses to replace a file that anyone else has open unless every
+// holder opened it with FILE_SHARE_DELETE, and Go's os.Open and os.ReadFile do
+// not ask for that. So a reader that merely reads users.json for a few
+// microseconds is enough to make a concurrent save fail with "Access is
+// denied" -- on a multi-node BBS, routine traffic rather than a rare race.
+//
+// Retrying is a treatment rather than a cure: the cure is for every reader to
+// open with FILE_SHARE_DELETE, which needs a Windows-specific open path that
+// os.ReadFile does not offer. What retrying buys is that a save no longer fails
+// because a reader happened to be mid-read, which is the failure that actually
+// bites. A destination held open indefinitely still fails, and should.
+func replace(src, dst string) error {
+	var err error
+	for attempt := 0; attempt < replaceAttempts; attempt++ {
+		err = os.Rename(src, dst)
+		if err == nil || !blockedByAnotherHandle(err) {
+			return err
+		}
+		time.Sleep(replacePause)
+	}
+	return err
+}
+
+// blockedByAnotherHandle reports whether err is Windows refusing the rename
+// because someone else has the file open, as opposed to a real permission or
+// path problem that retrying cannot help.
+func blockedByAnotherHandle(err error) bool {
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		return false
+	}
+	switch errno {
+	case syscall.Errno(windows.ERROR_ACCESS_DENIED),
+		syscall.Errno(windows.ERROR_SHARING_VIOLATION),
+		syscall.Errno(windows.ERROR_LOCK_VIOLATION):
+		return true
+	}
+	return false
+}

--- a/internal/config/config_binkd_test.go
+++ b/internal/config/config_binkd_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -63,6 +64,14 @@ func TestLoadFTNConfigBinkdPartialDefaults(t *testing.T) {
 	}
 }
 
+// absTestPath is an absolute path on whichever platform is running.
+var absTestPath = func() string {
+	if runtime.GOOS == "windows" {
+		return `C:\abs\secure_in`
+	}
+	return "/abs/secure_in"
+}()
+
 func TestFTNConfigResolvePaths(t *testing.T) {
 	cfg := FTNConfig{
 		InboundPath:       "data/ftn/in",
@@ -71,11 +80,15 @@ func TestFTNConfigResolvePaths(t *testing.T) {
 		BinkdOutboundPath: "data/ftn/out",
 		TempPath:          "data/ftn/temp",
 	}
+	// "/abs/..." is not an absolute path on Windows -- absolute there means a
+	// drive or a UNC share -- so ResolvePaths would rightly join it to the
+	// root. Use a path that is absolute on the platform running the test.
+	cfg.SecureInboundPath = absTestPath
 	cfg.ResolvePaths("/bbs")
 	if cfg.InboundPath != filepath.Join("/bbs", "data/ftn/in") {
 		t.Errorf("InboundPath = %q", cfg.InboundPath)
 	}
-	if cfg.SecureInboundPath != "/abs/secure_in" {
+	if cfg.SecureInboundPath != absTestPath {
 		t.Errorf("absolute path must be untouched, got %q", cfg.SecureInboundPath)
 	}
 	if cfg.BinkdOutboundPath != filepath.Join("/bbs", "data/ftn/out") {

--- a/internal/file/manager_test.go
+++ b/internal/file/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -67,13 +68,24 @@ func TestNewFileManager_ValidAreas(t *testing.T) {
 	}
 }
 
+// absAreaPath is absolute on whichever platform is running. "/etc" is not
+// absolute on Windows -- absolute there needs a drive or a UNC share -- so it
+// would be joined to the files root and accepted, and the case would test
+// nothing.
+var absAreaPath = func() string {
+	if runtime.GOOS == "windows" {
+		return `C:\Windows`
+	}
+	return "/etc"
+}()
+
 func TestNewFileManager_SkipsInvalidAreas(t *testing.T) {
 	areas := []FileArea{
-		{ID: 0, Tag: "BAD", Name: "Zero ID", Path: "bad"},          // ID <= 0
-		{ID: 1, Tag: "", Name: "Empty Tag", Path: "empty"},         // empty tag
-		{ID: 2, Tag: "ABS", Name: "Absolute Path", Path: "/etc"},   // absolute path
-		{ID: 3, Tag: "TRAV", Name: "Traversal", Path: "../escape"}, // path traversal
-		{ID: 4, Tag: "GOOD", Name: "Valid Area", Path: "good"},     // valid
+		{ID: 0, Tag: "BAD", Name: "Zero ID", Path: "bad"},             // ID <= 0
+		{ID: 1, Tag: "", Name: "Empty Tag", Path: "empty"},            // empty tag
+		{ID: 2, Tag: "ABS", Name: "Absolute Path", Path: absAreaPath}, // absolute path
+		{ID: 3, Tag: "TRAV", Name: "Traversal", Path: "../escape"},    // path traversal
+		{ID: 4, Tag: "GOOD", Name: "Valid Area", Path: "good"},        // valid
 	}
 	fm := setupTestFileManager(t, areas)
 

--- a/internal/ftn/binkd_ensure_test.go
+++ b/internal/ftn/binkd_ensure_test.go
@@ -3,6 +3,7 @@ package ftn
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -107,7 +108,11 @@ func TestEnsureBinkdConfCreatesWhenMissing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat regenerated conf: %v", err)
 	}
-	if info.Mode().Perm() != 0600 {
+	// Windows has no POSIX mode bits: os.Stat reports 0666 for every ordinary
+	// file, so this asserts nothing there. The restriction still matters on
+	// unix, where these files hold secrets, so the check stays rather than
+	// being softened for both platforms.
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0600 {
 		t.Errorf("want mode 0600, got %v", info.Mode().Perm())
 	}
 	data, err := os.ReadFile(confPath)

--- a/internal/ftn/binkd_sync_test.go
+++ b/internal/ftn/binkd_sync_test.go
@@ -2,6 +2,7 @@ package ftn
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -112,11 +113,11 @@ func TestRegenerateBinkdConfFromConfig(t *testing.T) {
 	}
 	got := readConf(t, confPath)
 	for _, want := range []string{
-		"domain fsxnet /real/root/data/ftn/out 21",
+		"domain fsxnet " + filepath.Join("/real/root", "data/ftn/out") + " 21",
 		"address 21:4/999@fsxnet",
 		"sysname \"Test Board\"",
 		"node 21:4/158@fsxnet pointhub.example.org:24556 s3cret",
-		"log /real/root/data/logs/binkd.log",
+		"log " + filepath.Join("/real/root", "data/logs/binkd.log"),
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("regenerated conf missing %q:\n%s", want, got)

--- a/internal/ftn/binkd_write.go
+++ b/internal/ftn/binkd_write.go
@@ -2,6 +2,7 @@ package ftn
 
 import (
 	"fmt"
+	"github.com/ViSiON-3/vision-3-bbs/internal/atomicfile"
 	"os"
 	"path/filepath"
 	"sort"
@@ -176,30 +177,14 @@ func rewriteBinkdConf(out *strings.Builder, content string, cfg BinkdConfig, out
 // writeFileAtomic creates the parent directory if needed and writes content via
 // a temp file + rename, so callers never see a partial/empty binkd.conf and
 // fresh installs (where data/ftn doesn't exist yet) don't fail.
+//
+// The replace itself is internal/atomicfile's, which retries on Windows while
+// another handle holds the destination open.
 func writeFileAtomic(path, content string, perm os.FileMode) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return fmt.Errorf("creating dir for %s: %w", path, err)
 	}
-	tmp, err := os.CreateTemp(filepath.Dir(path), ".tmp.*")
-	if err != nil {
-		return fmt.Errorf("creating temp file: %w", err)
-	}
-	tmpName := tmp.Name()
-	if _, err := tmp.WriteString(content); err != nil {
-		_ = tmp.Close()        // cleanup on error path
-		_ = os.Remove(tmpName) // cleanup on error path
-		return fmt.Errorf("writing %s: %w", path, err)
-	}
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpName) // cleanup on error path
-		return fmt.Errorf("closing %s: %w", path, err)
-	}
-	if err := os.Chmod(tmpName, perm); err != nil {
-		_ = os.Remove(tmpName) // cleanup on error path
-		return fmt.Errorf("chmod %s: %w", path, err)
-	}
-	if err := os.Rename(tmpName, path); err != nil {
-		_ = os.Remove(tmpName) // cleanup on error path
+	if err := atomicfile.WriteFile(path, []byte(content), perm); err != nil {
 		return fmt.Errorf("installing %s: %w", path, err)
 	}
 	return nil

--- a/internal/jam/pack.go
+++ b/internal/jam/pack.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/ViSiON-3/vision-3-bbs/internal/atomicfile"
 	"io"
 	"os"
 	"strings"
@@ -296,13 +297,15 @@ func (b *Base) packWithReplyIDCleanup(cleanReplyIDs bool) (PackResult, error) {
 	_ = b.jdtFile.Close()
 	_ = b.jdxFile.Close()
 
-	// Atomic rename
+	// Atomic rename. Via atomicfile so that on Windows a reader holding one of
+	// the three files open only delays the swap rather than failing the pack
+	// and leaving the base closed.
 	for _, pair := range [][2]string{
 		{tmpJhr, b.BasePath + ".jhr"},
 		{tmpJdt, b.BasePath + ".jdt"},
 		{tmpJdx, b.BasePath + ".jdx"},
 	} {
-		if err := os.Rename(pair[0], pair[1]); err != nil {
+		if err := atomicfile.Replace(pair[0], pair[1]); err != nil {
 			// Try to clean up remaining temp files
 			_ = os.Remove(tmpJhr) // cleanup on error path
 			_ = os.Remove(tmpJdt) // cleanup on error path

--- a/internal/jam/pack_test.go
+++ b/internal/jam/pack_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -280,6 +281,15 @@ func TestPackRenameFailureMarksBaseClosed(t *testing.T) {
 	// non-empty directory. The open handle still reads the unlinked file,
 	// but os.Rename onto a non-empty directory fails, and the recovery
 	// reopen of the original path fails too.
+	//
+	// The injection depends on unlinking a file that is still open, which
+	// Windows refuses -- os.Remove there fails with a sharing violation while
+	// the base holds the handle. The behaviour under test (a failed rename
+	// leaves the base closed rather than open with nil handles) is
+	// platform-independent; only this way of provoking it is not.
+	if runtime.GOOS == "windows" {
+		t.Skip("cannot unlink an open file on Windows, so the rename failure cannot be injected this way")
+	}
 	jhrPath := basePath + ".jhr"
 	if err := os.Remove(jhrPath); err != nil {
 		t.Fatalf("remove .jhr: %v", err)

--- a/internal/mailer/executable_unix.go
+++ b/internal/mailer/executable_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package mailer
+
+import (
+	"fmt"
+	"os"
+)
+
+// checkExecutable reports whether the binkd binary can actually be run.
+//
+// On unix the execute bits say so directly.
+func checkExecutable(path string, info os.FileInfo) error {
+	if info.Mode()&0111 == 0 {
+		return fmt.Errorf("binkd binary %s is not executable", path)
+	}
+	return nil
+}

--- a/internal/mailer/executable_windows.go
+++ b/internal/mailer/executable_windows.go
@@ -1,0 +1,59 @@
+//go:build windows
+
+package mailer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// checkExecutable reports whether the binkd binary can actually be run.
+//
+// Windows has no execute bit. Go's os.Stat reports 0666 for every ordinary
+// file there (0444 when read-only), so the unix test of Mode()&0111 is not
+// merely unhelpful, it is always false -- which made mailer.New fail on every
+// Windows installation and took FTN mail down with it.
+//
+// What decides executability on Windows is the extension, so check that
+// instead, along with the file being an ordinary file: a directory, device or
+// named pipe cannot be run whatever it is called.
+func checkExecutable(path string, info os.FileInfo) error {
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("binkd binary %s is not a regular file", path)
+	}
+	exts := executableExts()
+	ext := strings.ToLower(filepath.Ext(path))
+	for _, allowed := range exts {
+		if ext == allowed {
+			return nil
+		}
+	}
+	return fmt.Errorf("binkd binary %s does not have an executable extension; "+
+		"Windows needs one of %s", path, strings.Join(exts, " "))
+}
+
+// defaultExecutableExts is what Windows treats as runnable when PATHEXT says
+// nothing.
+var defaultExecutableExts = []string{".com", ".exe", ".bat", ".cmd"}
+
+// executableExts returns the extensions Windows treats as runnable, from
+// PATHEXT where it is set. Everything is lower-cased so comparisons are
+// case-insensitive, as the filesystem is.
+func executableExts() []string {
+	raw := os.Getenv("PATHEXT")
+	if raw == "" {
+		return defaultExecutableExts
+	}
+	var exts []string
+	for _, e := range strings.Split(raw, ";") {
+		if e = strings.ToLower(strings.TrimSpace(e)); e != "" {
+			exts = append(exts, e)
+		}
+	}
+	if len(exts) == 0 {
+		return defaultExecutableExts
+	}
+	return exts
+}

--- a/internal/mailer/executable_windows_test.go
+++ b/internal/mailer/executable_windows_test.go
@@ -1,0 +1,90 @@
+//go:build windows
+
+package mailer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCheckExecutableWindows covers the extension rule that replaces the unix
+// execute bit, and the file-type check alongside it.
+func TestCheckExecutableWindows(t *testing.T) {
+	dir := t.TempDir()
+
+	write := func(name string) string {
+		t.Helper()
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("stub"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	t.Setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+
+	for _, name := range []string{"binkd.exe", "binkd.EXE", "binkd.cmd", "binkd.bat"} {
+		p := write(name)
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := checkExecutable(p, info); err != nil {
+			t.Errorf("checkExecutable(%s) = %v, want nil", name, err)
+		}
+	}
+
+	// No extension at all was the shape that broke every Windows install: the
+	// unix check rejected it for having no execute bit, which Windows never
+	// sets on anything.
+	for _, name := range []string{"binkd", "binkd.txt", "binkd.dll"} {
+		p := write(name)
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := checkExecutable(p, info); err == nil {
+			t.Errorf("checkExecutable(%s) = nil, want an error", name)
+		}
+	}
+
+	// A directory named like an executable is still not one.
+	d := filepath.Join(dir, "notabinary.exe")
+	if err := os.Mkdir(d, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := checkExecutable(d, info); err == nil {
+		t.Error("checkExecutable on a directory = nil, want an error")
+	}
+}
+
+// TestExecutableExtsHonoursPATHEXT checks a site can extend the list, and that
+// an empty or unset PATHEXT falls back rather than accepting everything.
+func TestExecutableExtsHonoursPATHEXT(t *testing.T) {
+	t.Setenv("PATHEXT", ".EXE;.PS1")
+	got := executableExts()
+	want := map[string]bool{".exe": true, ".ps1": true}
+	if len(got) != len(want) {
+		t.Fatalf("exts = %v, want %v", got, want)
+	}
+	for _, e := range got {
+		if !want[e] {
+			t.Errorf("unexpected extension %q", e)
+		}
+	}
+
+	t.Setenv("PATHEXT", "")
+	if got := executableExts(); len(got) != len(defaultExecutableExts) {
+		t.Errorf("empty PATHEXT gave %v, want the default list", got)
+	}
+
+	t.Setenv("PATHEXT", ";  ;")
+	if got := executableExts(); len(got) != len(defaultExecutableExts) {
+		t.Errorf("blank PATHEXT gave %v, want the default list", got)
+	}
+}

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -68,8 +68,8 @@ func New(cfg Config) (*Service, error) {
 	if err != nil {
 		return nil, fmt.Errorf("binkd binary not found at %s: %w", binkdPath, err)
 	}
-	if info.Mode()&0111 == 0 {
-		return nil, fmt.Errorf("binkd binary %s is not executable", binkdPath)
+	if err := checkExecutable(binkdPath, info); err != nil {
+		return nil, err
 	}
 
 	confPath := filepath.Join(cfg.BBSRoot, "data", "ftn", "binkd.conf")

--- a/internal/mailer/mailer_test.go
+++ b/internal/mailer/mailer_test.go
@@ -13,6 +13,19 @@ import (
 	"github.com/ViSiON-3/vision-3-bbs/internal/message"
 )
 
+// binkdName is what the fake binkd is called. Windows decides executability by
+// extension rather than by a mode bit, so the fixture has to carry one there or
+// the preflight check rightly rejects it.
+var binkdName = func() string {
+	if runtime.GOOS == "windows" {
+		return "binkd.exe"
+	}
+	return "binkd"
+}()
+
+// binkdRelPath is the same name as the configured relative BinaryPath.
+var binkdRelPath = filepath.ToSlash(filepath.Join("bin", binkdName))
+
 // newTestRoot builds a BBS root with a fake binkd binary and a binkd.conf.
 func newTestRoot(t *testing.T) string {
 	t.Helper()
@@ -24,9 +37,11 @@ func newTestRoot(t *testing.T) string {
 			t.Fatal(err)
 		}
 	}
-	// Fake binkd: a shell script that sleeps.
+	// Fake binkd: a shell script that sleeps. Only the unix tests actually run
+	// it; the Windows ones exercise the preflight checks, which care about the
+	// name rather than the contents.
 	script := "#!/bin/sh\nsleep 60\n"
-	if err := os.WriteFile(filepath.Join(binDir, "binkd"), []byte(script), 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(binDir, binkdName), []byte(script), 0755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(ftnDir, "binkd.conf"), []byte("iport 24554\nloglevel 4\n"), 0600); err != nil {
@@ -41,7 +56,7 @@ func testFTNConfig() config.FTNConfig {
 			"fsxnet": {OwnAddress: "21:4/158", InternalTosserEnabled: true},
 		},
 		Binkd: config.BinkdServerConfig{
-			Enabled: true, Port: 24554, BinaryPath: "bin/binkd", LogLevel: 4, ExportSecs: 300,
+			Enabled: true, Port: 24554, BinaryPath: binkdRelPath, LogLevel: 4, ExportSecs: 300,
 		},
 	}
 }
@@ -59,7 +74,7 @@ func TestNewPreflightOK(t *testing.T) {
 
 func TestNewPreflightMissingBinary(t *testing.T) {
 	root := newTestRoot(t)
-	if err := os.Remove(filepath.Join(root, "bin", "binkd")); err != nil {
+	if err := os.Remove(filepath.Join(root, "bin", binkdName)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := New(Config{BBSRoot: root, FTN: testFTNConfig()}); err == nil {
@@ -237,7 +252,7 @@ func TestNewValidatesFTNPathsForExport(t *testing.T) {
 func TestNewPreflightAbsoluteBinaryPath(t *testing.T) {
 	root := newTestRoot(t)
 	cfg := testFTNConfig()
-	cfg.Binkd.BinaryPath = filepath.Join(root, "bin", "binkd") // absolute
+	cfg.Binkd.BinaryPath = filepath.Join(root, "bin", binkdName) // absolute
 	if _, err := New(Config{BBSRoot: root, FTN: cfg}); err != nil {
 		t.Fatalf("absolute binary path must work: %v", err)
 	}

--- a/internal/menueditor/fileio.go
+++ b/internal/menueditor/fileio.go
@@ -3,6 +3,7 @@ package menueditor
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/ViSiON-3/vision-3-bbs/internal/atomicfile"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -217,31 +218,8 @@ func atomicWriteJSON(path string, v any) error {
 		return fmt.Errorf("marshal: %w", err)
 	}
 	data = append(data, '\n')
-
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, ".menueditor-*.tmp")
-	if err != nil {
-		return fmt.Errorf("create temp: %w", err)
-	}
-	tmpPath := tmp.Name()
-
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()        // best-effort; already returning a write error
-		_ = os.Remove(tmpPath) // best-effort cleanup
-		return fmt.Errorf("write temp: %w", err)
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()        // best-effort
-		_ = os.Remove(tmpPath) // best-effort cleanup
-		return fmt.Errorf("sync temp: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpPath) // best-effort cleanup
-		return fmt.Errorf("close temp: %w", err)
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		_ = os.Remove(tmpPath) // best-effort cleanup
-		return fmt.Errorf("rename to %s: %w", path, err)
+	if err := atomicfile.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
 	}
 	return nil
 }

--- a/internal/qwkapi/tlscert_test.go
+++ b/internal/qwkapi/tlscert_test.go
@@ -3,6 +3,7 @@ package qwkapi
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/config"
@@ -24,7 +25,11 @@ func TestLoadOrCreateCert_GeneratesAndReloads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("key file missing: %v", err)
 	}
-	if keyInfo.Mode().Perm() != 0o600 {
+	// Windows has no POSIX mode bits: os.Stat reports 0666 for every ordinary
+	// file, so this asserts nothing there. The restriction still matters on
+	// unix, where these files hold secrets, so the check stays rather than
+	// being softened for both platforms.
+	if runtime.GOOS != "windows" && keyInfo.Mode().Perm() != 0o600 {
 		t.Errorf("key mode = %o, want 600", keyInfo.Mode().Perm())
 	}
 

--- a/internal/syncjs/engine_test.go
+++ b/internal/syncjs/engine_test.go
@@ -299,9 +299,12 @@ func TestEngineLiveLoadPathList(t *testing.T) {
 	os.MkdirAll(subDir, 0o755)
 	os.WriteFile(filepath.Join(subDir, "helper.js"), []byte(`var HELPER_VAL = 99;`), 0o644)
 
-	// Main script mutates js.load_path_list at runtime, then requires the module
+	// Main script mutates js.load_path_list at runtime, then requires the module.
+	// The path goes into a JS string literal, so it needs forward slashes: a
+	// Windows path pasted in raw turns \U, \A and \T into escape sequences and
+	// the module is never found. Windows file APIs accept forward slashes.
 	os.WriteFile(filepath.Join(eng.cfg.WorkingDir, "test.js"), []byte(`
-		js.load_path_list.unshift("`+subDir+`/");
+		js.load_path_list.unshift("`+filepath.ToSlash(subDir)+`/");
 		load("helper.js");
 		console.write("helper:" + HELPER_VAL);
 		js.load_path_list.shift();

--- a/internal/tosser/dupecheck.go
+++ b/internal/tosser/dupecheck.go
@@ -2,9 +2,9 @@ package tosser
 
 import (
 	"encoding/json"
+	"github.com/ViSiON-3/vision-3-bbs/internal/atomicfile"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"sync"
 	"time"
 )
@@ -112,32 +112,7 @@ func (db *DupeDB) saveLocked() error {
 // atomicWriteFile writes data to a temp file then renames it to path,
 // ensuring the target file is never left in a partially-written state.
 func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp*")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()        // cleanup on error path
-		_ = os.Remove(tmpPath) // cleanup on error path
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()        // cleanup on error path
-		_ = os.Remove(tmpPath) // cleanup on error path
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpPath) // cleanup on error path
-		return err
-	}
-	if err := os.Chmod(tmpPath, perm); err != nil {
-		_ = os.Remove(tmpPath) // cleanup on error path
-		return err
-	}
-	return os.Rename(tmpPath, path)
+	return atomicfile.WriteFile(path, data, perm)
 }
 
 // Count returns the number of entries in the database.

--- a/internal/transfer/protocol.go
+++ b/internal/transfer/protocol.go
@@ -231,7 +231,11 @@ func expandArgs(template []string, filePaths []string, targetDir string) ([]stri
 	// Some external programs (e.g. Synchronet sexyz) concatenate the directory
 	// path + filename without inserting a separator, producing a mangled path
 	// like "/tmp/.incoming-123MYFILE.ZIP" instead of "/tmp/.incoming-123/MYFILE.ZIP".
-	if targetDir != "" && !strings.HasSuffix(targetDir, string(filepath.Separator)) {
+	//
+	// Test for either separator rather than the native one: Windows accepts
+	// both, so a targetDir that already ends in "/" is terminated, and
+	// appending "\\" to it would produce "C:/upload/tmp/\\".
+	if targetDir != "" && !os.IsPathSeparator(targetDir[len(targetDir)-1]) {
 		targetDir += string(filepath.Separator)
 	}
 

--- a/internal/transfer/protocol_test.go
+++ b/internal/transfer/protocol_test.go
@@ -36,7 +36,9 @@ func TestExpandArgs_no_filePaths_no_placeholder(t *testing.T) {
 func TestExpandArgs_targetDir_standalone(t *testing.T) {
 	tmpl := []string{"-r", "{targetDir}"}
 	got, _, _ := expandArgs(tmpl, nil, "/upload/tmp")
-	want := []string{"-r", "/upload/tmp/"}
+	// The separator appended is the native one, so the expectation is native
+	// too: "\\" on Windows, "/" elsewhere.
+	want := []string{"-r", "/upload/tmp" + string(filepath.Separator)}
 	assertStringSlice(t, want, got)
 }
 

--- a/internal/user/atomic_write.go
+++ b/internal/user/atomic_write.go
@@ -1,65 +1,22 @@
 package user
 
 import (
-	"fmt"
 	"os"
-	"path/filepath"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/atomicfile"
 )
 
 // writeFileAtomic writes data to path by way of a temp file in the same
 // directory, then renames it into place.
 //
-// os.WriteFile truncates the target and then writes, so a crash — or a full
-// disk — between the two leaves a truncated or half-written users.json, and
-// the accounts that did not make it are simply gone. Rename is atomic on both
-// unix and Windows, so a reader sees either the whole old file or the whole
-// new one and never a partial write.
-//
-// The temp file has to live in the destination directory: rename is only
-// atomic within a filesystem, and os.TempDir may well be on another one.
+// The mechanics live in internal/atomicfile, which several packages had each
+// grown their own copy of. Sharing them matters beyond tidiness: the Windows
+// half of the problem is that a rename fails while any reader holds the
+// destination open, and a fix in five separate copies is a fix in four of them
+// sooner or later.
 //
 // ./ue has written this way since it was built (internal/usereditor/fileio.go);
 // this brings the BBS into line with it.
 func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
-	if err != nil {
-		return fmt.Errorf("create temp file in %s: %w", dir, err)
-	}
-	tmpPath := tmp.Name()
-
-	// Any failure from here on leaves the original untouched; clean up the
-	// temp file so a run of failed saves does not litter the data directory.
-	cleanup := func() {
-		_ = tmp.Close()
-		_ = os.Remove(tmpPath)
-	}
-
-	if _, err := tmp.Write(data); err != nil {
-		cleanup()
-		return fmt.Errorf("write temp file %s: %w", tmpPath, err)
-	}
-	// Flush to the device before the rename. Without this the rename can reach
-	// disk while the contents have not, and a crash in that window leaves a
-	// correctly-named file full of zeroes — worse than the truncation this is
-	// meant to prevent, because it looks intact.
-	if err := tmp.Sync(); err != nil {
-		cleanup()
-		return fmt.Errorf("sync temp file %s: %w", tmpPath, err)
-	}
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("close temp file %s: %w", tmpPath, err)
-	}
-	// CreateTemp makes the file 0600; set the caller's mode explicitly so the
-	// result does not depend on that default.
-	if err := os.Chmod(tmpPath, perm); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("chmod temp file %s: %w", tmpPath, err)
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("rename %s to %s: %w", tmpPath, path, err)
-	}
-	return nil
+	return atomicfile.WriteFile(path, data, perm)
 }

--- a/internal/user/manager_auth_previouslogin_test.go
+++ b/internal/user/manager_auth_previouslogin_test.go
@@ -87,8 +87,13 @@ func TestAuthenticateSnapshotIsSelfConsistent(t *testing.T) {
 		if u == nil {
 			t.Fatalf("session %d failed to authenticate", i)
 		}
-		if !u.PreviousLogin.Before(u.LastLogin) {
-			t.Errorf("session %d: PreviousLogin %v is not before its own LastLogin %v",
+		// The invariant is that a session never reports a PreviousLogin newer
+		// than its own LastLogin, which is what a torn read would produce.
+		// Equality is legitimate: two of these logins can land in the same
+		// clock tick, and Windows' wall clock ticks about every 15ms, so there
+		// it is routine rather than a freak race.
+		if u.PreviousLogin.After(u.LastLogin) {
+			t.Errorf("session %d: PreviousLogin %v is after its own LastLogin %v",
 				i, u.PreviousLogin, u.LastLogin)
 		}
 	}

--- a/internal/v3net/keystore/keystore_test.go
+++ b/internal/v3net/keystore/keystore_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -22,7 +23,11 @@ func TestLoad_GeneratesNewKeypair(t *testing.T) {
 	if err != nil {
 		t.Fatalf("key file not created: %v", err)
 	}
-	if info.Mode().Perm() != 0600 {
+	// Windows has no POSIX mode bits: os.Stat reports 0666 for every ordinary
+	// file, so this asserts nothing there. The restriction still matters on
+	// unix, where these files hold secrets, so the check stays rather than
+	// being softened for both platforms.
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0600 {
 		t.Errorf("expected file mode 0600, got %o", info.Mode().Perm())
 	}
 

--- a/internal/v3net/keystore/mnemonic_test.go
+++ b/internal/v3net/keystore/mnemonic_test.go
@@ -3,6 +3,7 @@ package keystore
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -230,7 +231,11 @@ func TestRecoverToFile_Permissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Stat failed: %v", err)
 	}
-	if info.Mode().Perm() != 0600 {
+	// Windows has no POSIX mode bits: os.Stat reports 0666 for every ordinary
+	// file, so this asserts nothing there. The restriction still matters on
+	// unix, where these files hold secrets, so the check stays rather than
+	// being softened for both platforms.
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0600 {
 		t.Errorf("expected 0600, got %o", info.Mode().Perm())
 	}
 }

--- a/internal/ziplab/pipeline.go
+++ b/internal/ziplab/pipeline.go
@@ -2,6 +2,7 @@ package ziplab
 
 import (
 	"fmt"
+	"github.com/ViSiON-3/vision-3-bbs/internal/atomicfile"
 	"io"
 	"log/slog"
 	"os"
@@ -186,7 +187,7 @@ func (p *Processor) handleScanFailure(archivePath string) {
 				return
 			}
 			dest := filepath.Join(p.config.QuarantinePath, filepath.Base(archivePath))
-			if err := os.Rename(archivePath, dest); err != nil {
+			if err := atomicfile.Replace(archivePath, dest); err != nil {
 				slog.Error("failed to quarantine file", "path", archivePath, "error", err)
 				if rmErr := os.Remove(archivePath); rmErr != nil {
 					slog.Error("failed to remove infected file after quarantine failure", "path", archivePath, "error", rmErr)

--- a/internal/ziplab/pipeline_test.go
+++ b/internal/ziplab/pipeline_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -119,7 +120,14 @@ func TestRunPipeline_StepTimingRecorded(t *testing.T) {
 
 	result := p.RunPipeline(zipPath, nil)
 	for _, sr := range result.StepResults {
-		if sr.Elapsed <= 0 {
+		if sr.Elapsed < 0 {
+			t.Errorf("step %d recorded a negative elapsed time: %v", sr.Step, sr.Elapsed)
+		}
+		// A step faster than one tick of the clock measures zero. Windows'
+		// timer granularity is around 15ms, which a no-op step comfortably
+		// beats, so require a positive reading only where the clock is fine
+		// enough to guarantee one.
+		if runtime.GOOS != "windows" && sr.Elapsed <= 0 {
 			t.Errorf("step %d should have positive elapsed time", sr.Step)
 		}
 	}

--- a/internal/ziplab/processor_adremoval.go
+++ b/internal/ziplab/processor_adremoval.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bufio"
 	"fmt"
+	"github.com/ViSiON-3/vision-3-bbs/internal/atomicfile"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -19,7 +20,11 @@ func (p *Processor) removeFilesFromZip(zipPath string, patterns []string) (retEr
 	if err != nil {
 		return fmt.Errorf("failed to open zip: %w", err)
 	}
-	defer func() { _ = r.Close() }() // read-only zip reader
+	defer func() {
+		if r != nil {
+			_ = r.Close() // no-op after the explicit close on the success path
+		}
+	}()
 
 	tmpPath := zipPath + ".tmp"
 	outFile, err := os.Create(tmpPath)
@@ -72,7 +77,15 @@ func (p *Processor) removeFilesFromZip(zipPath string, patterns []string) (retEr
 	if err := outFile.Close(); err != nil {
 		return fmt.Errorf("failed to close temp zip: %w", err)
 	}
-	return os.Rename(tmpPath, zipPath)
+	// Release the source before replacing it. Windows refuses to rename over a
+	// file that anyone still holds open, and here the holder is this function:
+	// the deferred close would not run until after the rename. No amount of
+	// retrying in atomicfile can help when we are the one holding it.
+	if err := r.Close(); err != nil {
+		return fmt.Errorf("failed to close source zip: %w", err)
+	}
+	r = nil
+	return atomicfile.Replace(tmpPath, zipPath)
 }
 
 // shouldRemoveFile checks if a filename matches any removal pattern (case-insensitive).

--- a/internal/ziplab/processor_zip.go
+++ b/internal/ziplab/processor_zip.go
@@ -3,6 +3,7 @@ package ziplab
 import (
 	"archive/zip"
 	"fmt"
+	"github.com/ViSiON-3/vision-3-bbs/internal/atomicfile"
 	"io"
 	"os"
 	"path/filepath"
@@ -18,7 +19,11 @@ func (p *Processor) testZipIntegrity(zipPath string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open zip %s: %w", zipPath, err)
 	}
-	defer func() { _ = r.Close() }() // read-only zip reader
+	defer func() {
+		if r != nil {
+			_ = r.Close() // no-op after the explicit close on the success path
+		}
+	}()
 
 	for _, f := range r.File {
 		rc, err := f.Open()
@@ -40,7 +45,11 @@ func (p *Processor) extractZip(zipPath, destDir string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open zip %s: %w", zipPath, err)
 	}
-	defer func() { _ = r.Close() }() // read-only zip reader
+	defer func() {
+		if r != nil {
+			_ = r.Close() // no-op after the explicit close on the success path
+		}
+	}()
 
 	for _, f := range r.File {
 		targetPath := filepath.Join(destDir, f.Name)
@@ -110,7 +119,11 @@ func (p *Processor) setZipComment(zipPath, comment string) (retErr error) {
 	if err != nil {
 		return fmt.Errorf("failed to open zip: %w", err)
 	}
-	defer func() { _ = r.Close() }() // read-only zip reader
+	defer func() {
+		if r != nil {
+			_ = r.Close() // no-op after the explicit close on the success path
+		}
+	}()
 
 	tmpPath := zipPath + ".tmp"
 	outFile, err := os.Create(tmpPath)
@@ -144,7 +157,15 @@ func (p *Processor) setZipComment(zipPath, comment string) (retErr error) {
 	if err := outFile.Close(); err != nil {
 		return fmt.Errorf("failed to close temp zip: %w", err)
 	}
-	return os.Rename(tmpPath, zipPath)
+	// Release the source before replacing it. Windows refuses to rename over a
+	// file that anyone still holds open, and here the holder is this function:
+	// the deferred close would not run until after the rename. No amount of
+	// retrying in atomicfile can help when we are the one holding it.
+	if err := r.Close(); err != nil {
+		return fmt.Errorf("failed to close source zip: %w", err)
+	}
+	r = nil
+	return atomicfile.Replace(tmpPath, zipPath)
 }
 
 // addFileToZip rewrites a ZIP adding a new file entry.
@@ -153,7 +174,11 @@ func (p *Processor) addFileToZip(zipPath, name string, data []byte) (retErr erro
 	if err != nil {
 		return fmt.Errorf("failed to open zip: %w", err)
 	}
-	defer func() { _ = r.Close() }() // read-only zip reader
+	defer func() {
+		if r != nil {
+			_ = r.Close() // no-op after the explicit close on the success path
+		}
+	}()
 
 	tmpPath := zipPath + ".tmp"
 	outFile, err := os.Create(tmpPath)
@@ -207,5 +232,13 @@ func (p *Processor) addFileToZip(zipPath, name string, data []byte) (retErr erro
 	if err := outFile.Close(); err != nil {
 		return fmt.Errorf("failed to close temp zip: %w", err)
 	}
-	return os.Rename(tmpPath, zipPath)
+	// Release the source before replacing it. Windows refuses to rename over a
+	// file that anyone still holds open, and here the holder is this function:
+	// the deferred close would not run until after the rename. No amount of
+	// retrying in atomicfile can help when we are the one holding it.
+	if err := r.Close(); err != nil {
+		return fmt.Errorf("failed to close source zip: %w", err)
+	}
+	r = nil
+	return atomicfile.Replace(tmpPath, zipPath)
 }


### PR DESCRIPTION
Addresses steps 1 and 2 of #235.

## The result that matters

**`internal/filelock` passes on Windows.** Including `TestLockExcludesASeparateProcess`, which re-executes the test binary as a child process to prove real cross-process exclusion.

That was #235's primary concern — #232 added the lock so the BBS and `./ue` could not destroy each other's writes to `users.json`, and the `LockFileEx` path had never once been executed. "A lock that silently fails to exclude is worse than no lock, because the design now assumes it works." It excludes. That is step 2 of the issue, and it came free with step 1 because the existing test turned out to be portable.

~30 other packages pass too, including `internal/menu`, `internal/message`, `internal/qwkservice` and all three TUI editors.

## What it found

Turning Windows on surfaced failures in 11 packages. Two are product bugs on a released platform:

- **#248 — FTN mail cannot start on Windows.** `internal/mailer/mailer.go:71` gates on `info.Mode()&0111 == 0`. Go never sets execute bits on Windows, so `mailer.New` always fails. Not degraded — non-functional.
- **#249 — `os.Rename` fails while another handle is open.** `TestSaveIsNeverObservedPartiallyWritten` reads `users.json` while saving it: `rename users.json.tmp → users.json: Access is denied`. Any concurrent read breaks the save, which on a multi-node BBS is routine traffic. `internal/jam` packing and `internal/ziplab` hit the same wall.

#249 is exactly what #235 predicted — "os.Rename fails outright if another process holds the destination open without `FILE_SHARE_DELETE` … a plausible way for a save to start failing on Windows only". It is no longer a prediction.

The remaining ~9 are test assumptions that do not hold on Windows — unix permission bits, path separators, ~15ms clock granularity — tracked in **#250**, which also tracks removing the `continue-on-error` added here.

## Why Windows reports but does not gate

`continue-on-error: ${{ matrix.os == 'windows-latest' }}`.

Blocking on these would stop every unrelated PR for bugs that predate this change, and excluding the failing packages would hide them. Reporting keeps the data visible and the failures attributable. #250 tracks flipping it.

## Changes

- `windows-latest` added alongside `ubuntu-latest`, `fail-fast: false` so neither platform's failure hides the other's result.
- `go vet ./...` added to the test job. Vet on Linux never analyses windows-tagged files — build constraints exclude them — so this is their first vet coverage. It is clean.
- `*.golden` marked `-text`. Those are byte-exact terminal captures; a runner with `autocrlf` would rewrite every LF to CRLF and fail on Windows alone, looking like a real regression rather than a checkout artefact.

## Not in scope

Step 3 of #235, `ReplaceFile` versus `os.Rename`, is now informed rather than abstract — see #249, which argues neither is quite the fix, since an open handle is a sharing-mode problem rather than a rename-semantics one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWTB1hR7kAkbdjEqnWvAh9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable atomic file replacement to prevent partially written configuration, archive, and data files.
  * Improved executable validation across Unix and Windows, including Windows extension support.
  * Improved path handling for mixed separators on Windows.

* **Bug Fixes**
  * Improved archive replacement reliability when files are open.
  * Prevented duplicate cleanup during archive updates.
  * Improved authentication timing checks in concurrent scenarios.

* **Tests**
  * Expanded cross-platform coverage across Windows and Unix-like systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->