### PR TITLE
fix(terminalio): decide a span's encoding as a whole, not rune by rune

### DIFF
--- a/internal/terminalio/writer.go
+++ b/internal/terminalio/writer.go
@@ -56,7 +56,10 @@ func writeUTF8Mode(writer io.Writer, data []byte) error {
 			if mapped == 0 {
 				out = append(out, '?')
 			} else {
-				out = append(out, []byte(string(mapped))...)
+				// AppendRune encodes straight into out; converting via string
+				// would allocate twice for every mapped byte, and a screen of
+				// CP437 art is nothing but mapped bytes.
+				out = utf8.AppendRune(out, mapped)
 			}
 		}
 	}

--- a/internal/terminalio/writer.go
+++ b/internal/terminalio/writer.go
@@ -28,29 +28,35 @@ func writeUTF8Mode(writer io.Writer, data []byte) error {
 		}
 		span := data[spanStart:i]
 
-		// Process span rune-by-rune to preserve valid UTF-8 while mapping invalid bytes to CP437
-		// This handles mixed UTF-8 + CP437 content correctly
-		pos := 0
-		for pos < len(span) {
-			r, size := utf8.DecodeRune(span[pos:])
-			if r == utf8.RuneError && size == 1 {
-				// Invalid UTF-8 byte - treat as CP437
-				sb := span[pos]
-				if sb < 0x80 {
-					out = append(out, sb)
-				} else {
-					mapped := ansi.Cp437ToUnicode[sb]
-					if mapped == 0 {
-						out = append(out, '?')
-					} else {
-						out = append(out, []byte(string(mapped))...)
-					}
-				}
-				pos++
+		// Decide the span's encoding as a whole rather than rune by rune.
+		//
+		// Deciding per rune looks like it handles mixed content, but the two
+		// encodings are not separable that way: plenty of adjacent CP437 pairs
+		// form a structurally valid UTF-8 sequence, and the decoder then
+		// swallows both bytes and emits one unrelated character. CP437 line
+		// art is full of such pairs — ▄│ (DC B3) decodes as U+0733, a Syriac
+		// combining mark — so exactly the content most likely to be CP437 was
+		// the content most likely to be misread (#280).
+		//
+		// A span that is valid UTF-8 throughout is taken as UTF-8; anything
+		// else is taken as CP437 and mapped byte for byte. Where a span is
+		// valid under both this still guesses, and only the message's own CHRS
+		// kludge can settle it — but it no longer mangles art that is
+		// unambiguously CP437.
+		if utf8.Valid(span) {
+			out = append(out, span...)
+			continue
+		}
+		for _, sb := range span {
+			if sb < 0x80 {
+				out = append(out, sb)
+				continue
+			}
+			mapped := ansi.Cp437ToUnicode[sb]
+			if mapped == 0 {
+				out = append(out, '?')
 			} else {
-				// Valid UTF-8 rune - preserve as-is
-				out = append(out, span[pos:pos+size]...)
-				pos += size
+				out = append(out, []byte(string(mapped))...)
 			}
 		}
 	}

--- a/internal/terminalio/writer.go
+++ b/internal/terminalio/writer.go
@@ -148,19 +148,21 @@ func WriteStringCP437(writer io.Writer, data []byte, mode ansi.OutputMode) error
 		}
 		span := data[spanStart:i]
 
-		// Process span rune-by-rune to handle mixed UTF-8 + raw CP437 content
-		pos := 0
-		for pos < len(span) {
-			r, size := utf8.DecodeRune(span[pos:])
-			if r == utf8.RuneError && size == 1 {
-				// Invalid UTF-8 byte - pass through as raw CP437
-				out = append(out, span[pos])
-				pos++
-				continue
-			}
+		// Decide the span's encoding as a whole, as the comment above always
+		// claimed and the rune-by-rune loop here did not. The same CP437 pairs
+		// that form valid UTF-8 sequences were decoded as one rune and then
+		// converted back — and since nothing like U+0733 exists in CP437, the
+		// pair came out as a single '?'. That is the mojibake #280 reported,
+		// on a terminal that would have rendered the original bytes correctly
+		// had they simply been left alone.
+		if !utf8.Valid(span) {
+			// Already CP437: hand it to the terminal untouched.
+			out = append(out, span...)
+			continue
+		}
+		for _, r := range string(span) {
 			if r < 0x80 {
 				out = append(out, byte(r))
-				pos += size
 				continue
 			}
 			if cp437Byte, ok := ansi.UnicodeToCP437[r]; ok {
@@ -168,7 +170,6 @@ func WriteStringCP437(writer io.Writer, data []byte, mode ansi.OutputMode) error
 			} else {
 				out = append(out, '?')
 			}
-			pos += size
 		}
 	}
 

--- a/internal/terminalio/writer_test.go
+++ b/internal/terminalio/writer_test.go
@@ -140,3 +140,43 @@ func TestWriteProcessedBytes_UTF8Mode_ShortAmbiguousSpanStaysUTF8(t *testing.T) 
 		t.Errorf("got %q, want %q — a two-byte span valid under both encodings is read as UTF-8", got, want)
 	}
 }
