### PR TITLE
feat(ftn): let sysops turn off binkp CRAM-MD5 per install

### DIFF
--- a/docs/sysop/messages/ftn-echomail.md
+++ b/docs/sysop/messages/ftn-echomail.md
@@ -48,8 +48,11 @@ Restart the BBS afterward. On startup, Vision/3 launches `bin/binkd` as a superv
 | `binary_path`             | `bin/binkd`    | Path to the binkd binary, relative to the BBS root              |
 | `log_level`               | `4`            | binkd log verbosity (synced to `binkd.conf`'s `loglevel`)       |
 | `export_interval_seconds` | `300`          | How often Vision/3 scans+packs outbound mail into binkd's outbound queue |
+| `disable_cram_md5`        | `false`        | Launch binkd with `-m`, forcing plaintext binkp passwords in both directions |
 
-These same fields appear in the Configuration Editor under **Server Setup** as "Binkd Mailer", "Binkd Port", "Binkd Binary", "Binkd Log Lvl", and "Export Secs". Saving from the config editor also re-syncs identity fields, link passwords, `iport`, and `loglevel` into `binkd.conf`.
+These same fields appear in the Configuration Editor under **Server Setup** as "Binkd Mailer", "Binkd Port", "Binkd Binary", "Binkd Log Lvl", "Export Secs", and "No CRAM-MD5". Saving from the config editor also re-syncs identity fields, link passwords, `iport`, and `loglevel` into `binkd.conf`.
+
+**About `disable_cram_md5`:** binkp normally negotiates CRAM-MD5, so the password is never sent in the clear. Leave this off. Turn it on only for a hub whose CRAM-MD5 rejects a password you have otherwise confirmed correct — the giveaway is `ERR Bad address or password` on your outgoing calls *and* `'CRAM-MD5-...': incorrect password` on the hub's incoming calls, while the same password succeeds once MD5 is out of the picture. `-m` both stops binkd offering CRAM-MD5 to callers and stops it answering a remote's offer, so it repairs both directions; the cost is that the session password crosses the network in plaintext.
 
 **Preflight checks:** before starting binkd, Vision/3 verifies the binary is present and executable, that `data/ftn/binkd.conf` exists and contains no unconfigured template placeholders (the wizard creates and fills it), and that at least one configured network has an `own_address` set. If any check fails, the BBS logs a warning and continues running without the mailer — it never blocks startup.
 

--- a/internal/config/config_binkd_test.go
+++ b/internal/config/config_binkd_test.go
@@ -29,6 +29,29 @@ func TestLoadFTNConfigBinkdDefaults(t *testing.T) {
 	if b.ExportSecs != 300 {
 		t.Errorf("ExportSecs = %d, want 300", b.ExportSecs)
 	}
+	// CRAM-MD5 stays on unless a sysop turns it off for a specific hub.
+	if b.DisableCramMD5 {
+		t.Error("DisableCramMD5 should default to false")
+	}
+}
+
+func TestLoadFTNConfigBinkdDisableCramMD5(t *testing.T) {
+	dir := t.TempDir()
+	body := `{"networks":{},"binkd":{"enabled":true,"disable_cram_md5":true}}`
+	if err := os.WriteFile(filepath.Join(dir, "ftn.json"), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadFTNConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadFTNConfig: %v", err)
+	}
+	if !cfg.Binkd.DisableCramMD5 {
+		t.Error("DisableCramMD5 = false, want true")
+	}
+	// Defaults must still fill the omitted numeric fields.
+	if cfg.Binkd.Port != 24554 || cfg.Binkd.LogLevel != 4 {
+		t.Errorf("defaults not applied: %+v", cfg.Binkd)
+	}
 }
 
 func TestLoadFTNConfigBinkdRoundTrip(t *testing.T) {

--- a/internal/config/config_ftn.go
+++ b/internal/config/config_ftn.go
@@ -85,6 +85,13 @@ type BinkdServerConfig struct {
 	BinaryPath string `json:"binary_path"`             // Path to binkd binary, relative to BBS root (default "bin/binkd")
 	LogLevel   int    `json:"log_level"`               // binkd loglevel (default 4)
 	ExportSecs int    `json:"export_interval_seconds"` // Outbound scan/pack cadence (default 300)
+
+	// DisableCramMD5 launches binkd with -m, which both stops it offering
+	// CRAM-MD5 to callers and stops it answering a remote's offer, so
+	// sessions authenticate with a plaintext password in both directions.
+	// Needed for hubs whose CRAM-MD5 rejects an otherwise-correct password;
+	// leave off unless a link actually fails that way (see issue #268).
+	DisableCramMD5 bool `json:"disable_cram_md5,omitempty"`
 }
 
 // FTNConfig holds all FTN (FidoNet Technology Network) echomail settings.

--- a/internal/configeditor/fields_system_network.go
+++ b/internal/configeditor/fields_system_network.go
@@ -171,7 +171,7 @@ func (m *Model) sysFieldsNetwork(cfg *config.ServerConfig) []fieldDef {
 			},
 		},
 		{
-			Label: "No CRAM-MD5", Help: "Use plaintext binkp passwords both ways; only for a hub CRAM-MD5 rejects", Type: ftYesNo, Col: 3, Row: 26, Width: 1,
+			Label: "No CRAM-MD5", Help: "Plaintext binkp passwords both ways; only for a hub whose CRAM-MD5 fails", Type: ftYesNo, Col: 3, Row: 26, Width: 1,
 			Get: func() string { return uitext.BoolToYN(binkd.DisableCramMD5) },
 			Set: func(val string) error { binkd.DisableCramMD5 = uitext.YNToBool(val); return nil },
 		},

--- a/internal/configeditor/fields_system_network.go
+++ b/internal/configeditor/fields_system_network.go
@@ -170,5 +170,10 @@ func (m *Model) sysFieldsNetwork(cfg *config.ServerConfig) []fieldDef {
 				return nil
 			},
 		},
