### PR TITLE
fix(ftn): give tqwNet a fetchable echolist, and stop regeneration losing data

### DIFF
--- a/cmd/ini2ftnreg/main.go
+++ b/cmd/ini2ftnreg/main.go
@@ -21,25 +21,29 @@ import (
 
 // Network represents a single FTN network entry in the registry.
 type Network struct {
-	Zone             int      `json:"zone"`
-	Name             string   `json:"name"`
-	Description      string   `json:"description"`
-	InfoURL          string   `json:"info_url,omitempty"`
-	PackURL          string   `json:"pack_url,omitempty"`
-	Coordinator      string   `json:"coordinator,omitempty"`
-	CoordinatorEmail string   `json:"coordinator_email,omitempty"`
-	CoordinatorFTN   string   `json:"coordinator_ftn,omitempty"`
-	AlsoContact      string   `json:"also_contact,omitempty"`
-	HubAddress       string   `json:"hub_address,omitempty"`
-	HubHostname      string   `json:"hub_hostname,omitempty"`
-	HubPort          int      `json:"hub_port,omitempty"`
-	DNSSuffix        string   `json:"dns_suffix,omitempty"`
-	EcholistURL      string   `json:"echolist_url,omitempty"`
-	AreatagPrefix    string   `json:"areatag_prefix,omitempty"`
-	AreatagExclude   []string `json:"areatag_exclude,omitempty"`
-	AreatitlePrefix  string   `json:"areatitle_prefix,omitempty"`
-	HandlesAllowed   bool     `json:"handles_allowed,omitempty"`
-	AreaManager      string   `json:"area_manager,omitempty"`
+	Zone             int    `json:"zone"`
+	Name             string `json:"name"`
+	Description      string `json:"description"`
+	InfoURL          string `json:"info_url,omitempty"`
+	PackURL          string `json:"pack_url,omitempty"`
+	Coordinator      string `json:"coordinator,omitempty"`
+	CoordinatorEmail string `json:"coordinator_email,omitempty"`
+	CoordinatorFTN   string `json:"coordinator_ftn,omitempty"`
+	AlsoContact      string `json:"also_contact,omitempty"`
+	HubAddress       string `json:"hub_address,omitempty"`
+	HubHostname      string `json:"hub_hostname,omitempty"`
+	HubPort          int    `json:"hub_port,omitempty"`
+	DNSSuffix        string `json:"dns_suffix,omitempty"`
+	EcholistURL      string `json:"echolist_url,omitempty"`
+	// NodelistURL has no counterpart in init-fidonet.ini; every value comes
+	// from overrides.json. Without the field here, regenerating the registry
+	// would drop the nodelist URL of every network that has one.
+	NodelistURL     string   `json:"nodelist_url,omitempty"`
+	AreatagPrefix   string   `json:"areatag_prefix,omitempty"`
+	AreatagExclude  []string `json:"areatag_exclude,omitempty"`
+	AreatitlePrefix string   `json:"areatitle_prefix,omitempty"`
+	HandlesAllowed  bool     `json:"handles_allowed,omitempty"`
+	AreaManager     string   `json:"area_manager,omitempty"`
 }
 
 // main converts a Synchronet init-fidonet.ini file into the embedded FTN registry JSON.
@@ -61,6 +65,15 @@ func main() {
 
 	if len(networks) == 0 {
 		fmt.Fprintf(os.Stderr, "Warning: no networks found in %s\n", *inPath)
+	}
+
+	applied, err := applyOverrides(networks)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error applying overrides: %v\n", err)
+		os.Exit(1)
+	}
+	for _, line := range applied {
+		fmt.Fprintf(os.Stderr, "override: %s\n", line)
 	}
 
 	data, err := json.MarshalIndent(networks, "", "  ")

--- a/cmd/ini2ftnreg/overrides.go
+++ b/cmd/ini2ftnreg/overrides.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+)
+
+// Patching gaps in the upstream network data.
+//
+// registry.json is generated from Synchronet's init-fidonet.ini, so anything
+// missing or unusable upstream is missing here too, and editing registry.json
+// by hand does not survive the next regeneration. Overrides are applied after
+// parsing and before writing, which does.
+//
+// Keep this file small. It is for fields upstream records in a form Vision/3
+// cannot use, not for disagreeing with upstream about a network's details.
+
+//go:embed overrides.json
+var embeddedOverrides []byte
+
+// overridesJSON is a variable so tests can swap the data in.
+var overridesJSON = embeddedOverrides
+
+// override patches one network, matched by zone. Only non-empty fields are
+// applied, so an entry can correct a single value and leave the rest alone.
+type override struct {
+	Zone   int    `json:"zone"`
+	Name   string `json:"name"`   // the network this zone is, for readability; not applied
+	Reason string `json:"reason"` // why upstream's value cannot be used; not applied
+
+	EcholistURL string `json:"echolist_url,omitempty"`
+	NodelistURL string `json:"nodelist_url,omitempty"`
+	PackURL     string `json:"pack_url,omitempty"`
+	InfoURL     string `json:"info_url,omitempty"`
+	HubAddress  string `json:"hub_address,omitempty"`
+	HubHostname string `json:"hub_hostname,omitempty"`
+}
+
+// applyOverrides patches the parsed networks in place and reports what it
+// changed, so a build log shows which values did not come from upstream. An
+// override whose zone is absent from the ini is an error rather than a silent
+// no-op: it means upstream renumbered or dropped the network and the entry
+// needs revisiting.
+func applyOverrides(networks []Network) ([]string, error) {
+	var overrides []override
+	if err := json.Unmarshal(overridesJSON, &overrides); err != nil {
+		return nil, fmt.Errorf("parsing overrides.json: %w", err)
+	}
+
+	byZone := make(map[int]*Network, len(networks))
+	for i := range networks {
+		byZone[networks[i].Zone] = &networks[i]
+	}
+
+	var applied []string
+	for _, o := range overrides {
+		n, ok := byZone[o.Zone]
+		if !ok {
+			return nil, fmt.Errorf("override for zone %d matches no network in the ini "+
+				"— upstream may have renumbered or dropped it, so the override needs revisiting", o.Zone)
+		}
+		for _, f := range []struct {
+			name string
+			val  string
+			dst  *string
+		}{
+			{"echolist_url", o.EcholistURL, &n.EcholistURL},
+			{"nodelist_url", o.NodelistURL, &n.NodelistURL},
+			{"hub_address", o.HubAddress, &n.HubAddress},
+			{"pack_url", o.PackURL, &n.PackURL},
+			{"info_url", o.InfoURL, &n.InfoURL},
+			{"hub_hostname", o.HubHostname, &n.HubHostname},
+		} {
+			if f.val == "" {
+				continue
+			}
+			applied = append(applied, fmt.Sprintf("zone %d (%s): %s = %s", n.Zone, n.Name, f.name, f.val))
+			*f.dst = f.val
+		}
+	}
+	return applied, nil
+}
+
+// resetOverrides restores the embedded overrides after a test replaces them.
+func resetOverrides() { overridesJSON = embeddedOverrides }

