### PR TITLE
fix(ftn): keep binkd.conf's outbound in step with binkd_outbound_path

### DIFF
--- a/internal/configeditor/ftn_wizard_save.go
+++ b/internal/configeditor/ftn_wizard_save.go
@@ -51,7 +51,7 @@ func (m Model) confirmFTNWizard() (Model, tea.Cmd) {
 		m.configs.FTN.OutboundPath = "data/ftn/outbound"
 	}
 	if m.configs.FTN.BinkdOutboundPath == "" {
-		m.configs.FTN.BinkdOutboundPath = "data/ftn/binkd_outbound"
+		m.configs.FTN.BinkdOutboundPath = "data/ftn/out"
 	}
 	if m.configs.FTN.TempPath == "" {
 		m.configs.FTN.TempPath = "data/ftn/temp"
@@ -159,12 +159,13 @@ func (m Model) confirmFTNWizard() (Model, tea.Cmd) {
 	binkdPath := filepath.Join(absRoot, "data", "ftn", "binkd.conf")
 
 	binkdCfg := ftn.BinkdConfig{
-		BBSRoot:   absRoot,
-		BoardName: m.configs.Server.BoardName,
-		SysopName: m.configs.Server.SysOpName,
-		Location:  m.configs.Server.BBSLocation,
-		Domains:   map[string]int{netKey: w.zone},
-		Addresses: []string{fmt.Sprintf("%s@%s", w.ownAddress, netKey)},
+		BBSRoot:      absRoot,
+		BoardName:    m.configs.Server.BoardName,
+		SysopName:    m.configs.Server.SysOpName,
+		Location:     m.configs.Server.BBSLocation,
+		Domains:      map[string]int{netKey: w.zone},
+		Addresses:    []string{fmt.Sprintf("%s@%s", w.ownAddress, netKey)},
+		OutboundPath: m.configs.FTN.BinkdOutboundPath,
 		Node: ftn.BinkdNode{
 			Address:     fmt.Sprintf("%s@%s", w.hubAddress, netKey),
 			Hostname:    fmt.Sprintf("%s:%d", w.hubHostname, w.hubPort),

--- a/internal/configeditor/update_save.go
+++ b/internal/configeditor/update_save.go
@@ -90,7 +90,8 @@ func (m *Model) saveAll() {
 			binkdSyncErr = ftn.SyncBinkdConf(binkdPath, identity, links) // non-fatal; surfaced below
 		}
 		if binkdSyncErr == nil {
-			binkdSyncErr = ftn.SyncBinkdSettings(binkdPath, m.configs.FTN.Binkd.Port, m.configs.FTN.Binkd.LogLevel)
+			binkdSyncErr = ftn.SyncBinkdSettings(binkdPath, m.configs.FTN.Binkd.Port, m.configs.FTN.Binkd.LogLevel,
+				ftn.BinkdOutboundDir(bbsRoot, m.configs.FTN.BinkdOutboundPath))
 		}
 	}
 	if err := config.SaveV3NetConfig(m.configPath, m.configs.V3Net); err != nil {

--- a/internal/ftn/binkd.go
+++ b/internal/ftn/binkd.go
@@ -34,6 +34,36 @@ type BinkdConfig struct {
 
 	// Node is the new hub node to add.
 	Node BinkdNode
+
+	// OutboundPath is binkd's BSO outbound directory, written into the
+	// "domain" lines. Empty falls back to <BBSRoot>/data/ftn/out.
+	OutboundPath string
+}
+
+// outboundPath returns the BSO outbound directory for the domain lines,
+// resolving a relative configured path against the BBS root.
+//
+// This must be the same directory the tosser packs bundles into (ftn.json's
+// binkd_outbound_path). binkd only sends what it finds in its own outbound,
+// and a mismatch is silent: the tosser reports bundles created, binkd reports
+// an empty queue, and echomail sits unsent with no error on either side.
+func (c BinkdConfig) outboundPath() string {
+	return BinkdOutboundDir(c.BBSRoot, c.OutboundPath)
+}
+
+// BinkdOutboundDir resolves ftn.json's binkd_outbound_path to the absolute
+// directory binkd uses as its BSO outbound, falling back to the historical
+// <bbsRoot>/data/ftn/out when unset. Callers hold the path in either form:
+// config.FTNConfig.ResolvePaths has already made it absolute for the running
+// BBS, while the config editor keeps the raw relative value.
+func BinkdOutboundDir(bbsRoot, configured string) string {
+	if configured == "" {
+		return filepath.Join(bbsRoot, "data", "ftn", "out")
+	}
+	if filepath.IsAbs(configured) {
+		return configured
+	}
+	return filepath.Join(bbsRoot, configured)
 }
 
 // identityOrDefaults fills fallback values for blank BBS identity fields.
@@ -84,7 +114,7 @@ func UpdateBinkdConf(confPath string, cfg BinkdConfig) error {
 		return writeFileAtomic(confPath, updated, 0600)
 	}
 
-	outPath := filepath.Join(cfg.BBSRoot, "data", "ftn", "out")
+	outPath := cfg.outboundPath()
 	logPath := filepath.Join(cfg.BBSRoot, "data", "logs", "binkd.log")
 	secureIn := filepath.Join(cfg.BBSRoot, "data", "ftn", "secure_in")
 	insecureIn := filepath.Join(cfg.BBSRoot, "data", "ftn", "in")

--- a/internal/ftn/binkd_ensure.go
+++ b/internal/ftn/binkd_ensure.go
@@ -16,11 +16,12 @@ import (
 // parseable own address — then there is nothing meaningful to write.
 func buildBinkdRegen(ftnCfg config.FTNConfig, server config.ServerConfig, bbsRoot string) (BinkdConfig, []BinkdNode, bool) {
 	cfg := BinkdConfig{
-		BBSRoot:   bbsRoot,
-		BoardName: server.BoardName,
-		SysopName: server.SysOpName,
-		Location:  server.BBSLocation,
-		Domains:   make(map[string]int),
+		BBSRoot:      bbsRoot,
+		BoardName:    server.BoardName,
+		SysopName:    server.SysOpName,
+		Location:     server.BBSLocation,
+		Domains:      make(map[string]int),
+		OutboundPath: ftnCfg.BinkdOutboundPath,
 	}
 	var nodes []BinkdNode
 
@@ -81,7 +82,7 @@ func EnsureBinkdConf(bbsRoot string, ftnCfg config.FTNConfig, server config.Serv
 	}
 	// The regenerated conf carries template defaults for port/loglevel;
 	// bring them in line with the configured values.
-	if err := SyncBinkdSettings(confPath, ftnCfg.Binkd.Port, ftnCfg.Binkd.LogLevel); err != nil {
+	if err := SyncBinkdSettings(confPath, ftnCfg.Binkd.Port, ftnCfg.Binkd.LogLevel, cfg.outboundPath()); err != nil {
 		return true, err
 	}
 	return true, nil

--- a/internal/ftn/binkd_outbound_test.go
+++ b/internal/ftn/binkd_outbound_test.go
@@ -10,18 +10,23 @@ import (
 )
 
 func TestBinkdOutboundDir(t *testing.T) {
+	root := t.TempDir()
+	// t.TempDir is absolute on every platform; a literal "/srv/mail/out" is
+	// not absolute on Windows and would be joined to the root instead.
+	absolute := filepath.Join(t.TempDir(), "mailout")
+
 	tests := []struct {
 		name       string
 		configured string
 		want       string
 	}{
-		{"unset falls back", "", filepath.Join("/bbs", "data", "ftn", "out")},
-		{"relative resolves against root", "data/ftn/out", filepath.Join("/bbs", "data/ftn/out")},
-		{"absolute kept as-is", "/srv/mail/out", "/srv/mail/out"},
+		{"unset falls back", "", filepath.Join(root, "data", "ftn", "out")},
+		{"relative resolves against root", "data/ftn/out", filepath.Join(root, "data/ftn/out")},
+		{"absolute kept as-is", absolute, absolute},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := BinkdOutboundDir("/bbs", tc.configured); got != tc.want {
+			if got := BinkdOutboundDir(root, tc.configured); got != tc.want {
 				t.Errorf("BinkdOutboundDir(%q) = %q, want %q", tc.configured, got, tc.want)
 			}
 		})
@@ -62,19 +67,21 @@ func TestUpdateBinkdConfHonorsOutboundPath(t *testing.T) {
 func TestRegenerateBinkdConfHonorsOutboundPath(t *testing.T) {
 	dir := t.TempDir()
 	conf := filepath.Join(dir, "binkd.conf")
+	outside := filepath.Join(t.TempDir(), "mailout") // absolute on every platform
 
 	cfg := BinkdConfig{
 		BBSRoot:      dir,
 		BoardName:    "Test BBS",
 		Domains:      map[string]int{"fsxnet": 21},
 		Addresses:    []string{"21:4/158@fsxnet"},
-		OutboundPath: "/srv/mail/out",
+		OutboundPath: outside,
 	}
 	if err := RegenerateBinkdConf(conf, cfg, nil); err != nil {
 		t.Fatalf("RegenerateBinkdConf: %v", err)
 	}
-	if got := readConf(t, conf); !strings.Contains(got, "domain fsxnet /srv/mail/out 21") {
-		t.Errorf("configured outbound path missing from:\n%s", got)
+	want := "domain fsxnet " + outside + " 21"
+	if got := readConf(t, conf); !strings.Contains(got, want) {
+		t.Errorf("want %q in:\n%s", want, got)
 	}
 }
 

--- a/internal/ftn/binkd_outbound_test.go
+++ b/internal/ftn/binkd_outbound_test.go
@@ -1,0 +1,109 @@
+package ftn
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+)
+
+func TestBinkdOutboundDir(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured string
+		want       string
+	}{
+		{"unset falls back", "", filepath.Join("/bbs", "data", "ftn", "out")},
+		{"relative resolves against root", "data/ftn/out", filepath.Join("/bbs", "data/ftn/out")},
+		{"absolute kept as-is", "/srv/mail/out", "/srv/mail/out"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := BinkdOutboundDir("/bbs", tc.configured); got != tc.want {
+				t.Errorf("BinkdOutboundDir(%q) = %q, want %q", tc.configured, got, tc.want)
+			}
+		})
+	}
+}
+
+// A fresh binkd.conf must point binkd at the directory the tosser packs into.
+// Hardcoding data/ftn/out here is what let a wizard-written ftn.json
+// (binkd_outbound_path: data/ftn/binkd_outbound) queue echomail into a
+// directory binkd never read.
+func TestUpdateBinkdConfHonorsOutboundPath(t *testing.T) {
+	dir := t.TempDir()
+	conf := filepath.Join(dir, "binkd.conf")
+
+	cfg := BinkdConfig{
+		BBSRoot:      dir,
+		BoardName:    "Test BBS",
+		Domains:      map[string]int{"fsxnet": 21},
+		Addresses:    []string{"21:4/158@fsxnet"},
+		OutboundPath: "data/ftn/binkd_outbound",
+		Node: BinkdNode{
+			Address:     "21:4/158@fsxnet",
+			Hostname:    "hub.example:24554",
+			SessionPwd:  "pw",
+			NetworkName: "fsxnet",
+		},
+	}
+	if err := UpdateBinkdConf(conf, cfg); err != nil {
+		t.Fatalf("UpdateBinkdConf: %v", err)
+	}
+	got := readConf(t, conf)
+	want := "domain fsxnet " + filepath.Join(dir, "data/ftn/binkd_outbound") + " 21"
+	if !strings.Contains(got, want) {
+		t.Errorf("want %q in:\n%s", want, got)
+	}
+}
+
+func TestRegenerateBinkdConfHonorsOutboundPath(t *testing.T) {
+	dir := t.TempDir()
+	conf := filepath.Join(dir, "binkd.conf")
+
+	cfg := BinkdConfig{
+		BBSRoot:      dir,
+		BoardName:    "Test BBS",
+		Domains:      map[string]int{"fsxnet": 21},
+		Addresses:    []string{"21:4/158@fsxnet"},
+		OutboundPath: "/srv/mail/out",
+	}
+	if err := RegenerateBinkdConf(conf, cfg, nil); err != nil {
+		t.Fatalf("RegenerateBinkdConf: %v", err)
+	}
+	if got := readConf(t, conf); !strings.Contains(got, "domain fsxnet /srv/mail/out 21") {
+		t.Errorf("configured outbound path missing from:\n%s", got)
+	}
+}
+
+// EnsureBinkdConf is the recovery path for a deleted binkd.conf; it must not
+// recreate the file with the drifted default.
+func TestEnsureBinkdConfUsesConfiguredOutbound(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "data", "ftn"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	ftnCfg := config.FTNConfig{
+		BinkdOutboundPath: "data/ftn/binkd_outbound",
+		Networks: map[string]config.FTNNetworkConfig{
+			"fsxnet": {
+				OwnAddress: "21:4/158",
+				Links:      []config.FTNLinkConfig{{Address: "21:4/100", Hostname: "hub.example", Port: 24554}},
+			},
+		},
+	}
+	created, err := EnsureBinkdConf(dir, ftnCfg, config.ServerConfig{BoardName: "Test BBS"})
+	if err != nil {
+		t.Fatalf("EnsureBinkdConf: %v", err)
+	}
+	if !created {
+		t.Fatal("expected binkd.conf to be created")
+	}
+	got := readConf(t, filepath.Join(dir, "data", "ftn", "binkd.conf"))
+	want := "domain fsxnet " + filepath.Join(dir, "data/ftn/binkd_outbound") + " 21"
+	if !strings.Contains(got, want) {
+		t.Errorf("want %q in:\n%s", want, got)
+	}
+}

--- a/internal/ftn/binkd_regen.go
+++ b/internal/ftn/binkd_regen.go
@@ -13,7 +13,7 @@ import (
 // could not be recreated. The caller supplies real values; iport/loglevel are
 // template defaults here and are corrected by SyncBinkdSettings afterwards.
 func RegenerateBinkdConf(confPath string, cfg BinkdConfig, nodes []BinkdNode) error {
-	outPath := filepath.Join(cfg.BBSRoot, "data", "ftn", "out")
+	outPath := cfg.outboundPath()
 	logPath := filepath.Join(cfg.BBSRoot, "data", "logs", "binkd.log")
 	secureIn := filepath.Join(cfg.BBSRoot, "data", "ftn", "secure_in")
 	insecureIn := filepath.Join(cfg.BBSRoot, "data", "ftn", "in")

--- a/internal/ftn/binkd_settings.go
+++ b/internal/ftn/binkd_settings.go
@@ -6,13 +6,21 @@ import (
 	"strings"
 )
 
-// Syncing the standalone binkd settings (listen port, log level) in place.
+// Syncing the standalone binkd settings (listen port, log level, outbound
+// directory) in place.
 
-// SyncBinkdSettings updates the iport and loglevel lines in binkd.conf to
-// match the configured values. The file is only rewritten when a value
-// differs; a missing binkd.conf is a no-op (the FTN Setup Wizard creates it).
-// Non-positive port/logLevel values leave the corresponding line untouched.
-func SyncBinkdSettings(confPath string, port, logLevel int) error {
+// SyncBinkdSettings updates the iport, loglevel and domain lines in
+// binkd.conf to match the configured values. The file is only rewritten when a
+// value differs; a missing binkd.conf is a no-op (the FTN Setup Wizard creates
+// it). Non-positive port/logLevel values, and an empty outboundPath, leave the
+// corresponding lines untouched.
+//
+// outboundPath is repointed on every domain line because binkd sends only what
+// it finds in its own outbound: if it disagrees with ftn.json's
+// binkd_outbound_path the tosser packs bundles into a directory binkd never
+// reads, and echomail queues up silently. Syncing here means an install that
+// has already drifted is repaired on the next binkd launch.
+func SyncBinkdSettings(confPath string, port, logLevel int, outboundPath string) error {
 	existing, err := os.ReadFile(confPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -40,6 +48,17 @@ func SyncBinkdSettings(confPath string, port, logLevel int) error {
 			newLine := fmt.Sprintf("loglevel %d", logLevel)
 			if trimmed != newLine {
 				out.WriteString(newLine)
+				out.WriteByte('\n')
+				changed = true
+				continue
+			}
+		}
+		// "domain <name> <outbound-path> <zone>": rewrite the path field
+		// only, leaving the sysop's network names and zones alone.
+		if strings.HasPrefix(trimmed, "domain ") && outboundPath != "" {
+			if fields := strings.Fields(trimmed); len(fields) == 4 && fields[2] != outboundPath {
+				fields[2] = outboundPath
+				out.WriteString(strings.Join(fields, " "))
 				out.WriteByte('\n')
 				changed = true
 				continue

--- a/internal/ftn/binkd_settings_test.go
+++ b/internal/ftn/binkd_settings_test.go
@@ -25,7 +25,7 @@ func writeConf(t *testing.T, content string) string {
 
 func TestSyncBinkdSettingsUpdatesLines(t *testing.T) {
 	path := writeConf(t, settingsConf)
-	if err := SyncBinkdSettings(path, 24555, 6); err != nil {
+	if err := SyncBinkdSettings(path, 24555, 6, ""); err != nil {
 		t.Fatalf("SyncBinkdSettings: %v", err)
 	}
 	got, _ := os.ReadFile(path)
@@ -44,7 +44,7 @@ func TestSyncBinkdSettingsUpdatesLines(t *testing.T) {
 func TestSyncBinkdSettingsNoChangeLeavesFile(t *testing.T) {
 	path := writeConf(t, settingsConf)
 	before, _ := os.Stat(path)
-	if err := SyncBinkdSettings(path, 24554, 4); err != nil {
+	if err := SyncBinkdSettings(path, 24554, 4, ""); err != nil {
 		t.Fatalf("SyncBinkdSettings: %v", err)
 	}
 	after, _ := os.Stat(path)
@@ -55,18 +55,64 @@ func TestSyncBinkdSettingsNoChangeLeavesFile(t *testing.T) {
 
 func TestSyncBinkdSettingsMissingFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "binkd.conf")
-	if err := SyncBinkdSettings(path, 24554, 4); err != nil {
+	if err := SyncBinkdSettings(path, 24554, 4, ""); err != nil {
 		t.Fatalf("missing file must be a no-op, got: %v", err)
 	}
 }
 
 func TestSyncBinkdSettingsNonPositiveIgnored(t *testing.T) {
 	path := writeConf(t, settingsConf)
-	if err := SyncBinkdSettings(path, 0, 0); err != nil {
+	if err := SyncBinkdSettings(path, 0, 0, ""); err != nil {
 		t.Fatalf("SyncBinkdSettings: %v", err)
 	}
 	got, _ := os.ReadFile(path)
 	if !strings.Contains(string(got), "iport 24554\n") || !strings.Contains(string(got), "loglevel 4\n") {
 		t.Errorf("zero values must leave lines untouched:\n%s", got)
+	}
+}
+
+// The drift this guards against shipped: the tosser packed bundles into
+// ftn.json's binkd_outbound_path while binkd.conf still pointed elsewhere, so
+// binkd reported an empty queue and echomail never left the board.
+func TestSyncBinkdSettingsRepointsDomainOutbound(t *testing.T) {
+	path := writeConf(t, settingsConf+"domain fsxnet /opt/v3/data/ftn/binkd_outbound 21\ndomain fidonet /opt/v3/data/ftn/binkd_outbound 3\n")
+	if err := SyncBinkdSettings(path, 24554, 4, "/opt/v3/data/ftn/out"); err != nil {
+		t.Fatalf("SyncBinkdSettings: %v", err)
+	}
+	got := readConf(t, path)
+	for _, want := range []string{
+		"domain fsxnet /opt/v3/data/ftn/out 21",
+		"domain fidonet /opt/v3/data/ftn/out 3",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "binkd_outbound") {
+		t.Errorf("stale outbound path survived:\n%s", got)
+	}
+}
+
+func TestSyncBinkdSettingsLeavesMatchingDomainAlone(t *testing.T) {
+	conf := settingsConf + "domain fsxnet /opt/v3/data/ftn/out 21\n"
+	path := writeConf(t, conf)
+	if err := SyncBinkdSettings(path, 24554, 4, "/opt/v3/data/ftn/out"); err != nil {
+		t.Fatalf("SyncBinkdSettings: %v", err)
+	}
+	if got := readConf(t, path); got != conf {
+		t.Errorf("file rewritten despite no change:\ngot:\n%s\nwant:\n%s", got, conf)
+	}
+}
+
+// An empty outboundPath means "not configured"; blanking the sysop's domain
+// lines would leave binkd with no outbound at all.
+func TestSyncBinkdSettingsEmptyOutboundLeavesDomains(t *testing.T) {
+	conf := settingsConf + "domain fsxnet /somewhere/else 21\n"
+	path := writeConf(t, conf)
+	if err := SyncBinkdSettings(path, 24554, 4, ""); err != nil {
+		t.Fatalf("SyncBinkdSettings: %v", err)
+	}
+	if got := readConf(t, path); got != conf {
+		t.Errorf("domain line touched with no configured path:\n%s", got)
 	}
 }

--- a/internal/mailer/supervisor.go
+++ b/internal/mailer/supervisor.go
@@ -51,6 +51,12 @@ func (t *stderrTail) String() string {
 	return strings.TrimSpace(string(t.buf))
 }
 
+// binkdOutboundDir is the BSO outbound directory binkd is configured with —
+// the same one the tosser packs bundles into, so the two cannot drift apart.
+func (s *Service) binkdOutboundDir() string {
+	return ftn.BinkdOutboundDir(s.cfg.BBSRoot, s.cfg.FTN.BinkdOutboundPath)
+}
+
 // ensureRuntimeDirs creates the directories binkd needs at startup (log dir
 // and inbound/outbound queues). binkd exits immediately if its log file's
 // directory is missing, and nothing else in the launch path creates these.
@@ -59,7 +65,7 @@ func (s *Service) ensureRuntimeDirs() {
 		filepath.Join(s.cfg.BBSRoot, "data", "logs"),
 		filepath.Join(s.cfg.BBSRoot, "data", "ftn", "in"),
 		filepath.Join(s.cfg.BBSRoot, "data", "ftn", "secure_in"),
-		filepath.Join(s.cfg.BBSRoot, "data", "ftn", "out"),
+		s.binkdOutboundDir(),
 	} {
 		if err := os.MkdirAll(d, 0755); err != nil {
 			slog.Warn("creating binkd runtime dir failed", "dir", d, "error", err)
@@ -82,7 +88,7 @@ func (s *Service) superviseLoop(ctx context.Context) {
 		// mid-session is only re-applied here after the BBS restarts (the TUI
 		// save path also syncs binkd.conf directly, for immediate effect).
 		b := s.cfg.FTN.Binkd
-		if err := ftn.SyncBinkdSettings(s.confPath, b.Port, b.LogLevel); err != nil {
+		if err := ftn.SyncBinkdSettings(s.confPath, b.Port, b.LogLevel, s.binkdOutboundDir()); err != nil {
 			slog.Warn("binkd.conf settings sync failed", "error", err)
 		}
 		s.ensureRuntimeDirs()


### PR DESCRIPTION
## Problem

binkd.conf's `domain` lines were written from a hardcoded `<bbsRoot>/data/ftn/out`, while the tosser packed bundles into `ftn.json`'s `binkd_outbound_path`. The FTN Setup Wizard defaulted that field to `data/ftn/binkd_outbound`, so a wizard-created install had the two halves of the pipeline pointing at different directories.

The failure is silent from both ends:

```
vision3.log: "binkd export cycle" network=fsxnet exported=1 bundles=1
binkd.log:   creating a poll for 21:4/158@fsxnet (`d' flavour)
             the queue is empty, quitting...
             done (from 21:4/158@fsxnet, OK, S/R: 0/0 (0/0 bytes))
```

Outbound echomail accumulates in a directory binkd never reads. Inbound is unaffected, so the board looks healthy. On the install this was found on, a week of posts sat unsent with no error in either log.

The sysop docs already say the two must agree (`ftn-echomail.md`: "`binkd_outbound_path` — Must match binkd's `domain` outbound path") and document `data/ftn/out`, so the wizard default was the outlier.

## Changes

- `BinkdConfig` gains `OutboundPath`; `UpdateBinkdConf` and `RegenerateBinkdConf` write it into the `domain` lines instead of a hardcoded path. Empty falls back to the historical `<bbsRoot>/data/ftn/out`.
- Exported `ftn.BinkdOutboundDir(bbsRoot, configured)` resolves the field for callers holding it in either absolute (post-`ResolvePaths`) or raw relative (config editor) form.
- Both `BinkdConfig` construction sites — the FTN wizard and `buildBinkdRegen` — now populate it from `binkd_outbound_path`.
- The wizard default becomes `data/ftn/out`, matching the shipped template, `cmd/helper`, and the docs.
- `SyncBinkdSettings` also repoints existing `domain` lines, so an install that has **already** drifted repairs itself on the next binkd launch rather than needing a hand edit. It rewrites only the path field, leaving network names and zones alone, and is a no-op when the configured path is empty.
- The mailer supervisor's `ensureRuntimeDirs` creates the configured outbound rather than a hardcoded one.

## Testing

`go test ./...` passes. New coverage in `internal/ftn`:

- `TestSyncBinkdSettingsRepointsDomainOutbound` — reproduces the exact drift and asserts it is repaired
- `TestSyncBinkdSettingsLeavesMatchingDomainAlone` / `TestSyncBinkdSettingsEmptyOutboundLeavesDomains` — no spurious rewrites, and an unset path never blanks a sysop's domain line
- `TestBinkdOutboundDir` — fallback, relative and absolute resolution
- `TestUpdateBinkdConfHonorsOutboundPath`, `TestRegenerateBinkdConfHonorsOutboundPath`, `TestEnsureBinkdConfUsesConfiguredOutbound` — all three write paths honor the configured directory

Verified against the affected production install: the queued bundles and `.clo` flow file were in `data/ftn/binkd_outbound` while binkd.conf's domain line read `data/ftn/out`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aBB1w3MxrqXFemC16xU15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Binkd now supports a configurable FTN outbound directory.
  * Outbound paths can be specified as absolute paths or relative to the BBS directory.
  * The default outbound directory is now `data/ftn/out`.
  * Generated and synchronized Binkd configurations consistently use the configured outbound path.
  * Runtime directory creation now follows the selected outbound location.

* **Bug Fixes**
  * Updated Binkd configuration handling to preserve domain details while correcting outbound directory paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->