+
+// TestWriteStringCP437_LeavesCP437ArtUntouched covers the other half of the
+// same defect, on the path a CP437 terminal actually takes. A CP437 pair that
+// forms a valid UTF-8 sequence was decoded as one rune and converted back —
+// and with nothing like U+0733 in CP437, the pair collapsed to a single '?'.
+// That is the mojibake in #280, produced on a terminal that would have
+// rendered the original bytes correctly had they been passed through.
+func TestWriteStringCP437_LeavesCP437ArtUntouched(t *testing.T) {
+	// A real art line from the fsxNet message in the report. DC B3 sits in the
+	// middle of it.
+	art := []byte{
+		0x3a, 0x20, 0x20, 0x20, 0x3a, 0x20,
+		0xda, 0xc4, 0xdc, 0xb3, 0x20, 0xda, 0xc4, 0xdc,
+		0xda, 0xc4, 0xdc, 0xde, 0xc4, 0xdc,
+	}
+	var buf bytes.Buffer
+	if err := WriteStringCP437(&buf, art, ansi.OutputModeCP437); err != nil {
+		t.Fatalf("WriteStringCP437: %v", err)
+	}
+	if got := buf.Bytes(); !bytes.Equal(got, art) {
+		t.Errorf("CP437 art must reach a CP437 terminal unchanged\n in: %x\nout: %x", art, got)
+	}
+	if n := bytes.Count(buf.Bytes(), []byte("?")); n != 0 {
+		t.Errorf("%d byte(s) were replaced with '?'", n)
+	}
+}
+
+// TestWriteStringCP437_ConvertsUTF8Strings covers the case this function
+// exists for: text from strings.json, which is UTF-8, being rendered on a
+// CP437 terminal.
+func TestWriteStringCP437_ConvertsUTF8Strings(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteStringCP437(&buf, []byte("┌─▄│"), ansi.OutputModeCP437); err != nil {
+		t.Fatalf("WriteStringCP437: %v", err)
+	}
+	want := []byte{0xDA, 0xC4, 0xDC, 0xB3}
+	if got := buf.Bytes(); !bytes.Equal(got, want) {
+		t.Errorf("got %x, want %x", got, want)
+	}
+}

--- a/internal/terminalio/writer_test.go
+++ b/internal/terminalio/writer_test.go
@@ -53,3 +53,90 @@ func TestWriteProcessedBytes_UTF8Mode_PreservesANSIAndMapsCP437(t *testing.T) {
 		t.Fatalf("unexpected output with ANSI: got %q want %q", out.String(), want)
 	}
 }
