### PR TITLE
fix(users): give the new-user sysop notice a string fallback

### DIFF
--- a/internal/config/config_strings.go
+++ b/internal/config/config_strings.go
@@ -102,6 +102,13 @@ var StringFallbacks = map[string]string{
 	"confNoAccessibleConfs": "\r\n|12No accessible conferences.|07\r\n",
 	"newUsersClosedStr":     "\r\n|12This BBS is not accepting new users at this time.|07\r\n",
 
+	// Without a fallback, an existing strings.json that predates this key
+	// yields an empty value, and the notice is skipped silently: the sysop sees
+	// notifySysopNewUser defaulting to true and nothing ever arriving. The
+	// setting defaults on precisely so an upgrade needs no edits, so the string
+	// it depends on has to as well.
+	"newUserSysopPage": "|12New user|07: |15%s|07 just signed up from node %d.",
+
 	// The rest of the batch download group. These are written straight to the
 	// terminal, so shipping them blank printed nothing where a message belongs
 	// -- an empty queue, or a failed save, looked like the command did nothing.

--- a/internal/config/new_string_defaults_test.go
+++ b/internal/config/new_string_defaults_test.go
@@ -65,3 +65,27 @@ func TestMatrixMessageKeysHaveDistinctArity(t *testing.T) {
 		t.Errorf("replacement key should take three verbs, found %d", n)
 	}
 }
+
+// An upgrade must not need a strings.json edit to get the new-user notice.
+// notifySysopNewUser defaults on so no config change is required; if the string
+// it formats has no fallback, an older strings.json leaves it empty and
+// notifySysopsOfNewUser skips silently — the setting would read as enabled
+// while nothing ever arrived.
+func TestNewUserSysopPageSurvivesAnOlderStringsFile(t *testing.T) {
+	dir := t.TempDir()
+	// A strings.json with no mention of the key, as any pre-upgrade file has.
+	if err := os.WriteFile(filepath.Join(dir, "strings.json"),
+		[]byte(`{"pauseString":"press a key"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadStrings(dir)
+	if err != nil {
+		t.Fatalf("LoadStrings: %v", err)
+	}
+	if cfg.NewUserSysopPage == "" {
+		t.Fatal("newUserSysopPage is empty for an older strings.json; the notice would be skipped silently")
+	}
+	if !strings.Contains(cfg.NewUserSysopPage, "%s") || !strings.Contains(cfg.NewUserSysopPage, "%d") {
+		t.Errorf("fallback %q lacks the handle/node verbs the call site passes", cfg.NewUserSysopPage)
+	}
+}


### PR DESCRIPTION
Follow-up to #261, found by asking what a production BBS actually has to copy over after that change.

## The bug

`notifySysopNewUser` defaults to `true` **precisely so an upgrade needs no `config.json` edit**. But the string it formats had no entry in `StringFallbacks`, so:

1. An existing `strings.json` — which by definition predates the key — leaves `NewUserSysopPage` empty.
2. `notifySysopsOfNewUser` treats empty as "no notice configured" and returns.
3. Nothing is logged above `debug`.

**Net effect on a production upgrade:** the setting reads as enabled, no error appears, and no SysOp is ever told anyone joined. The feature would look like it simply did not work — the worst shape for a bug, since there is nothing to notice.

## The fix

`StringFallbacks` is documented as *"the value the runtime substitutes when the configured value is empty"* — exactly this case. The shipped template already carried the text; it just was not mirrored into the fallback map.

`TestNewUserSysopPageSurvivesAnOlderStringsFile` loads a `strings.json` mentioning only an unrelated key and asserts the notice text survives, with both format verbs the call site passes.

## Why this was missed in #261

The template and the fallback map are two separate sources, and the tests that would have caught it (`TestCatalogCoversRuntimeStrings`, `TestTemplateKeysAreClassified`) check the *catalog* and the *template*, not whether a runtime-required string degrades safely when absent. Adding the key to the template satisfied both while leaving the upgrade path broken.

Verification: full suite, `go vet`, `gofmt`, `golangci-lint`, `git diff --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWTB1hR7kAkbdjEqnWvAh9