### PR TITLE
feat(messages): add a date column to the message list (#257)

### DIFF
--- a/internal/menu/message_list_render.go
+++ b/internal/menu/message_list_render.go
@@ -2,7 +2,9 @@ package menu
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
@@ -71,9 +73,15 @@ func drawMessageListScreen(terminal *term.Terminal, state *MessageListState, are
 		return err
 	}
 
-	// Column headers (bright white text, total interior: 77 chars)
-	// Layout: Status(1) + " N#" (3) + "  " (2) + "Subject" + pad (33) + "    " (4) + "From" + pad (17) + "  " (2) + "To" + pad (15) = 77
-	columnHeaders := "|11│|15 N#  Subject                               From               To             |11│|07\r\n"
+	// Column headers, built from the same widths as the rows so the two cannot
+	// drift apart. The status column has no label.
+	columnHeaders := fmt.Sprintf("|11│|15%s%s %s %s %s %s |11│|07\r\n",
+		strings.Repeat(" ", listStatusWidth),
+		ansi.PadLeft("N#", listNumWidth),
+		listCell("Subject", listSubjectWidth),
+		listCell("From", listFromWidth),
+		listCell("To", listToWidth),
+		listCell("Date", listDateWidth))
 	if err := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(columnHeaders)), outputMode); err != nil {
 		return err
 	}
@@ -155,46 +163,86 @@ func drawMessageListScreen(terminal *term.Terminal, state *MessageListState, are
 	return nil
 }
 