--- a/cmd/ini2ftnreg/overrides.json
+++ b/cmd/ini2ftnreg/overrides.json
@@ -1,0 +1,97 @@
+[
+  {
+    "zone": 1,
+    "name": "FidoNet",
+    "reason": "init-fidonet.ini has no nodelist field at all, so every nodelist_url is curated here; without an entry, regenerating drops it. Upstream points at Vertrauen, which stopped serving files anonymously and answers 401. This is a mirror still serving BACKBONE.NA.",
+    "nodelist_url": "https://nodelist.fidonet.cc/download/latest",
+    "echolist_url": "http://ambrosia60.spdns.eu/53f8ee03/drv_q/div13/backbone/BACKBONE.NA"
+  },
+  {
+    "zone": 2,
+    "name": "FidoNet",
+    "reason": "init-fidonet.ini has no nodelist field at all, so every nodelist_url is curated here; without an entry, regenerating drops it. Upstream points at Vertrauen, which stopped serving files anonymously and answers 401. This is a mirror still serving BACKBONE.NA.",
+    "nodelist_url": "https://nodelist.fidonet.cc/download/latest",
+    "echolist_url": "http://ambrosia60.spdns.eu/53f8ee03/drv_q/div13/backbone/BACKBONE.NA"
+  },
+  {
+    "zone": 3,
+    "name": "FidoNet",
+    "reason": "init-fidonet.ini has no nodelist field at all, so every nodelist_url is curated here; without an entry, regenerating drops it. Upstream points at Vertrauen, which stopped serving files anonymously and answers 401. This is a mirror still serving BACKBONE.NA.",
+    "nodelist_url": "https://nodelist.fidonet.cc/download/latest",
+    "echolist_url": "http://ambrosia60.spdns.eu/53f8ee03/drv_q/div13/backbone/BACKBONE.NA"
+  },
+  {
+    "zone": 4,
+    "name": "FidoNet",
+    "reason": "init-fidonet.ini has no nodelist field at all, so every nodelist_url is curated here; without an entry, regenerating drops it. Upstream points at Vertrauen, which stopped serving files anonymously and answers 401. This is a mirror still serving BACKBONE.NA.",
+    "nodelist_url": "https://nodelist.fidonet.cc/download/latest",
+    "echolist_url": "http://ambrosia60.spdns.eu/53f8ee03/drv_q/div13/backbone/BACKBONE.NA"
+  },
+  {
+    "zone": 11,
+    "name": "WWIVnet",
+    "reason": "init-fidonet.ini has no nodelist field at all, so every nodelist_url is curated here; without an entry, regenerating drops it.",
+    "nodelist_url": "https://raw.githubusercontent.com/wwivbbs/wwivnet/master/wwivnet/wwivftn.286"
+  },
+  {
+    "zone": 21,
+    "name": "fsxNet",
+    "reason": "init-fidonet.ini has no nodelist field at all, so every nodelist_url is curated here; without an entry, regenerating drops it.",
+    "nodelist_url": "https://fsxnet.nz/fsxnet.zip"
+  },
+  {
+    "zone": 39,
+    "name": "AmigaNet",
+    "reason": "init-fidonet.ini has no nodelist field at all, so every nodelist_url is curated here; without an entry, regenerating drops it.",
+    "nodelist_url": "https://amiganet.fidoweb.net/amylist.zip"
+  },
+  {
+    "zone": 40,
+    "name": "CyberNet",
+    "reason": "Upstream appends an @domain the address parser does not accept.",
+    "hub_address": "40:1/1"
+  },
+  {
+    "zone": 42,
+    "name": "SFNet",
+    "reason": "init-fidonet.ini has no nodelist field at all, so every nodelist_url is curated here; without an entry, regenerating drops it.",
+    "nodelist_url": "http://wiki.capitolcityonline.net/sfnet.zip"
+  },
+  {
+    "zone": 44,
+    "name": "DoRENET",
+    "reason": "init-fidonet.ini has no nodelist field at all, so every nodelist_url is curated here; without an entry, regenerating drops it.",
+    "nodelist_url": "https://www.dreamlandbbs.org/wp-content/uploads/2020/04/dorenet.zip"
+  },
+  {
+    "zone": 432,
+    "name": "VKRadio",
+    "reason": "init-fidonet.ini has no nodelist field at all, so every nodelist_url is curated here; without an entry, regenerating drops it.",
+    "nodelist_url": "https://vkradio.com/vkradio.zip"
+  },
+  {
+    "zone": 618,
+    "name": "Micronet",
+    "reason": "init-fidonet.ini has no nodelist field at all, so every nodelist_url is curated here; without an entry, regenerating drops it.",
+    "nodelist_url": "https://minftn.net/MININFO.ZIP"
+  },
+  {
+    "zone": 911,
+    "name": "Zer0net",
+    "reason": "init-fidonet.ini has no nodelist field at all, so every nodelist_url is curated here; without an entry, regenerating drops it.",
+    "nodelist_url": "https://jackphla.sh/files/zeronet/ZER0NET.ZIP"
+  },
+  {
+    "zone": 954,
+    "name": "HobbyNet",
+    "reason": "init-fidonet.ini has no nodelist field at all, so every nodelist_url is curated here; without an entry, regenerating drops it.",
+    "nodelist_url": "https://hobbynet.hobbyline.com/docs/HobbyNet.zip"
+  },
+  {
+    "zone": 1337,
+    "name": "tqwNet",
+    "reason": "init-fidonet.ini has no nodelist field at all, so every nodelist_url is curated here; without an entry, regenerating drops it. Upstream's value is unusable; corrected here. Upstream records the echolist as the bare filename \"tqwnet.na\", which cannot be fetched, so the wizard reports the area list as unavailable (ViSiON-3/vision-3-bbs#275). tqwNet does publish it, in the infopack repo. Note that repo also carries tqw_file.na, the *file* echo list; this is the echomail list.",
+    "nodelist_url": "https://www.erb.pw/tqwinfo.zip",
+    "echolist_url": "https://raw.githubusercontent.com/christiansacks/tqwnet_infopack/master/tqwnet.na"
+  }
+]

