### PR TITLE
fix(menuedit): adopt the shared TUI chrome and fix its geometry (#252)

### DIFF
--- a/docs/dev/menu-user-editor-audit-todo.md
+++ b/docs/dev/menu-user-editor-audit-todo.md
@@ -1,6 +1,7 @@
 # Menu editor and user editor TUI audit
 
-Created: 2026-09-08. Status: in progress.
+Created: 2026-09-08. Status: in progress. Section 1 and 2 shipped for
+`./menuedit`; `./ue` outstanding.
 
 Related issues:
 
@@ -46,8 +47,10 @@ Established by static reading plus a throwaway geometry probe modelled on
 `internal/configeditor/view_geometry_test.go`, run over both editors at 80×25,
 100×30, 120×45, 160×60, 200×100 and an undersized 60×15. The probe drove real
 keystrokes into each screen rather than assigning `m.mode` directly; assigning
-the mode leaves `textInput.Width` unset and produces false width failures that
-are artifacts of the probe, not defects in the editors.
+the mode leaves `textInput.Width` unset and produces width failures that are
+artifacts of the probe. Two of the first pass's hits were exactly that. Note the
+inverse trap as well: the first probe never entered the field-edit modes at all,
+and so missed a real one-column overflow there. See the section 2 results.
 
 ### Shared chrome not adopted (both editors)
 
@@ -135,16 +138,18 @@ Recorded so a later reader does not re-audit them:
 
 ## 1. Adopt the shared chrome
 
-- [ ] Replace both local `dosColors` / `dosBgColors` tables and their
+Done for `./menuedit`. `./ue` follows in the second PR.
+
+- [x] Replace both local `dosColors` / `dosBgColors` tables and their
   `dosStyle` / `dosColor` constructors with aliases onto `internal/tuiart`,
   following the pattern in `internal/configeditor/colors.go:13-20`. Keep every
   screen-specific style variable and its `MENUEDIT.PAS` / `UE.PAS` provenance
   comment; only the palette underneath changes.
-- [ ] Alias the backdrop the way `internal/configeditor/backdrop.go` does, load
+- [x] Alias the backdrop the way `internal/configeditor/backdrop.go` does, load
   it in each model's constructor and resize handler, and source the background
   fill from `backdrop.Segment(row, col, width)` instead of
   `strings.Repeat("░", …)`.
-- [ ] Judge, per screen, whether the art or `tuiart.Shaded` is right, because
+- [x] Judge, per screen, whether the art or `tuiart.Shaded` is right, because
   the art is 80 columns wide and centered, so a centered box occludes all but a
   sliver of it. This is not a defect: `./config` itself caps every box at 70
   columns (72 with borders) and therefore never shows more than 4 columns of art
@@ -155,24 +160,58 @@ Recorded so a later reader does not re-audit them:
   columns) are well clear. Check on the manual pass whether a 1-column sliver
   frames or just reads as a stray line; if it does not read as framing, use
   `tuiart.Shaded` for that screen alone, as `./strings` does.
-- [ ] Point the title and help bars at `tuiart.HeaderBarStyle` and
+- [x] Point the title and help bars at `tuiart.HeaderBarStyle` and
   `tuiart.HelpBarStyle`; collapse `./ue`'s `editTitleStyle` onto the same style.
-- [ ] Delete the local `centerText` / `padRight` and delegate to
+- [x] Delete the local `centerText` / `padRight` and delegate to
   `tuiart.CenterText` / `tuiart.PadRight`. `internal/usereditor/view_test.go`
   already pins the current behavior of `centerText`, including the rune-safe
   truncation case — keep those assertions passing.
 
 ## 2. Fix ./menuedit geometry (#252)
 
-- [ ] Rework the three broken screens to derive top and bottom padding from one
+Done.
+
+- [x] Rework the three broken screens to derive top and bottom padding from one
   declared fixed-row count, as `newListBox` does, rather than from independent
   magic constants. Do not floor `bottomPad` at 1; that floor is what turns a
   miscount into an overflow instead of a visible gap.
-- [ ] Decide whether the menu editor's list screens should use
+- [x] Decide whether the menu editor's list screens should use
   `configeditor.listBox` directly. It currently lives in `internal/configeditor`
   and is documented as keeping each screen's exact byte output. Extract it to a
   shared package **only** if both editors genuinely need it; the prior audit's
   standing instruction is to share chrome, not to rewrite editors.
+
+### Results
+
+All three row-count defects are fixed, and the cause of the first two turned out
+to be more specific than "magic constants". `menuFields()` returns **13** fields,
+but `model.go` declared `menuEditFields = 7` and the menu edit screen's box
+height was written for that smaller list. The field list grew; the hardcoded
+geometry did not follow. Both `menuEditFields` and `cmdEditFields` were dead
+code — nothing read either one — so they are deleted and both edit screens now
+size their box from `len(m.menuFields)` / `len(m.cmdFields)`.
+
+The shared scaffold landed as **`tuiart.Screen`** rather than by extracting
+`configeditor.listBox`: `listBox` also owns that editor's box styling, and
+moving it would put its byte-identical golden captures at risk for no gain.
+`tuiart.Screen` carries only the parts both remaining editors need — row-tracked
+background fill and `Split`, which derives both paddings from one declared
+fixed-row count and deliberately does **not** floor either at 1. That floor is
+what turned a miscount into an off-screen overflow instead of a visible gap.
+
+A fourth defect surfaced only once the geometry test entered the field-edit
+modes, which the initial probe never did: the actively-edited field row was one
+cell too wide on both edit screens, because the code padded against
+`m.textInput.Width` while `textinput.View()` renders a cursor cell after the
+text. Both sites now measure `uitext.ApproximateVisibleLen(m.textInput.View())`
+instead — the approach `./ue`'s password dialog already used, and the one the
+`./ue` finding above recommends adopting there too.
+
+Adopting the backdrop also exposed that the two confirm/input dialog overlays
+rebuilt the row to the right of the dialog as flat `░` fill, which erases the
+art from those rows. They now preserve both sides with the `padToCol` /
+`skipToCol` pair, which `./config` and this editor's own help overlay already
+used; `skipToCol` was defined in `view.go` but had no callers.
 
 ## 3. Two-dimensional field navigation in ./ue (#242)
 
@@ -190,7 +229,7 @@ Recorded so a later reader does not re-audit them:
 
 ## 4. Verification
 
-- [ ] Add `view_geometry_test.go` to both packages, covering every reachable
+- [x] Add `view_geometry_test.go` to both packages (`./menuedit` done), covering every reachable
   mode at 80×25, 100×30, 120×45, 160×60, 200×100 and 60×15. Drive real
   keystrokes into each mode; assigning `m.mode` directly leaves `textInput`
   unconfigured and reports width failures that do not exist.

