### PR TITLE
fix(configeditor): make P-reorder move the item live instead of just a cursor

### DIFF
--- a/internal/configeditor/reorder_livemove_test.go
+++ b/internal/configeditor/reorder_livemove_test.go
@@ -131,3 +131,33 @@ func equalStrings(a, b []string) bool {
 	}
 	return true
 }
+
+// TestReorderNoOpDoesNotDirty covers the review finding: pressing P then Enter
+// without moving (or after moving back to the start) must not renumber
+// positions or mark the config dirty — otherwise a look-but-don't-touch
+// reorder would normalize positions and prompt an unwanted save.
+func TestReorderNoOpDoesNotDirty(t *testing.T) {
+	m := configuredModel()
+	m.mode = modeRecordList
+	m.recordType = "msgarea"
+	m.recordCursor = 1
+	m.recordFields = m.buildRecordFields()
+	m.dirty = false
+
+	// P then Enter, no movement.
+	m = key(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	m = key(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.dirty {
+		t.Error("a no-move reorder should not mark the config dirty")
+	}
+
+	// P, down, back up (net no-op), Enter.
+	m.dirty = false
+	m = key(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	m = key(m, tea.KeyMsg{Type: tea.KeyDown})
+	m = key(m, tea.KeyMsg{Type: tea.KeyUp})
+	m = key(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.dirty {
+		t.Error("moving an item and back to its start should not mark dirty")
+	}
+}

--- a/internal/configeditor/reorder_livemove_test.go
+++ b/internal/configeditor/reorder_livemove_test.go
@@ -1,0 +1,133 @@
+package configeditor
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func reorderTags(m Model) []string {
+	t := make([]string, len(m.configs.MsgAreas))
+	for i, a := range m.configs.MsgAreas {
+		t[i] = a.Tag
+	}
+	return t
+}
+
+func key(m Model, k tea.KeyMsg) Model {
+	mm, _ := m.Update(k)
+	return mm.(Model)
+}
+
+// TestReorderMovesItemLive covers the reported bug: pressing P turned the row
+// green but the area would not move. The item now travels with the arrow keys —
+// the slice is reordered on each press (green rides the cursor) — so the move
+// is visible before Enter, not deferred to it.
+func TestReorderMovesItemLive(t *testing.T) {
+	m := configuredModel()
+	m.mode = modeRecordList
+	m.recordType = "msgarea"
+	m.recordCursor = 0
+	m.recordFields = m.buildRecordFields()
+
+	m = key(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	if m.mode != modeRecordReorder {
+		t.Fatalf("P did not enter reorder mode, got %v", m.mode)
+	}
+	first := reorderTags(m)[0]
+
+	m = key(m, tea.KeyMsg{Type: tea.KeyDown})
+	if reorderTags(m)[0] == first {
+		t.Errorf("item did not move on Down (still %q at top): %v", first, reorderTags(m))
+	}
+	if m.recordCursor != 1 {
+		t.Errorf("cursor should follow the moved item to index 1, got %d", m.recordCursor)
+	}
+}
+
+// TestReorderEscRestores covers cancel: the original order and positions must
+// come back exactly, since a cancelled reorder must change nothing.
+func TestReorderEscRestores(t *testing.T) {
+	m := configuredModel()
+	m.mode = modeRecordList
+	m.recordType = "msgarea"
+	m.recordCursor = 0
+	m.recordFields = m.buildRecordFields()
+	orig := reorderTags(m)
+
+	m = key(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	m = key(m, tea.KeyMsg{Type: tea.KeyDown})
+	m = key(m, tea.KeyMsg{Type: tea.KeyDown})
+	m = key(m, tea.KeyMsg{Type: tea.KeyEscape})
+
+	if got := reorderTags(m); !equalStrings(got, orig) {
+		t.Errorf("Esc did not restore order: got %v, want %v", got, orig)
+	}
+	if m.mode != modeRecordList {
+		t.Errorf("Esc should return to the list, got %v", m.mode)
+	}
+}
+
+// TestReorderEnterCommitsAndRenumbers covers commit: the new order sticks and
+// positions are renumbered 1..n.
+func TestReorderEnterCommitsAndRenumbers(t *testing.T) {
+	m := configuredModel()
+	m.mode = modeRecordList
+	m.recordType = "msgarea"
+	m.recordCursor = 0
+	m.recordFields = m.buildRecordFields()
+	orig := reorderTags(m)
+
+	m = key(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	m = key(m, tea.KeyMsg{Type: tea.KeyDown})
+	m = key(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if reorderTags(m)[0] == orig[0] {
+		t.Errorf("commit did not keep the new order: %v", reorderTags(m))
+	}
+	if !m.dirty {
+		t.Error("a committed reorder should mark the config dirty")
+	}
+	for i, a := range m.configs.MsgAreas {
+		if a.Position != i+1 {
+			t.Errorf("position %d of area %s not renumbered to %d", a.Position, a.Tag, i+1)
+		}
+	}
+}
+
+// TestReorderStaysWithinConference covers the conference clamp: an area cannot
+// be moved out of its conference. Positions are one global sequence, but the
+// ordering users see is per-conference, so reorder is confined to the block.
+func TestReorderStaysWithinConference(t *testing.T) {
+	m := configuredModel()
+	m.mode = modeRecordList
+	m.recordType = "msgarea"
+	m.recordFields = m.buildRecordFields()
+	// Put the cursor on the first area of its conference.
+	m.recordCursor = 0
+	confID := m.configs.MsgAreas[0].ConferenceID
+
+	m = key(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	// Drive it hard downward; it must stop at the conference boundary.
+	for i := 0; i < len(m.configs.MsgAreas)+2; i++ {
+		m = key(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+	if got := m.configs.MsgAreas[m.recordCursor].ConferenceID; got != confID {
+		t.Errorf("area escaped its conference: cursor conf %d, want %d", got, confID)
+	}
+	// Every area still belongs to a contiguous run of its conference (no area
+	// was dragged across a boundary).
+	m = key(m, tea.KeyMsg{Type: tea.KeyEscape})
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/configeditor/update_records_reorder.go
+++ b/internal/configeditor/update_records_reorder.go
@@ -21,42 +21,53 @@ func (m Model) updateRecordReorder(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	lo := m.reorderMinIdx
 	hi := m.reorderMaxIdx
 
+	target := m.recordCursor
 	switch msg.Type {
 	case tea.KeyUp:
-		if m.recordCursor > lo {
-			m.recordCursor--
-		}
+		target = m.recordCursor - 1
 	case tea.KeyDown:
-		if m.recordCursor < hi {
-			m.recordCursor++
-		}
+		target = m.recordCursor + 1
 	case tea.KeyHome:
-		m.recordCursor = lo
+		target = lo
 	case tea.KeyEnd:
-		m.recordCursor = hi
+		target = hi
 	case tea.KeyPgUp:
-		m.recordCursor -= listVisible
-		if m.recordCursor < lo {
-			m.recordCursor = lo
-		}
+		target = m.recordCursor - listVisible
 	case tea.KeyPgDown:
-		m.recordCursor += listVisible
-		if m.recordCursor > hi {
-			m.recordCursor = hi
-		}
+		target = m.recordCursor + listVisible
 	case tea.KeyEnter:
-		m.reorderRecord()
+		// Commit: the slice is already in its final order from the live moves;
+		// renumber positions once.
+		m.renumberReorderedPositions()
 		m.dirty = true
 		m.reorderSourceIdx = -1
 		m.mode = modeRecordList
 		m.clampRecordScroll()
 		return m, nil
 	case tea.KeyEscape:
+		// Cancel: carry the item back to where it started, restoring the
+		// original order. Positions were never touched, so nothing else to undo.
+		m.moveRecordSlice(m.recordCursor, m.reorderSourceIdx)
 		m.recordCursor = m.reorderSourceIdx
 		m.reorderSourceIdx = -1
 		m.mode = modeRecordList
 		m.clampRecordScroll()
 		return m, nil
+	default:
+		return m, nil
+	}
+
+	// Move the item to the clamped target so it travels with the cursor and is
+	// visibly reordered on screen (the row is painted green at recordCursor).
+	if target < lo {
+		target = lo
+	}
+	if target > hi {
+		target = hi
+	}
+	if target != m.recordCursor {
+		m.moveRecordSlice(m.recordCursor, target)
+		m.recordCursor = target
 	}
 	m.clampRecordScroll()
 	return m, nil

--- a/internal/configeditor/update_records_reorder.go
+++ b/internal/configeditor/update_records_reorder.go
@@ -36,10 +36,14 @@ func (m Model) updateRecordReorder(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case tea.KeyPgDown:
 		target = m.recordCursor + listVisible
 	case tea.KeyEnter:
-		// Commit: the slice is already in its final order from the live moves;
-		// renumber positions once.
-		m.renumberReorderedPositions()
-		m.dirty = true
+		// Commit. The slice is already in its final order from the live moves;
+		// renumber positions once. Only if the item actually ended up somewhere
+		// new — pressing P then Enter without moving (or after moving back) must
+		// not renumber or dirty the config.
+		if m.recordCursor != m.reorderSourceIdx {
+			m.renumberReorderedPositions()
+			m.dirty = true
+		}
 		m.reorderSourceIdx = -1
 		m.mode = modeRecordList
 		m.clampRecordScroll()

--- a/internal/configeditor/update_reorder.go
+++ b/internal/configeditor/update_reorder.go
@@ -5,30 +5,38 @@ import (
 	"github.com/ViSiON-3/vision-3-bbs/internal/message"
 )
 
-// reorderRecord performs the slice manipulation for the current record type:
-// removes the source item and inserts it at the cursor position, then renumbers positions.
-func (m *Model) reorderRecord() {
-	src := m.reorderSourceIdx
-	dst := m.recordCursor
+// moveRecordSlice moves the item at src to dst in the current record type's
+// slice, without renumbering. Reorder mode calls this on each arrow key so the
+// item travels live with the cursor; positions are renumbered once, on commit.
+func (m *Model) moveRecordSlice(src, dst int) {
 	if src == dst {
 		return
 	}
-
 	switch m.recordType {
 	case "msgarea":
 		m.configs.MsgAreas = reorderSlice(m.configs.MsgAreas, src, dst)
-		renumberMsgAreaPositions(m.configs.MsgAreas)
 	case "filearea":
 		m.configs.FileAreas = reorderSlice(m.configs.FileAreas, src, dst)
 	case "conference":
 		m.configs.Conferences = reorderSlice(m.configs.Conferences, src, dst)
-		renumberConferencePositions(m.configs.Conferences)
 	case "protocol":
 		m.configs.Protocols = reorderSlice(m.configs.Protocols, src, dst)
 	case "archiver":
 		m.configs.Archivers.Archivers = reorderSlice(m.configs.Archivers.Archivers, src, dst)
 	case "login":
 		m.configs.LoginSeq = reorderSlice(m.configs.LoginSeq, src, dst)
+	}
+}
+
+// renumberReorderedPositions renumbers the position field of the record types
+// that carry one, after a reorder is committed. Called on Enter only, so a
+// cancelled (Esc) reorder leaves positions exactly as they were.
+func (m *Model) renumberReorderedPositions() {
+	switch m.recordType {
+	case "msgarea":
+		renumberMsgAreaPositions(m.configs.MsgAreas)
+	case "conference":
+		renumberConferencePositions(m.configs.Conferences)
 	}
 }
 

--- a/internal/configeditor/view_list.go
+++ b/internal/configeditor/view_list.go
@@ -77,7 +77,9 @@ func (m Model) viewRecordList() string {
 	for i := 0; i < listVisible; i++ {
 		idx := m.recordScroll + i
 		isHighlight := idx == m.recordCursor
-		isSource := inReorder && idx == m.reorderSourceIdx
+		// In reorder mode the item being moved travels with the cursor, so it is
+		// painted green at its live position rather than its original one.
+		isSource := inReorder && idx == m.recordCursor
 
 		var rowContent string
 		if idx < 0 || idx >= total {

--- a/internal/configeditor/view_list.go
+++ b/internal/configeditor/view_list.go
@@ -97,9 +97,9 @@ func (m Model) viewRecordList() string {
 		} else {
 			content := m.renderRecordRow(idx, boxW)
 			switch {
-			case isSource && isHighlight:
-				rowContent = reorderSourceStyle.Render(content)
 			case isSource:
+				// In reorder mode the moving item rides the cursor, so this is
+				// also the highlighted row.
 				rowContent = reorderSourceStyle.Render(content)
 			case isHighlight:
 				rowContent = menuHighlightStyle.Render(content)


### PR DESCRIPTION
Two `./config` reorder issues raised together.

## 1. Pressing P turned the row green but the area wouldn't move

The mechanism actually worked — arrows moved a cursor and Enter committed — but it gave no feedback: the green **source** row stayed at its original position while a *separate* highlight moved, and the slice only changed on Enter. So it looked stuck.

Now the item **travels with the arrow keys**. Each Up/Down/Home/End/PgUp/PgDn moves it a step (or to the end) within its allowed range, the green highlight rides it, and the reorder is visible immediately. `Enter` commits and renumbers positions once; `Esc` carries the item back to its start index, restoring the original order. Because positions are renumbered only on commit, a cancel changes nothing.

## 2. Are positions absolute or conference-specific?

Both, in a way, and worth stating since it's the model behind the clamp:

- **Storage:** `Position` is a single global sequence across all message areas (`ListAreas` sorts by it globally, `renumberMsgAreaPositions` sets `1..n`).
- **Presentation & reorder:** areas are grouped and ordered **per conference** in the BBS, and reorder is confined to the area's conference — the config editor clamps cursor movement to the source's conference block, and `MoveAreaPositionInConference` rearranges only within that conference while others keep their relative order.

So you cannot drag an area out of its conference; within it, moving it just shuffles that conference's block of the global sequence. The reorder footer already names the scope (`Reorder within: <conf>`), which this makes true to the behavior.

## Testing

New tests: live movement on Down, Esc restores order, Enter commits + renumbers `1..n`, and the conference clamp holds when driven past the boundary. `go build`, `go vet`, full `go test ./...` green.