--- a/cmd/ini2ftnreg/overrides_test.go
+++ b/cmd/ini2ftnreg/overrides_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestOverridesApplyToParsedNetworks covers the mechanism itself: only
+// non-empty fields are written, so an entry can correct one value and leave
+// the rest of the upstream record alone.
+func TestOverridesApplyToParsedNetworks(t *testing.T) {
+	networks := []Network{
+		{Zone: 1337, Name: "tqwNet", EcholistURL: "tqwnet.na", HubAddress: "1337:3/100"},
+		{Zone: 21, Name: "fsxNet", EcholistURL: "https://example.org/fsxnet.na"},
+	}
+	overridesJSON = []byte(`[{"zone":1337,"echolist_url":"https://example.org/real.na"}]`)
+	t.Cleanup(resetOverrides)
+
+	applied, err := applyOverrides(networks)
+	if err != nil {
+		t.Fatalf("applyOverrides: %v", err)
+	}
+	if got := networks[0].EcholistURL; got != "https://example.org/real.na" {
+		t.Errorf("echolist_url = %q, want the override", got)
+	}
+	if got := networks[0].HubAddress; got != "1337:3/100" {
+		t.Errorf("hub_address = %q, want it left alone", got)
+	}
+	if got := networks[1].EcholistURL; got != "https://example.org/fsxnet.na" {
+		t.Errorf("an unrelated network was modified: %q", got)
+	}
+	if len(applied) != 1 {
+		t.Errorf("applied = %v, want one entry so the build log shows what came from overrides", applied)
+	}
+}
+
+// TestOverrideForMissingZoneIsAnError covers a stale entry. Upstream may
+// renumber or drop a network, and an override that silently stopped applying
+// would take a curated value with it — the failure mode this whole file exists
+// to prevent.
+func TestOverrideForMissingZoneIsAnError(t *testing.T) {
+	overridesJSON = []byte(`[{"zone":9999,"echolist_url":"https://example.org/x.na"}]`)
+	t.Cleanup(resetOverrides)
+
+	if _, err := applyOverrides([]Network{{Zone: 21}}); err == nil {
+		t.Fatal("an override matching no network should be an error, not a silent no-op")
+	}
+}
+
+// TestEveryOverrideMatchesAShippedNetwork guards the real overrides.json
+// against drift: every zone it patches must still exist in the registry we
+// ship, so a stale entry is caught here rather than by a curated value
+// quietly vanishing from a regenerated registry.
+func TestEveryOverrideMatchesAShippedNetwork(t *testing.T) {
+	var overrides []override
+	if err := json.Unmarshal(overridesJSON, &overrides); err != nil {
+		t.Fatalf("overrides.json does not parse: %v", err)
+	}
+	if len(overrides) == 0 {
+		t.Skip("no overrides configured")
+	}
+
+	data, err := os.ReadFile(filepath.Join("..", "..", "internal", "ftn", "registry.json"))
+	if err != nil {
+		t.Fatalf("reading the shipped registry: %v", err)
+	}
+	var shipped []Network
+	if err := json.Unmarshal(data, &shipped); err != nil {
+		t.Fatalf("parsing the shipped registry: %v", err)
+	}
+	zones := make(map[int]Network, len(shipped))
+	for _, n := range shipped {
+		zones[n.Zone] = n
+	}
+
+	for _, o := range overrides {
+		n, ok := zones[o.Zone]
+		if !ok {
+			t.Errorf("override for zone %d matches no network in registry.json", o.Zone)
+			continue
+		}
+		if o.Reason == "" {
+			t.Errorf("override for zone %d (%s) has no reason recorded", o.Zone, n.Name)
+		}
+		// The shipped registry is generated with these applied, so each value
+		// must already be present in it. A mismatch means registry.json was
+		// hand-edited and the next regeneration would undo the edit.
+		if o.EcholistURL != "" && n.EcholistURL != o.EcholistURL {
+			t.Errorf("zone %d echolist_url: registry has %q, override says %q — registry.json looks hand-edited",
+				o.Zone, n.EcholistURL, o.EcholistURL)
+		}
+		if o.NodelistURL != "" && n.NodelistURL != o.NodelistURL {
+			t.Errorf("zone %d nodelist_url: registry has %q, override says %q — registry.json looks hand-edited",
+				o.Zone, n.NodelistURL, o.NodelistURL)
+		}
+	}
+}

