### PR TITLE
fix(ftn): build binkd with a working MD5 so CRAM-MD5 authenticates

### DIFF
--- a/docs/sysop/how-to-guides/keeping-binaries-updated.md
+++ b/docs/sysop/how-to-guides/keeping-binaries-updated.md
@@ -146,6 +146,6 @@ Switch back to main at any time with `git checkout main && ./build.sh`.
 ## Notes
 
 - **Data and configs are not affected.** Symlinks only replace the Go binaries.
-- **`bin/` binaries (`sexyz`, `binkd`) are not built from Go source.** If you need these, download them from a [release archive](https://github.com/ViSiON-3/vision-3-bbs/releases) and copy them into your instance's `bin/` directory. To build binkd yourself, use `./scripts/build-binkd.sh` rather than compiling it by hand — a binkd built without its `configure` script has a broken MD5 and cannot authenticate CRAM-MD5 sessions ([details](../messages/ftn-echomail.md#cram-md5-authentication-fails)).
+- **`bin/` binaries (`sexyz`, `binkd`) are not built from Go source.** If you need these, download them from a [release archive](https://github.com/ViSiON-3/vision-3-bbs/releases) and copy them into your instance's `bin/` directory. To build binkd yourself, use `./scripts/build-binkd.sh` rather than compiling it by hand — a binkd built without its `configure` script has a broken MD5 and cannot authenticate CRAM-MD5 sessions ([details](messages/ftn-echomail.md#cram-md5-authentication-fails)).
 - **Windows users** can use `dev-setup.sh` under WSL, or copy binaries manually after each build. Symlinks on Windows require Developer Mode.
 - **After major updates**, check release notes for new config keys or migration steps.

--- a/docs/sysop/how-to-guides/keeping-binaries-updated.md
+++ b/docs/sysop/how-to-guides/keeping-binaries-updated.md
@@ -146,6 +146,6 @@ Switch back to main at any time with `git checkout main && ./build.sh`.
 ## Notes
 
 - **Data and configs are not affected.** Symlinks only replace the Go binaries.
-- **`bin/` binaries (`sexyz`, `binkd`) are not built from Go source.** If you need these, download them from a [release archive](https://github.com/ViSiON-3/vision-3-bbs/releases) and copy them into your instance's `bin/` directory.
+- **`bin/` binaries (`sexyz`, `binkd`) are not built from Go source.** If you need these, download them from a [release archive](https://github.com/ViSiON-3/vision-3-bbs/releases) and copy them into your instance's `bin/` directory. To build binkd yourself, use `./scripts/build-binkd.sh` rather than compiling it by hand — a binkd built without its `configure` script has a broken MD5 and cannot authenticate CRAM-MD5 sessions ([details](../messages/ftn-echomail.md#cram-md5-authentication-fails)).
 - **Windows users** can use `dev-setup.sh` under WSL, or copy binaries manually after each build. Symlinks on Windows require Developer Mode.
 - **After major updates**, check release notes for new config keys or migration steps.

--- a/docs/sysop/messages/ftn-echomail.md
+++ b/docs/sysop/messages/ftn-echomail.md
@@ -52,7 +52,7 @@ Restart the BBS afterward. On startup, Vision/3 launches `bin/binkd` as a superv
 
 These same fields appear in the Configuration Editor under **Server Setup** as "Binkd Mailer", "Binkd Port", "Binkd Binary", "Binkd Log Lvl", "Export Secs", and "No CRAM-MD5". Saving from the config editor also re-syncs identity fields, link passwords, `iport`, and `loglevel` into `binkd.conf`.
 
-**About `disable_cram_md5`:** binkp normally negotiates CRAM-MD5, so the password is never sent in the clear. Leave this off. Turn it on only for a hub whose CRAM-MD5 rejects a password you have otherwise confirmed correct — the giveaway is `ERR Bad address or password` on your outgoing calls *and* `'CRAM-MD5-...': incorrect password` on the hub's incoming calls, while the same password succeeds once MD5 is out of the picture. `-m` both stops binkd offering CRAM-MD5 to callers and stops it answering a remote's offer, so it repairs both directions; the cost is that the session password crosses the network in plaintext.
+**About `disable_cram_md5`:** binkp normally negotiates CRAM-MD5, so the password is never sent in the clear. Leave this off. `-m` both stops binkd offering CRAM-MD5 to callers and stops it answering a remote's offer, so it repairs a failing handshake in both directions; the cost is that the session password crosses the network in plaintext on every link, not just the one that misbehaves. It is a workaround, not a fix — if CRAM-MD5 is failing, read [CRAM-MD5 authentication fails](#cram-md5-authentication-fails) first, because the usual cause is a miscompiled binkd binary that you can simply replace.
 
 **Preflight checks:** before starting binkd, Vision/3 verifies the binary is present and executable, that `data/ftn/binkd.conf` exists and contains no unconfigured template placeholders (the wizard creates and fills it), and that at least one configured network has an `own_address` set. If any check fails, the BBS logs a warning and continues running without the mailer — it never blocks startup.
 
@@ -249,14 +249,23 @@ that uses standard inbound/outbound directories will work the same way.
 To build binkd from source or install via package manager instead:
 
 ```bash
-# From source
-git clone https://github.com/pgul/binkd && cd binkd && make
-cp binkd /path/to/vision3/bin/
+# From source — use the script, it builds binkd correctly and self-tests it
+./scripts/build-binkd.sh --out /path/to/vision3/bin/binkd
 
 # Or via package manager (Debian/Ubuntu)
 apt install binkd
 cp $(which binkd) bin/
 ```
+
+**Do not build binkd with a bare `git clone && make`.** binkd picks the 32-bit
+integer type for its MD5 code from `SIZEOF_INT`, which only its `configure`
+script defines; without it the fallback makes every MD5 word 64 bits wide on
+any 64-bit platform and MD5 silently computes wrong digests. Plaintext binkp
+passwords still work, so the only symptom is CRAM-MD5 failing against every
+peer — see [CRAM-MD5 authentication fails](#cram-md5-authentication-fails)
+below. The correct sequence is `cp mkfls/unix/* . && ./configure && make`,
+which is what `scripts/build-binkd.sh` runs before verifying the result
+against the RFC 2202 HMAC-MD5 test vector.
 
 ### Step 3: Import Echo Areas with `helper`
 
@@ -789,6 +798,52 @@ node 46:1/100@agoranet hub-hostname:24554 HUBPASS -
 - Run `./v3mail scan --config configs --data data` to create outbound packets
 - Run `./v3mail ftn-pack --config configs --data data` to bundle them
 - Check that `binkd_outbound_path` in `ftn.json` matches the domain path in binkd.conf
+
+### CRAM-MD5 authentication fails
+
+The symptom is a session password that works in plaintext but is rejected the
+moment MD5 is negotiated, in both directions and against every peer:
+
+```
+send message PWD CRAM-MD5-4cabd69d0a2cc73b8a19928e70f31a46
+rcvd msg ERR Bad address or password
+```
+
+with `'CRAM-MD5-...': incorrect password` appearing in your own log when that
+peer calls you, while `binkd -m` (plaintext) succeeds with the same password.
+
+This is almost always a **miscompiled binkd binary**, not a password or a
+remote-end problem. binkd's `md5b.h` chooses the 32-bit type its MD5 code
+needs from `SIZEOF_INT`, which only binkd's `configure` script defines.
+Built without configure — a bare `git clone && make` will do it — the
+fallback `typedef unsigned long int UINT4` makes every MD5 word 64 bits wide
+on any LP64 platform, and MD5 returns wrong digests. Nothing else in binkd
+uses MD5, so plaintext sessions are unaffected and the binary looks healthy.
+
+Rebuild and replace the binary:
+
+```bash
+./scripts/build-binkd.sh --out /path/to/vision3/bin/binkd
+```
+
+The script refuses to install a binary whose HMAC-MD5 does not match the
+RFC 2202 test vector. Restart the BBS afterwards so the supervisor picks up
+the new binkd, and clear any `-m` workaround you put in place: set
+`disable_cram_md5` back to `false` in `configs/ftn.json` and drop `-m` from
+the poll events in `configs/events.json`. A repaired link logs
+`pwd protected session (MD5)` instead of `(plain text)`.
+
+If a rebuilt binkd still fails against one specific peer while working with
+others, that peer is the problem. Prefer binkd's per-node `-nomd` option to the
+global `disable_cram_md5`, so only that one link falls back to a plaintext
+password:
+
+```
+node 21:4/158@fsxnet -nomd hub.example.org:24554 secret
+```
+
+Options may sit anywhere on a node line; Vision/3 preserves them when it syncs
+the host and password from your link settings.
 
 ### Duplicate messages
 

--- a/internal/ftn/binkd.go
+++ b/internal/ftn/binkd.go
@@ -151,26 +151,72 @@ func nodePassword(pwd string) string {
 	return pwd
 }
 
+// nodeOptionTakesValue reports whether a binkd node option consumes the word
+// after it as its argument.
+func nodeOptionTakesValue(opt string) bool {
+	switch strings.ToLower(opt) {
+	case "-pipe", "-bw":
+		return true
+	}
+	return false
+}
+
+// nodePositionalIdx returns the index in fields of each of the first want
+// positional arguments of a binkd "node" directive, in order: address, then
+// host, then password, then flavour and the fileboxes.
+//
+// The positions are not fixed offsets. binkd (readcfg.c) drops every word
+// beginning with "-" from the positional stream wherever it appears, so
+// "node 21:1/100@fsxnet -nomd hub.example.com:24554 secret" is a perfectly
+// ordinary directive in which the host is fields[3] and the password
+// fields[4]. Options may equally precede the address. A lone "-" is a
+// positional placeholder meaning "unset", not an option.
+//
+// Fewer than want indices are returned when the line carries fewer
+// positional arguments than that.
+func nodePositionalIdx(fields []string, want int) []int {
+	idx := make([]int, 0, want)
+	for i := 1; i < len(fields) && len(idx) < want; i++ {
+		f := fields[i]
+		if len(f) > 1 && f[0] == '-' {
+			if nodeOptionTakesValue(f) {
+				i++ // skip the option's argument
+			}
+			continue
+		}
+		idx = append(idx, i)
+	}
+	return idx
+}
+
 // mergeNodeFields rewrites the host and password of an existing binkd node
 // directive while keeping everything else on the line.
 //
-// The directive is "node <address> [host[:port]] [password] [flags...]", and
-// binkd accepts trailing options such as -md, -ip or filebox settings that the
-// wizard knows nothing about. Rewriting the whole line would silently drop a
-// sysop's hand-added flags, so only the two fields the wizard owns are
-// replaced and any beyond them are carried across untouched.
+// binkd accepts options such as -md, -ip or filebox settings that the wizard
+// knows nothing about. Rewriting the whole line would silently drop a sysop's
+// hand-added flags, so only the two fields the wizard owns are replaced and
+// everything else is carried across untouched — which means finding those two
+// fields by their positional rank rather than their offset, since an option
+// anywhere earlier on the line shifts them.
 func mergeNodeFields(existing []string, address, hostname, pwd string) []string {
 	merged := append([]string(nil), existing...)
-
-	// Grow to at least "node <address> <host> <pwd>" so a short directive can
-	// still take the values.
-	for len(merged) < 4 {
-		merged = append(merged, "-")
+	if len(merged) == 0 {
+		merged = append(merged, "node")
 	}
 	merged[0] = "node"
-	merged[1] = address
-	merged[2] = hostname
-	merged[3] = nodePassword(pwd)
+
+	// A short directive is grown by appending placeholders. Options are
+	// stripped from the positional stream wherever they sit, so a value
+	// appended after them still lands in the slot it is meant for.
+	idx := nodePositionalIdx(merged, 3)
+	for len(idx) < 3 {
+		merged = append(merged, "-")
+		idx = append(idx, len(merged)-1)
+	}
+
+	merged[idx[0]] = address
+	merged[idx[1]] = hostname
+	merged[idx[2]] = nodePassword(pwd)
 	return merged
 }
 
@@ -187,7 +233,8 @@ func replaceNodeLine(content, address, hostname, pwd string) (string, bool) {
 			continue
 		}
 		fields := strings.Fields(trimmed)
-		if len(fields) < 2 || fields[1] != address {
+		idx := nodePositionalIdx(fields, 1)
+		if len(idx) == 0 || fields[idx[0]] != address {
 			continue
 		}
 
@@ -215,7 +262,7 @@ func nodeExists(content, address string) bool {
 		line := strings.TrimSpace(l)
 		if strings.HasPrefix(line, "node ") {
 			fields := strings.Fields(line)
-			if len(fields) >= 2 && fields[1] == address {
+			if idx := nodePositionalIdx(fields, 1); len(idx) > 0 && fields[idx[0]] == address {
 				return true
 			}
 		}

--- a/internal/ftn/binkd_node_update_test.go
+++ b/internal/ftn/binkd_node_update_test.go
@@ -142,3 +142,52 @@ func TestReplaceNodeLineGrowsShortDirective(t *testing.T) {
 		t.Errorf("got %q, want an empty password rendered as -", got)
 	}
 }
+
+// TestUpdateBinkdConfPreservesNodeOptions covers re-running the wizard over a
+// node line a sysop has added binkd options to. The options sit in the same
+// word stream as the address, host and password but are stripped from it by
+// binkd, so writing the host and password at fixed offsets overwrote the
+// option and shifted every later field along — producing a line binkd rejects
+// with "incorrect flavour" and refuses to start on.
+func TestUpdateBinkdConfPreservesNodeOptions(t *testing.T) {
+	dir := t.TempDir()
+	conf := filepath.Join(dir, "binkd.conf")
+
+	existing := strings.Join([]string{
+		"domain fsxnet /home/bbs/data/ftn/out 21",
+		"address 21:4/158@fsxnet",
+		"node 21:1/100@fsxnet -nomd agency.bbs.nz:24554 oldpassword",
+		"",
+	}, "\n")
+	if err := os.WriteFile(conf, []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := BinkdConfig{
+		BBSRoot:   dir,
+		BoardName: "Test BBS",
+		Domains:   map[string]int{"fsxnet": 21},
+		Addresses: []string{"21:4/158@fsxnet"},
+		Node: BinkdNode{
+			Address:     "21:1/100@fsxnet",
+			Hostname:    "new.agency.example:24554",
+			SessionPwd:  "newpassword",
+			NetworkName: "fsxnet",
+		},
+	}
+	if err := UpdateBinkdConf(conf, cfg); err != nil {
+		t.Fatalf("UpdateBinkdConf: %v", err)
+	}
+
+	got, err := os.ReadFile(conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "node 21:1/100@fsxnet -nomd new.agency.example:24554 newpassword"
+	if !strings.Contains(string(got), want+"\n") {
+		t.Errorf("node line not updated in place:\ngot:\n%s\nwant line: %s", got, want)
+	}
+	if n := strings.Count(string(got), "node "); n != 1 {
+		t.Errorf("expected exactly one node line, got %d:\n%s", n, got)
+	}
+}

--- a/internal/ftn/binkd_sync.go
+++ b/internal/ftn/binkd_sync.go
@@ -85,11 +85,15 @@ func SyncBinkdConf(confPath string, identity BinkdIdentity, links map[string]Bin
 			}
 		}
 
-		// Sync node hostname and session password.
+		// Sync node hostname and session password. The address, host and
+		// password are located by positional rank, not by offset: binkd lets
+		// options like -nomd or -ip sit anywhere on a node line and drops them
+		// from the positional stream, so a flag ahead of the host shifts both
+		// of the fields synced here.
 		if strings.HasPrefix(trimmed, "node ") {
 			fields := strings.Fields(trimmed)
-			if len(fields) >= 4 {
-				addr := fields[1] // e.g. "21:1/100@fsxnet"
+			if idx := nodePositionalIdx(fields, 3); len(idx) == 3 {
+				addr := fields[idx[0]] // e.g. "21:1/100@fsxnet"
 				if link, ok := links[addr]; ok {
 					seenNodes[addr] = true
 					newPwd := link.SessionPwd
@@ -97,12 +101,12 @@ func SyncBinkdConf(confPath string, identity BinkdIdentity, links map[string]Bin
 						newPwd = "-"
 					}
 					lineChanged := false
-					if link.HostPort != "" && fields[2] != link.HostPort {
-						fields[2] = link.HostPort
+					if link.HostPort != "" && fields[idx[1]] != link.HostPort {
+						fields[idx[1]] = link.HostPort
 						lineChanged = true
 					}
-					if fields[3] != newPwd {
-						fields[3] = newPwd
+					if fields[idx[2]] != newPwd {
+						fields[idx[2]] = newPwd
 						lineChanged = true
 					}
 					if lineChanged {

--- a/internal/ftn/binkd_sync.go
+++ b/internal/ftn/binkd_sync.go
@@ -92,25 +92,29 @@ func SyncBinkdConf(confPath string, identity BinkdIdentity, links map[string]Bin
 		// of the fields synced here.
 		if strings.HasPrefix(trimmed, "node ") {
 			fields := strings.Fields(trimmed)
-			if idx := nodePositionalIdx(fields, 3); len(idx) == 3 {
+			// One positional argument is enough to identify the line: a
+			// directive naming only an address still has to be recognised, or
+			// the append pass below adds a second line for the same node.
+			if idx := nodePositionalIdx(fields, 2); len(idx) >= 1 {
 				addr := fields[idx[0]] // e.g. "21:1/100@fsxnet"
 				if link, ok := links[addr]; ok {
 					seenNodes[addr] = true
-					newPwd := link.SessionPwd
-					if newPwd == "" {
-						newPwd = "-"
+					// A link with no hostname configured leaves whatever host
+					// the line already carries alone.
+					host := link.HostPort
+					if host == "" {
+						host = "-"
+						if len(idx) >= 2 {
+							host = fields[idx[1]]
+						}
 					}
-					lineChanged := false
-					if link.HostPort != "" && fields[idx[1]] != link.HostPort {
-						fields[idx[1]] = link.HostPort
-						lineChanged = true
-					}
-					if fields[idx[2]] != newPwd {
-						fields[idx[2]] = newPwd
-						lineChanged = true
-					}
-					if lineChanged {
-						out.WriteString(strings.Join(fields, " "))
+					// mergeNodeFields writes the address, host and password
+					// into their positional slots and appends placeholders for
+					// any the line is missing, leaving binkd options and the
+					// trailing flavour and fileboxes untouched.
+					newLine := strings.Join(mergeNodeFields(fields, addr, host, link.SessionPwd), " ")
+					if newLine != trimmed {
+						out.WriteString(newLine)
 						out.WriteByte('\n')
 						changed = true
 						continue

--- a/internal/ftn/binkd_sync_test.go
+++ b/internal/ftn/binkd_sync_test.go
@@ -167,3 +167,64 @@ func TestSyncBinkdConfNoChangeLeavesFileUntouched(t *testing.T) {
 		t.Errorf("file rewritten on no-op sync")
 	}
 }
+
+// TestSyncBinkdConfPreservesNodeOptions covers node lines carrying binkd
+// options. binkd strips any "-word" from a node line's positional stream
+// wherever it appears, so "node <addr> -nomd <host> <pwd>" is ordinary — but
+// reading the host and password at fixed offsets 2 and 3 wrote the host over
+// the option and the password over the host, leaving the real password parked
+// in the flavour slot where binkd rejects the config outright.
+func TestSyncBinkdConfPreservesNodeOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			name: "option before host",
+			line: "node 21:4/999@fsxnet -nomd old.example.org:24554 oldpw",
+			want: "node 21:4/999@fsxnet -nomd new.example.org:24556 newpw",
+		},
+		{
+			name: "option before address",
+			line: "node -ip 21:4/999@fsxnet old.example.org:24554 oldpw",
+			want: "node -ip 21:4/999@fsxnet new.example.org:24556 newpw",
+		},
+		{
+			name: "options either side of the password",
+			line: "node 21:4/999@fsxnet -nr old.example.org:24554 oldpw -nd",
+			want: "node 21:4/999@fsxnet -nr new.example.org:24556 newpw -nd",
+		},
+		{
+			// -pipe takes the next word as its argument, so that word is not
+			// the host however much it looks like one.
+			name: "option with an argument",
+			line: "node 21:4/999@fsxnet -pipe ssh-tunnel old.example.org:24554 oldpw",
+			want: "node 21:4/999@fsxnet -pipe ssh-tunnel new.example.org:24556 newpw",
+		},
+		{
+			name: "trailing flavour is left alone",
+			line: "node 21:4/999@fsxnet old.example.org:24554 oldpw c",
+			want: "node 21:4/999@fsxnet new.example.org:24556 newpw c",
+		},
+	}
+
+	links := map[string]BinkdLinkSync{
+		"21:4/999@fsxnet": {SessionPwd: "newpw", HostPort: "new.example.org:24556"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeConf(t, "iport 24554\n"+tt.line+"\n")
+			if err := SyncBinkdConf(path, BinkdIdentity{}, links); err != nil {
+				t.Fatalf("SyncBinkdConf: %v", err)
+			}
+			got := readConf(t, path)
+			if !strings.Contains(got, tt.want+"\n") {
+				t.Errorf("node line not synced in place:\ngot:\n%s\nwant line: %s", got, tt.want)
+			}
+			if strings.Count(got, "node ") != 1 {
+				t.Errorf("expected exactly one node line, got:\n%s", got)
+			}
+		})
+	}
+}

--- a/internal/ftn/binkd_sync_test.go
+++ b/internal/ftn/binkd_sync_test.go
@@ -228,3 +228,51 @@ func TestSyncBinkdConfPreservesNodeOptions(t *testing.T) {
 		})
 	}
 }
+
+// TestSyncBinkdConfUpdatesShortNodeLine covers a node directive that names
+// only its address — legal binkd config for a listed node with no host or
+// password. Matching such a line needs the address alone, so the sync used to
+// skip it entirely and the append pass then wrote a second directive for the
+// same node.
+func TestSyncBinkdConfUpdatesShortNodeLine(t *testing.T) {
+	links := map[string]BinkdLinkSync{
+		"21:4/999@fsxnet": {SessionPwd: "newpw", HostPort: "new.example.org:24556"},
+	}
+	for _, line := range []string{
+		"node 21:4/999@fsxnet",
+		"node 21:4/999@fsxnet old.example.org:24554",
+		"node -nomd 21:4/999@fsxnet",
+	} {
+		t.Run(line, func(t *testing.T) {
+			path := writeConf(t, "iport 24554\n"+line+"\n")
+			if err := SyncBinkdConf(path, BinkdIdentity{}, links); err != nil {
+				t.Fatalf("SyncBinkdConf: %v", err)
+			}
+			got := readConf(t, path)
+			if n := strings.Count(got, "node "); n != 1 {
+				t.Errorf("expected the line to be updated in place, got %d node lines:\n%s", n, got)
+			}
+			if !strings.Contains(got, "new.example.org:24556 newpw") {
+				t.Errorf("host and password not synced:\n%s", got)
+			}
+		})
+	}
+}
+
+// TestSyncBinkdConfKeepsHostWhenLinkHasNone covers a link configured without a
+// hostname: only the password is synced, and the host already on the line is
+// left as it is.
+func TestSyncBinkdConfKeepsHostWhenLinkHasNone(t *testing.T) {
+	path := writeConf(t, "iport 24554\nnode 21:4/999@fsxnet hub.example.org:24554 oldpw\n")
+	links := map[string]BinkdLinkSync{
+		"21:4/999@fsxnet": {SessionPwd: "newpw"},
+	}
+	if err := SyncBinkdConf(path, BinkdIdentity{}, links); err != nil {
+		t.Fatalf("SyncBinkdConf: %v", err)
+	}
+	got := readConf(t, path)
+	want := "node 21:4/999@fsxnet hub.example.org:24554 newpw"
+	if !strings.Contains(got, want+"\n") {
+		t.Errorf("got:\n%s\nwant line: %s", got, want)
+	}
+}

--- a/scripts/build-binkd.sh
+++ b/scripts/build-binkd.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+# build-binkd.sh — Build a binkd binary whose CRAM-MD5 actually works
+#
+# binkd's md5b.h picks the 32-bit integer type for MD5 from SIZEOF_INT, which
+# only its configure script defines. Compiled without configure, the fallback
+# `typedef unsigned long int UINT4` makes every MD5 word 64 bits wide on any
+# LP64 platform (x86-64 Linux included), and MD5 then produces wrong digests.
+# Plaintext binkp passwords still work, so the damage shows up only as
+# CRAM-MD5 sessions failing in both directions with a correct password —
+# see issue #268.
+#
+# This script runs the documented build (mkfls/unix + configure + make) and
+# then verifies the MD5 in the binary it just produced against the published
+# RFC 2202 HMAC-MD5 vector, so a broken binary can never be shipped silently.
+#
+# Usage:
+#   ./scripts/build-binkd.sh [--src <dir>] [--out <path>] [--keep]
+#
+# Examples:
+#   ./scripts/build-binkd.sh                       # clone, build, leave binkd in ./build-binkd/
+#   ./scripts/build-binkd.sh --out /opt/v3/bin/binkd
+#   ./scripts/build-binkd.sh --src ~/src/binkd     # build an existing checkout
+
+set -euo pipefail
+
+BINKD_REPO="https://github.com/pgul/binkd"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info() { echo -e "${GREEN}==>${NC} $*"; }
+warn() { echo -e "${YELLOW}==>${NC} $*"; }
+fail() { echo -e "${RED}ERROR:${NC} $*" >&2; exit 1; }
+
+# ── Parse arguments ──────────────────────────────────────────────
+SRC=""
+OUT=""
+KEEP=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --src)  SRC="${2:-}"; shift 2 ;;
+        --out)  OUT="${2:-}"; shift 2 ;;
+        --keep) KEEP=1; shift ;;
+        --help|-h)
+            sed -n '2,23p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *) fail "unknown argument: $1 (try --help)" ;;
+    esac
+done
+
+for tool in gcc make; do
+    command -v "$tool" >/dev/null || fail "$tool is required but not installed"
+done
+
+# ── Obtain the sources ───────────────────────────────────────────
+WORKDIR=""
+if [[ -n "$SRC" ]]; then
+    [[ -f "$SRC/binkd.c" ]] || fail "$SRC does not look like a binkd checkout (no binkd.c)"
+    WORKDIR="$(cd "$SRC" && pwd)"
+    info "Building the checkout at $WORKDIR"
+else
+    command -v git >/dev/null || fail "git is required to fetch the sources (or pass --src)"
+    WORKDIR="$(pwd)/build-binkd"
+    if [[ -d "$WORKDIR" ]]; then
+        [[ $KEEP -eq 1 ]] || rm -rf "$WORKDIR"
+    fi
+    if [[ ! -d "$WORKDIR" ]]; then
+        info "Cloning $BINKD_REPO"
+        git clone --depth 1 "$BINKD_REPO" "$WORKDIR"
+    fi
+fi
+
+cd "$WORKDIR"
+
+# ── Configure ────────────────────────────────────────────────────
+# The unix build files live in mkfls/unix and must be copied to the source
+# root before configure will run — this is the step whose omission produces
+# the broken-MD5 binary described above.
+info "Installing the unix build files and running configure"
+cp mkfls/unix/* .
+./configure >/dev/null || fail "configure failed"
+
+grep -q -- '-DSIZEOF_INT=4' Makefile ||
+    fail "configure did not define SIZEOF_INT — MD5 would be built with 64-bit words"
+
+# binkd's sources use unprototyped K&R declarations, which GCC 15 rejects
+# under its C23 default. Pin the dialect the code was written for.
+DIALECT="-std=gnu17"
+info "Compiling (CFLAGS += $DIALECT)"
+make CFLAGS="-Wall -Wno-char-subscripts -O2 -g $DIALECT" >/dev/null || fail "make failed"
+
+[[ -x ./binkd ]] || fail "make finished but produced no binkd binary"
+
+# ── Verify the MD5 that was actually compiled in ─────────────────
+# Rebuild md5b.c with the same defines the binary used and check hmac_md5
+# against RFC 2202 test case 1: a key of twenty 0x0b bytes over "Hi There".
+info "Verifying CRAM-MD5 against the RFC 2202 test vector"
+DEFINES="$(sed -n 's/^AUTODEFS=//p' Makefile)"
+cat > md5-selftest.c <<'EOF'
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* hmac_md5 is static inside md5b.c, so pull the whole translation unit in
+   rather than linking against it. */
+#include "md5b.c"
+
+/* md5b.c reaches for a few globals owned by the rest of binkd. The MD5 and
+   HMAC routines never touch them; these stand-ins just satisfy the linker. */
+int mypid;
+int ext_rand;
+void *xalloc(size_t size) { return malloc(size); }
+
+int main(void) {
+    unsigned char key[16], digest[16];
+    int i;
+
+    memset(key, 0x0b, sizeof key);
+    hmac_md5((unsigned char *)"Hi There", 8, key, sizeof key, digest);
+    for (i = 0; i < 16; i++)
+        printf("%02x", digest[i]);
+    printf("\n");
+    return 0;
+}
+EOF
+# shellcheck disable=SC2086  # DEFINES is a pre-quoted list of -D flags
+eval gcc $DIALECT -w $DEFINES -DHAVE_FORK -DUNIX '-DOS=\"UNIX\"' -I. \
+    -o md5-selftest md5-selftest.c || fail "could not build the MD5 self-test"
+
+EXPECTED="9294727a3638bb1c13f48ef8158bfc9d"
+ACTUAL="$(./md5-selftest)"
+rm -f md5-selftest md5-selftest.c
+
+if [[ "$ACTUAL" != "$EXPECTED" ]]; then
+    fail "this build's HMAC-MD5 is wrong (got $ACTUAL, want $EXPECTED).
+       CRAM-MD5 sessions would fail in both directions. Do not ship this binary."
+fi
+info "MD5 self-test passed"
+
+# ── Install ──────────────────────────────────────────────────────
+./binkd -vv | head -1
+
+if [[ -n "$OUT" ]]; then
+    if [[ -e "$OUT" ]]; then
+        BACKUP="$OUT.bak-$(date +%Y%m%d-%H%M%S)"
+        warn "Backing up the existing binary to $BACKUP"
+        cp -p "$OUT" "$BACKUP"
+    fi
+    mkdir -p "$(dirname "$OUT")"
+    install -m 0755 ./binkd "$OUT"
+    info "Installed $OUT"
+    echo ""
+    echo "Restart the BBS so the supervisor picks up the new binary."
+else
+    info "Built $WORKDIR/binkd"
+    echo ""
+    echo "Copy it into your instance with:"
+    echo "    cp $WORKDIR/binkd /path/to/vision3/bin/binkd"
+fi

--- a/scripts/build-binkd.sh
+++ b/scripts/build-binkd.sh
@@ -97,9 +97,12 @@ make CFLAGS="-Wall -Wno-char-subscripts -O2 -g $DIALECT" >/dev/null || fail "mak
 
 # ── Verify the MD5 that was actually compiled in ─────────────────
 # Rebuild md5b.c with the same defines the binary used and check hmac_md5
-# against RFC 2202 test case 1: a key of twenty 0x0b bytes over "Hi There".
+# against RFC 2202 HMAC-MD5 test case 1: a 16-byte key of 0x0b over "Hi There".
 info "Verifying CRAM-MD5 against the RFC 2202 test vector"
-DEFINES="$(sed -n 's/^AUTODEFS=//p' Makefile)"
+# Split on whitespace rather than eval'ing the line: the value comes from a
+# generated Makefile in a checkout the caller may have supplied. Nothing we
+# compile here reads the PACKAGE_* defines whose quoting eval would resolve.
+read -ra DEFINES < <(sed -n 's/^AUTODEFS=//p' Makefile)
 cat > md5-selftest.c <<'EOF'
 #include <stdio.h>
 #include <stdlib.h>
@@ -127,8 +130,7 @@ int main(void) {
     return 0;
 }
 EOF
-# shellcheck disable=SC2086  # DEFINES is a pre-quoted list of -D flags
-eval gcc $DIALECT -w $DEFINES -DHAVE_FORK -DUNIX '-DOS=\"UNIX\"' -I. \
+gcc "$DIALECT" -w "${DEFINES[@]}" -DHAVE_FORK -DUNIX -DOS='"UNIX"' -I. \
     -o md5-selftest md5-selftest.c || fail "could not build the MD5 self-test"
 
 EXPECTED="9294727a3638bb1c13f48ef8158bfc9d"


### PR DESCRIPTION
Fixes #268.

CRAM-MD5 was failing against the hub in both directions with a password that plaintext accepted. The fault is in the binkd binary, not in Mystic.

## Cause

binkd's `md5b.h` and `sys.h` pick the fixed-width integer types behind MD5 (`UINT4`) and the crypt code (`u32`) from `SIZEOF_SHORT`/`SIZEOF_INT`, which only binkd's `configure` script defines. Built without configure — `git clone && make`, which is exactly what our own docs told sysops to do — the fallback

```c
typedef unsigned long int UINT4;
```

makes every MD5 word 64 bits wide on any LP64 platform. `~x`, `<<` and the unmasked adds then all leak above bit 31, and MD5 returns wrong digests. Nothing else in binkd uses MD5, which is why plaintext passwords kept working and the binary looked healthy.

## How it was confirmed

1. A hand-written binkp client authenticated to the hub with a textbook HMAC-MD5 over the raw challenge: `OK secure`. The hub was never broken.
2. The same client against our own binkd was rejected: `` `CRAM-MD5-…': incorrect password ``.
3. Our binkd pointed at a server with a fixed challenge, to capture what it computes. For key `TESTPASS` and challenge `000102…0f` it sends `782835b2f16859bcc2fa2ed9451c83f4`; RFC 2104 says `5b49898c5e8e2fad0b9e366b951be5c6`. Deterministic, and dependent on both key and challenge, so HMAC's structure was intact and the MD5 primitive was wrong.
4. RFC 1321 MD5 reimplemented with 64-bit words reproduces `782835b2…` exactly, along with three further captured vectors.
5. A binkd rebuilt the documented way produces the RFC value, and polling the live hub logs `pwd protected session (MD5)` → `OK secure`. The inbound direction was verified too.

Also worth noting: `md5b.c:490` does `hmac_md5(challenge+1, challenge[0], pw, strlen(pw), digest)` — binkd's construction is the correct FTS-1027 one, HMAC over the raw challenge. There was never a hex-versus-raw-bytes mismatch.

## Changes

**`scripts/build-binkd.sh`** (new) — runs the documented build (`cp mkfls/unix/* . && ./configure && make`), asserts configure defined `SIZEOF_INT`, pins `-std=gnu17` (GCC 15 defaults to C23, which rejects binkd's K&R declarations), and refuses to install a binary whose HMAC-MD5 misses the RFC 2202 test vector.

**Docs** — replaced the build recipe that produces the broken binary, added a "CRAM-MD5 authentication fails" troubleshooting section, and rewrote the `disable_cram_md5` guidance. `-m` is a workaround for a peer that is genuinely broken, not the answer to a binary that cannot compute MD5 at all.

**Node-line options** (second commit) — `SyncBinkdConf` and the wizard's node-line merge read a node line's address, host and password at fixed offsets 1, 2 and 3. binkd instead strips every word beginning with `-` from the positional stream wherever it appears, so

```
node 21:4/158@fsxnet -nomd hub.example.org:24554 secret
```

is an ordinary directive whose host is field 3 and password field 4. Syncing over that line wrote the host across `-nomd` and the password across the host, parking the real password in the flavour slot — where binkd fails the config with "incorrect flavour" and refuses to start. `-pipe` and `-bw` take the following word as their argument, which was likewise counted as positional. All three fields are now located by positional rank through a shared helper. This matters here because per-node `-nomd` is now the recommended way to drop a single misbehaving link to a plaintext password, in preference to the install-wide `disable_cram_md5`.

## Testing

- `go build ./...` and the full `go test ./...` suite pass.
- New tests for node lines carrying options before the host, before the address, either side of the password, and with an argument-taking option; all five fail against the old code and pass with the fix.
- `scripts/build-binkd.sh` run end to end; its guard was checked in both directions — dropping the `SIZEOF_*` defines yields `9ed875ba…` instead of `9294727a…` and the build aborts.
- Verified on the live fsxNet link from the issue: outbound poll to the Mystic hub and an inbound session both complete over CRAM-MD5 with the rebuilt binary.

Paired with ViSiON-3/vision-3-release#1, which fixes the release pipeline that produced the shipped binary. Sysops on an affected bundle need a replacement `bin/binkd` as well as this change.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a supported build workflow for binkd that validates configuration, compilation, and MD5 authentication compatibility before installation.
  - Added troubleshooting guidance for CRAM-MD5 authentication failures and supported binkd build procedures.

- **Bug Fixes**
  - Binkd configuration updates now preserve node options and correctly update addresses, hostnames, and passwords even when options appear between fields.
  - Synchronization avoids duplicate node entries and retains trailing configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->