-// drawMessageListLine renders a single message line with optional highlighting
-func drawMessageListLine(terminal *term.Terminal, entry MessageListEntry, isHighlighted bool, outputMode ansi.OutputMode) error {
-	// Format status character (aware of highlight state)
-	statusStr := formatStatusChar(entry, isHighlighted)
+// Message list column widths. They sum, with the single-space separators
+// between them, to listInteriorWidth.
+//
+// Every cell is built to its exact width by listCell rather than with a %-Ns
+// verb. Two reasons, both of which had already gone wrong here: fmt's width is
+// a *minimum*, so "%3d" quietly grew to four columns at message 1000 and walked
+// the right border out of the frame; and its padding counts bytes, so a
+// multi-byte name padded short and pulled the border the other way.
+const (
+	listStatusWidth   = 1
+	listNumWidth      = 5 // up to 99999; see listNumCell for what happens beyond
+	listSubjectWidth  = 31
+	listFromWidth     = 16
+	listToWidth       = 11
+	listDateWidth     = 8 // 01/02/06
+	listInteriorWidth = 77
 
-	// Format message number (right-aligned, 3 chars)
-	numStr := fmt.Sprintf("%3d", entry.MsgNum)
+	// Four single-space separators between the six columns, plus one trailing
+	// space so the date does not touch the right border.
+	listSeparators = 5
+)
 
-	// Truncate fields to fit columns
-	// Layout: Status(1) + Num(3) + Sep(2) + Subject(33) + Sep(4) + From(17) + Sep(2) + To(15) = 77 chars
+// listCell renders s as exactly width columns, truncating with an ellipsis and
+// padding with spaces. Both halves count runes, so the result is exact for
+// multi-byte input as well as ASCII.
+func listCell(s string, width int) string {
+	return ansi.PadRight(ansi.TruncateRunes(s, width, "..."), width)
+}
+
+// listNumCell right-aligns a message number in listNumWidth columns.
+//
+// A number too large for the column keeps its leading digits rather than
+// widening the row: the frame holding is worth more than the last digit of a
+// six-figure message number, and the number is only a label here — the reader
+// shows it in full.
+func listNumCell(n int) string {
+	return ansi.PadLeft(ansi.TruncateRunes(strconv.Itoa(n), listNumWidth, ""), listNumWidth)
+}
+
+// listDateCell formats a message date for the list. A zero time renders blank
+// rather than as year 1, which is what a message with no usable date carries.
+func listDateCell(t time.Time) string {
+	if t.IsZero() {
+		return strings.Repeat(" ", listDateWidth)
+	}
+	return listCell(t.Format("01/02/06"), listDateWidth)
+}
+
+// messageListRow builds the 77-column interior of one message row, without the
+// status character, which is written separately because it carries pipe codes
+// in the unhighlighted case and is always exactly one column.
+func messageListRow(entry MessageListEntry, outputMode ansi.OutputMode) string {
 	subjectVal, fromVal, toVal := entry.Subject, entry.From, entry.To
 	if outputMode == ansi.OutputModeCP437 {
 		subjectVal = toCP437Safe(subjectVal)
 		fromVal = toCP437Safe(fromVal)
 		toVal = toCP437Safe(toVal)
 	}
-	subject := truncateString(subjectVal, 33)
-	from := truncateString(fromVal, 17)
-	to := truncateString(toVal, 15)
+	// Trailing space so the date does not butt against the right border, the
+	// way the status column keeps the number off the left one.
+	return listNumCell(entry.MsgNum) + " " +
+		listCell(subjectVal, listSubjectWidth) + " " +
+		listCell(fromVal, listFromWidth) + " " +
+		listCell(toVal, listToWidth) + " " +
+		listDateCell(entry.Date) + " "
+}
 
-	// Format the line (total width: 79 chars including borders)
-	// Interior: Status(1) + Num(3) + Spaces(2) + Subject(33) + Spaces(4) + From(17) + Spaces(2) + To(15) = 77
-	// Total: Border(1) + Interior(77) + Border(1) = 79
+// drawMessageListLine renders a single message line with optional highlighting
+func drawMessageListLine(terminal *term.Terminal, entry MessageListEntry, isHighlighted bool, outputMode ansi.OutputMode) error {
+	// Format status character (aware of highlight state)
+	statusStr := formatStatusChar(entry, isHighlighted)
+	row := messageListRow(entry, outputMode)
+
 	var line string
 	if isHighlighted {
 		// Use ANSI reverse video for highlighting (black on white)
-		line = fmt.Sprintf("|11│\x1b[7m%s%s  %-33s    %-17s  %-15s\x1b[27m|11│|07\r\n",
-			statusStr,
-			numStr,
-			subject,
-			from,
-			to)
+		line = fmt.Sprintf("|11│\x1b[7m%s%s\x1b[27m|11│|07\r\n", statusStr, row)
 	} else {
 		// Normal display (bright white text on black)
-		line = fmt.Sprintf("|11│|15%s%s  %-33s    %-17s  %-15s|11│|07\r\n",
-			statusStr,
-			numStr,
-			subject,
-			from,
-			to)
+		line = fmt.Sprintf("|11│|15%s%s|11│|07\r\n", statusStr, row)
 	}
 
 	return terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(line)), outputMode)

--- a/internal/menu/message_list_render.go
+++ b/internal/menu/message_list_render.go
@@ -78,10 +78,10 @@ func drawMessageListScreen(terminal *term.Terminal, state *MessageListState, are
 	columnHeaders := fmt.Sprintf("|11│|15%s%s %s %s %s %s |11│|07\r\n",
 		strings.Repeat(" ", listStatusWidth),
 		ansi.PadLeft("N#", listNumWidth),
-		listCell("Subject", listSubjectWidth),
-		listCell("From", listFromWidth),
-		listCell("To", listToWidth),
-		listCell("Date", listDateWidth))
+		listCell("Subject", listSubjectWidth, outputMode),
+		listCell("From", listFromWidth, outputMode),
+		listCell("To", listToWidth, outputMode),
+		listCell("Date", listDateWidth, outputMode))
 	if err := terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(columnHeaders)), outputMode); err != nil {
 		return err
 	}
@@ -186,10 +186,24 @@ const (
 )
 
 // listCell renders s as exactly width columns, truncating with an ellipsis and
