### PR TITLE
fix(helper): match commands case-insensitively and parse NA lists properly

### DIFF
--- a/cmd/helper/ftnsetup_na_test.go
+++ b/cmd/helper/ftnsetup_na_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeNA(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.na")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestParseNAFileSeparators covers the two shapes the published area lists
+// come in: a tag and description separated by whitespace alone, and the
+// dash-separated form tqwNet uses. The dash is a separator, not part of the
+// description — left in place it becomes the leading characters of the area
+// name every user sees.
+func TestParseNAFileSeparators(t *testing.T) {
+	areas, err := parseNAFile(writeNA(t, strings.Join([]string{
+		"% tqwNet Echo List",
+		"",
+		"FSX_GEN         General Chat + More..",
+		"TQW_ADS         - BBS Adverts",
+		"TQW_GEN     -   General Chat",
+		"; a semicolon comment",
+		"# a hash comment",
+	}, "\n")))
+	if err != nil {
+		t.Fatalf("parseNAFile: %v", err)
+	}
+	want := []naArea{
+		{Tag: "FSX_GEN", Description: "General Chat + More.."},
+		{Tag: "TQW_ADS", Description: "BBS Adverts"},
+		{Tag: "TQW_GEN", Description: "General Chat"},
+	}
+	if len(areas) != len(want) {
+		t.Fatalf("got %d areas, want %d: %+v", len(areas), len(want), areas)
+	}
+	for i, w := range want {
+		if areas[i] != w {
+			t.Errorf("area %d = %+v, want %+v", i, areas[i], w)
+		}
+	}
+}
+
+// TestParseNAFileRejectsFileEchoList covers pointing ftnsetup at a network's
+// *file* echo list, which is easy to do when both lists ship as ".na" and one
+// is named for the network. Every line begins with the literal word "Area", so
+// the old parser read the tag as "Area" on each and would have created that
+// many junk areas without a word of complaint.
+func TestParseNAFileRejectsFileEchoList(t *testing.T) {
+	_, err := parseNAFile(writeNA(t, strings.Join([]string{
+		"% ==================================",
+		"%  tqwNet Fileecho List",
+		"%",
+		"Area TQW_NODE\t\t0\t!\tWeekly Nodelists",
+		"Area TQW_INFO\t\t0\t!\tWeekly Infopacks",
+	}, "\n")))
+	if err == nil {
+		t.Fatal("expected an error for a file echo list, got none")
+	}
+	if !strings.Contains(err.Error(), "duplicate area tag") {
+		t.Errorf("error should name the duplicate tag, got: %v", err)
+	}
+}
+
+// TestParseNAFileSkipsPercentComments covers "%", which the published lists
+// use for their headers. A header line's first word parsed as a tag would
+// otherwise become an area.
+func TestParseNAFileSkipsPercentComments(t *testing.T) {
+	areas, err := parseNAFile(writeNA(t, strings.Join([]string{
+		"% File Echo                   Description",
+		"% ------------------------------------------",
+		"TQW_TEST        Test Echo",
+	}, "\n")))
+	if err != nil {
+		t.Fatalf("parseNAFile: %v", err)
+	}
+	if len(areas) != 1 || areas[0].Tag != "TQW_TEST" {
+		t.Errorf("got %+v, want the single TQW_TEST area", areas)
+	}
+}

--- a/cmd/helper/main.go
+++ b/cmd/helper/main.go
@@ -79,6 +79,8 @@ func main() {
 	// upper case, so a sysop who types what the help screen shows —
 	// `helper FTNSETUP` — was told "Unknown command" and shown that same
 	// screen again, with nothing to indicate the name had to be lower case.
+	// Errors quote os.Args[1] rather than cmd, so a typo is echoed back as the
+	// sysop typed it.
 	cmd := strings.ToLower(os.Args[1])
 	if cmd == "--version" || cmd == "-version" {
 		printHeader()
@@ -99,7 +101,7 @@ func main() {
 	case "files":
 		cmdFiles(os.Args[2:])
 	default:
-		printUsage(fmt.Sprintf("Unknown command: %s", cmd))
+		printUsage(fmt.Sprintf("Unknown command: %s", os.Args[1]))
 		os.Exit(1)
 	}
 }

--- a/cmd/helper/main.go
+++ b/cmd/helper/main.go
@@ -75,7 +75,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	cmd := os.Args[1]
+	// Match the command case-insensitively. printUsage lists every command in
+	// upper case, so a sysop who types what the help screen shows —
+	// `helper FTNSETUP` — was told "Unknown command" and shown that same
+	// screen again, with nothing to indicate the name had to be lower case.
+	cmd := strings.ToLower(os.Args[1])
 	if cmd == "--version" || cmd == "-version" {
 		printHeader()
 		return
@@ -1003,10 +1007,14 @@ func parseNAFile(path string) ([]naArea, error) {
 	defer func() { _ = f.Close() }() // read-only
 
 	var areas []naArea
+	seen := make(map[string]bool)
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, ";") || strings.HasPrefix(line, "#") {
+		// "%" starts a comment in the area lists several networks publish,
+		// tqwNet's among them.
+		if line == "" || strings.HasPrefix(line, ";") || strings.HasPrefix(line, "#") ||
+			strings.HasPrefix(line, "%") {
 			continue
 		}
 
@@ -1017,10 +1025,23 @@ func parseNAFile(path string) ([]naArea, error) {
 
 		tag := parts[0]
 		desc := strings.Join(parts[1:], " ")
+		// Some lists separate the tag from its description with a dash
+		// ("TQW_ADS  - BBS Adverts"); without this the dash ends up in the
+		// area name shown to users.
+		desc = strings.TrimSpace(strings.TrimPrefix(desc, "-"))
 
 		if !isValidEchoTag(tag) {
 			continue
 		}
+		// A repeated tag means this is not an echo list in the expected
+		// "<tag> <description>" form — a file echo list ("Area TQW_NODE 0 !
+		// Weekly Nodelists") parses as the tag "Area" on every line, and
+		// importing it would silently create that many junk areas.
+		if seen[strings.ToUpper(tag)] {
+			return nil, fmt.Errorf("duplicate area tag %q on line %q — this does not look like an echomail area list "+
+				"(a file echo list will do this, its lines starting with the literal word \"Area\")", tag, line)
+		}
+		seen[strings.ToUpper(tag)] = true
 
 		areas = append(areas, naArea{Tag: tag, Description: desc})
 	}


### PR DESCRIPTION
Fixes #277.

Three things that between them made setting up a network's echo areas harder than it should be. Found while trying to add tqwNet areas on a live system.

## The command name the help screen shows does not work

```
$ ./helper FTNSETUP
■  Unknown command: FTNSETUP
■  Valid Commands Are As Follows...
   FTNSETUP             - Import FTN echo areas from a FIDONET.NA file
```

The dispatch is case-sensitive and lower-case only, while `printUsage` lists every command in upper case. So typing exactly what the help screen shows gets you "Unknown command" and the same screen again, with nothing to indicate the name has to be lower case — which reads as "this command has no options documented".

`ftnsetup` in lower case has always printed a complete usage message with every flag and two worked examples. It was just unreachable by the advertised name. This affected every command, not only `ftnsetup`:

```
AREAFIX    -> Unknown command: AREAFIX
USERS      -> Unknown command: USERS
FILES      -> Unknown command: FILES
```

Fixed by lower-casing the argument before the switch.

## A dash separator ended up in the area name

Some networks separate the tag from its description with a dash. tqwNet's list:

```
TQW_ADS         - BBS Adverts
TQW_BBSGEN      - General BBS Chat
```

The parser joined everything after the tag, so all 17 areas would have been created named `- BBS Adverts`, `- General BBS Chat` and so on — in the area list every user sees. A leading dash is now trimmed.

## Pointing it at a file echo list silently created junk

Networks publish two lists and both ship as `.na`. For tqwNet the *file* echo list is the one named after the network (`tqwnet.na`), and the echomail list is inside the infopack. Feeding it the wrong one produced this, with no error:

```
Areas to add (8):
  AREA                 TQW_NODE 0 ! Weekly Nodelists
  AREA                 TQW_INFO 0 ! Weekly Infopacks
  ...
```

Every line of a file echo list starts with the literal word `Area`, which parses as a valid tag, so eight lines became eight areas all tagged `AREA` with the real tag buried in the name. A repeated tag is never valid in an echo list, so the file is now rejected and the message says what it looks like:

```
Error parsing NA file: duplicate area tag "Area" on line "Area TQW_INFO ... Weekly Infopacks"
  — this does not look like an echomail area list (a file echo list will do this,
    its lines starting with the literal word "Area")
```

`%` comments are also skipped now; the published lists use them for their headers.

## Testing

- Three new tests over `parseNAFile`: both separator styles, rejection of a file echo list, and `%` comment handling.
- `go build ./...` and the full `go test ./...` suite pass.
- Verified against the real tqwNet lists on a live system: `FTNSETUP`, `ftnsetup` and `FtnSetup` all reach the command, the file echo list is rejected, and the echomail list parses to 17 correctly-named areas.

Related: #275 (the wizard cannot fetch tqwNet's area list) is a different problem — the registry records `echolist_url` as the bare filename `tqwnet.na` rather than a URL. The list is on the web at <https://github.com/christiansacks/tqwnet_infopack>, so that entry could carry a real URL. Not touched here, and note `registry.json` is generated from Synchronet's `init-fidonet.ini` by the release pipeline, so a fix there needs to survive regeneration.