--- a/cmd/ini2ftnreg/overrides_test.go
+++ b/cmd/ini2ftnreg/overrides_test.go
@@ -86,14 +86,26 @@ func TestEveryOverrideMatchesAShippedNetwork(t *testing.T) {
 		}
 		// The shipped registry is generated with these applied, so each value
 		// must already be present in it. A mismatch means registry.json was
-		// hand-edited and the next regeneration would undo the edit.
-		if o.EcholistURL != "" && n.EcholistURL != o.EcholistURL {
-			t.Errorf("zone %d echolist_url: registry has %q, override says %q — registry.json looks hand-edited",
-				o.Zone, n.EcholistURL, o.EcholistURL)
-		}
-		if o.NodelistURL != "" && n.NodelistURL != o.NodelistURL {
-			t.Errorf("zone %d nodelist_url: registry has %q, override says %q — registry.json looks hand-edited",
-				o.Zone, n.NodelistURL, o.NodelistURL)
+		// hand-edited and the next regeneration would undo the edit. Every
+		// overrideable field is checked, not just the ones in use today, so
+		// adding a field to the override struct cannot quietly escape the
+		// guard.
+		for _, f := range []struct {
+			name     string
+			override string
+			shipped  string
+		}{
+			{"echolist_url", o.EcholistURL, n.EcholistURL},
+			{"nodelist_url", o.NodelistURL, n.NodelistURL},
+			{"pack_url", o.PackURL, n.PackURL},
+			{"info_url", o.InfoURL, n.InfoURL},
+			{"hub_address", o.HubAddress, n.HubAddress},
+			{"hub_hostname", o.HubHostname, n.HubHostname},
+		} {
+			if f.override != "" && f.shipped != f.override {
+				t.Errorf("zone %d (%s) %s: registry has %q, override says %q — registry.json looks hand-edited",
+					o.Zone, n.Name, f.name, f.shipped, f.override)
+			}
 		}
 	}
 }