-// padding with spaces. Both halves count runes, so the result is exact for
-// multi-byte input as well as ASCII.
-func listCell(s string, width int) string {
-	return ansi.PadRight(ansi.TruncateRunes(s, width, "..."), width)
+// padding with spaces.
+//
+// Order matters. toCP437Safe emits one byte per rune, and CP437's high bytes
+// are not valid UTF-8, so anything that decodes runes must run before the
+// conversion: truncating afterwards turns every accented character into U+FFFD
+// while leaving the column count correct, which is corruption a width check
+// cannot see. Truncate and measure in Unicode, convert, then pad with ASCII
+// spaces that are the same byte either way.
+func listCell(s string, width int, outputMode ansi.OutputMode) string {
+	s = ansi.TruncateRunes(s, width, "...")
+	n := utf8.RuneCountInString(s)
+	if outputMode == ansi.OutputModeCP437 {
+		s = toCP437Safe(s)
+	}
+	if n < width {
+		s += strings.Repeat(" ", width-n)
+	}
+	return s
 }
 
 // listNumCell right-aligns a message number in listNumWidth columns.
@@ -204,29 +218,25 @@ func listNumCell(n int) string {
 
 // listDateCell formats a message date for the list. A zero time renders blank
 // rather than as year 1, which is what a message with no usable date carries.
+// The format is ASCII, so it needs no output-mode handling.
 func listDateCell(t time.Time) string {
 	if t.IsZero() {
 		return strings.Repeat(" ", listDateWidth)
 	}
-	return listCell(t.Format("01/02/06"), listDateWidth)
+	return ansi.PadRight(ansi.TruncateRunes(t.Format("01/02/06"), listDateWidth, ""), listDateWidth)
 }
 
-// messageListRow builds the 77-column interior of one message row, without the
-// status character, which is written separately because it carries pipe codes
-// in the unhighlighted case and is always exactly one column.
+// messageListRow builds every column of one message row except the status
+// character, which the caller writes separately because it carries pipe codes
+// in the unhighlighted case. The result is listInteriorWidth - listStatusWidth
+// columns wide.
 func messageListRow(entry MessageListEntry, outputMode ansi.OutputMode) string {
-	subjectVal, fromVal, toVal := entry.Subject, entry.From, entry.To
-	if outputMode == ansi.OutputModeCP437 {
-		subjectVal = toCP437Safe(subjectVal)
-		fromVal = toCP437Safe(fromVal)
-		toVal = toCP437Safe(toVal)
-	}
 	// Trailing space so the date does not butt against the right border, the
 	// way the status column keeps the number off the left one.
 	return listNumCell(entry.MsgNum) + " " +
-		listCell(subjectVal, listSubjectWidth) + " " +
-		listCell(fromVal, listFromWidth) + " " +
-		listCell(toVal, listToWidth) + " " +
+		listCell(entry.Subject, listSubjectWidth, outputMode) + " " +
+		listCell(entry.From, listFromWidth, outputMode) + " " +
+		listCell(entry.To, listToWidth, outputMode) + " " +
 		listDateCell(entry.Date) + " "
 }
 

--- a/internal/menu/message_list_state.go
+++ b/internal/menu/message_list_state.go
@@ -3,6 +3,7 @@ package menu
 import (
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/message"
@@ -14,6 +15,7 @@ type MessageListEntry struct {
 	Subject   string
 	From      string
 	To        string
+	Date      time.Time // When the message was written; blank in the list if zero
 	IsPrivate bool
 	IsRead    bool // Based on JAM lastread pointer
 }
@@ -119,6 +121,7 @@ func buildMessageList(msgMgr *message.MessageManager, areaID int, username strin
 			Subject:   msg.Subject,
 			From:      msg.From,
 			To:        msg.To,
+			Date:      msg.DateTime,
 			IsPrivate: isPrivate,
 			IsRead:    isRead,
 		}

--- a/internal/menu/message_list_test.go
+++ b/internal/menu/message_list_test.go
@@ -2,10 +2,12 @@ package menu
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
@@ -379,5 +381,109 @@ func TestDrawMessageListScreenNonASCIITitleDoesNotPanic(t *testing.T) {
 	stripped := testAnsiEscape.ReplaceAllString(titleLine, "")
 	if got := utf8.RuneCountInString(stripped); got != 79 {
 		t.Errorf("title line visible width = %d runes, want 79 (line %q)", got, stripped)
+	}
+}
+
+// The column widths and their separators must add up to the frame's interior.
+// Nothing enforces this at compile time, and getting it wrong moves the right
+// border on message rows only — the header and separators keep their width, so
+// the frame looks torn rather than simply narrow.
+func TestMessageListColumnWidthsFillTheFrame(t *testing.T) {
+	sum := listStatusWidth + listNumWidth + listSubjectWidth +
+		listFromWidth + listToWidth + listDateWidth + listSeparators
+	if sum != listInteriorWidth {
+		t.Errorf("columns plus separators = %d, want %d (the frame interior)", sum, listInteriorWidth)
+	}
+}
+
+// Every message row is exactly 79 visible columns, whatever it contains.
+//
+// The number column used to be "%3d", and fmt's width is a minimum rather than
+// a maximum: at message 1000 the row grew to 80 columns and the right border
+// stepped outside the frame, which is what a busy area looks like all the time.
+// The other fields had the mirror-image problem — they were truncated by rune
+// but padded by byte, so a multi-byte name pulled the border inward instead.
+func TestMessageListRowWidthIsExact(t *testing.T) {
+	sample := time.Date(2026, 9, 9, 5, 18, 0, 0, time.UTC)
+	cases := []struct {
+		name  string
+		entry MessageListEntry
+	}{
+		{"single digit", MessageListEntry{MsgNum: 7, Subject: "Hi", From: "a", To: "All", Date: sample}},
+		{"three digits", MessageListEntry{MsgNum: 375, Subject: "Hi", From: "a", To: "All", Date: sample}},
+		{"four digits", MessageListEntry{MsgNum: 3754, Subject: "Hi", From: "a", To: "All", Date: sample}},
+		{"five digits", MessageListEntry{MsgNum: 37541, Subject: "Hi", From: "a", To: "All", Date: sample}},
+		{"more digits than the column", MessageListEntry{MsgNum: 1234567, Subject: "Hi", From: "a", To: "All", Date: sample}},
+		{"zero date renders blank", MessageListEntry{MsgNum: 12, Subject: "Hi", From: "a", To: "All"}},
+		{"every field overlong", MessageListEntry{
+			MsgNum:  9999,
+			Subject: strings.Repeat("subject ", 20),
+			From:    strings.Repeat("sender ", 10),
+			To:      strings.Repeat("recipient ", 10),
+			Date:    sample,
+		}},
+		{"multi-byte fields", MessageListEntry{
+			MsgNum:  4242,
+			Subject: "Ünïcödé sübjéct with åccents everywhere",
+			From:    "Jörg Müller",
+			To:      "Renée",
+			Date:    sample,
+		}},
+	}
+
+	for _, mode := range []ansi.OutputMode{ansi.OutputModeUTF8, ansi.OutputModeCP437} {
+		for _, tc := range cases {
+			for _, hl := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/%v/hl=%v", tc.name, mode, hl), func(t *testing.T) {
+					ts := newTestSession("")
+					terminal := newTestTerminal(ts)
+					if err := drawMessageListLine(terminal, tc.entry, hl, mode); err != nil {
+						t.Fatalf("drawMessageListLine: %v", err)
+					}
+					line := strings.TrimRight(strings.Split(ts.output(), "\n")[0], "\r")
+					stripped := testAnsiEscape.ReplaceAllString(line, "")
+					if got := utf8.RuneCountInString(stripped); got != 79 {
+						t.Errorf("row width = %d runes, want 79\n%q", got, stripped)
+					}
+				})
+			}
+		}
+	}
+}
+
+// The header must line up with the rows it labels; it is built from the same
+// widths so that it cannot drift, and this pins that it did not.
+func TestMessageListHeaderMatchesRowWidth(t *testing.T) {
+	ts := newTestSession("")
+	terminal := newTestTerminal(ts)
+	state := &MessageListState{Entries: []MessageListEntry{}, CurrentPage: 1, ItemsPerPage: 5}
+	if err := drawMessageListScreen(terminal, state, "General", "Main", ansi.OutputModeUTF8); err != nil {
+		t.Fatalf("drawMessageListScreen: %v", err)
+	}
+	for _, line := range strings.Split(ts.output(), "\n") {
+		stripped := testAnsiEscape.ReplaceAllString(strings.TrimRight(line, "\r"), "")
+		if stripped == "" {
+			continue
+		}
+		if got := utf8.RuneCountInString(stripped); got != 79 {
+			t.Errorf("screen line is %d runes, want 79\n%q", got, stripped)
+		}
+	}
+}
+
+// The date column shows the message's own date, not today's.
+func TestMessageListShowsTheMessageDate(t *testing.T) {
+	ts := newTestSession("")
+	terminal := newTestTerminal(ts)
+	entry := MessageListEntry{
+		MsgNum: 42, Subject: "Hi", From: "a", To: "All",
+		Date: time.Date(2019, 3, 7, 12, 0, 0, 0, time.UTC),
+	}
+	if err := drawMessageListLine(terminal, entry, false, ansi.OutputModeUTF8); err != nil {
+		t.Fatalf("drawMessageListLine: %v", err)
+	}
+	stripped := testAnsiEscape.ReplaceAllString(ts.output(), "")
+	if !strings.Contains(stripped, "03/07/19") {
+		t.Errorf("row does not carry the message date 03/07/19:\n%q", stripped)
 	}
 }

