### PR TITLE
fix(configeditor): fix the help region to the editor's tallest field, so nothing jumps

### DIFF
--- a/internal/configeditor/help_wrap_test.go
+++ b/internal/configeditor/help_wrap_test.go
@@ -150,15 +150,21 @@ func TestFieldHelpAreaStableLayout(t *testing.T) {
 		}
 		return b.String()
 	}
-	layout := func(label string) (boxTop, total int) {
+	layout := func(t *testing.T, label string) (boxTop, total int) {
+		t.Helper()
 		m := configuredModel()
 		m.width, m.height, m.mode = 78, 40, modeRecordEdit
 		m.recordType, m.recordEditIdx = "msgarea", 0
 		m.recordFields = m.buildRecordFields()
+		found := false
 		for i, f := range m.recordFields {
 			if f.Label == label {
 				m.editField = i
+				found = true
 			}
+		}
+		if !found {
+			t.Fatalf("field %q not found in the record fields", label)
 		}
 		lines := strings.Split(m.viewRecordEdit(), "\n")
 		boxTop = -1
@@ -168,11 +174,14 @@ func TestFieldHelpAreaStableLayout(t *testing.T) {
 				break
 			}
 		}
+		if boxTop < 0 {
+			t.Fatalf("box header row not found in rendered output for field %q", label)
+		}
 		return boxTop, len(lines)
 	}
 	// "Tag" has one-line help; "Area Type" wraps to two.
-	topShort, nShort := layout("Tag")
-	topWrap, nWrap := layout("Area Type")
+	topShort, nShort := layout(t, "Tag")
+	topWrap, nWrap := layout(t, "Area Type")
 	if topShort != topWrap {
 		t.Errorf("box jumped between fields: top row %d vs %d", topShort, topWrap)
 	}

--- a/internal/configeditor/help_wrap_test.go
+++ b/internal/configeditor/help_wrap_test.go
@@ -126,3 +126,57 @@ func TestFieldHelpAreaKeepsGap(t *testing.T) {
 		})
 	}
 }
+
+// TestFieldHelpAreaStableLayout covers the no-jump requirement: within one
+// editor, moving between a short-help field and a field whose help wraps must
+// not shift the box or change the total height. The help region is sized to the
+// tallest field, not the active one, so the layout is fixed.
+func TestFieldHelpAreaStableLayout(t *testing.T) {
+	strip := func(s string) string {
+		var b strings.Builder
+		esc := false
+		for _, r := range s {
+			if r == 0x1b {
+				esc = true
+				continue
+			}
+			if esc {
+				if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+					esc = false
+				}
+				continue
+			}
+			b.WriteRune(r)
+		}
+		return b.String()
+	}
+	layout := func(label string) (boxTop, total int) {
+		m := configuredModel()
+		m.width, m.height, m.mode = 78, 40, modeRecordEdit
+		m.recordType, m.recordEditIdx = "msgarea", 0
+		m.recordFields = m.buildRecordFields()
+		for i, f := range m.recordFields {
+			if f.Label == label {
+				m.editField = i
+			}
+		}
+		lines := strings.Split(m.viewRecordEdit(), "\n")
+		boxTop = -1
+		for i, ln := range lines {
+			if strings.Contains(strip(ln), "Edit ") {
+				boxTop = i
+				break
+			}
+		}
+		return boxTop, len(lines)
+	}
+	// "Tag" has one-line help; "Area Type" wraps to two.
+	topShort, nShort := layout("Tag")
+	topWrap, nWrap := layout("Area Type")
+	if topShort != topWrap {
+		t.Errorf("box jumped between fields: top row %d vs %d", topShort, topWrap)
+	}
+	if nShort != nWrap {
+		t.Errorf("total height changed between fields: %d vs %d", nShort, nWrap)
+	}
+}

--- a/internal/configeditor/view_ftn_wizard.go
+++ b/internal/configeditor/view_ftn_wizard.go
@@ -138,7 +138,7 @@ func (m Model) viewFTNWizardForm() string {
 	}
 
 	// Message or field help text.
-	b.WriteString(m.renderFieldHelpLine(m.ftnWizardFields, padL, padR, boxW, row))
+	b.WriteString(m.renderFieldHelpLine(m.ftnWizardFields, padL, padR, boxW, row, helpRegionRows))
 	b.WriteByte('\n')
 	row += helpRegionRows
 