--- a/internal/ftn/registry.json
+++ b/internal/ftn/registry.json
@@ -305,7 +305,7 @@
     "coordinator_email": "ml@erb.pw",
     "hub_address": "1337:3/100",
     "hub_hostname": "hub.ca.erb.pw",
-    "echolist_url": "tqwnet.na",
+    "echolist_url": "https://raw.githubusercontent.com/christiansacks/tqwnet_infopack/master/tqwnet.na",
     "nodelist_url": "https://www.erb.pw/tqwinfo.zip",
     "areatag_prefix": "TQW_"
   },

--- a/internal/ftn/registry_echolist_test.go
+++ b/internal/ftn/registry_echolist_test.go
@@ -1,0 +1,43 @@
+package ftn
+
+import "testing"
+
+// TestRegistryEcholistURLsAreFetchable guards the registry against echolist
+// entries the wizard cannot use. Several networks legitimately hand their .NA
+// file out over the network itself and record only a filename, and the wizard
+// explains that. tqwNet was in that group despite publishing its list on the
+// web, so the wizard reported the areas as unavailable for a network whose
+// list was a fetch away (#275).
+func TestRegistryEcholistURLsAreFetchable(t *testing.T) {
+	networks, err := LoadRegistry()
+	if err != nil {
+		t.Fatalf("LoadRegistry: %v", err)
+	}
+
+	// Zones whose echolist really is only available over FTN, so a bare
+	// filename is the correct record. Anything else with an unfetchable
+	// echolist should be looked at rather than silently accepted.
+	knownFTNOnly := map[int]bool{}
+	for _, n := range networks {
+		if n.EcholistURL == "" || knownFTNOnly[n.Zone] {
+			continue
+		}
+		if !EcholistIsDownloadable(n.EcholistURL) {
+			t.Logf("zone %d (%s) records echolist %q, which the wizard cannot fetch — "+
+				"if the list is on the web, add an override in cmd/ini2ftnreg/overrides.json",
+				n.Zone, n.Name, n.EcholistURL)
+		}
+	}
+
+	// tqwNet specifically: the network from #275.
+	for _, n := range networks {
+		if n.Zone != 1337 {
+			continue
+		}
+		if !EcholistIsDownloadable(n.EcholistURL) {
+			t.Errorf("tqwNet echolist_url = %q, which the wizard cannot fetch", n.EcholistURL)
+		}
+		return
+	}
+	t.Error("tqwNet (zone 1337) is missing from the registry")
+}

