### PR TITLE
fix(helper): assign positions to imported FTN areas so they group with their conference

### DIFF
--- a/cmd/helper/ftnsetup_position_test.go
+++ b/cmd/helper/ftnsetup_position_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/message"
+)
+
+// TestFTNSetupAssignsSequentialPositions covers the import bug behind areas
+// landing "out of place": ftnsetup created areas with no Position (0), so they
+// all sorted to the top of the config editor's list, away from their
+// conference. Imported areas must instead get the next positions after the
+// existing ones.
+func TestFTNSetupAssignsSequentialPositions(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONFile(t, filepath.Join(dir, "message_areas.json"), []message.MessageArea{
+		{ID: 1, Position: 1, Tag: "GENERAL", Name: "General", ConferenceID: 1, AreaType: "local"},
+		{ID: 2, Position: 2, Tag: "PRIVMAIL", Name: "Private", ConferenceID: 1, AreaType: "local"},
+	})
+	writeJSONFile(t, filepath.Join(dir, "conferences.json"), []conferenceConfig{})
+
+	naPath := filepath.Join(dir, "tqwnet.na")
+	if err := os.WriteFile(naPath, []byte("TQW_FOO Foo Area\nTQW_BAR Bar Area\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmdFTNSetup([]string{
+		"--na", naPath,
+		"--address", "1337:3/123.1",
+		"--hub", "1337:3/100",
+		"--network", "tqwnet",
+		"--config", dir,
+		"--quiet",
+	})
+
+	var areas []message.MessageArea
+	data, err := os.ReadFile(filepath.Join(dir, "message_areas.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &areas); err != nil {
+		t.Fatal(err)
+	}
+
+	byTag := map[string]message.MessageArea{}
+	for _, a := range areas {
+		byTag[a.Tag] = a
+	}
+	for _, tc := range []struct {
+		tag string
+		pos int
+	}{
+		{"TQW_FOO", 3},
+		{"TQW_BAR", 4},
+	} {
+		a, ok := byTag[tc.tag]
+		if !ok {
+			t.Fatalf("imported area %s missing", tc.tag)
+		}
+		if a.Position != tc.pos {
+			t.Errorf("%s position = %d, want %d (sequential after existing, never 0)", tc.tag, a.Position, tc.pos)
+		}
+	}
+}
+
+func writeJSONFile(t *testing.T, path string, v interface{}) {
+	t.Helper()
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/helper/main.go
+++ b/cmd/helper/main.go
@@ -547,10 +547,14 @@ func cmdFTNSetup(args []string) {
 	// 3. Build existing tag set for duplicate detection
 	existingTags := make(map[string]int) // tag -> area ID
 	maxAreaID := 0
+	maxAreaPos := 0
 	for _, a := range existingAreas {
 		existingTags[strings.ToUpper(a.Tag)] = a.ID
 		if a.ID > maxAreaID {
 			maxAreaID = a.ID
+		}
+		if a.Position > maxAreaPos {
+			maxAreaPos = a.Position
 		}
 	}
 
@@ -692,13 +696,18 @@ func cmdFTNSetup(args []string) {
 		})
 	}
 
-	// 8b. Add message areas
+	// 8b. Add message areas. Each gets the next position after the existing
+	// areas, so imported areas land at the end of the list in order rather
+	// than all at position 0 (which sorts them to the top, away from their
+	// conference).
 	nextID := maxAreaID + 1
+	nextPos := maxAreaPos + 1
 	for _, a := range newAreas {
 		effectiveTag := strings.ToUpper(*tagPrefix + a.Tag)
 		basePath := "msgbases/" + strings.ToLower(effectiveTag)
 		existingAreas = append(existingAreas, message.MessageArea{
 			ID:           nextID,
+			Position:     nextPos,
 			Tag:          effectiveTag,
 			Name:         a.Description,
 			Description:  a.Description,
@@ -714,6 +723,7 @@ func cmdFTNSetup(args []string) {
 			MaxAge:       365,
 		})
 		nextID++
+		nextPos++
 	}
 
 	// 8c. Update FTN network config


### PR DESCRIPTION
Found from a live board: after importing tqwNet's 17 echo areas, they showed up **out of place** at the top of the config editor's Message Areas list, far from `tqwnet_netmail` and the rest of the TQWNET conference — and couldn't easily be moved down.

## Cause

`helper ftnsetup` created each imported area with **no `Position`**, so it defaulted to `0`. The config editor and the BBS order areas by `Position`, so a whole batch imported at once (all `0`) sorts to the top of the list, split from the rest of their conference. On the live board all 17 tqwNet echoes sat at position 0 while `tqwnet_netmail` was at 24.

## Fix

Assign each new area the next position after the existing ones (max existing position + 1, incrementing per area), mirroring how the ID is already assigned. Imported areas now land at the end of the list, in order, contiguous with their conference.

## Testing

`TestFTNSetupAssignsSequentialPositions` runs `cmdFTNSetup` against a temp config with two existing areas at positions 1 and 2, and asserts the two imported areas get positions 3 and 4 — verified to fail (positions 0) without the fix.

## Note

The already-affected data (the position-0 areas created before this fix) needs a one-time renumber; that's a data fix, not code. It pairs with #289 (the live P-reorder fix) for rearranging areas by hand afterward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Imported message areas now receive sequential positions after existing areas.
  * Import order is preserved when assigning positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->