### PR TITLE
fix(tosser): stop half-importing corrupt packets and surface unclaimed mail

### DIFF
--- a/cmd/v3mail/cmd_ftn.go
+++ b/cmd/v3mail/cmd_ftn.go
@@ -28,6 +28,10 @@ func cmdToss(args []string) {
 
 	totalImported, totalDupes, totalPackets := 0, 0, 0
 	hadErrors := false
+	// Merged across networks: a packet every network declined is the signal
+	// that no configured link matches the address sending it.
+	skippedOrigins := map[string]int{}
+	ranAllNetworks := *networkName == ""
 
 	for name, netCfg := range ftnCfg.Networks {
 		if !netCfg.InternalTosserEnabled {
@@ -48,6 +52,9 @@ func cmdToss(args []string) {
 		totalPackets += result.PacketsProcessed
 		totalImported += result.MessagesImported
 		totalDupes += result.DupesSkipped
+		for origin, n := range result.SkippedOrigins {
+			skippedOrigins[origin] += n
+		}
 
 		if !*quiet {
 			fmt.Printf("[%s] toss: %d packets, %d imported, %d dupes",
@@ -63,9 +70,34 @@ func cmdToss(args []string) {
 		}
 	}
 
+	// Only meaningful once every enabled network has had its turn: a bundle is
+	// removed by whichever tosser takes it, so what remains is mail nobody
+	// would take. Limiting the run to one network with --network says nothing
+	// about what the others would have claimed.
+	var unclaimed tosser.UnclaimedReport
+	if ranAllNetworks {
+		unclaimed = tosser.FindUnclaimed(ftnCfg, skippedOrigins)
+		unclaimed.QuarantineStale(ftnCfg.TempPath)
+		unclaimed.Log()
+	}
+
 	if !*quiet {
 		fmt.Printf("Toss complete: %d packets, %d messages imported, %d dupes skipped\n",
 			totalPackets, totalImported, totalDupes)
+		if n := len(unclaimed.Files) + len(unclaimed.Quarantined); n > 0 {
+			// Without this the run looks identical to one that had no mail
+			// waiting, which is how a backlog goes unnoticed for weeks.
+			fmt.Printf("WARNING: %d inbound file(s) matched no configured network", n)
+			if origins := unclaimed.OriginList(); origins != "" {
+				fmt.Printf(" — from %s", origins)
+			}
+			fmt.Println()
+			fmt.Println("         Check that each network's links list the address its mail comes from.")
+			if len(unclaimed.Quarantined) > 0 {
+				fmt.Printf("         %d moved to %s\n",
+					len(unclaimed.Quarantined), filepath.Dir(unclaimed.Quarantined[0]))
+			}
+		}
 	}
 
 	if hadErrors {

--- a/cmd/v3mail/cmd_ftn.go
+++ b/cmd/v3mail/cmd_ftn.go
@@ -28,9 +28,13 @@ func cmdToss(args []string) {
 
 	totalImported, totalDupes, totalPackets := 0, 0, 0
 	hadErrors := false
-	// Merged across networks: a packet every network declined is the signal
-	// that no configured link matches the address sending it.
-	skippedOrigins := map[string]int{}
+	// Merged across networks and keyed by inbound file, so the whole-pass
+	// check can discard the origins of anything a later network claimed.
+	skippedByFile := map[string]map[string]int{}
+	// The whole-pass check is only sound once every enabled network has
+	// actually tossed: a tosser that failed to construct might have been the
+	// one to claim the mail, so its absence has to suppress the check as
+	// surely as --network does.
 	ranAllNetworks := *networkName == ""
 
 	for name, netCfg := range ftnCfg.Networks {
@@ -45,6 +49,7 @@ func cmdToss(args []string) {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating tosser for %s: %v\n", name, err)
 			hadErrors = true
+			ranAllNetworks = false
 			continue
 		}
 
@@ -52,8 +57,13 @@ func cmdToss(args []string) {
 		totalPackets += result.PacketsProcessed
 		totalImported += result.MessagesImported
 		totalDupes += result.DupesSkipped
-		for origin, n := range result.SkippedOrigins {
-			skippedOrigins[origin] += n
+		// Replace rather than sum: every enabled network passes over the same
+		// packets in a shared inbound directory and reports the same origins
+		// for the same file.
+		for file, origins := range result.SkippedByFile {
+			if _, seen := skippedByFile[file]; !seen {
+				skippedByFile[file] = origins
+			}
 		}
 
 		if !*quiet {
@@ -76,7 +86,7 @@ func cmdToss(args []string) {
 	// about what the others would have claimed.
 	var unclaimed tosser.UnclaimedReport
 	if ranAllNetworks {
-		unclaimed = tosser.FindUnclaimed(ftnCfg, skippedOrigins)
+		unclaimed = tosser.FindUnclaimed(ftnCfg, skippedByFile)
 		unclaimed.QuarantineStale(ftnCfg.TempPath)
 		unclaimed.Log()
 	}

--- a/internal/tosser/import.go
+++ b/internal/tosser/import.go
@@ -34,6 +34,22 @@ type TossResult struct {
 	MessagesExported int
 	DupesSkipped     int
 	Errors           []string
+
+	// SkippedOrigins counts packets left for another network's tosser, keyed by
+	// the origin address that matched none of this network's links. Skipping is
+	// routine — networks sharing an inbound directory each pass over the
+	// others' mail — so it is recorded rather than logged per packet, and only
+	// becomes news once every network has passed and the mail is still there.
+	// See ReportUnclaimed.
+	SkippedOrigins map[string]int
+}
+
+// noteSkipped records a packet this network declined, keyed by origin address.
+func (r *TossResult) noteSkipped(origin string) {
+	if r.SkippedOrigins == nil {
+		r.SkippedOrigins = make(map[string]int)
+	}
+	r.SkippedOrigins[origin]++
 }
 
 // ScannerUser is the synthetic username stored in each JAM base's .jlr file
@@ -212,9 +228,11 @@ func (t *Tosser) processBundle(path, name string, result *TossResult) {
 // tossPktFile processes a single .PKT file at path and updates result.
 // Returns true if the packet was skipped (foreign network).
 func (t *Tosser) tossPktFile(path, displayName string, result *TossResult) bool {
-	imported, dupes, errs, skipped := t.tossPacket(path)
-	if skipped {
-		return true // packet doesn't belong to this network; leave for correct tosser
+	imported, dupes, errs, skippedOrigin := t.tossPacket(path)
+	if skippedOrigin != "" {
+		// Not ours; leave it for the tosser whose links include that origin.
+		result.noteSkipped(skippedOrigin)
+		return true
 	}
 
 	result.PacketsProcessed++
@@ -240,21 +258,24 @@ func (t *Tosser) tossPktFile(path, displayName string, result *TossResult) bool 
 // source address is checked against the network's known links. If the packet
 // doesn't originate from a known link, it is skipped (returned with skipped=true)
 // so the correct network's tosser can process it later.
-func (t *Tosser) tossPacket(path string) (imported, dupes int, errs []string, skipped bool) {
+func (t *Tosser) tossPacket(path string) (imported, dupes int, errs []string, skippedOrigin string) {
 	f, err := os.Open(path)
 	if err != nil {
-		return 0, 0, []string{fmt.Sprintf("open %s: %v", path, err)}, false
+		return 0, 0, []string{fmt.Sprintf("open %s: %v", path, err)}, ""
 	}
 	defer func() { _ = f.Close() }() // read-only
 
 	pktHdr, msgs, err := ftn.ReadPacket(f)
 	if err != nil {
-		if len(msgs) == 0 {
-			return 0, 0, []string{fmt.Sprintf("parse %s: %v", path, err)}, false
-		}
-		// Partial parse: packet is truncated but some messages were read before the
-		// bad offset. Process what we have and treat the truncation as a warning.
-		slog.Warn("truncated packet, processing available messages", "network", t.networkName, "packet", filepath.Base(path), "error", err, "count", len(msgs))
+		// Import nothing from a packet that failed to parse, even when some
+		// messages were read before the failing offset. Whatever corrupted the
+		// packet can have desynced the reader well earlier, in which case those
+		// "messages" are mid-body bytes wearing a message's shape — a real one
+		// reached a sysop's netmail inbox with ANSI art as its subject line.
+		// tossPktFile quarantines a packet its caller reports errors for, so the
+		// data is held for inspection rather than half-imported and deleted.
+		return 0, 0, []string{fmt.Sprintf("parse %s: %v (%d message(s) recovered from the prefix, none imported)",
+			filepath.Base(path), err, len(msgs))}, ""
 	}
 
 	// Check if this packet belongs to our network by matching the source address
@@ -265,8 +286,9 @@ func (t *Tosser) tossPacket(path string) (imported, dupes int, errs []string, sk
 		if pktZone == 0 {
 			pktZone = pktHdr.QOrigZone
 		}
-		slog.Debug("skipping packet from unknown link", "network", t.networkName, "packet", filepath.Base(path), "zone", pktZone, "net", pktHdr.OrigNet, "node", pktHdr.OrigNode)
-		return 0, 0, nil, true
+		origin := fmt.Sprintf("%d:%d/%d", pktZone, pktHdr.OrigNet, pktHdr.OrigNode)
+		slog.Debug("skipping packet from unknown link", "network", t.networkName, "packet", filepath.Base(path), "origin", origin)
+		return 0, 0, nil, origin
 	}
 
 	for i, msg := range msgs {
@@ -281,7 +303,7 @@ func (t *Tosser) tossPacket(path string) (imported, dupes int, errs []string, sk
 		imported++
 	}
 
-	return imported, dupes, errs, false
+	return imported, dupes, errs, ""
 }
 
 var errDupe = fmt.Errorf("duplicate message")

--- a/internal/tosser/import.go
+++ b/internal/tosser/import.go
@@ -35,21 +35,31 @@ type TossResult struct {
 	DupesSkipped     int
 	Errors           []string
 
-	// SkippedOrigins counts packets left for another network's tosser, keyed by
-	// the origin address that matched none of this network's links. Skipping is
-	// routine — networks sharing an inbound directory each pass over the
-	// others' mail — so it is recorded rather than logged per packet, and only
-	// becomes news once every network has passed and the mail is still there.
-	// See ReportUnclaimed.
-	SkippedOrigins map[string]int
+	// SkippedByFile records packets left for another network's tosser: inbound
+	// file path, then origin address that matched none of this network's
+	// links, then packet count. Skipping is routine — networks sharing an
+	// inbound directory each pass over the others' mail — so it is recorded
+	// rather than logged per packet, and only becomes news once every network
+	// has passed and the file is still there.
+	//
+	// Keyed by file rather than by origin alone because a network that
+	// declines a packet says nothing about whether a later network took it.
+	// Attributing the origins to the file lets the whole-pass check discard
+	// everything that was subsequently claimed, instead of naming addresses
+	// whose mail arrived perfectly well. See FindUnclaimed.
+	SkippedByFile map[string]map[string]int
 }
 
-// noteSkipped records a packet this network declined, keyed by origin address.
-func (r *TossResult) noteSkipped(origin string) {
-	if r.SkippedOrigins == nil {
-		r.SkippedOrigins = make(map[string]int)
+// noteSkipped records that inboundFile held a packet from origin that this
+// network declined.
+func (r *TossResult) noteSkipped(inboundFile, origin string) {
+	if r.SkippedByFile == nil {
+		r.SkippedByFile = make(map[string]map[string]int)
 	}
-	r.SkippedOrigins[origin]++
+	if r.SkippedByFile[inboundFile] == nil {
+		r.SkippedByFile[inboundFile] = make(map[string]int)
+	}
+	r.SkippedByFile[inboundFile][origin]++
 }
 
 // ScannerUser is the synthetic username stored in each JAM base's .jlr file
@@ -146,8 +156,10 @@ func (t *Tosser) processInboundDir(dir string, result *TossResult) {
 		path := filepath.Join(dir, name)
 
 		if strings.HasSuffix(nameLower, ".pkt") {
-			// Direct .PKT file
-			t.tossPktFile(path, name, result)
+			// Direct .PKT file: it is its own inbound file.
+			if origin := t.tossPktFile(path, name, result); origin != "" {
+				result.noteSkipped(path, origin)
+			}
 			continue
 		}
 
@@ -185,12 +197,14 @@ func (t *Tosser) processBundle(path, name string, result *TossResult) {
 	// tossPktFile handles cleanup of each extracted .PKT (removes on success, moves to temp on error).
 	allSkipped := true
 	var skippedPkts []string
+	skippedOrigins := map[string]int{}
 	for _, pktPath := range pktPaths {
-		skipped := t.tossPktFile(pktPath, filepath.Base(pktPath), result)
-		if !skipped {
+		origin := t.tossPktFile(pktPath, filepath.Base(pktPath), result)
+		if origin == "" {
 			allSkipped = false
 		} else {
 			skippedPkts = append(skippedPkts, pktPath)
+			skippedOrigins[origin]++
 		}
 	}
 
@@ -199,6 +213,13 @@ func (t *Tosser) processBundle(path, name string, result *TossResult) {
 	if allSkipped && len(pktPaths) > 0 {
 		for _, pktPath := range pktPaths {
 			_ = os.Remove(pktPath) // best-effort cleanup of skipped packets
+		}
+		// The bundle stays, so its origins are attributed to it. A bundle any
+		// network claims is removed by that network and never reaches here.
+		for origin, n := range skippedOrigins {
+			for i := 0; i < n; i++ {
+				result.noteSkipped(path, origin)
+			}
 		}
 		slog.Debug("skipping foreign bundle", "network", t.networkName, "bundle", name)
 		return
@@ -227,12 +248,14 @@ func (t *Tosser) processBundle(path, name string, result *TossResult) {
 
 // tossPktFile processes a single .PKT file at path and updates result.
 // Returns true if the packet was skipped (foreign network).
-func (t *Tosser) tossPktFile(path, displayName string, result *TossResult) bool {
+// It returns the origin address when the packet was declined, empty otherwise;
+// the caller attributes that to whichever inbound file the packet came from,
+// which for a bundle is the bundle rather than the extracted packet.
+func (t *Tosser) tossPktFile(path, displayName string, result *TossResult) string {
 	imported, dupes, errs, skippedOrigin := t.tossPacket(path)
 	if skippedOrigin != "" {
 		// Not ours; leave it for the tosser whose links include that origin.
-		result.noteSkipped(skippedOrigin)
-		return true
+		return skippedOrigin
 	}
 
 	result.PacketsProcessed++
@@ -250,7 +273,7 @@ func (t *Tosser) tossPktFile(path, displayName string, result *TossResult) bool 
 			slog.Warn("failed to move bad packet", "path", path, "dest", badPath, "error", err)
 		}
 	}
-	return false
+	return ""
 }
 
 // tossPacket processes a single .PKT file, returning counts and errors.

--- a/internal/tosser/unclaimed.go
+++ b/internal/tosser/unclaimed.go
@@ -78,10 +78,12 @@ func (r UnclaimedReport) OriginList() string {
 // It must be called only after every enabled network has run, because a
 // bundle is removed by whichever tosser processes it: anything still present
 // is therefore mail that no configured network would take. skipped merges the
-// SkippedOrigins of every network's result, which is what turns "nobody wanted
-// this" into a message naming the address whose mail is piling up.
-func FindUnclaimed(ftnCfg config.FTNConfig, skipped map[string]int) UnclaimedReport {
-	report := UnclaimedReport{Origins: skipped}
+// SkippedByFile maps of every network's result, which is what turns "nobody
+// wanted this" into a message naming the address whose mail is piling up.
+// Counts are taken per file rather than summed, since each enabled network
+// passes over the same packets and would otherwise multiply the total.
+func FindUnclaimed(ftnCfg config.FTNConfig, skippedByFile map[string]map[string]int) UnclaimedReport {
+	report := UnclaimedReport{Origins: map[string]int{}}
 
 	seen := make(map[string]bool)
 	for _, dir := range []string{ftnCfg.SecureInboundPath, ftnCfg.InboundPath} {
@@ -104,6 +106,17 @@ func FindUnclaimed(ftnCfg config.FTNConfig, skipped map[string]int) UnclaimedRep
 			}
 			path := filepath.Join(dir, entry.Name())
 			report.Files = append(report.Files, path)
+			// Only the origins of files still present are reported. A file a
+			// later network claimed has been removed by it, so the addresses
+			// an earlier network declined it under are not news.
+			for origin, n := range skippedByFile[path] {
+				if n > report.Origins[origin] {
+					// Every network that declined this file saw the same
+					// packets in it, so take the count rather than summing
+					// one pass per enabled network.
+					report.Origins[origin] = n
+				}
+			}
 			if info, err := entry.Info(); err == nil {
 				if report.Oldest.IsZero() || info.ModTime().Before(report.Oldest) {
 					report.Oldest = info.ModTime()

--- a/internal/tosser/unclaimed.go
+++ b/internal/tosser/unclaimed.go
@@ -1,0 +1,173 @@
+package tosser
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+	"github.com/ViSiON-3/vision-3-bbs/internal/ftn"
+)
+
+// Reporting on inbound mail that no configured network would take.
+//
+// A tosser leaves a bundle in place when every packet inside it comes from an
+// address that matches none of its links, on the assumption that some other
+// network's tosser will claim it. Nothing checked that assumption. When it did
+// not hold — a link address that did not match the uplink actually sending the
+// mail — the bundles sat in the inbound directory indefinitely, every tosser
+// re-extracted and re-parsed all of them on every cycle, and the run still
+// reported "0 packets, 0 imported" and exited 0. A live system accumulated
+// 23 bundles and 5,496 packets over eight weeks that way, with nothing in the
+// logs above Debug to say so (#276).
+
+// quarantineAfter is how long a bundle must have gone unclaimed before it is
+// moved aside. Mail is only ever a few minutes old when a network is briefly
+// misconfigured or disabled, so waiting a day leaves room to fix the config
+// and have the mail tossed normally, while still bounding how large the
+// inbound directory and the per-cycle rescan can grow.
+const quarantineAfter = 24 * time.Hour
+
+// UnclaimedDirName is the subdirectory of the temp path that unclaimed bundles
+// are moved to. They are moved, never deleted: the usual cause is a
+// correctable config mistake, and moving them back is how a sysop recovers.
+const UnclaimedDirName = "unclaimed"
+
+// UnclaimedReport describes inbound mail left behind after every enabled
+// network has had its turn.
+type UnclaimedReport struct {
+	Files       []string       // paths still in the inbound directories
+	Origins     map[string]int // origin address -> packets declined, across all networks
+	Oldest      time.Time      // modification time of the oldest file
+	Quarantined []string       // files moved aside this run
+}
+
+// Empty reports whether anything was left unclaimed.
+func (r UnclaimedReport) Empty() bool { return len(r.Files) == 0 }
+
+// OriginList renders the declined origin addresses in a stable order, most
+// packets first, for a log line or a console summary.
+func (r UnclaimedReport) OriginList() string {
+	type kv struct {
+		addr string
+		n    int
+	}
+	pairs := make([]kv, 0, len(r.Origins))
+	for a, n := range r.Origins {
+		pairs = append(pairs, kv{a, n})
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].n != pairs[j].n {
+			return pairs[i].n > pairs[j].n
+		}
+		return pairs[i].addr < pairs[j].addr
+	})
+	parts := make([]string, 0, len(pairs))
+	for _, p := range pairs {
+		parts = append(parts, fmt.Sprintf("%s (%d packets)", p.addr, p.n))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// FindUnclaimed reports the inbound mail that survived a full toss pass.
+//
+// It must be called only after every enabled network has run, because a
+// bundle is removed by whichever tosser processes it: anything still present
+// is therefore mail that no configured network would take. skipped merges the
+// SkippedOrigins of every network's result, which is what turns "nobody wanted
+// this" into a message naming the address whose mail is piling up.
+func FindUnclaimed(ftnCfg config.FTNConfig, skipped map[string]int) UnclaimedReport {
+	report := UnclaimedReport{Origins: skipped}
+
+	seen := make(map[string]bool)
+	for _, dir := range []string{ftnCfg.SecureInboundPath, ftnCfg.InboundPath} {
+		if dir == "" || seen[dir] {
+			continue
+		}
+		seen[dir] = true
+
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue // a missing inbound directory is not this function's problem
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			nameLower := strings.ToLower(entry.Name())
+			if !ftn.BundleExtension(nameLower) && !strings.HasSuffix(nameLower, ".pkt") {
+				continue
+			}
+			path := filepath.Join(dir, entry.Name())
+			report.Files = append(report.Files, path)
+			if info, err := entry.Info(); err == nil {
+				if report.Oldest.IsZero() || info.ModTime().Before(report.Oldest) {
+					report.Oldest = info.ModTime()
+				}
+			}
+		}
+	}
+	sort.Strings(report.Files)
+	return report
+}
+
+// QuarantineStale moves unclaimed files older than quarantineAfter into the
+// temp path's unclaimed directory, and records them on the report. Anything
+// newer is left alone so a config fix made the same day still tosses normally.
+func (r *UnclaimedReport) QuarantineStale(tempPath string) {
+	if tempPath == "" || len(r.Files) == 0 {
+		return
+	}
+	cutoff := time.Now().Add(-quarantineAfter)
+	dest := filepath.Join(tempPath, UnclaimedDirName)
+
+	var kept []string
+	for _, path := range r.Files {
+		info, err := os.Stat(path)
+		if err != nil || !info.ModTime().Before(cutoff) {
+			kept = append(kept, path)
+			continue
+		}
+		if err := os.MkdirAll(dest, 0755); err != nil {
+			slog.Warn("cannot create unclaimed directory, leaving mail in place", "dir", dest, "error", err)
+			return
+		}
+		target := filepath.Join(dest, filepath.Base(path))
+		if err := os.Rename(path, target); err != nil {
+			// Leave it where it is: an unclaimed bundle in the inbound
+			// directory is recoverable, and this runs again next cycle.
+			slog.Warn("cannot quarantine unclaimed mail, leaving it in place", "path", path, "error", err)
+			kept = append(kept, path)
+			continue
+		}
+		r.Quarantined = append(r.Quarantined, target)
+	}
+	r.Files = kept
+}
+
+// Log writes the report to the log. It is the one place that turns routine,
+// per-packet skipping into a single operator-visible line, so it says which
+// address the mail came from — the piece needed to spot that a link address
+// does not match the uplink actually sending.
+func (r UnclaimedReport) Log() {
+	if r.Empty() && len(r.Quarantined) == 0 {
+		return
+	}
+	args := []any{"files", len(r.Files) + len(r.Quarantined)}
+	if origins := r.OriginList(); origins != "" {
+		args = append(args, "origins", origins)
+	}
+	if !r.Oldest.IsZero() {
+		args = append(args, "oldest", r.Oldest.Format(time.RFC3339))
+	}
+	if len(r.Quarantined) > 0 {
+		args = append(args, "quarantined", len(r.Quarantined),
+			"quarantine_dir", filepath.Dir(r.Quarantined[0]))
+	}
+	slog.Warn("inbound mail claimed by no configured network — check that each network's links "+
+		"list the address its mail actually comes from", args...)
+}

--- a/internal/tosser/unclaimed_test.go
+++ b/internal/tosser/unclaimed_test.go
@@ -136,12 +136,58 @@ func TestSkippedOriginsAreRecorded(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	writeGoodPacket(t, env.inboundDir, "foreign.pkt", 1337, 3, 123)
+	path := writeGoodPacket(t, env.inboundDir, "foreign.pkt", 1337, 3, 123)
 
 	result := tsr.ProcessInbound()
 
-	if got := result.SkippedOrigins["1337:3/123"]; got != 1 {
-		t.Errorf("SkippedOrigins[1337:3/123] = %d, want 1 (got %v)", got, result.SkippedOrigins)
+	if got := result.SkippedByFile[path]["1337:3/123"]; got != 1 {
+		t.Errorf("SkippedByFile[%s][1337:3/123] = %d, want 1 (got %v)",
+			path, got, result.SkippedByFile)
+	}
+}
+
+// TestSkippedOriginsAreDroppedForClaimedFiles covers the reporting rule that
+// matters when networks share an inbound directory. Every network declines the
+// others' mail, so an origin recorded during one pass says nothing on its own.
+// Only files still present after the whole pass are unclaimed, and only their
+// origins may be named — otherwise a single genuinely stuck file would drag
+// every address any network ever declined into the warning.
+func TestSkippedOriginsAreDroppedForClaimedFiles(t *testing.T) {
+	env := setupTestEnv(t)
+
+	claimed := filepath.Join(env.inboundDir, "claimed.pkt")
+	stuck := writeGoodPacket(t, env.inboundDir, "stuck.pkt", 1337, 3, 123)
+
+	// Pretend one network declined both files, then another took the first —
+	// which is what removing it from the inbound directory represents.
+	skipped := map[string]map[string]int{
+		claimed: {"21:4/158": 9},
+		stuck:   {"1337:3/123": 2},
+	}
+
+	report := FindUnclaimed(env.globalCfg, skipped)
+
+	if _, named := report.Origins["21:4/158"]; named {
+		t.Errorf("origin of a file that was claimed must not be reported: %v", report.Origins)
+	}
+	if got := report.Origins["1337:3/123"]; got != 2 {
+		t.Errorf("Origins[1337:3/123] = %d, want 2: %v", got, report.Origins)
+	}
+}
+
+// TestSkippedCountsAreNotMultipliedByNetworkCount pins the counting rule. Each
+// enabled network passes over the same packets, so summing their reports would
+// multiply the total by the number of networks configured.
+func TestSkippedCountsAreNotMultipliedByNetworkCount(t *testing.T) {
+	env := setupTestEnv(t)
+	stuck := writeGoodPacket(t, env.inboundDir, "stuck.pkt", 1337, 3, 123)
+
+	report := FindUnclaimed(env.globalCfg, map[string]map[string]int{
+		stuck: {"1337:3/123": 5},
+	})
+
+	if got := report.Origins["1337:3/123"]; got != 5 {
+		t.Errorf("Origins[1337:3/123] = %d, want the per-file count of 5", got)
 	}
 }
 
@@ -152,7 +198,9 @@ func TestFindUnclaimedReportsLeftoverMail(t *testing.T) {
 	env := setupTestEnv(t)
 	writeGoodPacket(t, env.inboundDir, "leftover.pkt", 1337, 3, 123)
 
-	report := FindUnclaimed(env.globalCfg, map[string]int{"1337:3/123": 42})
+	report := FindUnclaimed(env.globalCfg, map[string]map[string]int{
+		filepath.Join(env.inboundDir, "leftover.pkt"): {"1337:3/123": 42},
+	})
 
 	if report.Empty() {
 		t.Fatal("expected the leftover packet to be reported")

--- a/internal/tosser/unclaimed_test.go
+++ b/internal/tosser/unclaimed_test.go
@@ -1,0 +1,204 @@
+package tosser
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ftn"
+)
+
+// writeGoodPacket writes a one-message packet from the given origin into dir.
+func writeGoodPacket(t *testing.T, dir, name string, origZone, origNet, origNode uint16) string {
+	t.Helper()
+	hdr := ftn.NewPacketHeader(origZone, origNet, origNode, 0, 21, 4, 158, 1, "")
+	body := &ftn.ParsedBody{
+		Area:    "FSX_TEST",
+		Text:    "hello\r",
+		Kludges: []string{"MSGID: 21:4/158 11111111"},
+	}
+	packed := &ftn.PackedMessage{
+		MsgType: 2, OrigNode: origNode, DestNode: 158,
+		OrigNet: origNet, DestNet: 4,
+		DateTime: "01 Mar 26  12:00:00", To: "All", From: "Someone",
+		Subject: "hi", Body: ftn.FormatPackedMessageBody(body),
+	}
+	var buf bytes.Buffer
+	if err := ftn.WritePacket(&buf, hdr, []*ftn.PackedMessage{packed}); err != nil {
+		t.Fatalf("WritePacket: %v", err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, buf.Bytes(), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// packetBytes builds a packet from our hub carrying n identical messages.
+func packetBytes(t *testing.T, n int) []byte {
+	t.Helper()
+	hdr := ftn.NewPacketHeader(21, 4, 158, 0, 21, 4, 158, 1, "")
+	body := &ftn.ParsedBody{
+		Area:    "FSX_TEST",
+		Text:    strings.Repeat("padding to make the message long enough to cut into\r", 4),
+		Kludges: []string{"MSGID: 21:4/158 22222222"},
+	}
+	msgs := make([]*ftn.PackedMessage, 0, n)
+	for i := 0; i < n; i++ {
+		msgs = append(msgs, &ftn.PackedMessage{
+			MsgType: 2, OrigNode: 158, DestNode: 158, OrigNet: 4, DestNet: 4,
+			DateTime: "01 Mar 26  12:00:00", To: "All", From: "Someone",
+			Subject: "hi", Body: ftn.FormatPackedMessageBody(body),
+		})
+	}
+	var buf bytes.Buffer
+	if err := ftn.WritePacket(&buf, hdr, msgs); err != nil {
+		t.Fatalf("WritePacket: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// readPacketFile parses a packet from disk, for asserting on test fixtures.
+func readPacketFile(t *testing.T, path string) (*ftn.PacketHeader, []*ftn.PackedMessage, error) {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	return ftn.ReadPacket(f)
+}
+
+// TestCorruptPacketIsQuarantinedNotPartiallyImported covers a packet whose
+// parse fails partway. Messages read before the failing offset used to be
+// imported and the packet then deleted as processed — but a corrupt packet can
+// desync the reader well before it notices, so those "messages" may be
+// mid-body bytes. One reached a live sysop's netmail inbox with a strip of
+// ANSI art as its subject (#276). Nothing should be imported, and the packet
+// must survive for inspection.
+func TestCorruptPacketIsQuarantinedNotPartiallyImported(t *testing.T) {
+	env := setupTestEnv(t)
+	tsr, err := New("testnet", env.netCfg, env.globalCfg, env.dupeDB, env.msgMgr)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Two messages from our own hub, truncated inside the second so the
+	// reader parses the first cleanly and then runs off the end. That prefix
+	// is exactly what the old code imported.
+	oneMsg := packetBytes(t, 1)
+	twoMsg := packetBytes(t, 2)
+	// A packet ends with a two-byte terminator, so the single-message packet's
+	// length less that terminator is where the second message begins.
+	cut := len(oneMsg) - 2 + 16
+	if cut >= len(twoMsg) {
+		t.Fatalf("truncation offset %d is not inside the second message (packet is %d bytes)", cut, len(twoMsg))
+	}
+	full := filepath.Join(env.inboundDir, "corrupt.pkt")
+	if err := os.WriteFile(full, twoMsg[:cut], 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Guard the guard: the truncated packet must still yield a parse error
+	// with at least one message recovered, or this test proves nothing.
+	if _, msgs, err := readPacketFile(t, full); err == nil || len(msgs) == 0 {
+		t.Fatalf("test fixture is wrong: want a partial parse, got err=%v msgs=%d", err, len(msgs))
+	}
+
+	result := tsr.ProcessInbound()
+
+	if result.MessagesImported != 0 {
+		t.Errorf("imported %d message(s) from a packet that failed to parse; want 0",
+			result.MessagesImported)
+	}
+	if len(result.Errors) == 0 {
+		t.Error("a packet that failed to parse should be reported as an error")
+	}
+	if _, err := os.Stat(full); !os.IsNotExist(err) {
+		t.Error("the corrupt packet should have been moved out of the inbound directory")
+	}
+	quarantined := filepath.Join(env.tempDir, "corrupt.pkt")
+	if _, err := os.Stat(quarantined); err != nil {
+		t.Errorf("the corrupt packet should be held for inspection at %s: %v", quarantined, err)
+	}
+}
+
+// TestSkippedOriginsAreRecorded covers the bookkeeping that makes unclaimed
+// mail visible. Skipping another network's packet is routine and must stay
+// quiet per packet, but the origin has to be recorded so a full pass can
+// report what nobody took.
+func TestSkippedOriginsAreRecorded(t *testing.T) {
+	env, extCfg := setupExtendedTestEnv(t)
+	tsr, err := New("testnet", extCfg, env.globalCfg, env.dupeDB, env.msgMgr)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	writeGoodPacket(t, env.inboundDir, "foreign.pkt", 1337, 3, 123)
+
+	result := tsr.ProcessInbound()
+
+	if got := result.SkippedOrigins["1337:3/123"]; got != 1 {
+		t.Errorf("SkippedOrigins[1337:3/123] = %d, want 1 (got %v)", got, result.SkippedOrigins)
+	}
+}
+
+// TestFindUnclaimedReportsLeftoverMail covers the whole-pass check: whatever is
+// still in the inbound directory once every network has run is mail no
+// configured network would take.
+func TestFindUnclaimedReportsLeftoverMail(t *testing.T) {
+	env := setupTestEnv(t)
+	writeGoodPacket(t, env.inboundDir, "leftover.pkt", 1337, 3, 123)
+
+	report := FindUnclaimed(env.globalCfg, map[string]int{"1337:3/123": 42})
+
+	if report.Empty() {
+		t.Fatal("expected the leftover packet to be reported")
+	}
+	if len(report.Files) != 1 {
+		t.Errorf("got %d files, want 1: %v", len(report.Files), report.Files)
+	}
+	if !strings.Contains(report.OriginList(), "1337:3/123 (42 packets)") {
+		t.Errorf("origin list should name the address and count, got %q", report.OriginList())
+	}
+	if report.Oldest.IsZero() {
+		t.Error("report should carry the oldest file's timestamp")
+	}
+}
+
+// TestQuarantineStaleMovesOnlyOldFiles covers the age gate. Mail that arrived
+// while a network was briefly misconfigured must stay put so a same-day fix
+// still tosses it; only a genuine backlog is moved aside, and moved rather
+// than deleted so it can be recovered.
+func TestQuarantineStaleMovesOnlyOldFiles(t *testing.T) {
+	env := setupTestEnv(t)
+	fresh := writeGoodPacket(t, env.inboundDir, "fresh.pkt", 1337, 3, 123)
+	stale := writeGoodPacket(t, env.inboundDir, "stale.pkt", 1337, 3, 123)
+
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	report := FindUnclaimed(env.globalCfg, nil)
+	report.QuarantineStale(env.tempDir)
+
+	if len(report.Quarantined) != 1 {
+		t.Fatalf("quarantined %d file(s), want 1: %v", len(report.Quarantined), report.Quarantined)
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Errorf("a file younger than the cutoff must be left in place: %v", err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Error("the stale file should have been moved out of the inbound directory")
+	}
+	moved := filepath.Join(env.tempDir, UnclaimedDirName, "stale.pkt")
+	if _, err := os.Stat(moved); err != nil {
+		t.Errorf("the stale file should be recoverable at %s: %v", moved, err)
+	}
+	if len(report.Files) != 1 || filepath.Base(report.Files[0]) != "fresh.pkt" {
+		t.Errorf("report should still list the file left behind, got %v", report.Files)
+	}
+}


### PR DESCRIPTION
Addresses #276. Found on a live system where inbound echomail had been arriving and going nowhere for about eight weeks, with nothing in the logs to say so.

## A failed parse was treated as a partial success

`tossPacket` imported whatever `ftn.ReadPacket` had produced before it errored, on the assumption that the prefix was sound. Corruption can desync the reader well before it notices, so the recovered entries may be mid-body bytes that merely look like messages. One reached a sysop's netmail inbox:

| field | value |
|---|---|
| `SENDERNAME` | `0` |
| `RECEIVERNAME` | *(absent)* |
| `SUBJECT` | `BA 20 20 BA 20 20 BA BA BA BA BA …` — CP437 `║`, a strip of ANSI art |
| body | empty |

The packet was then removed as successfully processed, so there was nothing left to examine or reprocess.

Now nothing is imported from a packet that would not parse, and the failure is reported as an error — which routes it through the quarantine path `tossPktFile` already had, so the packet is held in `temp/` instead.

This does mean a genuinely truncated packet whose prefix *was* good no longer contributes its readable messages. That trade is deliberate: a held packet can be inspected or re-requested, whereas a half-imported one silently mixes garbage into the message bases and destroys the evidence.

## Mail nobody would take piled up silently

`processBundle` leaves a bundle in place when every packet in it comes from an unmatched address, so another network's tosser can claim it. Nothing verified such a tosser existed. When none did — a link address that didn't match the uplink actually sending — the result was:

- 23 bundles / 5,496 packets / 31 MB sitting in `secure_in`, oldest 8 weeks old
- both tossers re-extracting and re-parsing all of it every cycle, after every inbound binkp session and on the schedule, then discarding the results (4.2s and 31 MB per run, growing with the backlog)
- `0 packets, 0 imported` and exit 0 — indistinguishable from "no mail arrived"
- the only trace at `slog.Debug`, which is off at default log level

Skipping is routine where networks share an inbound directory, so this keeps it quiet per packet and records the declined origin on `TossResult.SkippedOrigins` instead. Once every network has run, anything still in the inbound directories was claimed by nobody — a bundle is removed by whichever tosser takes it — and that becomes one warning naming the addresses and counts:

```
WARNING: 23 inbound file(s) matched no configured network — from 1337:3/123 (5496 packets)
         Check that each network's links list the address its mail comes from.
```

The origin address is the part that matters: it is what reveals a link pointing at the wrong node, and it is the detail whose absence turned a one-line config fix into a forensic exercise.

Files unclaimed for more than 24h are moved to `temp/unclaimed/`, which bounds the directory and stops the repeated rescan. Moved, never deleted — the usual cause is a correctable config mistake and moving them back is how a sysop recovers. The delay is there so mail arriving while a network is briefly misconfigured or disabled is still tossed normally once the config is fixed the same day.

The whole-pass check is skipped under `--network`, since running one network says nothing about what the others would have claimed.

## Testing

Four new tests, plus the existing suite:

- a packet truncated **inside its second message**, so the reader parses the first cleanly and then runs off the end — the exact shape the old code imported. It asserts nothing is imported and the packet is quarantined, and carries a fixture guard that fails the test if the truncation stops producing a partial parse, so it cannot silently stop testing anything.
- declined origins are recorded on the result
- a full pass reports leftover mail with its origin address and oldest timestamp
- the age gate moves only stale files, leaves fresh ones in place, and keeps the moved file recoverable

Verified the corrupt-packet test fails against the old behavior — `imported 1 message(s) from a packet that failed to parse; want 0` — rather than passing vacuously. `go build ./...`, `go vet ./...` and `go test ./...` all clean.

## Not covered here

The config-side check the issue also suggests — warning at load when a network's `own_address` is a point whose boss node is not among its links — is not in this PR. It would have caught the original misconfiguration at startup rather than at toss time, and is worth doing separately.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reports inbound files that do not match a configured network, including their origins, age, and quarantine location.
  - Automatically quarantines unclaimed files older than 24 hours for recoverable handling.
  - Aggregates skipped inbound origins across networks for clearer reporting.

- **Bug Fixes**
  - Prevents partially importing packets that contain parsing errors; recovered messages are discarded and the packet is quarantined.
  - Provides clearer warnings for files that match no configured network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->