--- a/internal/configeditor/view_record.go
+++ b/internal/configeditor/view_record.go
@@ -186,7 +186,7 @@ func (m Model) viewRecordEdit() string {
 
 	// Help area: active field help (wraps to a second line when long) plus a
 	// blank separator; fieldHelpRegionRows above budgeted its height.
-	b.WriteString(m.renderFieldHelpLine(m.recordFields, padL, padR, boxW, row))
+	b.WriteString(m.renderFieldHelpLine(m.recordFields, padL, padR, boxW, row, helpRegionRows))
 	b.WriteByte('\n')
 	row += helpRegionRows
 
@@ -352,20 +352,19 @@ func (m Model) renderRecordField(fieldIdx int, f fieldDef) (string, int) {
 // sourcing its background fill from m.backdrop. Priority: flash message >
 // active field help text > blank fill. row is the absolute screen row this
 // line occupies.
-func (m Model) renderFieldHelpLine(fields []fieldDef, padL, padR, boxW, row int) string {
+func (m Model) renderFieldHelpLine(fields []fieldDef, padL, padR, boxW, row, region int) string {
 	// Renders the help area: the active field's help (one line, or two when it
-	// wraps — #274), or a flash message, padded with blank backdrop rows to a
+	// wraps — #274), or a flash message, padded with blank backdrop rows to the
 	// fixed region height so the trailing blank(s) always sit above the footer.
-	// The region is sized to the tallest help in this field set, not the active
-	// field (fieldHelpRegionRows), so moving between fields never shifts the box
-	// or the footer — no jump when a field's help happens to wrap.
+	// The caller passes region (from fieldHelpRegionRows, used for its layout
+	// math), which is sized to the tallest help in this field set — not the
+	// active field — so moving between fields never shifts the box or footer.
 	helpLine := func(text string, r int) string {
 		return m.backdrop.Segment(r, 0, padL) +
 			editInfoLabelStyle.Render(centerText(text, boxW+1)) +
 			m.backdrop.Segment(r, m.width-(padR+1), padR+1)
 	}
 
-	region := m.fieldHelpRegionRows(fields, boxW)
 	var rows []string
 	switch {
 	case m.message != "":

--- a/internal/configeditor/view_record.go
+++ b/internal/configeditor/view_record.go
@@ -354,16 +354,18 @@ func (m Model) renderRecordField(fieldIdx int, f fieldDef) (string, int) {
 // line occupies.
 func (m Model) renderFieldHelpLine(fields []fieldDef, padL, padR, boxW, row int) string {
 	// Renders the help area: the active field's help (one line, or two when it
-	// is long enough to wrap — #274), or a flash message, followed by one blank
-	// separator row before the footer. The separator is always present, so the
-	// gap below the help is preserved whether or not the help wrapped. Callers
-	// budget the row count with fieldHelpRegionRows and advance row by it.
+	// wraps — #274), or a flash message, padded with blank backdrop rows to a
+	// fixed region height so the trailing blank(s) always sit above the footer.
+	// The region is sized to the tallest help in this field set, not the active
+	// field (fieldHelpRegionRows), so moving between fields never shifts the box
+	// or the footer — no jump when a field's help happens to wrap.
 	helpLine := func(text string, r int) string {
 		return m.backdrop.Segment(r, 0, padL) +
 			editInfoLabelStyle.Render(centerText(text, boxW+1)) +
 			m.backdrop.Segment(r, m.width-(padR+1), padR+1)
 	}
 
+	region := m.fieldHelpRegionRows(fields, boxW)
 	var rows []string
 	switch {
 	case m.message != "":
@@ -376,45 +378,56 @@ func (m Model) renderFieldHelpLine(fields []fieldDef, padL, padR, boxW, row int)
 		if line2 != "" {
 			rows = append(rows, helpLine(line2, row+len(rows)))
 		}
-	default:
-		rows = append(rows, m.backdrop.Line(row))
 	}
-	// Trailing blank separator between the help and the footer.
-	rows = append(rows, m.backdrop.Line(row+len(rows)))
+	// Pad to the fixed region height. The trailing blank(s) are the gap above
+	// the footer; there is always at least one because region > max content.
+	for len(rows) < region {
+		rows = append(rows, m.backdrop.Line(row+len(rows)))
+	}
 	return strings.Join(rows, "\n")
 }
 
 // activeFieldHelp returns the help text for the field being edited, with its
-// interaction hint appended, or "" when there is no active help. Shared by the
-// renderer and the row-count budget so the two agree on when help wraps.
+// interaction hint appended, or "" when there is no active help.
 func (m Model) activeFieldHelp(fields []fieldDef) string {
-	if m.editField < 0 || m.editField >= len(fields) || fields[m.editField].Help == "" {
+	if m.editField < 0 || m.editField >= len(fields) {
 		return ""
 	}
-	help := fields[m.editField].Help
-	switch fields[m.editField].Type {
-	case ftYesNo:
-		help += " (Space toggles)"
-	case ftLookup:
-		help += " (Enter to select)"
-	}
-	return help
+	return fieldHelpText(fields[m.editField])
 }
 
-// fieldHelpRegionRows is how many screen rows renderFieldHelpLine occupies for
-// the given state: the help/message content (one row, or two when the active
-// help wraps) plus one blank separator row. Views use it to keep the footer
-// position and the vertical padding math exact.
+// fieldHelpText is a field's help with its interaction hint appended.
+func fieldHelpText(f fieldDef) string {
+	if f.Help == "" {
+		return ""
+	}
+	switch f.Type {
+	case ftYesNo:
+		return f.Help + " (Space toggles)"
+	case ftLookup:
+		return f.Help + " (Enter to select)"
+	}
+	return f.Help
+}
+
+// fieldHelpRegionRows is the fixed number of screen rows the help area occupies
+// for this field set: the tallest field help (one line, or two when it wraps)
+// plus one blank separator row. It depends only on the fields and box width —
+// not on which field is active — so the footer and box stay put as the user
+// moves between fields, and the blank gap above the footer is always present.
 func (m Model) fieldHelpRegionRows(fields []fieldDef, boxW int) int {
-	content := 1
-	if m.message == "" {
-		if help := m.activeFieldHelp(fields); help != "" {
-			if _, line2 := wrapHelpTwoLines(help, boxW+1); line2 != "" {
-				content = 2
-			}
+	maxContent := 1
+	for i := range fields {
+		help := fieldHelpText(fields[i])
+		if help == "" {
+			continue
+		}
+		if _, line2 := wrapHelpTwoLines(help, boxW+1); line2 != "" {
+			maxContent = 2
+			break
 		}
 	}
-	return content + 1 // + separator
+	return maxContent + 1 // + separator
 }
 
 // wrapHelpTwoLines splits help text to fit a field-help area that is at most

--- a/internal/configeditor/view_system.go
+++ b/internal/configeditor/view_system.go
@@ -147,7 +147,7 @@ func (m Model) viewSysConfigEdit() string {
 	}
 
 	// Message or field help text
-	b.WriteString(m.renderFieldHelpLine(m.sysFields, padL, padR, boxW, row))
+	b.WriteString(m.renderFieldHelpLine(m.sysFields, padL, padR, boxW, row, helpRegionRows))
 	b.WriteByte('\n')
 	row += helpRegionRows
 

--- a/internal/configeditor/view_wizard_form.go
+++ b/internal/configeditor/view_wizard_form.go
@@ -120,7 +120,7 @@ func (m Model) viewWizardForm() string {
 	}
 
 	// Message or field help text
-	b.WriteString(m.renderFieldHelpLine(m.wizardFields, padL, padR, boxW, row))
+	b.WriteString(m.renderFieldHelpLine(m.wizardFields, padL, padR, boxW, row, helpRegionRows))
 	b.WriteByte('\n')
 	row += helpRegionRows
 


### PR DESCRIPTION
Follow-up to #287, addressing feedback that the box **jumps** when a field's help wraps.

## Cause

#287 sized the help region to the *active* field's help — one row if it fit, two if it wrapped — and folded that into each view's vertical-padding math. So when you moved onto a field whose help wrapped, the region grew by a row, `extraV` shrank, and the whole box shifted up one row. Visible jump while navigating.

## Fix

Size the region to the **tallest help in the field set**, not the active field. It no longer depends on `m.editField`, so `extraV` — and therefore the box and footer positions — are constant as you move between fields. The active field's help is rendered and padded with blank rows to that fixed height, so there's always at least one blank gap above the footer.

Consequences:
- Editors with no wrapping help (the FTN network editor, after #287's one-line trims) keep the original 2-row region and a single tight gap — unchanged from before.
- Editors that contain a genuinely long help (message-area type, newscan default, native-door command) reserve the extra row uniformly across *all* their fields, so a short-help field there shows help + two blank rows. Stable, no jump.

## Testing

- New `TestFieldHelpAreaStableLayout`: the box top row and total height are identical for a one-line-help field (`Tag`) and a wrapping-help field (`Area Type`) in the same editor — i.e. no jump.
- `TestFieldHelpAreaKeepsGap` still passes for both one-line and wrapped help.
- `go build`, `go vet`, full `go test ./...` green.