+
+// TestWriteProcessedBytes_UTF8Mode_CP437PairsThatLookLikeUTF8 covers the pairs
+// that made CP437 art unreadable. Deciding the encoding one rune at a time
+// looks like it separates mixed content, but adjacent CP437 bytes routinely
+// form a structurally valid UTF-8 sequence — the decoder then consumes both
+// and emits one unrelated character. Line art is dense with such pairs, so the
+// content most likely to be CP437 was the content most likely to be misread
+// (#280).
+func TestWriteProcessedBytes_UTF8Mode_CP437PairsThatLookLikeUTF8(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want string
+	}{
+		{
+			// DC B3 is a well-formed two-byte UTF-8 sequence for U+0733, a
+			// Syriac combining mark, and used to be emitted as one. In a span
+			// that is CP437 overall it is two characters.
+			name: "lower half block then vertical line",
+			in:   []byte{0xDA, 0xC4, 0xDC, 0xB3},
+			want: "┌─▄│",
+		},
+		{
+			// C4 B3 decodes as U+0133 on its own.
+			name: "horizontal line then vertical line",
+			in:   []byte{0xDA, 0xC4, 0xB3, 0xBF},
+			want: "┌─│┐",
+		},
+		{
+			// A real line lifted from an fsxNet message that rendered as
+			// mojibake on a live board.
+			name: "art line from a real message",
+			in: []byte{
+				0x3a, 0x20, 0x20, 0x20, 0x3a, 0x20,
+				0xda, 0xc4, 0xdc, 0xb3, 0x20, 0xda, 0xc4, 0xdc,
+				0xda, 0xc4, 0xdc, 0xde, 0xc4, 0xdc,
+			},
+			want: ":   : ┌─▄│ ┌─▄┌─▄▐─▄",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := WriteProcessedBytes(&buf, tt.in, ansi.OutputModeUTF8); err != nil {
+				t.Fatalf("WriteProcessedBytes: %v", err)
+			}
+			if got := buf.String(); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestWriteProcessedBytes_UTF8Mode_MixedSpanPrefersCP437 pins the trade-off
+// made when a span cannot be both. A span carrying any invalid sequence is
+// read as CP437 throughout, because a body that is truly UTF-8 is valid
+// throughout and takes the passthrough path above.
+func TestWriteProcessedBytes_UTF8Mode_MixedSpanPrefersCP437(t *testing.T) {
+	// "é" as UTF-8 (C3 A9) followed by a byte that cannot continue any
+	// sequence, so the span as a whole is invalid.
+	in := []byte{0xC3, 0xA9, 0xDB}
+	var buf bytes.Buffer
+	if err := WriteProcessedBytes(&buf, in, ansi.OutputModeUTF8); err != nil {
+		t.Fatalf("WriteProcessedBytes: %v", err)
+	}
+	want := "├⌐█" // C3, A9 and DB each read as CP437
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestWriteProcessedBytes_UTF8Mode_ShortAmbiguousSpanStaysUTF8 records what
+// this heuristic cannot do. A span short enough to be valid under both
+// encodings is genuinely ambiguous — DC B3 is both "▄│" in CP437 and U+0733 in
+// UTF-8 — and is read as UTF-8. Only the message's own CHRS kludge can settle
+// it, so plumbing that through to the writer is the real fix; until then this
+// is the residual case, pinned here so a future change to it is deliberate.
+func TestWriteProcessedBytes_UTF8Mode_ShortAmbiguousSpanStaysUTF8(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteProcessedBytes(&buf, []byte{0xDC, 0xB3}, ansi.OutputModeUTF8); err != nil {
+		t.Fatalf("WriteProcessedBytes: %v", err)
+	}
+	if got, want := buf.String(), "\u0733"; got != want {
+		t.Errorf("got %q, want %q — a two-byte span valid under both encodings is read as UTF-8", got, want)
+	}
+}


### PR DESCRIPTION
Fixes #280.

The message in that report is stored correctly — I read it back out of the JAM base and every non-ASCII byte is valid CP437 line art (`0xDA` `┌`, `0xC4` `─`, `0xB3` `│`, `0xDB` `█`), with the sender's own `CHRS: CP437 2` kludge confirming it. The tosser wrote it faithfully. The damage happens between the message base and the terminal.

## Cause

`writeUTF8Mode` decided the encoding one rune at a time: decode a rune, and if it came back `RuneError` with size 1, treat that single byte as CP437. The comment described this as handling mixed UTF-8 + CP437 content.

The two encodings are not separable that way. Adjacent CP437 bytes routinely form a *structurally valid* UTF-8 sequence, and the decoder then consumes both and emits one unrelated character. Line art is dense with exactly those pairs, so the content most likely to be CP437 was the content most likely to be misread.

Run through the real bytes from the reported message:

```
got : ":   : ┌─ܳ ┌─▄┌─▄▐─▄┌─▄┌ ▄┌─▄ … "
want: ":   : ┌─▄│ ┌─▄┌─▄▐─▄┌─▄┌ ▄┌─▄ … "
```

`▄│` — `DC B3` — is a well-formed two-byte sequence for U+0733, a Syriac combining mark. Two characters became one wrong one. `C4 B3` similarly decodes as U+0133.

## Both output paths had it, and the reported session took the other one

`WriteStringCP437` — the path to a CP437 terminal such as the SyncTERM session in the screenshot — carried the identical defect. Its comment already claimed it converted "only for spans that are entirely valid UTF-8"; the loop underneath decided per rune. So the same pair was decoded to one rune and converted *back* to CP437, and since nothing like U+0733 exists in CP437 it collapsed to a single `?`:

```
 in: 3a2020203a20 dac4 dcb3 20dac4dc…
out: 3a2020203a20 dac4 3f   20dac4dc…
```

That is where the `?` characters in the screenshot come from — on a terminal that would have rendered the original bytes correctly had they simply been passed through. Both functions are fixed the same way.

## Fix

Decide per span rather than per rune: a span that is valid UTF-8 throughout is passed through untouched, anything else is mapped byte for byte as CP437. A body that genuinely is UTF-8 is valid throughout and takes the first path, so this does not cost UTF-8 messages anything, while art that is unambiguously CP437 now survives.

ANSI escape handling is unchanged — spans are still cut at escape sequences, which pass through as before.

## What this does not fix

A span short enough to be valid under *both* encodings remains ambiguous: `DC B3` on its own really is both `▄│` in CP437 and U+0733 in UTF-8, and nothing in the byte stream can settle it. Only the message's own `CHRS` kludge can, and plumbing that from the message through to the writer is the principled fix — a larger change than this one, and worth doing separately.

I have pinned the residual case in a test rather than leaving it undocumented, so that if someone later changes that behaviour it is a deliberate act and not a surprise. In practice it does not affect real art, which is long enough to contain at least one invalid sequence.

## Testing

Four new cases alongside the three existing ones:

- the `DC B3` and `C4 B3` pairs, in a span that is CP437 overall
- a real art line lifted from the fsxNet message in the report
- a mixed span, pinning the trade-off that a span carrying any invalid sequence is read as CP437 throughout
- the short ambiguous span described above

Verified against the live message: before the change the line rendered `┌─ܳ`, after it renders `┌─▄│`, matching a byte-for-byte CP437 mapping. `go build ./...`, `go vet ./...` and `go test ./...` all clean, and the pre-existing terminalio tests pass unchanged.