--- a/internal/menu/message_list_test.go
+++ b/internal/menu/message_list_test.go
@@ -1,6 +1,7 @@
 package menu
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -485,5 +486,62 @@ func TestMessageListShowsTheMessageDate(t *testing.T) {
 	stripped := testAnsiEscape.ReplaceAllString(ts.output(), "")
 	if !strings.Contains(stripped, "03/07/19") {
 		t.Errorf("row does not carry the message date 03/07/19:\n%q", stripped)
+	}
+}
+
+// In CP437 mode the row must carry real CP437 bytes, not replacement
+// characters.
+//
+// toCP437Safe emits one byte per rune, and CP437's high bytes are not valid
+// UTF-8. Converting before truncating meant TruncateRunes decoded those bytes,
+// turned every accented character into U+FFFD, and left the column count
+// correct — so a width check passed over corrupted text. é (0x82) came out as
+// ef bf bd.
+func TestMessageListCP437FieldsSurviveTruncation(t *testing.T) {
+	entry := MessageListEntry{
+		MsgNum:  1234,
+		Subject: "Café Ñoño über Grüße and more text than the column can hold",
+		From:    "Jörg Müller with an overlong name",
+		To:      "Renée",
+		Date:    time.Date(2026, 9, 9, 5, 0, 0, 0, time.UTC),
+	}
+
+	ts := newTestSession("")
+	terminal := newTestTerminal(ts)
+	if err := drawMessageListLine(terminal, entry, false, ansi.OutputModeCP437); err != nil {
+		t.Fatalf("drawMessageListLine: %v", err)
+	}
+	out := []byte(ts.output())
+
+	// Compare bytes, not runes. Ranging a Go string over CP437's high bytes
+	// yields RuneError for each one, so a rune-level check for U+FFFD cannot
+	// tell a corrupted character from a correctly encoded é.
+	if bytes.Contains(out, []byte{0xef, 0xbf, 0xbd}) {
+		t.Error("row contains an encoded U+FFFD: CP437 bytes were decoded as UTF-8 somewhere")
+	}
+	// 0x82 is é in CP437, 0xa5 is ñ. Both must reach the terminal as one byte.
+	for _, b := range []byte{0x82, 0xa5} {
+		if !bytes.Contains(out, []byte{b}) {
+			t.Errorf("row lost the CP437 byte %#x:\n% x", b, out)
+		}
+	}
+}
+
+// The same subject in UTF-8 mode keeps its accents as UTF-8.
+func TestMessageListUTF8FieldsKeepAccents(t *testing.T) {
+	entry := MessageListEntry{
+		MsgNum: 1234, Subject: "Café Ñoño über", From: "Jörg", To: "Renée",
+		Date: time.Date(2026, 9, 9, 5, 0, 0, 0, time.UTC),
+	}
+	ts := newTestSession("")
+	terminal := newTestTerminal(ts)
+	if err := drawMessageListLine(terminal, entry, false, ansi.OutputModeUTF8); err != nil {
+		t.Fatalf("drawMessageListLine: %v", err)
+	}
+	out := ts.output()
+	for _, want := range []string{"Café", "Jörg", "Renée"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("row lost %q in UTF-8 mode", want)
+		}
 	}
 }