+		{
+			Label: "No CRAM-MD5", Help: "Use plaintext binkp passwords both ways; only for a hub CRAM-MD5 rejects", Type: ftYesNo, Col: 3, Row: 26, Width: 1,
+			Get: func() string { return uitext.BoolToYN(binkd.DisableCramMD5) },
+			Set: func(val string) error { binkd.DisableCramMD5 = uitext.YNToBool(val); return nil },
+		},
 	}
 }

--- a/internal/mailer/binkd_args_test.go
+++ b/internal/mailer/binkd_args_test.go
@@ -1,0 +1,37 @@
+package mailer
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+)
+
+// binkd parses flags before the positional config path, so -m has to come
+// first; passing it after the path makes binkd treat it as a second config
+// file and abort.
+func TestBinkdArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		disable  bool
+		wantArgs []string
+	}{
+		{"default keeps CRAM-MD5", false, []string{"/bbs/data/ftn/binkd.conf"}},
+		{"disabled passes -m first", true, []string{"-m", "/bbs/data/ftn/binkd.conf"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Service{
+				confPath: "/bbs/data/ftn/binkd.conf",
+				cfg: Config{
+					FTN: config.FTNConfig{
+						Binkd: config.BinkdServerConfig{DisableCramMD5: tc.disable},
+					},
+				},
+			}
+			if got := s.binkdArgs(); !reflect.DeepEqual(got, tc.wantArgs) {
+				t.Errorf("binkdArgs() = %v, want %v", got, tc.wantArgs)
+			}
+		})
+	}
+}

--- a/internal/mailer/supervisor.go
+++ b/internal/mailer/supervisor.go
@@ -116,6 +116,20 @@ func (s *Service) superviseLoop(ctx context.Context) {
 	}
 }
 
