### PR TITLE
fix(configeditor): save the FTN origin line, and wrap field help that overruns the box

### DIFF
--- a/internal/configeditor/fields_doors.go
+++ b/internal/configeditor/fields_doors.go
@@ -173,7 +173,7 @@ func (m *Model) fieldsDoor() []fieldDef {
 			// Code is the door's identity: doors.json is saved as an array and
 			// re-keyed by Code on load, and DOOR:CODE menu lookups uppercase the
 			// input — so renaming re-keys the map and normalizes to uppercase.
-			Label: "Code", Help: "Internal code used in DOOR:CODE menu commands (A-Z, 0-9, _ or -, max 16)", Type: ftString, Col: 3, Row: row, Width: 16,
+			Label: "Code", Help: "Code for DOOR:CODE menu commands (A-Z 0-9 _ - , max 16)", Type: ftString, Col: 3, Row: row, Width: 16,
 			Get: func() string { return dPtr.Code },
 			Set: func(rawVal string) error {
 				val, err := config.NormalizeDoorCode(rawVal)
@@ -219,7 +219,7 @@ func (m *Model) fieldsDoor() []fieldDef {
 	// Door type selector — determines which type-specific fields are shown
 	row++
 	fields = append(fields, fieldDef{
-		Label: "Type", Help: "Door type: Native binary, DOS (dosemu2), Synchronet JS, or VPL script", Type: ftLookup, Col: 3, Row: row, Width: 20,
+		Label: "Type", Help: "Door type: Native, DOS (dosemu2), Synchronet JS, or VPL script", Type: ftLookup, Col: 3, Row: row, Width: 20,
 		Get: func() string {
 			switch dPtr.Type {
 			case "synchronet_js":

--- a/internal/configeditor/fields_ftn.go
+++ b/internal/configeditor/fields_ftn.go
@@ -35,7 +35,7 @@ func (m *Model) fieldsFTNLink() []fieldDef {
 
 	return []fieldDef{
 		{
-			Label: "Network Name", Help: "Network identifier (e.g. fsxnet, fidonet) — also the binkd domain; stored lowercase", Type: ftString, Col: 3, Row: 1, Width: 30,
+			Label: "Network Name", Help: "Network name; also the binkd domain, stored lowercase (e.g. fsxnet)", Type: ftString, Col: 3, Row: 1, Width: 30,
 			Get: func() string { return key },
 			Set: func(val string) error {
 				// The key is the binkd domain (addresses are <addr>@<key> and
@@ -79,7 +79,7 @@ func (m *Model) fieldsFTNLink() []fieldDef {
 			},
 		},
 		{
-			Label: "Own Address", Help: "Your FTN address, with your point if you have one (e.g. 21:1/100 or 21:1/100.5)", Type: ftString, Col: 3, Row: 2, Width: 30,
+			Label: "Own Address", Help: "Your FTN address with point if any (e.g. 21:1/100 or 21:1/100.5)", Type: ftString, Col: 3, Row: 2, Width: 30,
 			Get: func() string { return netPtr.OwnAddress },
 			Set: func(val string) error {
 				val = strings.TrimSpace(val)

--- a/internal/configeditor/fields_protocols.go
+++ b/internal/configeditor/fields_protocols.go
@@ -81,7 +81,7 @@ func (m *Model) fieldsProtocol() []fieldDef {
 			Set: func(val string) error { p.SendCmd = val; return nil },
 		},
 		{
-			Label: "Send Args", Help: "Arguments for send command (JSON array, e.g. [\"arg1\",\"arg with space\"])", Type: ftString, Col: 3, Row: 5, Width: 40,
+			Label: "Send Args", Help: "Send command args (JSON array, e.g. [\"arg1\",\"arg 2\"])", Type: ftString, Col: 3, Row: 5, Width: 40,
 			Get: func() string { return joinArgs(p.SendArgs) },
 			Set: func(val string) error {
 				args, err := splitArgs(val)
@@ -98,7 +98,7 @@ func (m *Model) fieldsProtocol() []fieldDef {
 			Set: func(val string) error { p.RecvCmd = val; return nil },
 		},
 		{
-			Label: "Recv Args", Help: "Arguments for receive command (JSON array, e.g. [\"arg1\",\"arg with space\"])", Type: ftString, Col: 3, Row: 7, Width: 40,
+			Label: "Recv Args", Help: "Receive command args (JSON array, e.g. [\"arg1\",\"arg 2\"])", Type: ftString, Col: 3, Row: 7, Width: 40,
 			Get: func() string { return joinArgs(p.RecvArgs) },
 			Set: func(val string) error {
 				args, err := splitArgs(val)

--- a/internal/configeditor/fields_system_network.go
+++ b/internal/configeditor/fields_system_network.go
@@ -171,7 +171,7 @@ func (m *Model) sysFieldsNetwork(cfg *config.ServerConfig) []fieldDef {
 			},
 		},
 		{
-			Label: "No CRAM-MD5", Help: "Plaintext binkp passwords both ways; only for a hub whose CRAM-MD5 fails", Type: ftYesNo, Col: 3, Row: 26, Width: 1,
+			Label: "No CRAM-MD5", Help: "Plaintext binkp passwords both ways; for a hub whose CRAM-MD5 fails", Type: ftYesNo, Col: 3, Row: 26, Width: 1,
 			Get: func() string { return uitext.BoolToYN(binkd.DisableCramMD5) },
 			Set: func(val string) error { binkd.DisableCramMD5 = uitext.YNToBool(val); return nil },
 		},

--- a/internal/configeditor/ftn_wizard_edit_test.go
+++ b/internal/configeditor/ftn_wizard_edit_test.go
@@ -87,6 +87,7 @@ func TestStartFTNWizardEditLoadsExistingConfig(t *testing.T) {
 		{"areafixPassword", w.areafixPassword, "afpw"},
 		{"sessionPassword", w.sessionPassword, "sesspw"},
 		{"packetPassword", w.packetPassword, "pktpw"},
+		{"originLine", w.originLine, "Custom Origin Line"},
 	} {
 		if tc.got != tc.want {
 			t.Errorf("%s = %q, want %q", tc.name, tc.got, tc.want)
@@ -277,5 +278,42 @@ func TestUnsubscribedTagCountIgnoresAreasAbsentFromEcholist(t *testing.T) {
 	w.selectedAreas = []bool{false}
 	if n := w.unsubscribedTagCount(); n != 1 {
 		t.Errorf("dropped = %d, want 1 — FSX_GEN was offered and unticked", n)
+	}
+}
+
+// TestConfirmFTNWizardEditSavesEditedOrigin covers #273 on the edit path: the
+// wizard shows an Origin Line field, so a value the sysop changes there must
+// reach ftn.json — the field used to be write-only in the UI and dropped on save.
+func TestConfirmFTNWizardEditSavesEditedOrigin(t *testing.T) {
+	m, _ := configuredModel().startFTNWizardEdit("fsxnet")
+	m.ftnWizard.originLine = "Reworded Origin"
+	m.configPath = t.TempDir()
+
+	m, _ = m.confirmFTNWizard()
+
+	if got := m.configs.FTN.Networks["fsxnet"].Origin; got != "Reworded Origin" {
+		t.Errorf("Origin = %q, want the edited value saved", got)
+	}
+}
+
+// TestConfirmFTNWizardAddSavesOrigin covers #273 on the create path: a new
+// network must persist the origin entered in the wizard rather than always
+// leaving it empty.
+func TestConfirmFTNWizardAddSavesOrigin(t *testing.T) {
+	m := configuredModel()
+	m.ftnWizard = &ftnWizardState{
+		networkName: "tqwnet",
+		ownAddress:  "1337:3/123",
+		hubAddress:  "1337:3/100",
+		hubHostname: "hub.example.org",
+		hubPort:     24554,
+		originLine:  "My Board - example.org",
+	}
+	m.configPath = t.TempDir()
+
+	m, _ = m.confirmFTNWizard()
+
+	if got := m.configs.FTN.Networks["tqwnet"].Origin; got != "My Board - example.org" {
+		t.Errorf("Origin = %q, want the entered value saved", got)
 	}
 }

--- a/internal/configeditor/ftn_wizard_save.go
+++ b/internal/configeditor/ftn_wizard_save.go
@@ -77,6 +77,7 @@ func (m Model) confirmFTNWizard() (Model, tea.Cmd) {
 		// rewriting them with the wizard's create-time defaults would throw
 		// away whatever the sysop set there.
 		existing.OwnAddress = w.ownAddress
+		existing.Origin = w.originLine
 		existing.Links = replaceHubLink(existing.Links, link)
 		m.configs.FTN.Networks[netKey] = existing
 
@@ -93,9 +94,10 @@ func (m Model) confirmFTNWizard() (Model, tea.Cmd) {
 		m.configs.FTN.Networks[netKey] = config.FTNNetworkConfig{
 			InternalTosserEnabled: true,
 			OwnAddress:            w.ownAddress,
-			// Origin left empty: echomail then falls back to the board name.
-			// The tearline is not configurable — the software stamps it.
-			Links: []config.FTNLinkConfig{link},
+			// Origin as entered in the wizard; blank falls back to the board
+			// name. The tearline is not configurable — the software stamps it.
+			Origin: w.originLine,
+			Links:  []config.FTNLinkConfig{link},
 		}
 	}
 

--- a/internal/configeditor/help_wrap_test.go
+++ b/internal/configeditor/help_wrap_test.go
@@ -1,0 +1,37 @@
+package configeditor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// TestWrapHelpTwoLines covers #274: field help longer than the box was cut
+// mid-word at the right edge. It must now wrap onto a second line, on word
+// boundaries, and preserve the whole text.
+func TestWrapHelpTwoLines(t *testing.T) {
+	const width = 71 // boxW(70)+1, the field-help area
+
+	// The Network Name help from the screenshot — 83 cells, was cut at "stor".
+	long := "Network identifier (e.g. fsxnet, fidonet) — also the binkd domain; stored lowercase"
+	l1, l2 := wrapHelpTwoLines(long, width)
+	if l2 == "" {
+		t.Fatal("expected the over-long help to wrap onto a second line")
+	}
+	if lipgloss.Width(l1) > width || lipgloss.Width(l2) > width {
+		t.Errorf("wrapped lines exceed width: %d / %d > %d", lipgloss.Width(l1), lipgloss.Width(l2), width)
+	}
+	// No word is split across the break, and nothing is lost.
+	if l1[len(l1)-1] == ' ' || strings.HasPrefix(l2, " ") {
+		t.Errorf("break landed inside whitespace: %q | %q", l1, l2)
+	}
+	if got := strings.Join(strings.Fields(l1+" "+l2), " "); got != long {
+		t.Errorf("text not preserved across wrap:\n got %q\nwant %q", got, long)
+	}
+
+	// Short help stays on one line.
+	if a, b := wrapHelpTwoLines("Enable built-in echomail tosser", width); b != "" || a != "Enable built-in echomail tosser" {
+		t.Errorf("short help should not wrap: %q | %q", a, b)
+	}
+}

--- a/internal/configeditor/help_wrap_test.go
+++ b/internal/configeditor/help_wrap_test.go
@@ -8,12 +8,10 @@ import (
 )
 
 // TestWrapHelpTwoLines covers #274: field help longer than the box was cut
-// mid-word at the right edge. It must now wrap onto a second line, on word
-// boundaries, and preserve the whole text.
+// mid-word. It must wrap onto a second line, on word boundaries, losing nothing.
 func TestWrapHelpTwoLines(t *testing.T) {
-	const width = 71 // boxW(70)+1, the field-help area
+	const width = 71 // boxW(70)+1
 
-	// The Network Name help from the screenshot — 83 cells, was cut at "stor".
 	long := "Network identifier (e.g. fsxnet, fidonet) — also the binkd domain; stored lowercase"
 	l1, l2 := wrapHelpTwoLines(long, width)
 	if l2 == "" {
@@ -22,16 +20,109 @@ func TestWrapHelpTwoLines(t *testing.T) {
 	if lipgloss.Width(l1) > width || lipgloss.Width(l2) > width {
 		t.Errorf("wrapped lines exceed width: %d / %d > %d", lipgloss.Width(l1), lipgloss.Width(l2), width)
 	}
-	// No word is split across the break, and nothing is lost.
-	if l1[len(l1)-1] == ' ' || strings.HasPrefix(l2, " ") {
+	if strings.HasSuffix(l1, " ") || strings.HasPrefix(l2, " ") {
 		t.Errorf("break landed inside whitespace: %q | %q", l1, l2)
 	}
 	if got := strings.Join(strings.Fields(l1+" "+l2), " "); got != long {
-		t.Errorf("text not preserved across wrap:\n got %q\nwant %q", got, long)
+		t.Errorf("text not preserved:\n got %q\nwant %q", got, long)
 	}
 
-	// Short help stays on one line.
 	if a, b := wrapHelpTwoLines("Enable built-in echomail tosser", width); b != "" || a != "Enable built-in echomail tosser" {
 		t.Errorf("short help should not wrap: %q | %q", a, b)
+	}
+}
+
+// TestWrapHelpWideGlyphStaysInWidth covers the display-width truncation both
+// reviewers flagged: a single word wider than the line, in full-width glyphs,
+// must be cut by display cells (not rune count) so it never overruns the box.
+func TestWrapHelpWideGlyphStaysInWidth(t *testing.T) {
+	const width = 20
+	wide := strings.Repeat("漢", 40) // 80 display cells, one unbreakable "word"
+	l1, l2 := wrapHelpTwoLines(wide, width)
+	if lipgloss.Width(l1) > width {
+		t.Errorf("line1 width %d exceeds %d: %q", lipgloss.Width(l1), width, l1)
+	}
+	if l2 != "" {
+		t.Errorf("a single word should not spill to a second line: %q", l2)
+	}
+	if !strings.HasSuffix(l1, "…") {
+		t.Errorf("truncated help should be marked with an ellipsis: %q", l1)
+	}
+}
+
+// TestTruncateWithEllipsis measures in display cells and reserves the ellipsis.
+func TestTruncateWithEllipsis(t *testing.T) {
+	if got := truncateWithEllipsis("hello", 10); got != "hello" {
+		t.Errorf("short string should be unchanged, got %q", got)
+	}
+	got := truncateWithEllipsis(strings.Repeat("漢", 10), 9) // 20 cells -> 9
+	if lipgloss.Width(got) > 9 {
+		t.Errorf("width %d exceeds 9: %q", lipgloss.Width(got), got)
+	}
+}
+
+// TestFieldHelpAreaKeepsGap covers the user request: the blank separator row
+// between the field help and the footer must survive whether the help fits on
+// one line or wraps to two. Renders the record editor for a short-help and a
+// long-help field and checks the second-to-last help-region row is blank.
+func TestFieldHelpAreaKeepsGap(t *testing.T) {
+	strip := func(s string) string {
+		var b strings.Builder
+		esc := false
+		for _, r := range s {
+			if r == 0x1b {
+				esc = true
+				continue
+			}
+			if esc {
+				if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+					esc = false
+				}
+				continue
+			}
+			b.WriteRune(r)
+		}
+		return b.String()
+	}
+	// The separator/gap row is a backdrop-fill line (shading glyphs), not
+	// spaces, so "blank" here means "carries no help/footer text" — no letters.
+	hasLetter := func(s string) bool {
+		for _, r := range strip(s) {
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+				return true
+			}
+		}
+		return false
+	}
+
+	build := func(recType, label string) []string {
+		m := configuredModel()
+		m.width, m.height, m.mode = 78, 40, modeRecordEdit
+		m.recordType, m.recordEditIdx = recType, 0
+		m.recordFields = m.buildRecordFields()
+		for i, f := range m.recordFields {
+			if f.Label == label {
+				m.editField = i
+			}
+		}
+		return strings.Split(m.viewRecordEdit(), "\n")
+	}
+
+	for _, tc := range []struct{ name, recType, field string }{
+		{"short help", "ftn", "Tosser Enabled"},
+		{"wrapped help", "msgarea", "Area Type"}, // 84-cell help, wraps to two lines
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lines := build(tc.recType, tc.field)
+			// last line is the footer (help bar); the line above it must be blank.
+			footer := len(lines) - 1
+			if !hasLetter(lines[footer]) {
+				t.Fatalf("last line is not the footer: %q", strip(lines[footer]))
+			}
+			if hasLetter(lines[footer-1]) {
+				t.Errorf("no blank separator above the footer:\n above=%q\n footer=%q",
+					strip(lines[footer-1]), strip(lines[footer]))
+			}
+		})
 	}
 }

--- a/internal/configeditor/update_ftn_wizard.go
+++ b/internal/configeditor/update_ftn_wizard.go
@@ -111,6 +111,7 @@ func (m Model) startFTNWizardEdit(netKey string) (Model, tea.Cmd) {
 		editingKey:     netKey,
 		networkName:    netKey,
 		ownAddress:     net.OwnAddress,
+		originLine:     net.Origin,
 		hubPort:        24554,
 		autoJoinAreas:  true,
 		subscribedTags: make(map[string]bool),

--- a/internal/configeditor/view_ftn_wizard.go
+++ b/internal/configeditor/view_ftn_wizard.go
@@ -137,13 +137,10 @@ func (m Model) viewFTNWizardForm() string {
 	}
 
 	// Message or field help text.
+	// Field help; renders two rows (wraps long help onto the second).
 	b.WriteString(m.renderFieldHelpLine(m.ftnWizardFields, padL, padR, boxW, row))
 	b.WriteByte('\n')
-	row++
-
-	b.WriteString(m.backdrop.Line(row))
-	b.WriteByte('\n')
-	row++
+	row += 2
 
 	helpBarStr := "Enter - Edit  |  S - Save  |  ESC - Back"
 	helpText := centerText(helpBarStr, m.width)

--- a/internal/configeditor/view_ftn_wizard.go
+++ b/internal/configeditor/view_ftn_wizard.go
@@ -29,7 +29,8 @@ func (m Model) viewFTNWizardForm() string {
 	if visibleRows > maxFieldRows {
 		visibleRows = maxFieldRows
 	}
-	extraV := maxInt(0, m.height-visibleRows-10)
+	helpRegionRows := m.fieldHelpRegionRows(m.ftnWizardFields, boxW)
+	extraV := maxInt(0, m.height-visibleRows-8-helpRegionRows)
 	topPad := extraV / 2
 	bottomPad := extraV - topPad
 
@@ -137,10 +138,9 @@ func (m Model) viewFTNWizardForm() string {
 	}
 
 	// Message or field help text.
-	// Field help; renders two rows (wraps long help onto the second).
 	b.WriteString(m.renderFieldHelpLine(m.ftnWizardFields, padL, padR, boxW, row))
 	b.WriteByte('\n')
-	row += 2
+	row += helpRegionRows
 
 	helpBarStr := "Enter - Edit  |  S - Save  |  ESC - Back"
 	helpText := centerText(helpBarStr, m.width)

--- a/internal/configeditor/view_record.go
+++ b/internal/configeditor/view_record.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -183,13 +184,10 @@ func (m Model) viewRecordEdit() string {
 	}
 
 	// Message or field help text
+	// Field help; renders two rows (wraps long help onto the second).
 	b.WriteString(m.renderFieldHelpLine(m.recordFields, padL, padR, boxW, row))
 	b.WriteByte('\n')
-	row++
-
-	b.WriteString(m.backdrop.Line(row))
-	b.WriteByte('\n')
-	row++
+	row += 2
 
 	helpBarStr := "Enter - Edit  |  PgUp/PgDn - Records  |  ESC - Return"
 	if m.recordEditIdx < 0 {
@@ -354,10 +352,22 @@ func (m Model) renderRecordField(fieldIdx int, f fieldDef) (string, int) {
 // active field help text > blank fill. row is the absolute screen row this
 // line occupies.
 func (m Model) renderFieldHelpLine(fields []fieldDef, padL, padR, boxW, row int) string {
+	// Returns TWO screen rows: `row` and `row+1`. Help text that overruns the
+	// box wraps onto the second row instead of being cut mid-word at the box
+	// edge (#274); the second row is otherwise a blank backdrop line, which is
+	// what used to follow this line anyway. Callers advance row by 2 and emit
+	// no blank line of their own.
+	helpLine := func(text string, r int) string {
+		return m.backdrop.Segment(r, 0, padL) +
+			editInfoLabelStyle.Render(centerText(text, boxW+1)) +
+			m.backdrop.Segment(r, m.width-(padR+1), padR+1)
+	}
+
 	if m.message != "" {
-		return m.backdrop.Segment(row, 0, padL) +
+		first := m.backdrop.Segment(row, 0, padL) +
 			flashMessageStyle.Render(" "+padRight(m.message, boxW)) +
 			m.backdrop.Segment(row, m.width-(padR+1), padR+1)
+		return first + "\n" + m.backdrop.Line(row+1)
 	}
 	if m.editField >= 0 && m.editField < len(fields) && fields[m.editField].Help != "" {
 		helpText := fields[m.editField].Help
@@ -368,9 +378,44 @@ func (m Model) renderFieldHelpLine(fields []fieldDef, padL, padR, boxW, row int)
 		case ftLookup:
 			helpText += " (Enter to select)"
 		}
-		return m.backdrop.Segment(row, 0, padL) +
-			editInfoLabelStyle.Render(centerText(helpText, boxW+1)) +
-			m.backdrop.Segment(row, m.width-(padR+1), padR+1)
+		line1, line2 := wrapHelpTwoLines(helpText, boxW+1)
+		second := m.backdrop.Line(row + 1)
+		if line2 != "" {
+			second = helpLine(line2, row+1)
+		}
+		return helpLine(line1, row) + "\n" + second
 	}
-	return m.backdrop.Line(row)
+	return m.backdrop.Line(row) + "\n" + m.backdrop.Line(row+1)
+}
+
+// wrapHelpTwoLines splits help text to fit a field-help area that is at most
+// two lines of the given display width. It breaks on spaces where it can; the
+// second line is truncated with an ellipsis only if the text is too long even
+// for two lines. Returns the whole text as line1 (line2 empty) when it fits.
+func wrapHelpTwoLines(s string, width int) (string, string) {
+	if lipgloss.Width(s) <= width {
+		return s, ""
+	}
+	words := strings.Fields(s)
+	var line1 string
+	i := 0
+	for ; i < len(words); i++ {
+		cand := words[i]
+		if line1 != "" {
+			cand = line1 + " " + words[i]
+		}
+		if lipgloss.Width(cand) > width {
+			break
+		}
+		line1 = cand
+	}
+	if line1 == "" {
+		// A single word wider than the line — hard-cut it with an ellipsis.
+		return ansi.TruncateRunes(s, width, "…"), ""
+	}
+	line2 := strings.Join(words[i:], " ")
+	if lipgloss.Width(line2) > width {
+		line2 = ansi.TruncateRunes(line2, width, "…")
+	}
+	return line1, line2
 }

--- a/internal/configeditor/view_record.go
+++ b/internal/configeditor/view_record.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -56,9 +55,11 @@ func (m Model) viewRecordEdit() string {
 	if visibleRows > maxFieldRows {
 		visibleRows = maxFieldRows
 	}
-	// Fixed rows: globalheader(1) + box(border+boxtitle+header+empty+visibleRows+empty+info+border = visibleRows+7) + helptxt(1) + bgline(1) + helpbar(1)
-	// Total fixed = visibleRows + 11
-	extraV := maxInt(0, m.height-visibleRows-11)
+	// Fixed rows: header(1) + box(visibleRows+7) + helpbar(1) = visibleRows+9,
+	// plus the help region (help content + a blank separator), which is 2 rows
+	// unless the active field's help wraps to a second line.
+	helpRegionRows := m.fieldHelpRegionRows(m.recordFields, boxW)
+	extraV := maxInt(0, m.height-visibleRows-9-helpRegionRows)
 	topPad := extraV / 2
 	bottomPad := extraV - topPad
 
@@ -183,11 +184,11 @@ func (m Model) viewRecordEdit() string {
 		row++
 	}
 
-	// Message or field help text
-	// Field help; renders two rows (wraps long help onto the second).
+	// Help area: active field help (wraps to a second line when long) plus a
+	// blank separator; fieldHelpRegionRows above budgeted its height.
 	b.WriteString(m.renderFieldHelpLine(m.recordFields, padL, padR, boxW, row))
 	b.WriteByte('\n')
-	row += 2
+	row += helpRegionRows
 
 	helpBarStr := "Enter - Edit  |  PgUp/PgDn - Records  |  ESC - Return"
 	if m.recordEditIdx < 0 {
@@ -352,46 +353,76 @@ func (m Model) renderRecordField(fieldIdx int, f fieldDef) (string, int) {
 // active field help text > blank fill. row is the absolute screen row this
 // line occupies.
 func (m Model) renderFieldHelpLine(fields []fieldDef, padL, padR, boxW, row int) string {
-	// Returns TWO screen rows: `row` and `row+1`. Help text that overruns the
-	// box wraps onto the second row instead of being cut mid-word at the box
-	// edge (#274); the second row is otherwise a blank backdrop line, which is
-	// what used to follow this line anyway. Callers advance row by 2 and emit
-	// no blank line of their own.
+	// Renders the help area: the active field's help (one line, or two when it
+	// is long enough to wrap — #274), or a flash message, followed by one blank
+	// separator row before the footer. The separator is always present, so the
+	// gap below the help is preserved whether or not the help wrapped. Callers
+	// budget the row count with fieldHelpRegionRows and advance row by it.
 	helpLine := func(text string, r int) string {
 		return m.backdrop.Segment(r, 0, padL) +
 			editInfoLabelStyle.Render(centerText(text, boxW+1)) +
 			m.backdrop.Segment(r, m.width-(padR+1), padR+1)
 	}
 
-	if m.message != "" {
-		first := m.backdrop.Segment(row, 0, padL) +
-			flashMessageStyle.Render(" "+padRight(m.message, boxW)) +
-			m.backdrop.Segment(row, m.width-(padR+1), padR+1)
-		return first + "\n" + m.backdrop.Line(row+1)
-	}
-	if m.editField >= 0 && m.editField < len(fields) && fields[m.editField].Help != "" {
-		helpText := fields[m.editField].Help
-		// Add interaction hints
-		switch fields[m.editField].Type {
-		case ftYesNo:
-			helpText += " (Space toggles)"
-		case ftLookup:
-			helpText += " (Enter to select)"
-		}
-		line1, line2 := wrapHelpTwoLines(helpText, boxW+1)
-		second := m.backdrop.Line(row + 1)
+	var rows []string
+	switch {
+	case m.message != "":
+		rows = append(rows, m.backdrop.Segment(row, 0, padL)+
+			flashMessageStyle.Render(" "+padRight(m.message, boxW))+
+			m.backdrop.Segment(row, m.width-(padR+1), padR+1))
+	case m.activeFieldHelp(fields) != "":
+		line1, line2 := wrapHelpTwoLines(m.activeFieldHelp(fields), boxW+1)
+		rows = append(rows, helpLine(line1, row))
 		if line2 != "" {
-			second = helpLine(line2, row+1)
+			rows = append(rows, helpLine(line2, row+len(rows)))
 		}
-		return helpLine(line1, row) + "\n" + second
+	default:
+		rows = append(rows, m.backdrop.Line(row))
 	}
-	return m.backdrop.Line(row) + "\n" + m.backdrop.Line(row+1)
+	// Trailing blank separator between the help and the footer.
+	rows = append(rows, m.backdrop.Line(row+len(rows)))
+	return strings.Join(rows, "\n")
+}
+
+// activeFieldHelp returns the help text for the field being edited, with its
+// interaction hint appended, or "" when there is no active help. Shared by the
+// renderer and the row-count budget so the two agree on when help wraps.
+func (m Model) activeFieldHelp(fields []fieldDef) string {
+	if m.editField < 0 || m.editField >= len(fields) || fields[m.editField].Help == "" {
+		return ""
+	}
+	help := fields[m.editField].Help
+	switch fields[m.editField].Type {
+	case ftYesNo:
+		help += " (Space toggles)"
+	case ftLookup:
+		help += " (Enter to select)"
+	}
+	return help
+}
+
+// fieldHelpRegionRows is how many screen rows renderFieldHelpLine occupies for
+// the given state: the help/message content (one row, or two when the active
+// help wraps) plus one blank separator row. Views use it to keep the footer
+// position and the vertical padding math exact.
+func (m Model) fieldHelpRegionRows(fields []fieldDef, boxW int) int {
+	content := 1
+	if m.message == "" {
+		if help := m.activeFieldHelp(fields); help != "" {
+			if _, line2 := wrapHelpTwoLines(help, boxW+1); line2 != "" {
+				content = 2
+			}
+		}
+	}
+	return content + 1 // + separator
 }
 
 // wrapHelpTwoLines splits help text to fit a field-help area that is at most
 // two lines of the given display width. It breaks on spaces where it can; the
 // second line is truncated with an ellipsis only if the text is too long even
 // for two lines. Returns the whole text as line1 (line2 empty) when it fits.
+// All measurement and truncation is by display width, so wide (e.g. CJK)
+// glyphs cannot push a line past the box edge.
 func wrapHelpTwoLines(s string, width int) (string, string) {
 	if lipgloss.Width(s) <= width {
 		return s, ""
@@ -410,12 +441,25 @@ func wrapHelpTwoLines(s string, width int) (string, string) {
 		line1 = cand
 	}
 	if line1 == "" {
-		// A single word wider than the line — hard-cut it with an ellipsis.
-		return ansi.TruncateRunes(s, width, "…"), ""
+		// A single word wider than the line — hard-cut it by display width.
+		return truncateWithEllipsis(s, width), ""
 	}
 	line2 := strings.Join(words[i:], " ")
 	if lipgloss.Width(line2) > width {
-		line2 = ansi.TruncateRunes(line2, width, "…")
+		line2 = truncateWithEllipsis(line2, width)
 	}
 	return line1, line2
+}
+
+// truncateWithEllipsis cuts s to at most width display cells, reserving room
+// for a one-cell ellipsis. Rune-based truncation would overshoot width when s
+// contains wide glyphs, so measure in display cells throughout.
+func truncateWithEllipsis(s string, width int) string {
+	if lipgloss.Width(s) <= width {
+		return s
+	}
+	if width <= 1 {
+		return truncateToDisplayWidth(s, width)
+	}
+	return truncateToDisplayWidth(s, width-1) + "…"
 }

--- a/internal/configeditor/view_system.go
+++ b/internal/configeditor/view_system.go
@@ -146,13 +146,10 @@ func (m Model) viewSysConfigEdit() string {
 	}
 
 	// Message or field help text
+	// Field help; renders two rows (wraps long help onto the second).
 	b.WriteString(m.renderFieldHelpLine(m.sysFields, padL, padR, boxW, row))
 	b.WriteByte('\n')
-	row++
-
-	b.WriteString(m.backdrop.Line(row))
-	b.WriteByte('\n')
-	row++
+	row += 2
 
 	helpText := centerText("Enter - Edit  |  PgUp/PgDn - Screens  |  ESC - Return", m.width)
 	b.WriteString(helpBarStyle.Render(helpText))

--- a/internal/configeditor/view_system.go
+++ b/internal/configeditor/view_system.go
@@ -38,7 +38,8 @@ func (m Model) viewSysConfigEdit() string {
 	}
 	// Fixed rows: globalheader(1) + box(border+header+empty+visibleRows+empty+info+border = visibleRows+6) + helptxt(1) + bgline(1) + helpbar(1)
 	// Total fixed = visibleRows + 10
-	extraV := maxInt(0, m.height-visibleRows-10)
+	helpRegionRows := m.fieldHelpRegionRows(m.sysFields, boxW)
+	extraV := maxInt(0, m.height-visibleRows-8-helpRegionRows)
 	topPad := extraV / 2
 	bottomPad := extraV - topPad
 
@@ -146,10 +147,9 @@ func (m Model) viewSysConfigEdit() string {
 	}
 
 	// Message or field help text
-	// Field help; renders two rows (wraps long help onto the second).
 	b.WriteString(m.renderFieldHelpLine(m.sysFields, padL, padR, boxW, row))
 	b.WriteByte('\n')
-	row += 2
+	row += helpRegionRows
 
 	helpText := centerText("Enter - Edit  |  PgUp/PgDn - Screens  |  ESC - Return", m.width)
 	b.WriteString(helpBarStyle.Render(helpText))

--- a/internal/configeditor/view_wizard_form.go
+++ b/internal/configeditor/view_wizard_form.go
@@ -119,13 +119,10 @@ func (m Model) viewWizardForm() string {
 	}
 
 	// Message or field help text
+	// Field help; renders two rows (wraps long help onto the second).
 	b.WriteString(m.renderFieldHelpLine(m.wizardFields, padL, padR, boxW, row))
 	b.WriteByte('\n')
-	row++
-
-	b.WriteString(m.backdrop.Line(row))
-	b.WriteByte('\n')
-	row++
+	row += 2
 
 	helpBarStr := "Enter - Edit  |  S - Save  |  ESC - Back"
 	helpText := centerText(helpBarStr, m.width)

--- a/internal/configeditor/view_wizard_form.go
+++ b/internal/configeditor/view_wizard_form.go
@@ -32,7 +32,8 @@ func (m Model) viewWizardForm() string {
 	visibleRows := maxRow
 	// Fixed rows: globalheader(1) + box(border+title+empty+rows+empty+info+border = rows+6) + helptxt(1) + bgline(1) + helpbar(1)
 	// Total fixed = rows + 10
-	extraV := maxInt(0, m.height-visibleRows-10)
+	helpRegionRows := m.fieldHelpRegionRows(m.wizardFields, boxW)
+	extraV := maxInt(0, m.height-visibleRows-8-helpRegionRows)
 	topPad := extraV / 2
 	bottomPad := extraV - topPad
 
@@ -119,10 +120,9 @@ func (m Model) viewWizardForm() string {
 	}
 
 	// Message or field help text
-	// Field help; renders two rows (wraps long help onto the second).
 	b.WriteString(m.renderFieldHelpLine(m.wizardFields, padL, padR, boxW, row))
 	b.WriteByte('\n')
-	row += 2
+	row += helpRegionRows
 
 	helpBarStr := "Enter - Edit  |  S - Save  |  ESC - Back"
 	helpText := centerText(helpBarStr, m.width)


### PR DESCRIPTION
Fixes #273 and #274 — two bugs in the config-editor FTN screens.

## #273 — the FTN wizard's Origin Line field was dead

The wizard shows an "Origin Line" field, but nothing it captured ever reached `ftn.json`:

- **Create** hard-coded an empty origin (`// Origin left empty`), ignoring what was typed.
- **Edit** never loaded the existing origin into the field (so it showed blank when editing) and never wrote it back on save.

Now the edit path loads `net.Origin` into the field, and both save branches write `w.originLine`. An existing test that asserted the origin was "preserved" on edit now validates the round-trip instead; two new tests cover a typed origin being saved on create and on edit.

## #274 — field help was cut mid-word at the box edge

Help text longer than the 70-column box was truncated with an empty ellipsis, so the Network Name help rendered `...binkd domain; stor` and stopped:

![before](https://github.com/user-attachments/assets/264b729b-5e75-456d-8a66-2831a2766677)

`renderFieldHelpLine` now returns two rows and wraps over-long help onto the second — on word boundaries, using the blank line that already sat below it, so the layout height is unchanged. Only text too long for even two lines is ellipsized. The renderer is shared by the record, system, and both wizard views, so every field's help benefits, not just this one. New `wrapHelpTwoLines` unit test uses the exact string from the screenshot.

## Testing
`go build`, `go vet`, and the full `go test ./...` pass. New tests: origin saved on create and edit, origin loaded into the edit field, and the help-wrap behavior. The four call sites all advance the row count identically, so the box geometry (and the `extraV` padding math) is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - FTN network origins now load correctly when editing and are saved for both edited and newly created networks.
  - New networks with a blank origin now use the board name as a fallback.
  - Long field-help text now wraps cleanly across configuration editors, preserving layout and readability.
  - Oversized help text is truncated with an ellipsis instead of disrupting the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->