### PR DESCRIPTION
Closes #257.

## The 4-digit number problem

The number column was `"%3d"`. **fmt's width is a minimum, not a maximum**, so message 1000 rendered four columns in a three-column slot and pushed everything after it one place right:

```
msgnum 375     row width = 79 runes
msgnum 3754    row width = 80 runes   <-- right border outside the frame
msgnum 37541   row width = 81 runes
```

The row grew past the 79-column frame and the right border stepped outside it. On an area with thousands of messages that is *every row on screen*, which is what the screenshot in the issue shows.

The other fields had the **mirror-image bug**: truncated by rune via `truncateString`, but padded by byte via `%-Ns`. A multi-byte sender name padded short and pulled the border inward instead.

## The fix

Every cell is now built to an exact rune width, so a row is 77 columns **by construction** rather than by the inputs happening to behave. A number too wide for its column keeps its leading digits rather than widening the row — the frame holding is worth more than the last digit of a six-figure label, and the reader shows the number in full anyway.

## The date column

From the message's own `DateTime`, formatted `01/02/06` to match the reader's existing date substitution (`message_reader_subst.go:157`). A zero time — what a message with no usable date carries — renders blank rather than as year 1.

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                        Main > BBS Ads - Message List                        │
├─────────────────────────────────────────────────────────────────────────────┤
│    N# Subject                         From             To          Date     │
├─────────────────────────────────────────────────────────────────────────────┤
│  3754 Wrong Number PC/Amiga/Linux ... Wrong Number ... All         09/08/26 │
│N 3753 [ANSI] Anime BBS                Shurato          All         09/07/26 │
│  3752 TheForze [New Files]            opicron          All         09/06/26 │
│P 3748 2o fOr beeRS bbS                paulie420        All         09/02/26 │
│  3745 K4JTT BBS                       Jafo             All         08/30/26 │
├─────────────────────────────────────────────────────────────────────────────┤
│                    Page 1 of 752 [1-5 of 3759 messages]                     │
└─────────────────────────────────────────────────────────────────────────────┘
```

Interior 77: status 1, number 5, subject 31, from 16, to 11, date 8, plus five single-space separators. The last is a trailing space so the date does not butt against the right border, the way the status column keeps the number off the left one.

## Keeping it from drifting again

The **column header is generated from the same constants** as the rows, so the two cannot disagree. `TestMessageListColumnWidthsFillTheFrame` fails if the widths stop summing to the interior — nothing enforces that at compile time, and getting it wrong moves the border on message rows only, so the frame looks torn rather than simply narrow.

## Tests

32 cases asserting a row is exactly 79 columns: 1 through 7 digit message numbers, overlong fields, multi-byte fields, a zero date, both output modes, both highlight states. Plus every line of the drawn screen at 79, and that the date shown is the message's rather than today's.

Full suite, `-race` on `internal/menu`, `go vet`, `gofmt`, `golangci-lint`, `git diff --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWTB1hR7kAkbdjEqnWvAh9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected message-list rows so each message displays its own date.
  - Improved handling of long and multibyte text to prevent misaligned columns.
  - Ensured message numbers remain properly formatted within the available space.

- **Improvements**
  - Standardized message-list column widths and row layout for consistent alignment.
  - Improved highlighted and normal row rendering so screen lines maintain a uniform width.
  - Blank dates now display cleanly when no date is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->