--- a/docs/dev/menu-user-editor-audit-todo.md
+++ b/docs/dev/menu-user-editor-audit-todo.md
@@ -1,0 +1,232 @@
+# Menu editor and user editor TUI audit
+
+Created: 2026-09-08. Status: in progress.
+
+Related issues:
+
+- [#252: ./menuedit TUI should follow same base layout/behavior as ./config TUI](https://github.com/ViSiON-3/vision-3-bbs/issues/252)
+- [#242: ./ue TUI should align with base UI settings with ./config and ./strings, and use arrow keys to move between fields](https://github.com/ViSiON-3/vision-3-bbs/issues/242)
+
+Prior art: the `./strings` and `./config` audit,
+[`string-editor-audit-todo.md`](string-editor-audit-todo.md), shipped in
+[#241](https://github.com/ViSiON-3/vision-3-bbs/pull/241) and
+[#243](https://github.com/ViSiON-3/vision-3-bbs/pull/243). That audit extracted
+the shared chrome into **`internal/tuiart`** and established `./config` as the
+reference. This audit finishes the job for the two editors it did not cover.
+
+## Objective
+
+Bring `./menuedit` and `./ue` onto the same visual baseline as `./config` and
+`./strings`, and give `./ue`'s two-column edit screen the arrow-key navigation
+its layout already implies.
+
+The scope is deliberately narrow: adopt the existing `internal/tuiart` chrome
+and fix the geometry defects that adopting it exposes. This is not a licence to
+restyle either editor. Both are faithful recreations of `MENUEDIT.PAS` and
+`UE.PAS`, and their screen-specific colors, box characters, and column layouts
+are intentional and stay as they are.
+
+`./config` is the reference to inspect, not an assumption of correctness — the
+same standard the prior audit applied to it, which is how its own geometry came
+to be probed.
+
+## Shipping plan
+
+Two PRs, one per issue, in this order. The `tuiart` adoption is nearly identical
+in both editors, so the second rebases cleanly on the first.
+
+1. **#252 — `./menuedit`**: adopt `internal/tuiart`, fix the vertical geometry
+   defects, add the geometry probe and golden captures.
+2. **#242 — `./ue`**: the same chrome adoption, plus two-dimensional field
+   navigation on the edit screen.
+
+## Confirmed findings
+
+Established by static reading plus a throwaway geometry probe modelled on
+`internal/configeditor/view_geometry_test.go`, run over both editors at 80×25,
+100×30, 120×45, 160×60, 200×100 and an undersized 60×15. The probe drove real
+keystrokes into each screen rather than assigning `m.mode` directly; assigning
+the mode leaves `textInput.Width` unset and produces false width failures that
+are artifacts of the probe, not defects in the editors.
+
+### Shared chrome not adopted (both editors)
+
+- Both editors define their own `dosColors` as **ANSI 256-color indices**
+  (`internal/menueditor/colors.go:8`, `internal/usereditor/colors.go:10`) —
+  `"4"` for blue, `"6"` for cyan, and so on. `internal/tuiart/colors.go` exists
+  specifically to replace that: it pins the canonical VGA hex values because
+  most terminal themes map ANSI blue to a bright, low-contrast shade that
+  washes out the white-and-yellow-on-blue UI. `./config` and `./strings` render
+  the authentic navy `#0000AA`; these two do not, so the four binaries do not
+  match on a stock terminal.
+- Neither editor paints backdrop art. `./config` composites a randomly chosen
+  embedded `.ANS` screen, centered, behind everything via `tuiart.Backdrop`;
+  both editors instead fill flat `░` (`internal/menueditor/view.go:23`,
+  `internal/usereditor/view.go:38`). `internal/tuiart/assets/TUIUSEREDIT.ANS`
+  already ships — art named for the user editor that only `./config` displays.
+- Title and help bars are rebuilt by hand rather than taken from
+  `tuiart.HeaderBarStyle` / `tuiart.HelpBarStyle`. `./ue` carries a third
+  near-duplicate in `editTitleStyle`.
+- `centerText` and `padRight` are duplicated locally in both
+  (`internal/menueditor/fields.go:173,178`; `internal/usereditor/fields.go:314`
+  and `view.go:343`) instead of `tuiart.CenterText` / `tuiart.PadRight`. The
+  shared versions truncate before centering, so an over-long title is cut to
+  the column budget rather than pushing a border out.
+- Neither package has a geometry test or a `testdata` directory. `./config` and
+  `./strings` both prove every row is exactly terminal-width at six sizes, and
+  `./strings` archives golden captures.
+
+### `./menuedit` geometry defects
+
+Each screen hand-rolls its own vertical arithmetic from magic constants, and
+three of them are wrong. `./config` derives padding from a single declared
+`fixedRows` passed to `newListBox` (`internal/configeditor/view_list_box.go:24`,
+`view_list.go:24`), which is why it has no equivalent defects.
+
+- **The menu edit screen emits one row too many at every size.** 26 rows in an
+  80×25 terminal, 101 in a 200×100 one. The last row is pushed off-screen and
+  the terminal scrolls. `internal/menueditor/view_menu_edit.go:34-36` computes
+  `extraV` against a fixed-content count of 26 and then floors `bottomPad` at 1.
+- **The command edit screen has the same defect**, from the same shape of
+  arithmetic against a different constant
+  (`internal/menueditor/view_command_edit.go:42-44`).
+- **The command list emits one row too few on any terminal taller than 25.** 29
+  rows at 100×30, 44 at 120×45, 99 at 200×100, leaving an unpainted row at the
+  bottom. It is correct only at 80×25 and below.
+  `internal/menueditor/view_command_list.go:35` computes `extraV` from
+  `m.height-24` while the screen's fixed content is 25 rows.
+
+### `./ue` findings
+
+- **Geometry is sound.** Every row of every screen is exactly the terminal width
+  and every screen is exactly the terminal height, across all six sizes and all
+  nine states probed: list, edit, field edit, delete confirm, validate, save-on-
+  leave, key list, password entry, and info alert. No changes needed here beyond
+  what the backdrop adoption itself requires.
+- **Field navigation ignores the column layout.** `fieldDef` already carries an
+  explicit `Col` (3 for the left column, 50 for the right) and `Row`
+  (`internal/usereditor/fields.go:31-32`), and `editFields()` assigns both for
+  every field. But `internal/usereditor/model.go:451-455` maps Down and Up to
+  `nextEditableField(±1)`, a linear walk of the field slice, and Left and Right
+  are unhandled in edit mode. Reaching `Validated` (Col 50, Row 4) from `Handle`
+  (Col 3, Row 4) takes eleven presses of Down through the whole left column.
+  This is #242's second item. The geometry needed to fix it is already in the
+  data; no layout change is required.
+- **Two different approaches to measuring `textinput.View()` coexist.**
+  `renderField` assumes the widget renders `Width+1` cells
+  (`internal/usereditor/view_edit.go:222-228`), while `overlayPasswordDialog`
+  measures the actual visible width because "textinput.View() width varies"
+  (`view_edit.go:273-276`). Both are correct today. Worth reconciling on the
+  measured approach while the file is open, since the assumption is the kind
+  that breaks silently on a dependency bump.
+
+### Already consistent across all four binaries
+
+Recorded so a later reader does not re-audit them:
+
+- Terminal lifecycle: all four construct with
+  `tea.NewProgram(model, tea.WithAltScreen(), tea.WithInputTTY())`.
+- An 80×25 minimum with clamping below it, applied identically in every
+  `tea.WindowSizeMsg` handler.
+- Fixed list heights. `./config`'s `recordListVisible()` returns a hard 13
+  (`internal/configeditor/update_save.go:155`). Growing a list to fill the
+  terminal was a `./strings`-specific fix, **not** part of the baseline, so
+  neither editor should adopt it here.
+
+## 1. Adopt the shared chrome
+
+- [ ] Replace both local `dosColors` / `dosBgColors` tables and their
+  `dosStyle` / `dosColor` constructors with aliases onto `internal/tuiart`,
+  following the pattern in `internal/configeditor/colors.go:13-20`. Keep every
+  screen-specific style variable and its `MENUEDIT.PAS` / `UE.PAS` provenance
+  comment; only the palette underneath changes.
+- [ ] Alias the backdrop the way `internal/configeditor/backdrop.go` does, load
+  it in each model's constructor and resize handler, and source the background
+  fill from `backdrop.Segment(row, col, width)` instead of
+  `strings.Repeat("░", …)`.
+- [ ] Judge, per screen, whether the art or `tuiart.Shaded` is right, because
+  the art is 80 columns wide and centered, so a centered box occludes all but a
+  sliver of it. This is not a defect: `./config` itself caps every box at 70
+  columns (72 with borders) and therefore never shows more than 4 columns of art
+  on each side, plus the rows above and below the box — where most of the
+  picture actually reads. The two editors' boxes are wider, so the vertical
+  sliver is thinner: 2 columns each side for `./menuedit`'s 74-column edit boxes
+  and 1 column for `./ue`'s 76-column edit box. Their list screens (50 and 60
+  columns) are well clear. Check on the manual pass whether a 1-column sliver
+  frames or just reads as a stray line; if it does not read as framing, use
+  `tuiart.Shaded` for that screen alone, as `./strings` does.
+- [ ] Point the title and help bars at `tuiart.HeaderBarStyle` and
+  `tuiart.HelpBarStyle`; collapse `./ue`'s `editTitleStyle` onto the same style.
+- [ ] Delete the local `centerText` / `padRight` and delegate to
+  `tuiart.CenterText` / `tuiart.PadRight`. `internal/usereditor/view_test.go`
+  already pins the current behavior of `centerText`, including the rune-safe
+  truncation case — keep those assertions passing.
+
+## 2. Fix ./menuedit geometry (#252)
+
+- [ ] Rework the three broken screens to derive top and bottom padding from one
+  declared fixed-row count, as `newListBox` does, rather than from independent
+  magic constants. Do not floor `bottomPad` at 1; that floor is what turns a
+  miscount into an overflow instead of a visible gap.
+- [ ] Decide whether the menu editor's list screens should use
+  `configeditor.listBox` directly. It currently lives in `internal/configeditor`
+  and is documented as keeping each screen's exact byte output. Extract it to a
+  shared package **only** if both editors genuinely need it; the prior audit's
+  standing instruction is to share chrome, not to rewrite editors.
+
+## 3. Two-dimensional field navigation in ./ue (#242)
+
+- [ ] Move Up and Down to walk within the current column by `Row`, and map Left
+  and Right to move to the nearest editable field in the adjacent column,
+  preserving the row where one exists there.
+- [ ] Decide and document the edge behavior: what Up does on the top row, what
+  Right does from the right column, and whether the read-only footer block
+  (rows 18-21, `Type: ftDisplay`) participates. `nextEditableField` currently
+  wraps and skips `ftDisplay`; keep skipping, and state the wrap rule.
+- [ ] Keep Tab, Enter, `ctrl+home`, and `ctrl+end` behaving as they do now. Tab
+  and Enter advance in field order and are the existing muscle memory; the
+  arrow keys are additive.
+- [ ] Update the help bar only if a key's meaning changes.
+
+## 4. Verification
+
+- [ ] Add `view_geometry_test.go` to both packages, covering every reachable
+  mode at 80×25, 100×30, 120×45, 160×60, 200×100 and 60×15. Drive real
+  keystrokes into each mode; assigning `m.mode` directly leaves `textInput`
+  unconfigured and reports width failures that do not exist.
+- [ ] Add golden captures for both editors under `testdata`, following
+  `internal/stringeditor/view_golden_test.go`.
+- [ ] Add coverage for the new navigation: each arrow from each column, the
+  edges, and that `ftDisplay` fields stay unreachable.
+- [ ] Run the package tests, the repository suite with race checks, `go vet`,
+  formatting checks, and `git diff --check`.
+- [ ] Perform a manual visual pass over `./menuedit` and `./ue` in a real
+  terminal, at small and large sizes, resizing repeatedly. **The automated
+  suite does not retire this.** The prior audit's manual pass found two defects
+  that every geometry and golden check passed cleanly, because row and column
+  arithmetic cannot tell a bar that stops in the right place from one that stops
+  a cell late. See
+  [`string-editor-audit-todo.md`](string-editor-audit-todo.md#why-the-manual-pass-was-not-redundant).
+- [ ] Run both editors against disposable copies of configuration. Do not save
+  test changes to the live development BBS.
+
+## Starting points in the code
+
+- [`internal/tuiart/`](../../internal/tuiart/): the shared palette, bar styles,
+  text helpers, and backdrop rasterizer this audit adopts.
+- [`internal/configeditor/colors.go`](../../internal/configeditor/colors.go) and
+  [`backdrop.go`](../../internal/configeditor/backdrop.go): the aliasing pattern
+  to copy, which kept `./config`'s call sites and golden output unchanged.
+- [`internal/configeditor/view_list_box.go`](../../internal/configeditor/view_list_box.go):
+  the `fixedRows` padding derivation the menu editor's screens should follow.
+- [`internal/configeditor/view_geometry_test.go`](../../internal/configeditor/view_geometry_test.go):
+  the probe to port to both packages.
+- [`internal/menueditor/view_menu_edit.go`](../../internal/menueditor/view_menu_edit.go),
+  [`view_command_edit.go`](../../internal/menueditor/view_command_edit.go), and
+  [`view_command_list.go`](../../internal/menueditor/view_command_list.go): the
+  three screens with vertical geometry defects.
+- [`internal/usereditor/fields.go`](../../internal/usereditor/fields.go): the
+  `Col` / `Row` field geometry the new navigation reads.
+- [`internal/usereditor/model.go`](../../internal/usereditor/model.go):
+  `nextEditableField`, `firstEditableField`, `lastEditableField`, and the edit
+  mode key handler.

--- a/internal/menueditor/backdrop.go
+++ b/internal/menueditor/backdrop.go
@@ -1,0 +1,17 @@
+package menueditor
+
+import "github.com/ViSiON-3/vision-3-bbs/internal/tuiart"
+
+// The backdrop rasterizer and its embedded ANSI art live in internal/tuiart so
+// every editor paints the same screen. These aliases mirror
+// internal/configeditor/backdrop.go.
+
+type backdrop = tuiart.Backdrop
+
+// pickBackdropArt chooses one embedded backdrop screen at random.
+func pickBackdropArt() []byte { return tuiart.Pick() }
+
+// loadBackdropFrom composites art bytes onto a width×height canvas.
+func loadBackdropFrom(data []byte, width, height int) *backdrop {
+	return tuiart.LoadFrom(data, width, height)
+}

--- a/internal/menueditor/colors.go
+++ b/internal/menueditor/colors.go
@@ -2,64 +2,32 @@ package menueditor
 
 import (
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/tuiart"
 )
 
-// DOS CGA color palette mapped to ANSI 256-color indices.
-var dosColors = [16]string{
-	"0",  // 0:  Black
-	"4",  // 1:  Blue
-	"2",  // 2:  Green
-	"6",  // 3:  Cyan
-	"1",  // 4:  Red
-	"5",  // 5:  Magenta
-	"3",  // 6:  Brown/Yellow
-	"7",  // 7:  Light Gray
-	"8",  // 8:  Dark Gray
-	"12", // 9:  Light Blue
-	"10", // 10: Light Green
-	"14", // 11: Light Cyan
-	"9",  // 12: Light Red
-	"13", // 13: Light Magenta
-	"11", // 14: Yellow
-	"15", // 15: White
-}
-
-var dosBgColors = [8]string{
-	"0", // 0: Black BG
-	"4", // 1: Blue BG
-	"2", // 2: Green BG
-	"6", // 3: Cyan BG
-	"1", // 4: Red BG
-	"5", // 5: Magenta BG
-	"3", // 6: Brown BG
-	"7", // 7: Light Gray BG
-}
+// The DOS palette and its style constructors live in internal/tuiart so every
+// editor renders in the same colors. These aliases keep the menu editor's call
+// sites unchanged; only the palette underneath changes, from ANSI 256 indices
+// to the pinned VGA hex values.
+var dosColors = tuiart.Palette
 
 // dosStyle creates a lipgloss style from a DOS TextAttr byte (bg<<4 | fg).
-func dosStyle(attr byte) lipgloss.Style {
-	fg := attr & 0x0F
-	bg := (attr >> 4) & 0x07
-	return lipgloss.NewStyle().
-		Foreground(lipgloss.Color(dosColors[fg])).
-		Background(lipgloss.Color(dosBgColors[bg]))
-}
+func dosStyle(attr byte) lipgloss.Style { return tuiart.Style(attr) }
 
 // dosColor creates a lipgloss style from separate DOS bg, fg values
 // matching the Pascal Color(bg, fg) procedure.
-func dosColor(bg, fg int) lipgloss.Style {
-	return lipgloss.NewStyle().
-		Foreground(lipgloss.Color(dosColors[fg&0x0F])).
-		Background(lipgloss.Color(dosBgColors[bg&0x07]))
-}
+func dosColor(bg, fg int) lipgloss.Style { return tuiart.Color(bg, fg) }
 
 // --- Title/Status bars ---
 // MENUEDIT.PAS: Color(8,15) → dark gray bg, white fg
-var titleBarStyle = dosColor(0, 15).Bold(true).Background(lipgloss.Color("8"))
-var helpBarStyle = dosColor(0, 15).Bold(true).Background(lipgloss.Color("8"))
+var titleBarStyle = tuiart.HeaderBarStyle
+var helpBarStyle = tuiart.HelpBarStyle
 
 // --- Background fill ---
-// MENUEDIT.PAS: Fill_Screen('░',7,1) → light gray fg, blue bg
-var bgFillStyle = dosColor(1, 7)
+// MENUEDIT.PAS: Fill_Screen('░',7,1) → light gray fg, blue bg. Used only when
+// the backdrop art is unavailable; tuiart.Backdrop renders this fill itself.
+var bgFillStyle = tuiart.FillStyle
 
 // --- Menu list box ---
 // MENUEDIT.PAS Open_Screen: Color(3,11) GrowBox → cyan bg, light cyan fg
@@ -80,7 +48,7 @@ var listHighlightStyle = dosColor(1, 15)
 // --- Edit box (menu/command edit screens) ---
 // MENUEDIT.PAS Edit_Menu: Color(8,15) box border → dark gray bg, white fg (actually uses Color(15,8) for White_Colors)
 // White_Colors: PColor=$F1(bg=7/white, fg=1/blue), NormColor=$F0(bg=7/white, fg=0/black)
-var editBorderStyle = dosColor(0, 15).Background(lipgloss.Color("8"))
+var editBorderStyle = dosColor(0, 15).Background(lipgloss.Color(dosColors[8]))
 
 // Field label: PColor=$F1 → light gray bg, blue fg
 var fieldLabelStyle = dosStyle(0xF1)

--- a/internal/menueditor/colors.go
+++ b/internal/menueditor/colors.go
@@ -24,11 +24,6 @@ func dosColor(bg, fg int) lipgloss.Style { return tuiart.Color(bg, fg) }
 var titleBarStyle = tuiart.HeaderBarStyle
 var helpBarStyle = tuiart.HelpBarStyle
 
-// --- Background fill ---
-// MENUEDIT.PAS: Fill_Screen('░',7,1) → light gray fg, blue bg. Used only when
-// the backdrop art is unavailable; tuiart.Backdrop renders this fill itself.
-var bgFillStyle = tuiart.FillStyle
-
 // --- Menu list box ---
 // MENUEDIT.PAS Open_Screen: Color(3,11) GrowBox → cyan bg, light cyan fg
 var listBorderStyle = dosColor(3, 11)

--- a/internal/menueditor/dialogs.go
+++ b/internal/menueditor/dialogs.go
@@ -2,6 +2,8 @@ package menueditor
 
 import (
 	"strings"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/tuiart"
 )
 
 // overlayConfirmDialog renders a Y/N confirm dialog centered over the background.
@@ -116,10 +118,15 @@ func (m Model) overlayInputDialog(background, title, prompt, inputView string) s
 		inputDialogTextStyle.Render(promptContent+strings.Repeat(" ", max(0, innerW-len(promptContent)))) +
 		side
 
+	// Bound the widget's output and pad from what it actually occupies. Using
+	// m.textInput.Width assumed the view was exactly that wide; it renders a
+	// cursor cell after the text, so a filled field pushed this row one column
+	// past the dialog border.
+	fittedInput, inputW := tuiart.FitInput(inputView, innerW-2)
 	inputLine := side +
 		inputDialogTextStyle.Render("  ") +
-		inputView +
-		inputDialogTextStyle.Render(strings.Repeat(" ", max(0, dialogW-4-m.textInput.Width))) +
+		fittedInput +
+		inputDialogTextStyle.Render(strings.Repeat(" ", max(0, innerW-2-inputW))) +
 		side
 
 	hintLine := side +

--- a/internal/menueditor/dialogs.go
+++ b/internal/menueditor/dialogs.go
@@ -64,12 +64,13 @@ func (m Model) overlayConfirmDialog(background, title, question string) string {
 
 	dialogLines := []string{border, titleLine, emptyLine, questionLine, emptyLine, buttonLine, borderBot}
 
-	tailW := max(0, m.width-startCol-dialogW)
-	tail := bgFillStyle.Render(strings.Repeat("░", tailW))
+	// Keep the screen behind the dialog on both sides. Rebuilding the right
+	// side as flat fill would erase the backdrop art from those rows.
+	endCol := startCol + dialogW
 	for i, dl := range dialogLines {
 		row := startRow + i
 		if row >= 0 && row < len(lines) {
-			lines[row] = padToCol(lines[row], startCol) + dl + tail
+			lines[row] = padToCol(lines[row], startCol) + dl + skipToCol(lines[row], endCol)
 		}
 	}
 
@@ -127,12 +128,13 @@ func (m Model) overlayInputDialog(background, title, prompt, inputView string) s
 
 	dialogLines := []string{border, titleLine, emptyLine, promptLine, inputLine, hintLine, borderBot}
 
-	tailW := max(0, m.width-startCol-dialogW)
-	tail := bgFillStyle.Render(strings.Repeat("░", tailW))
+	// Keep the screen behind the dialog on both sides. Rebuilding the right
+	// side as flat fill would erase the backdrop art from those rows.
+	endCol := startCol + dialogW
 	for i, dl := range dialogLines {
 		row := startRow + i
 		if row >= 0 && row < len(lines) {
-			lines[row] = padToCol(lines[row], startCol) + dl + tail
+			lines[row] = padToCol(lines[row], startCol) + dl + skipToCol(lines[row], endCol)
 		}
 	}
 

--- a/internal/menueditor/fields.go
+++ b/internal/menueditor/fields.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/stringeditor"
+	"github.com/ViSiON-3/vision-3-bbs/internal/tuiart"
 )
 
 // fieldType defines the edit behaviour for a field.
@@ -170,11 +170,7 @@ func cmdFields() []fieldDef {
 }
 
 // padRight pads a string to width with spaces, truncating if longer.
-func padRight(s string, width int) string {
-	return ansi.PadRight(ansi.TruncateRunes(s, width, ""), width)
-}
+func padRight(s string, width int) string { return tuiart.PadRight(s, width) }
 
 // centerText centers a string within a given width.
-func centerText(s string, width int) string {
-	return ansi.Center(ansi.TruncateRunes(s, width, ""), width)
-}
+func centerText(s string, width int) string { return tuiart.CenterText(s, width) }

--- a/internal/menueditor/model.go
+++ b/internal/menueditor/model.go
@@ -13,9 +13,7 @@ const (
 	minWidth  = 80
 	minHeight = 25
 
-	listVisible    = 15 // rows visible in the menu/command list
-	menuEditFields = 7  // number of editable menu fields
-	cmdEditFields  = 6  // number of editable command fields
+	listVisible = 15 // rows visible in the menu/command list
 )
 
 // editorMode represents the current interaction state.
@@ -80,6 +78,11 @@ type Model struct {
 	height int
 	mode   editorMode
 
+	// Backdrop art painted behind every screen. backdropArt holds the raw
+	// bytes chosen at startup, reused when the backdrop is rebuilt on resize.
+	backdrop    *backdrop
+	backdropArt []byte
+
 	message string // flash message (cleared on next key)
 }
 
@@ -95,6 +98,11 @@ func New(menuBase string) (Model, error) {
 	ti.CharLimit = 80
 	ti.Width = 40
 
+	// Choose the backdrop screen once per startup; the bytes are reused on
+	// resize so the picture behind the boxes does not change as the terminal
+	// is dragged.
+	art := pickBackdropArt()
+
 	return Model{
 		menuBase:             menuBase,
 		menus:                menus,
@@ -105,6 +113,8 @@ func New(menuBase string) (Model, error) {
 		pendingDeleteMenuIdx: -1,
 		width:                minWidth,
 		height:               minHeight,
+		backdropArt:          art,
+		backdrop:             loadBackdropFrom(art, minWidth, minHeight),
 		mode:                 modeMenuList,
 	}, nil
 }
@@ -126,6 +136,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.height < minHeight {
 			m.height = minHeight
 		}
+		m.backdrop = loadBackdropFrom(m.backdropArt, m.width, m.height)
 		return m, nil
 
 	case tea.KeyMsg:

--- a/internal/menueditor/view.go
+++ b/internal/menueditor/view.go
@@ -19,11 +19,6 @@ func (m Model) View() string {
 	}
 }
 
-// bgLine returns a full-width background fill line.
-func (m Model) bgLine() string {
-	return bgFillStyle.Render(strings.Repeat("░", m.width))
-}
-
 // padToCol truncates or pads a line to reach a specific visible column.
 func padToCol(line string, col int) string {
 	vis := uitext.ApproximateVisibleLen(line)

--- a/internal/menueditor/view_command_edit.go
+++ b/internal/menueditor/view_command_edit.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/tuiart"
-	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 )
 
 // viewCommandEditScreen renders the per-command field editor.
@@ -129,15 +128,13 @@ func (m Model) renderCmdField(fieldIdx int, f fieldDef, d *CmdData, boxW int) st
 
 	// Actively editing this field
 	if isActive && m.mode == modeCommandEditField {
-		// Measure what the widget actually renders rather than assuming it
-		// occupies textInput.Width cells: it appends a cursor cell after the
-		// text, so assuming Width overflowed the box by exactly one column.
-		inputW := uitext.ApproximateVisibleLen(m.textInput.View())
-		if inputW > maxW {
-			inputW = maxW
-		}
+		// Bound the widget's own output, not just the padding around it. It
+		// appends a cursor cell after the text, so a value that fills the
+		// field renders Width+1 cells; clamping only the padding leaves the
+		// oversized view to overrun the box.
+		view, inputW := tuiart.FitInput(m.textInput.View(), boxW-lpad-labelLen)
 		fillW := max(0, boxW-lpad-labelLen-inputW)
-		return leftPadStr + fieldLabelStyle.Render(label) + m.textInput.View() +
+		return leftPadStr + fieldLabelStyle.Render(label) + view +
 			fieldDisplayStyle.Render(strings.Repeat(" ", fillW))
 	}
 

--- a/internal/menueditor/view_command_edit.go
+++ b/internal/menueditor/view_command_edit.go
@@ -3,6 +3,9 @@ package menueditor
 import (
 	"fmt"
 	"strings"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/tuiart"
+	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 )
 
 // viewCommandEditScreen renders the per-command field editor.
@@ -24,67 +27,43 @@ func (m Model) viewCommandEditScreen() string {
 	}
 
 	cmd := m.cmds[m.cmdEditIdx]
-	var b strings.Builder
+
+	// Fixed rows: title(1) + box(border, box title, empty, fields, info, empty,
+	// border = len(fields)+6) + help(1). Derived from the live field count for
+	// the same reason as the menu edit screen.
+	boxRows := len(m.cmdFields) + 6
+	topPad, bottomPad := tuiart.Split(m.height, boxRows+2)
+
+	sc := tuiart.NewScreen(m.width, m.backdrop)
 
 	// === Row 1: Title bar ===
-	title := centerText("-- ViSiON/3 Menu Editor v1.0 --", m.width)
-	b.WriteString(titleBarStyle.Render(title))
-	b.WriteByte('\n')
-
-	bg := m.bgLine()
+	sc.Line(titleBarStyle.Render(centerText("-- ViSiON/3 Menu Editor v1.0 --", m.width)))
+	sc.BgRows(topPad)
 
 	// Box dimensions: MENUEDIT.PAS GrowBox(2,9,78,16) → 74 cols wide
 	boxW := 74
 	padL := max(0, (m.width-boxW-2)/2)
 	padR := max(0, m.width-padL-boxW-2)
 
-	// Vertical centering
-	extraV := max(0, m.height-24)
-	topPad := max(4, extraV/2+4)
-	bottomPad := max(1, m.height-1-topPad-12)
-
-	for i := 0; i < topPad; i++ {
-		b.WriteString(bg)
-		b.WriteByte('\n')
+	box := func(content string) {
+		sc.Line(sc.Pad(padL, padR,
+			editBorderStyle.Render("│")+content+editBorderStyle.Render("│")))
 	}
+	emptyRow := func() { box(fieldDisplayStyle.Render(strings.Repeat(" ", boxW))) }
 
 	// === Top border ===
-	topBorder := bgFillStyle.Render(strings.Repeat("░", padL)) +
-		editBorderStyle.Render("┌"+strings.Repeat("─", boxW)+"┐") +
-		bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-	b.WriteString(topBorder)
-	b.WriteByte('\n')
+	sc.Line(sc.Pad(padL, padR, editBorderStyle.Render("┌"+strings.Repeat("─", boxW)+"┐")))
 
 	// === Title row inside box ===
 	// MENUEDIT.PAS: Color(15,12) Center_Write('Command Editing (MenuTitle)')
-	boxTitle := fmt.Sprintf("Command Editing (%s)", menuTitle)
-	titleRow := bgFillStyle.Render(strings.Repeat("░", padL)) +
-		editBorderStyle.Render("│") +
-		editTitleStyle.Render(centerText(boxTitle, boxW)) +
-		editBorderStyle.Render("│") +
-		bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-	b.WriteString(titleRow)
-	b.WriteByte('\n')
+	box(editTitleStyle.Render(centerText(fmt.Sprintf("Command Editing (%s)", menuTitle), boxW)))
 
 	// === Empty separator ===
-	emptyRow := bgFillStyle.Render(strings.Repeat("░", padL)) +
-		editBorderStyle.Render("│") +
-		fieldDisplayStyle.Render(strings.Repeat(" ", boxW)) +
-		editBorderStyle.Render("│") +
-		bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-	b.WriteString(emptyRow)
-	b.WriteByte('\n')
+	emptyRow()
 
 	// === Field rows ===
 	for i, f := range m.cmdFields {
-		row := m.renderCmdField(i, f, &cmd, boxW)
-		line := bgFillStyle.Render(strings.Repeat("░", padL)) +
-			editBorderStyle.Render("│") +
-			row +
-			editBorderStyle.Render("│") +
-			bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-		b.WriteString(line)
-		b.WriteByte('\n')
+		box(m.renderCmdField(i, f, &cmd, boxW))
 	}
 
 	// === Info row: file + command number ===
@@ -92,37 +71,22 @@ func (m Model) viewCommandEditScreen() string {
 	// consolidated here to avoid per-field right-column overflow.
 	infoFile := fmt.Sprintf("  File: %s.CFG", menuName)
 	infoNum := fmt.Sprintf("Cmd: %d of %d", m.cmdEditIdx+1, len(m.cmds))
-	infoText := padRight(infoFile, 40) + infoNum
-	infoRow := bgFillStyle.Render(strings.Repeat("░", padL)) +
-		editBorderStyle.Render("│") +
-		editInfoLabelStyle.Render(padRight(infoText, boxW)) +
-		editBorderStyle.Render("│") +
-		bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-	b.WriteString(infoRow)
-	b.WriteByte('\n')
+	box(editInfoLabelStyle.Render(padRight(padRight(infoFile, 40)+infoNum, boxW)))
 
 	// === Empty bottom row ===
-	b.WriteString(emptyRow)
-	b.WriteByte('\n')
+	emptyRow()
 
 	// === Bottom border ===
-	botBorder := bgFillStyle.Render(strings.Repeat("░", padL)) +
-		editBorderStyle.Render("└"+strings.Repeat("─", boxW)+"┘") +
-		bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-	b.WriteString(botBorder)
-	b.WriteByte('\n')
+	sc.Line(sc.Pad(padL, padR, editBorderStyle.Render("└"+strings.Repeat("─", boxW)+"┘")))
 
-	for i := 0; i < bottomPad; i++ {
-		b.WriteString(bg)
-		b.WriteByte('\n')
-	}
+	sc.BgRows(bottomPad)
 
 	// === Help bar ===
-	helpText := centerText("PgUp/PgDn Prev/Next  F2 Delete  F5 Add New  F8 Abort  ESC Save+Back", m.width)
-	b.WriteString(helpBarStyle.Render(helpText))
+	sc.Last(helpBarStyle.Render(centerText(
+		"PgUp/PgDn Prev/Next  F2 Delete  F5 Add New  F8 Abort  ESC Save+Back", m.width)))
 
 	// Overlay dialogs
-	result := b.String()
+	result := sc.String()
 	if m.mode == modeDeleteCmdConfirm {
 		desc := cmd.NodeActivity
 		if desc == "" {
@@ -165,7 +129,10 @@ func (m Model) renderCmdField(fieldIdx int, f fieldDef, d *CmdData, boxW int) st
 
 	// Actively editing this field
 	if isActive && m.mode == modeCommandEditField {
-		inputW := m.textInput.Width
+		// Measure what the widget actually renders rather than assuming it
+		// occupies textInput.Width cells: it appends a cursor cell after the
+		// text, so assuming Width overflowed the box by exactly one column.
+		inputW := uitext.ApproximateVisibleLen(m.textInput.View())
 		if inputW > maxW {
 			inputW = maxW
 		}

--- a/internal/menueditor/view_command_list.go
+++ b/internal/menueditor/view_command_list.go
@@ -3,6 +3,8 @@ package menueditor
 import (
 	"fmt"
 	"strings"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/tuiart"
 )
 
 // viewCommandListScreen renders the command list browser for the selected menu.
@@ -17,118 +19,74 @@ func (m Model) viewCommandListScreen() string {
 		}
 	}
 
-	var b strings.Builder
+	// Fixed rows: title(1) + box(border, section title, column header, empty,
+	// listVisible, border = listVisible+5) + message(1) + help(1). The previous
+	// count was 24 against an actual 23, which left the bottom row of any
+	// terminal taller than 25 unpainted.
+	topPad, bottomPad := tuiart.Split(m.height, listVisible+8)
+
+	sc := tuiart.NewScreen(m.width, m.backdrop)
 
 	// === Row 1: Title bar ===
-	title := centerText("-- ViSiON/3 Menu Editor v1.0 --", m.width)
-	b.WriteString(titleBarStyle.Render(title))
-	b.WriteByte('\n')
-
-	bg := m.bgLine()
+	sc.Line(titleBarStyle.Render(centerText("-- ViSiON/3 Menu Editor v1.0 --", m.width)))
+	sc.BgRows(topPad)
 
 	// Box dimensions: MENUEDIT.PAS GrowBox(4,4,76,22) → 70 cols wide
 	boxW := 70
 	padL := max(0, (m.width-boxW-2)/2)
 	padR := max(0, m.width-padL-boxW-2)
 
-	// Vertical centering: title(1) + box(21) + message(1) + help(1) = 24 rows
-	extraV := max(0, m.height-24)
-	topPad := max(1, extraV/2)
-	bottomPad := max(1, extraV-topPad)
-
-	for i := 0; i < topPad; i++ {
-		b.WriteString(bg)
-		b.WriteByte('\n')
+	box := func(content string) {
+		sc.Line(sc.Pad(padL, padR,
+			listBorderStyle.Render("│")+content+listBorderStyle.Render("│")))
 	}
 
 	// === Top border ===
 	// MENUEDIT.PAS: Color(4,12) GrowBox → red bg, light red fg
-	topBorder := bgFillStyle.Render(strings.Repeat("░", padL)) +
-		listBorderStyle.Render("┌"+strings.Repeat("─", boxW)+"┐") +
-		bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-	b.WriteString(topBorder)
-	b.WriteByte('\n')
+	sc.Line(sc.Pad(padL, padR, listBorderStyle.Render("┌"+strings.Repeat("─", boxW)+"┐")))
 
 	// === Section title inside box ===
 	// MENUEDIT.PAS: Color(4,14) Center_Write('Editing Menu Commands for: ...')
-	sectionTitle := fmt.Sprintf("Editing Menu Commands for: %s", menuTitle)
-	titleRow := bgFillStyle.Render(strings.Repeat("░", padL)) +
-		listBorderStyle.Render("│") +
-		listHeaderStyle.Render(centerText(sectionTitle, boxW)) +
-		listBorderStyle.Render("│") +
-		bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-	b.WriteString(titleRow)
-	b.WriteByte('\n')
+	box(listHeaderStyle.Render(centerText(
+		fmt.Sprintf("Editing Menu Commands for: %s", menuTitle), boxW)))
 
 	// === Column header ===
 	// MENUEDIT.PAS: 'Command Description   Keystroke(s)    Command(s)'
-	colText := padRight("   Node Activity          Keys       Command", boxW)
-	colLine := bgFillStyle.Render(strings.Repeat("░", padL)) +
-		listBorderStyle.Render("│") +
-		listColTitleStyle.Render(colText) +
-		listBorderStyle.Render("│") +
-		bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-	b.WriteString(colLine)
-	b.WriteByte('\n')
+	box(listColTitleStyle.Render(padRight("   Node Activity          Keys       Command", boxW)))
 
 	// === Empty separator ===
-	emptyLine := bgFillStyle.Render(strings.Repeat("░", padL)) +
-		listBorderStyle.Render("│") +
-		listItemStyle.Render(strings.Repeat(" ", boxW)) +
-		listBorderStyle.Render("│") +
-		bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-	b.WriteString(emptyLine)
-	b.WriteByte('\n')
+	box(listItemStyle.Render(strings.Repeat(" ", boxW)))
 
 	// === Command list (listVisible rows) ===
 	total := len(m.cmds)
 	for row := 0; row < listVisible; row++ {
 		idx := m.cmdScroll + row
-		var rowContent string
 		if idx < 0 || idx >= total {
-			rowContent = listItemStyle.Render(strings.Repeat(" ", boxW))
-		} else {
-			rowContent = m.renderCmdRow(idx, boxW)
+			box(listItemStyle.Render(strings.Repeat(" ", boxW)))
+			continue
 		}
-		line := bgFillStyle.Render(strings.Repeat("░", padL)) +
-			listBorderStyle.Render("│") +
-			rowContent +
-			listBorderStyle.Render("│") +
-			bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-		b.WriteString(line)
-		b.WriteByte('\n')
+		box(m.renderCmdRow(idx, boxW))
 	}
 
 	// === Bottom border ===
-	botBorder := bgFillStyle.Render(strings.Repeat("░", padL)) +
-		listBorderStyle.Render("└"+strings.Repeat("─", boxW)+"┘") +
-		bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-	b.WriteString(botBorder)
-	b.WriteByte('\n')
+	sc.Line(sc.Pad(padL, padR, listBorderStyle.Render("└"+strings.Repeat("─", boxW)+"┘")))
 
 	// === Message or fill ===
 	if m.message != "" {
-		msgLine := bgFillStyle.Render(strings.Repeat("░", padL)) +
-			flashMessageStyle.Render(" "+padRight(m.message, boxW)) +
-			bgFillStyle.Render(strings.Repeat("░", max(0, padR+1)))
-		b.WriteString(msgLine)
+		sc.Line(sc.Pad(padL, padR+1, flashMessageStyle.Render(" "+padRight(m.message, boxW))))
 	} else {
-		b.WriteString(bg)
+		sc.BgLine()
 	}
-	b.WriteByte('\n')
 
-	for i := 0; i < bottomPad; i++ {
-		b.WriteString(bg)
-		b.WriteByte('\n')
-	}
+	sc.BgRows(bottomPad)
 
 	// === Help bar ===
 	// MENUEDIT.PAS: 'F2 Delete Command  F5 Add New Command  ALT-H Help  ESC Exits'
-	helpText := centerText("(Enter) Edit  F2 Delete  F5 Add New Command  ESC Back", m.width)
-	b.WriteString(helpBarStyle.Render(helpText))
+	sc.Last(helpBarStyle.Render(centerText(
+		"(Enter) Edit  F2 Delete  F5 Add New Command  ESC Back", m.width)))
 
 	// Overlay dialogs
-	result := b.String()
+	result := sc.String()
 	if m.mode == modeDeleteCmdConfirm {
 		desc := ""
 		if m.cmdCursor >= 0 && m.cmdCursor < len(m.cmds) {

--- a/internal/menueditor/view_geometry_test.go
+++ b/internal/menueditor/view_geometry_test.go
@@ -1,0 +1,140 @@
+package menueditor
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/mattn/go-runewidth"
+)
+
+// screenCells returns the width in terminal cells of s, ignoring ANSI escapes.
+func screenCells(s string) int {
+	inEsc := false
+	n := 0
+	for _, r := range s {
+		if r == '\x1b' {
+			inEsc = true
+			continue
+		}
+		if inEsc {
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+				inEsc = false
+			}
+			continue
+		}
+		n += runewidth.RuneWidth(r)
+	}
+	return n
+}
+
+func sizeLabel(w, h int) string {
+	return strings.ReplaceAll(strings.TrimSpace(itoa(w)+"x"+itoa(h)), " ", "")
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+// enterMode drives real keystrokes from the menu list into the target mode.
+//
+// The modes must be reached by keystroke rather than by assigning m.mode: the
+// screens that host a text input size their rows from m.textInput.Width, which
+// only the real transition sets. Assigning the mode leaves the input at its
+// constructor width and reports failures that are artifacts of the test.
+func enterMode(t *testing.T, m Model, mode editorMode) Model {
+	t.Helper()
+	switch mode {
+	case modeMenuList:
+	case modeMenuEdit:
+		m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	case modeMenuEditField:
+		m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+		m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	case modeAddMenu:
+		m = press(t, m, tea.KeyMsg{Type: tea.KeyF5})
+	case modeDeleteMenuConfirm:
+		m = press(t, m, tea.KeyMsg{Type: tea.KeyF2})
+	case modeCommandList:
+		m = press(t, m, tea.KeyMsg{Type: tea.KeyF10})
+	case modeCommandEdit:
+		m = press(t, m, tea.KeyMsg{Type: tea.KeyF10})
+		m = press(t, m, tea.KeyMsg{Type: tea.KeyF5})
+	case modeCommandEditField:
+		m = press(t, m, tea.KeyMsg{Type: tea.KeyF10})
+		m = press(t, m, tea.KeyMsg{Type: tea.KeyF5})
+		m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	case modeDeleteCmdConfirm:
+		m = press(t, m, tea.KeyMsg{Type: tea.KeyF10})
+		m = press(t, m, tea.KeyMsg{Type: tea.KeyF5})
+		m = press(t, m, tea.KeyMsg{Type: tea.KeyEscape})
+		m = press(t, m, tea.KeyMsg{Type: tea.KeyF2})
+	default:
+		m.mode = mode
+	}
+	if m.mode != mode {
+		t.Fatalf("keystrokes landed in mode %v, want %v", m.mode, mode)
+	}
+	return m
+}
+
+// TestViewGeometry checks that every screen the menu editor can draw fills
+// exactly the terminal it was told it has, matching the guarantee ./config and
+// ./strings already carry.
+//
+// Three screens failed this before the audit: the menu edit and command edit
+// screens each emitted one row too many, pushing content off the bottom and
+// scrolling the terminal, and the command list emitted one row too few on any
+// terminal taller than 25.
+func TestViewGeometry(t *testing.T) {
+	sizes := []struct{ w, h int }{
+		{80, 25}, {100, 30}, {120, 45}, {160, 60}, {60, 15}, {200, 100},
+	}
+	modes := []struct {
+		name string
+		mode editorMode
+	}{
+		{"menu_list", modeMenuList},
+		{"menu_edit", modeMenuEdit},
+		{"menu_edit_field", modeMenuEditField},
+		{"add_menu", modeAddMenu},
+		{"delete_menu_confirm", modeDeleteMenuConfirm},
+		{"command_list", modeCommandList},
+		{"command_edit", modeCommandEdit},
+		{"command_edit_field", modeCommandEditField},
+		{"delete_cmd_confirm", modeDeleteCmdConfirm},
+		{"exit_confirm", modeExitConfirm},
+		{"help", modeHelp},
+	}
+
+	for _, size := range sizes {
+		for _, mc := range modes {
+			t.Run(mc.name+"_"+sizeLabel(size.w, size.h), func(t *testing.T) {
+				m := newTestEditor(t)
+				m = asModel(t, mustUpdate(m.Update(tea.WindowSizeMsg{Width: size.w, Height: size.h})))
+				m = enterMode(t, m, mc.mode)
+
+				out := m.View()
+				lines := strings.Split(out, "\n")
+				if len(lines) != m.height {
+					t.Fatalf("rendered %d rows, want %d", len(lines), m.height)
+				}
+				for i, line := range lines {
+					if got := screenCells(line); got != m.width {
+						t.Errorf("row %d is %d cells wide, want %d", i, got, m.width)
+					}
+				}
+			})
+		}
+	}
+}
+
+func mustUpdate(m tea.Model, _ tea.Cmd) tea.Model { return m }

--- a/internal/menueditor/view_geometry_test.go
+++ b/internal/menueditor/view_geometry_test.go
@@ -138,3 +138,86 @@ func TestViewGeometry(t *testing.T) {
 }
 
 func mustUpdate(m tea.Model, _ tea.Cmd) tea.Model { return m }
+
+// TestViewGeometryWithFilledInputs re-runs the width check with every text
+// input carrying a value that fills its field.
+//
+// TestViewGeometry drives real keystrokes but types nothing, so every input it
+// renders is empty. Two overflows hid behind that: bubbles/textinput appends a
+// cursor cell after the text, so a field whose value fills its configured Width
+// renders Width+1 cells. The menu edit row ran 2 cells past its box and the Add
+// Menu dialog 1 cell past its border, and only once something was typed.
+func TestViewGeometryWithFilledInputs(t *testing.T) {
+	sizes := []struct{ w, h int }{{80, 25}, {120, 45}}
+	// Each case names the field to open, because the overflow only appears on
+	// the widest one: a 20-column field's view still fits its row with the
+	// cursor cell attached, so opening the first field would prove nothing.
+	cases := []struct {
+		name  string
+		mode  editorMode
+		field string
+		typed string
+	}{
+		{"menu_edit_field", modeMenuEditField, "Prompt Line 1", strings.Repeat("X", 80)},
+		{"command_edit_field", modeCommandEditField, "", strings.Repeat("X", 80)},
+		{"add_menu", modeAddMenu, "", "ABCDEFGH"},
+	}
+
+	for _, size := range sizes {
+		for _, mc := range cases {
+			t.Run(mc.name+"_"+sizeLabel(size.w, size.h), func(t *testing.T) {
+				m := newTestEditor(t)
+				m = asModel(t, mustUpdate(m.Update(tea.WindowSizeMsg{Width: size.w, Height: size.h})))
+				if mc.field != "" {
+					m = openWidestField(t, m, mc.field)
+				} else {
+					m = enterMode(t, m, mc.mode)
+				}
+				if m.mode != mc.mode {
+					t.Fatalf("landed in mode %v, want %v", m.mode, mc.mode)
+				}
+				m = typeText(t, m, mc.typed)
+
+				lines := strings.Split(m.View(), "\n")
+				if len(lines) != m.height {
+					t.Fatalf("rendered %d rows, want %d", len(lines), m.height)
+				}
+				for i, line := range lines {
+					if got := screenCells(line); got != m.width {
+						t.Errorf("row %d is %d cells wide, want %d", i, got, m.width)
+					}
+				}
+			})
+		}
+	}
+}
+
+// The widest menu field is Prompt Line 1 at 55 columns, the case that actually
+// overflowed. Pin that it is the field the filled-input test reaches, so the
+// coverage cannot quietly move to a narrower field.
+func TestPromptLineIsTheWidestMenuField(t *testing.T) {
+	m := newTestEditor(t)
+	widest := 0
+	for _, f := range m.menuFields {
+		if f.Width > widest {
+			widest = f.Width
+		}
+	}
+	if widest != 55 {
+		t.Errorf("widest menu field is %d columns, expected 55 (Prompt Line)", widest)
+	}
+}
+
+// openWidestField enters the menu editor and opens the named field for editing.
+func openWidestField(t *testing.T, m Model, label string) Model {
+	t.Helper()
+	m = press(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // menu list -> menu edit
+	for i := 0; i < len(m.menuFields); i++ {
+		if strings.TrimSpace(m.menuFields[m.menuEditFld].Label) == label {
+			return press(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // -> edit field
+		}
+		m = press(t, m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+	t.Fatalf("no menu field labelled %q", label)
+	return m
+}

--- a/internal/menueditor/view_menu_edit.go
+++ b/internal/menueditor/view_menu_edit.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/stringeditor"
 	"github.com/ViSiON-3/vision-3-bbs/internal/tuiart"
-	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 )
 
 // viewMenuEditScreen renders the per-menu field editor.
@@ -128,15 +127,13 @@ func (m Model) renderMenuField(fieldIdx int, f fieldDef, d *MenuData, boxW int) 
 
 	// Actively editing this field
 	if isActive && m.mode == modeMenuEditField {
-		// Measure what the widget actually renders rather than assuming it
-		// occupies textInput.Width cells: it appends a cursor cell after the
-		// text, so assuming Width overflowed the box by exactly one column.
-		inputW := uitext.ApproximateVisibleLen(m.textInput.View())
-		if inputW > maxW {
-			inputW = maxW
-		}
+		// Bound the widget's own output, not just the padding around it. It
+		// appends a cursor cell after the text, so a value that fills the
+		// field renders Width+1 cells; clamping only the padding leaves the
+		// oversized view to overrun the box.
+		view, inputW := tuiart.FitInput(m.textInput.View(), boxW-lpad-labelLen)
 		fillW := max(0, boxW-lpad-labelLen-inputW)
-		return leftPad + fieldLabelStyle.Render(label) + m.textInput.View() +
+		return leftPad + fieldLabelStyle.Render(label) + view +
 			fieldDisplayStyle.Render(strings.Repeat(" ", fillW))
 	}
 

--- a/internal/menueditor/view_menu_edit.go
+++ b/internal/menueditor/view_menu_edit.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/stringeditor"
+	"github.com/ViSiON-3/vision-3-bbs/internal/tuiart"
+	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
 )
 
 // viewMenuEditScreen renders the per-menu field editor.
@@ -15,38 +17,35 @@ func (m Model) viewMenuEditScreen() string {
 	}
 	entry := m.menus[m.menuEditIdx]
 
-	var b strings.Builder
+	// Fixed rows: title(1) + box(border, box title, empty, fields, empty, info,
+	// empty, border = len(fields)+7) + help(1). Derived from the live field
+	// count: this screen used to hardcode a box height for seven fields, and
+	// silently overflowed the terminal once the list grew to thirteen.
+	boxRows := len(m.menuFields) + 7
+	topPad, bottomPad := tuiart.Split(m.height, boxRows+2)
+
+	sc := tuiart.NewScreen(m.width, m.backdrop)
 
 	// === Row 1: Title bar ===
-	title := centerText("-- ViSiON/3 Menu Editor v1.0 --", m.width)
-	b.WriteString(titleBarStyle.Render(title))
-	b.WriteByte('\n')
-
-	bg := m.bgLine()
+	sc.Line(titleBarStyle.Render(centerText("-- ViSiON/3 Menu Editor v1.0 --", m.width)))
+	sc.BgRows(topPad)
 
 	// Box dimensions matching Pascal GrowBOX(2,6,78,20)
-	// width = 78-2-2 = 74 interior, height ~15 rows
+	// width = 78-2-2 = 74 interior
 	boxW := 74
 	padL := max(0, (m.width-boxW-2)/2)
 	padR := max(0, m.width-padL-boxW-2)
 
-	// Vertical centering: title(1) + gap(2) + box(20) + gap(2) + help(1) = 26
-	extraV := max(0, m.height-26)
-	topPad := max(2, extraV/2+2)
-	bottomPad := max(1, m.height-1-topPad-20)
-
-	for i := 0; i < topPad; i++ {
-		b.WriteString(bg)
-		b.WriteByte('\n')
+	// box writes one row of box content wrapped in the side borders.
+	box := func(content string) {
+		sc.Line(sc.Pad(padL, padR,
+			editBorderStyle.Render("│")+content+editBorderStyle.Render("│")))
 	}
+	emptyRow := func() { box(fieldDisplayStyle.Render(strings.Repeat(" ", boxW))) }
 
 	// === Top border ===
 	// MENUEDIT.PAS: Color(15,8) → dark gray bg, white fg for box
-	topBorder := bgFillStyle.Render(strings.Repeat("░", padL)) +
-		editBorderStyle.Render("┌"+strings.Repeat("─", boxW)+"┐") +
-		bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-	b.WriteString(topBorder)
-	b.WriteByte('\n')
+	sc.Line(sc.Pad(padL, padR, editBorderStyle.Render("┌"+strings.Repeat("─", boxW)+"┐")))
 
 	// === Title row inside box ===
 	// MENUEDIT.PAS: Color(15,12) center_write 'Command Editing...'
@@ -54,71 +53,37 @@ func (m Model) viewMenuEditScreen() string {
 	if entry.Data.Title != "" {
 		boxTitle = entry.Data.Title + " (" + entry.Name + ".MNU)"
 	}
-	titleRow := bgFillStyle.Render(strings.Repeat("░", padL)) +
-		editBorderStyle.Render("│") +
-		editTitleStyle.Render(centerText(boxTitle, boxW)) +
-		editBorderStyle.Render("│") +
-		bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-	b.WriteString(titleRow)
-	b.WriteByte('\n')
+	box(editTitleStyle.Render(centerText(boxTitle, boxW)))
 
 	// === Empty separator ===
-	emptyRow := bgFillStyle.Render(strings.Repeat("░", padL)) +
-		editBorderStyle.Render("│") +
-		fieldDisplayStyle.Render(strings.Repeat(" ", boxW)) +
-		editBorderStyle.Render("│") +
-		bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-	b.WriteString(emptyRow)
-	b.WriteByte('\n')
+	emptyRow()
 
 	// === Field rows ===
 	for i, f := range m.menuFields {
-		row := m.renderMenuField(i, f, &entry.Data, boxW)
-		line := bgFillStyle.Render(strings.Repeat("░", padL)) +
-			editBorderStyle.Render("│") +
-			row +
-			editBorderStyle.Render("│") +
-			bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-		b.WriteString(line)
-		b.WriteByte('\n')
+		box(m.renderMenuField(i, f, &entry.Data, boxW))
 	}
 
 	// === Empty row above info ===
-	b.WriteString(emptyRow)
-	b.WriteByte('\n')
+	emptyRow()
 
 	// === Info row: current file + number (centered) ===
-	infoText := centerText(fmt.Sprintf("Menu %d of %d", m.menuEditIdx+1, len(m.menus)), boxW)
-	infoRow := bgFillStyle.Render(strings.Repeat("░", padL)) +
-		editBorderStyle.Render("│") +
-		editInfoLabelStyle.Render(infoText) +
-		editBorderStyle.Render("│") +
-		bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-	b.WriteString(infoRow)
-	b.WriteByte('\n')
+	box(editInfoLabelStyle.Render(
+		centerText(fmt.Sprintf("Menu %d of %d", m.menuEditIdx+1, len(m.menus)), boxW)))
 
 	// === Empty row below info ===
-	b.WriteString(emptyRow)
-	b.WriteByte('\n')
+	emptyRow()
 
 	// === Bottom border ===
-	botBorder := bgFillStyle.Render(strings.Repeat("░", padL)) +
-		editBorderStyle.Render("└"+strings.Repeat("─", boxW)+"┘") +
-		bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-	b.WriteString(botBorder)
-	b.WriteByte('\n')
+	sc.Line(sc.Pad(padL, padR, editBorderStyle.Render("└"+strings.Repeat("─", boxW)+"┘")))
 
-	for i := 0; i < bottomPad; i++ {
-		b.WriteString(bg)
-		b.WriteByte('\n')
-	}
+	sc.BgRows(bottomPad)
 
 	// === Help bar ===
-	helpText := centerText("PgUp/PgDn Prev/Next  F2 Delete  F5 Add New  F10 Edit Commands  ESC Back", m.width)
-	b.WriteString(helpBarStyle.Render(helpText))
+	sc.Last(helpBarStyle.Render(centerText(
+		"PgUp/PgDn Prev/Next  F2 Delete  F5 Add New  F10 Edit Commands  ESC Back", m.width)))
 
 	// Overlay dialogs
-	result := b.String()
+	result := sc.String()
 	switch m.mode {
 	case modeDeleteMenuConfirm:
 		result = m.overlayConfirmDialog(result,
@@ -163,7 +128,10 @@ func (m Model) renderMenuField(fieldIdx int, f fieldDef, d *MenuData, boxW int) 
 
 	// Actively editing this field
 	if isActive && m.mode == modeMenuEditField {
-		inputW := m.textInput.Width
+		// Measure what the widget actually renders rather than assuming it
+		// occupies textInput.Width cells: it appends a cursor cell after the
+		// text, so assuming Width overflowed the box by exactly one column.
+		inputW := uitext.ApproximateVisibleLen(m.textInput.View())
 		if inputW > maxW {
 			inputW = maxW
 		}

--- a/internal/menueditor/view_menu_list.go
+++ b/internal/menueditor/view_menu_list.go
@@ -3,114 +3,77 @@ package menueditor
 import (
 	"fmt"
 	"strings"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/tuiart"
 )
 
 // viewMenuListScreen renders the main menu browser.
 // Faithfully recreates MENUEDIT.PAS Open_Screen + Select_Menu.
 func (m Model) viewMenuListScreen() string {
-	var b strings.Builder
+	// Fixed rows: title(1) + box(border, column header, empty, listVisible,
+	// border = listVisible+4) + message(1) + help(1). This screen has no
+	// section-title row, so it is one shorter than the command list.
+	topPad, bottomPad := tuiart.Split(m.height, listVisible+7)
+
+	sc := tuiart.NewScreen(m.width, m.backdrop)
 
 	// === Row 1: Title bar ===
 	// MENUEDIT.PAS: Color(8,15) Center_Write('ViSiON/2 MENU EDITOR v1.0')
-	title := centerText("-- ViSiON/3 Menu Editor v1.0 --", m.width)
-	b.WriteString(titleBarStyle.Render(title))
-	b.WriteByte('\n')
-
-	bg := m.bgLine()
-
-	// Vertical centering: 1 title + box(19) + message(1) + help(1) = 22 rows
-	extraV := max(0, m.height-22)
-	topPad := extraV / 2
-	bottomPad := extraV - topPad
-
-	for i := 0; i < topPad; i++ {
-		b.WriteString(bg)
-		b.WriteByte('\n')
-	}
+	sc.Line(titleBarStyle.Render(centerText("-- ViSiON/3 Menu Editor v1.0 --", m.width)))
+	sc.BgRows(topPad)
 
 	// Box dimensions: MENUEDIT.PAS GrowBox(15,5,65,22) → 50 cols wide
 	boxW := 50
 	padL := max(0, (m.width-boxW-2)/2)
 	padR := max(0, m.width-padL-boxW-2)
 
+	box := func(content string) {
+		sc.Line(sc.Pad(padL, padR,
+			listBorderStyle.Render("│")+content+listBorderStyle.Render("│")))
+	}
+
 	// === Top border ===
 	// MENUEDIT.PAS: Color(3,11) GrowBox → cyan bg, light cyan fg
-	topBorder := bgFillStyle.Render(strings.Repeat("░", padL)) +
-		listBorderStyle.Render("┌"+strings.Repeat("─", boxW)+"┐") +
-		bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-	b.WriteString(topBorder)
-	b.WriteByte('\n')
+	sc.Line(sc.Pad(padL, padR, listBorderStyle.Render("┌"+strings.Repeat("─", boxW)+"┐")))
 
 	// === Column header ===
 	// MENUEDIT.PAS: Color(11,3) ' Menu Title           File Names'
 	// nameColW=14: 3+14+1=18 chars before file column, leaving 32 for filenames
-	colHeader := padRight("   Menu Title     File Names", boxW)
-	colLine := bgFillStyle.Render(strings.Repeat("░", padL)) +
-		listBorderStyle.Render("│") +
-		listColTitleStyle.Render(colHeader) +
-		listBorderStyle.Render("│") +
-		bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-	b.WriteString(colLine)
-	b.WriteByte('\n')
+	box(listColTitleStyle.Render(padRight("   Menu Title     File Names", boxW)))
 
 	// === Empty separator ===
-	emptyLine := bgFillStyle.Render(strings.Repeat("░", padL)) +
-		listBorderStyle.Render("│") +
-		listItemStyle.Render(strings.Repeat(" ", boxW)) +
-		listBorderStyle.Render("│") +
-		bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-	b.WriteString(emptyLine)
-	b.WriteByte('\n')
+	box(listItemStyle.Render(strings.Repeat(" ", boxW)))
 
 	// === Menu list (listVisible rows) ===
 	total := len(m.menus)
 	for row := 0; row < listVisible; row++ {
 		idx := m.menuScroll + row
-		var rowContent string
 		if idx < 0 || idx >= total {
-			rowContent = listItemStyle.Render(strings.Repeat(" ", boxW))
-		} else {
-			rowContent = m.renderMenuRow(idx, boxW)
+			box(listItemStyle.Render(strings.Repeat(" ", boxW)))
+			continue
 		}
-		line := bgFillStyle.Render(strings.Repeat("░", padL)) +
-			listBorderStyle.Render("│") +
-			rowContent +
-			listBorderStyle.Render("│") +
-			bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-		b.WriteString(line)
-		b.WriteByte('\n')
+		box(m.renderMenuRow(idx, boxW))
 	}
 
 	// === Bottom border ===
-	botBorder := bgFillStyle.Render(strings.Repeat("░", padL)) +
-		listBorderStyle.Render("└"+strings.Repeat("─", boxW)+"┘") +
-		bgFillStyle.Render(strings.Repeat("░", max(0, padR)))
-	b.WriteString(botBorder)
-	b.WriteByte('\n')
+	sc.Line(sc.Pad(padL, padR, listBorderStyle.Render("└"+strings.Repeat("─", boxW)+"┘")))
 
 	// === Message or fill ===
 	if m.message != "" {
-		msgLine := bgFillStyle.Render(strings.Repeat("░", padL)) +
-			flashMessageStyle.Render(" "+padRight(m.message, boxW)) +
-			bgFillStyle.Render(strings.Repeat("░", max(0, padR+1)))
-		b.WriteString(msgLine)
+		sc.Line(sc.Pad(padL, padR+1, flashMessageStyle.Render(" "+padRight(m.message, boxW))))
 	} else {
-		b.WriteString(bg)
+		sc.BgLine()
 	}
-	b.WriteByte('\n')
 
-	for i := 0; i < bottomPad; i++ {
-		b.WriteString(bg)
-		b.WriteByte('\n')
-	}
+	sc.BgRows(bottomPad)
 
 	// === Help bar ===
 	// MENUEDIT.PAS: '(CR) Edits Menu  F10 Edits Menu Commands  F2 Delete  F5 Add Menu  ESC Exits'
-	helpText := centerText("(Enter) Edit Menu  F10 Commands  F2 Delete  F5 Add Menu  ESC Exit", m.width)
-	b.WriteString(helpBarStyle.Render(helpText))
+	sc.Last(helpBarStyle.Render(centerText(
+		"(Enter) Edit Menu  F10 Commands  F2 Delete  F5 Add Menu  ESC Exit", m.width)))
 
 	// Overlay dialogs
-	result := b.String()
+	result := sc.String()
 	switch m.mode {
 	case modeDeleteMenuConfirm:
 		name := ""

--- a/internal/tuiart/screen.go
+++ b/internal/tuiart/screen.go
@@ -1,0 +1,92 @@
+package tuiart
+
+import "strings"
+
+// Screen accumulates full-width terminal rows for one editor screen, tracking
+// the row it is about to write so background fill can be sourced from the
+// backdrop at the matching offset.
+//
+// It exists because every editor screen has the same shape — a header row, top
+// background padding, a centered box, bottom padding, a help bar — and each one
+// that hand-rolled that shape from its own constants got it wrong in a
+// different way. Deriving the padding from a single declared fixed-row count
+// (see Split) is what keeps a screen exactly as tall as its terminal.
+//
+// internal/configeditor has an equivalent scaffold of its own, listBox, which
+// predates this type and additionally owns that editor's box styling. It was
+// left alone deliberately: migrating it would change no pixels but would put
+// its byte-identical golden captures at risk for no gain.
+type Screen struct {
+	b      strings.Builder
+	width  int
+	bd     *Backdrop
+	rowIdx int
+}
+
+// NewScreen returns a Screen that writes width-column rows against bd.
+// A nil bd is valid and renders the legacy shaded fill.
+func NewScreen(width int, bd *Backdrop) *Screen {
+	return &Screen{width: width, bd: bd}
+}
+
+// Split returns the top and bottom background padding that vertically centers
+// fixedRows of content in a terminal of the given height.
+//
+// Neither value is floored at a minimum. A floor turns a miscounted fixedRows
+// into content that overflows the terminal and scrolls it, which is far harder
+// to see than the blank row a plain subtraction leaves behind.
+func Split(height, fixedRows int) (top, bottom int) {
+	extra := height - fixedRows
+	if extra < 0 {
+		extra = 0
+	}
+	top = extra / 2
+	return top, extra - top
+}
+
+// Row reports the screen row that the next Line will occupy.
+func (s *Screen) Row() int { return s.rowIdx }
+
+// Rows reports how many rows have been written so far.
+func (s *Screen) Rows() int { return s.rowIdx }
+
+// Line writes one full-width row and advances to the next.
+func (s *Screen) Line(content string) {
+	s.b.WriteString(content)
+	s.b.WriteByte('\n')
+	s.rowIdx++
+}
+
+// BgLine writes one full-width row of backdrop.
+func (s *Screen) BgLine() { s.Line(s.bd.Segment(s.rowIdx, 0, s.width)) }
+
+// BgRows writes n full-width rows of backdrop.
+func (s *Screen) BgRows(n int) {
+	for i := 0; i < n; i++ {
+		s.BgLine()
+	}
+}
+
+// Pad surrounds box content with backdrop on both sides, sourced from the row
+// Line is about to write. Call it as s.Line(s.Pad(padL, padR, content)) so the
+// backdrop offset matches the row the content lands on.
+func (s *Screen) Pad(padL, padR int, content string) string {
+	if padL < 0 {
+		padL = 0
+	}
+	if padR < 0 {
+		padR = 0
+	}
+	return s.bd.Segment(s.rowIdx, 0, padL) + content +
+		s.bd.Segment(s.rowIdx, s.width-padR, padR)
+}
+
+// Last writes the final row without a trailing newline, which is what keeps a
+// screen exactly height rows tall rather than height plus an empty one.
+func (s *Screen) Last(content string) {
+	s.b.WriteString(content)
+	s.rowIdx++
+}
+
+// String returns the assembled screen.
+func (s *Screen) String() string { return s.b.String() }

--- a/internal/tuiart/text.go
+++ b/internal/tuiart/text.go
@@ -1,6 +1,9 @@
 package tuiart
 
-import "github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+import (
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/uitext"
+)
 
 // CenterText centers a string within width using visual (rune) width.
 //
@@ -13,4 +16,22 @@ func CenterText(s string, width int) string {
 // PadRight pads a string to width with spaces, truncating if longer.
 func PadRight(s string, width int) string {
 	return ansi.PadRight(ansi.TruncateRunes(s, width, ""), width)
+}
+
+// FitInput bounds a rendered bubbles/textinput view to width cells and reports
+// the width it occupies, so a caller can pad the rest of its row.
+//
+// The widget renders a cursor cell after the text, so a field whose value fills
+// its configured Width returns Width+1 cells. Measuring that for padding is not
+// enough on its own: when the view is wider than the space available, the
+// padding goes to zero but the oversized view is still emitted and the row
+// overruns its box. Bounding the view is what actually holds the row width.
+func FitInput(view string, width int) (string, int) {
+	if width < 0 {
+		width = 0
+	}
+	if w := uitext.ApproximateVisibleLen(view); w <= width {
+		return view, w
+	}
+	return uitext.TruncateToVisual(view, width), width
 }


### PR DESCRIPTION
Closes #252.

First of two PRs from `docs/dev/menu-user-editor-audit-todo.md`, which this PR also adds. `./ue` (#242) follows.

## Why

`./menuedit` was the last editor still rendering from its own ANSI 256-index palette, with no backdrop art and hand-built title and help bars. `internal/tuiart` exists to hold exactly that chrome — it pins the VGA hex values because most terminal themes map ANSI blue to a bright, low-contrast shade that washes out the white-and-yellow-on-blue UI. So `./config` and `./strings` rendered one way and this editor another. It now aliases `tuiart` the way `internal/configeditor` does.

## The part worth reading

Adopting the backdrop meant every screen had to know which row it was painting, and that is what surfaced the real defects. **Three of the four screens did not fill their terminal**, at every size tested:

- The **menu edit** screen emitted one row too many, pushing content off the bottom and scrolling the terminal. The cause was more specific than "magic constants": `menuFields()` returns **13** fields, but the constant `menuEditFields` claimed **7** and the box height was written for that smaller list. The field list grew and the geometry never followed. Both `menuEditFields` and `cmdEditFields` turned out to be dead code — nothing read either — so they are deleted and both edit screens size their box from `len(fields)`.
- The **command edit** screen overflowed the same way.
- The **command list** emitted one row too *few* on any terminal taller than 25, leaving the bottom row unpainted. It was correct only at 80×25.

Two more defects surfaced during the work:

- The **actively-edited field row was one cell too wide** on both edit screens: the padding was computed against `m.textInput.Width`, but `textinput.View()` renders a cursor cell after the text. Both sites now measure the rendered width, which is what `./ue`'s password dialog already does. This one was invisible to the first probe, which never entered the field-edit modes — the inverse of the artifact trap noted below.
- The confirm and input **dialogs rebuilt the row to the right of the dialog as flat fill**, which erases the backdrop from those rows. They now preserve both sides with `padToCol`/`skipToCol`, as `./config` and this editor's own help overlay already did. `skipToCol` was defined here but had no callers.

## Where the shared scaffold went

As `tuiart.Screen`, not by extracting `configeditor.listBox`. `listBox` also owns that editor's box styling, and moving it would put its byte-identical golden captures at risk for no gain. `Screen` carries only what both remaining editors need: row-tracked background fill, and `Split`, which derives both paddings from one declared fixed-row count.

`Split` deliberately does **not** floor either padding at 1. That floor is what turned a miscount into content scrolling off the screen instead of a visible blank row.

## Verification

`view_geometry_test.go` pins 11 modes × 6 terminal sizes (80×25, 100×30, 120×45, 160×60, 200×100, and an undersized 60×15) — every row exactly terminal-width, every screen exactly terminal-tall, matching the guarantee `./config` and `./strings` already carry.

It drives real keystrokes into each mode rather than assigning `m.mode`. Assigning the mode leaves `textInput` at its constructor width and reports width failures that are artifacts of the test; two hits in the first probe were exactly that.

Full suite, `-race` on the touched packages, `go vet`, `gofmt`, and `git diff --check` all clean.

**Still outstanding:** a manual visual pass in a real terminal. The prior audit's manual pass found two defects that every geometry and golden check passed cleanly, so the automated suite does not retire it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWTB1hR7kAkbdjEqnWvAh9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated the menu editor’s visual styling for a more consistent interface.
  - Improved screen layout across terminal sizes with dynamic spacing and sizing.
  - Corrected field widths and row-count issues in editor views.
  - Dialogs now preserve surrounding background artwork instead of replacing it with a flat fill.
  - Backdrop artwork remains consistent when the terminal is resized.
  - Prevented long input values from overflowing dialog and editor boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->