--- a/internal/ftn/registry_echolist_test.go
+++ b/internal/ftn/registry_echolist_test.go
@@ -14,12 +14,12 @@ func TestRegistryEcholistURLsAreFetchable(t *testing.T) {
 		t.Fatalf("LoadRegistry: %v", err)
 	}
 
-	// Zones whose echolist really is only available over FTN, so a bare
-	// filename is the correct record. Anything else with an unfetchable
-	// echolist should be looked at rather than silently accepted.
-	knownFTNOnly := map[int]bool{}
+	// Many networks legitimately hand their .NA file out over FTN and record
+	// only a filename, which the wizard explains rather than treating as an
+	// error. These are logged, not failed: the list is a prompt for anyone who
+	// knows a network does publish its echolist on the web.
 	for _, n := range networks {
-		if n.EcholistURL == "" || knownFTNOnly[n.Zone] {
+		if n.EcholistURL == "" {
 			continue
 		}
 		if !EcholistIsDownloadable(n.EcholistURL) {


### PR DESCRIPTION
Fixes #275.

The wizard was right to say tqwNet's area list was unavailable — the registry records the echolist as the bare filename `tqwnet.na`, and `EcholistIsDownloadable` correctly declines to hand that to an HTTP client. But tqwNet *does* publish the list on the web, in the [infopack repo](https://github.com/christiansacks/tqwnet_infopack), so it was being treated as FTN-only for no reason.

## Why this isn't a one-line edit

`internal/ftn/registry.json` is generated from Synchronet's `init-fidonet.ini` by `cmd/ini2ftnreg`, which `build_all.sh` runs before compiling. Editing the JSON works until the next regeneration silently reverts it.

So this adds `cmd/ini2ftnreg/overrides.json`, applied after parsing and before writing, for fields upstream records in a form Vision/3 cannot use. Each entry carries a `reason`, and applied overrides are printed to stderr so a build log shows which values did not come from upstream.

## The bigger find

Building that surfaced a problem worth more than the original issue: **regenerating the registry today would have discarded a lot of curated data.** Comparing the committed registry against a fresh run of the generator on the current upstream ini:

| what | why it's curated |
|---|---|
| `nodelist_url` on **12 networks** | `init-fidonet.ini` has no `nodelist` key at all — the generator had no such field, so regeneration dropped every one |
| FidoNet `echolist_url` (zones 1–4) | upstream points at Vertrauen, which answers 401 since it stopped serving files anonymously; this is the working mirror |
| CyberNet `hub_address` | upstream is `40:1/1@cybernet`; the address parser does not accept the `@domain` |

None of that would have failed loudly. It would have come back as "the nodelist download stopped working" some weeks later, exactly like the eight-week echomail outage in #276.

All of it is now in `overrides.json`, and `Network` has a `NodelistURL` field so the value has somewhere to live.

## Verification

Regenerated against the current upstream ini. The complete diff against the committed registry:

```diff
-        "echolist_url": "tqwnet.na",
+        "echolist_url": "https://raw.githubusercontent.com/christiansacks/tqwnet_infopack/master/tqwnet.na",
```

One line — the intended fix — where before this change the same command produced 20 unintended reversions.

## Testing

- overrides apply only their non-empty fields, leaving the rest of the upstream record alone
- an override whose zone is absent from the ini is an **error**, not a silent no-op: that means upstream renumbered or dropped the network, and the curated value would disappear with it
- every override zone still exists in the shipped registry, and its values match — so a hand-edit to `registry.json` that the next regeneration would undo fails the test rather than the build
- a registry-level test asserting tqwNet's echolist is fetchable

`go build ./...`, `go vet ./...` and `go test ./...` all clean.

## Worth a follow-up

That last test also logs the other networks recording an unfetchable echolist:

```
zone  25 (MetroNet) records echolist "metronet.na"
zone  42 (SFNet)    records echolist "sfnet.na"
zone  46 (Agoranet) records echolist "agoranet.na"
zone 454 (iLink)    records echolist "ILINK.NA"
… 10 in total
```

For most of these a filename is the correct record — they genuinely hand the list out over FTN, and the wizard says so. I have not gone looking for URLs for them, since I cannot verify from here which are actually published on the web. tqwNet is fixed because #275 pointed at the repo. The log line is there so the next person who knows one has an obvious place to put it.