+// binkdArgs is binkd's argv after the binary name. Flags must precede the
+// positional config path, which binkd expects last.
+func (s *Service) binkdArgs() []string {
+	args := make([]string, 0, 2)
+	if s.cfg.FTN.Binkd.DisableCramMD5 {
+		// -m stops binkd both offering CRAM-MD5 to callers and answering a
+		// remote's offer, so both directions fall back to a plaintext
+		// password. Only useful against a peer whose CRAM-MD5 rejects an
+		// otherwise-correct password (issue #268).
+		args = append(args, "-m")
+	}
+	return append(args, s.confPath)
+}
+
 // runOnce starts binkd and blocks until it exits or ctx is cancelled.
 // On cancellation it sends SIGTERM, waits termGrace, then kills.
 func (s *Service) runOnce(ctx context.Context) error {
@@ -123,7 +137,7 @@ func (s *Service) runOnce(ctx context.Context) error {
 	// BBS's signal-driven shutdown (SIGTERM, then a grace period, then
 	// SIGKILL) is what stops it on exit; on Unix an orphaned child process
 	// can otherwise outlive its parent.
-	cmd := exec.Command(s.binkdPath, s.confPath)
+	cmd := exec.Command(s.binkdPath, s.binkdArgs()...)
 	cmd.Stdout = nil // binkd logs to file per binkd.conf
 	// Startup failures (config errors, unopenable log file, port in use) go
 	// to stderr before binkd ever opens its log file, so keep a bounded tail


### PR DESCRIPTION
Closes the configuration half of #268.

## Problem

Some hubs reject a CRAM-MD5 digest for a password that is demonstrably correct. On a live fsxNet point (21:4/158.1) against a Mystic 1.12A48 hub, the link failed **both ways** while the same address and secret worked in plaintext:

| Direction | Auth | Result |
|---|---|---|
| us → hub | CRAM-MD5 | `rcvd msg ERR Bad address or password` |
| hub → us | CRAM-MD5 | `` `CRAM-MD5-93466acd...': incorrect password `` |
| us → hub | plaintext | `rcvd msg OK secure`, `S/R: 0/1 (0/886 bytes)` |
| hub → us | plaintext | OK, mail transferred |

Ruled out on the way to this: password mismatch (plaintext works), case sensitivity between binkd's plaintext compare and an exact digest (`whit2024`/`Whit2024`/`WHIT2024` all fail under MD5), address/point config, port, TLS, and BSO flavour. Full evidence in #268.

`binkd -m` fixes it, and fixes *both* directions — it suppresses the CRAM-MD5 advertisement on our server side too, so a peer that would otherwise challenge us falls back to plaintext:

```
our daemon (no -m):  CMD0 OPT CRAM-MD5-a4cc6f3684d6de552ecc278120f660ee
scratch binkd -m:    (no CRAM-MD5 line)
```

But there was no way to reach the flag from configuration. Scheduled poll events in `events.json` can carry `-m` since their args are config-driven, but the supervised daemon was launched as `exec.Command(s.binkdPath, s.confPath)` — so the inbound half stayed broken with no supported workaround short of patching the invocation.

## Changes

- New `ftn.binkd.disable_cram_md5` (bool, `omitempty`, defaults false).
- `Service.binkdArgs()` builds the daemon's argv, putting `-m` **before** the positional config path — binkd parses flags first, and a flag after the path is read as a second config file.
- Config editor gains "No CRAM-MD5" on the Server Setup panel beside the existing binkd fields.
- Docs: new row in the binkd settings table plus a note on the exact symptom that justifies turning it on, and the plaintext-on-the-wire tradeoff.

Default is off. CRAM-MD5 is what keeps the session password off the wire, so this is opt-in per install rather than something to reach for casually.

## Testing

`go vet ./...` and `go test ./...` pass.

- `TestBinkdArgs` — table test over both states, asserting `-m` lands first and is absent by default
- `TestLoadFTNConfigBinkdDisableCramMD5` — round-trips the field and confirms the other defaults still apply alongside it
- `TestLoadFTNConfigBinkdDefaults` — extended to assert the field defaults false
- Config editor geometry tests pass with the added row

Verified against the affected production link: with `-m`, `pwd protected session (plain text)` / `done (to 21:4/158@fsxnet, OK)`, and a poll pulled down and tossed real mail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aBB1w3MxrqXFemC16xU15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Binkd network setting to disable CRAM-MD5 authentication and use plaintext passwords.
  * Binkd now applies the corresponding connection option when launching sessions.
* **Documentation**
  * Added configuration guidance for resolving CRAM-MD5 authentication failures by enabling plaintext password sessions.
* **Tests**
  * Added coverage for the setting’s defaults, configuration handling, and Binkd command behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->