### PR TITLE
feat(config): per-area Allow Anonymous toggle (default no); drop redundant ESC label

### DIFF
--- a/internal/configeditor/allow_anon_field_test.go
+++ b/internal/configeditor/allow_anon_field_test.go
@@ -1,0 +1,45 @@
+package configeditor
+
+import "testing"
+
+// TestAllowAnonymousField covers the new per-area Allow Anonymous Y/N field:
+// an unset value reads as No (the default), and setting Y/N writes an explicit
+// pointer the posting path honors.
+func TestAllowAnonymousField(t *testing.T) {
+	m := configuredModel()
+	m.recordType = "msgarea"
+	m.recordEditIdx = 0
+
+	field := func() fieldDef {
+		for _, f := range m.fieldsMsgArea() {
+			if f.Label == "Allow Anonymous" {
+				return f
+			}
+		}
+		t.Fatal("Allow Anonymous field not found")
+		return fieldDef{}
+	}
+
+	// Unset -> "N".
+	m.configs.MsgAreas[0].AllowAnon = nil
+	if got := field().Get(); got != "N" {
+		t.Errorf("unset AllowAnon renders %q, want N (default no)", got)
+	}
+	// Set Y -> explicit true.
+	if err := field().Set("Y"); err != nil {
+		t.Fatal(err)
+	}
+	if a := m.configs.MsgAreas[0].AllowAnon; a == nil || !*a {
+		t.Errorf("Set(Y) should write &true, got %v", a)
+	}
+	if got := field().Get(); got != "Y" {
+		t.Errorf("after Set(Y), Get = %q, want Y", got)
+	}
+	// Set N -> explicit false.
+	if err := field().Set("N"); err != nil {
+		t.Fatal(err)
+	}
+	if a := m.configs.MsgAreas[0].AllowAnon; a == nil || *a {
+		t.Errorf("Set(N) should write &false, got %v", a)
+	}
+}

--- a/internal/configeditor/dialogs.go
+++ b/internal/configeditor/dialogs.go
@@ -11,7 +11,7 @@ func (m Model) overlayConfirmDialog(background, title, question string) string {
 	lines := strings.Split(background, "\n")
 
 	dialogW := 62
-	dialogH := 8
+	dialogH := 7
 	startRow := (m.height - dialogH) / 2
 	startCol := (m.width - dialogW) / 2
 	if startRow < 0 {
@@ -67,14 +67,8 @@ func (m Model) overlayConfirmDialog(background, title, question string) string {
 		dialogTextStyle.Render(strings.Repeat(" ", maxInt(0, dialogW-2-btnPad-btnVisW))) +
 		side
 
-	// ESC hint line
-	escHint := "[ESC] Cancel"
-	escPad := (dialogW - 2 - len(escHint)) / 2
-	escLine := side +
-		dialogTextStyle.Render(strings.Repeat(" ", maxInt(0, escPad))+escHint+strings.Repeat(" ", maxInt(0, dialogW-2-escPad-len(escHint)))) +
-		side
-
-	dialogLines := []string{border, titleLine, emptyLine, questionLine, emptyLine, buttonLine, escLine, borderBot}
+	// ESC still cancels; the label was redundant, so it is not drawn.
+	dialogLines := []string{border, titleLine, emptyLine, questionLine, emptyLine, buttonLine, borderBot}
 
 	// Overlay dialog on background, preserving content on both sides
 	endCol := startCol + dialogW

--- a/internal/configeditor/fields_areas.go
+++ b/internal/configeditor/fields_areas.go
@@ -145,29 +145,34 @@ func (m *Model) fieldsMsgArea() []fieldDef {
 			Get: func() string { return uitext.BoolToYN(a.RealNameOnly) },
 			Set: func(val string) error { a.RealNameOnly = uitext.YNToBool(val); return nil },
 		},
+		{
+			Label: "Allow Anonymous", Help: "Allow anonymous posts here even for users with the access level (default No)", Type: ftYesNo, Col: 3, Row: 14, Width: 1,
+			Get: func() string { return uitext.BoolToYN(a.AllowAnon != nil && *a.AllowAnon) },
+			Set: func(val string) error { v := uitext.YNToBool(val); a.AllowAnon = &v; return nil },
+		},
 	}
 
 	switch strings.ToLower(a.AreaType) {
 	case "echomail":
 		fields = append(fields,
 			fieldDef{
-				Label: "Network", Help: "FTN network key from ftn.json (e.g. fsxnet)", Type: ftLookup, Col: 3, Row: 14, Width: 20,
+				Label: "Network", Help: "FTN network key from ftn.json (e.g. fsxnet)", Type: ftLookup, Col: 3, Row: 15, Width: 20,
 				Get:         func() string { return a.Network },
 				Set:         func(val string) error { a.Network = val; return nil },
 				LookupItems: func() []LookupItem { return m.buildFTNNetworkLookupItems() },
 			},
 			fieldDef{
-				Label: "Echo Tag", Help: "FTN echo tag matching the network's area list (e.g. FSX_GEN)", Type: ftString, Col: 3, Row: 15, Width: 30,
+				Label: "Echo Tag", Help: "FTN echo tag matching the network's area list (e.g. FSX_GEN)", Type: ftString, Col: 3, Row: 16, Width: 30,
 				Get: func() string { return a.EchoTag },
 				Set: func(val string) error { a.EchoTag = val; return nil },
 			},
 			fieldDef{
-				Label: "Origin Addr", Help: "Your FTN origin address for this echo (e.g. 21:4/158.1)", Type: ftString, Col: 3, Row: 16, Width: 20,
+				Label: "Origin Addr", Help: "Your FTN origin address for this echo (e.g. 21:4/158.1)", Type: ftString, Col: 3, Row: 17, Width: 20,
 				Get: func() string { return a.OriginAddr },
 				Set: func(val string) error { a.OriginAddr = val; return nil },
 			},
 			fieldDef{
-				Label: "Sponsor", Help: "Handle of the echo sponsor/moderator (optional)", Type: ftString, Col: 3, Row: 17, Width: 30,
+				Label: "Sponsor", Help: "Handle of the echo sponsor/moderator (optional)", Type: ftString, Col: 3, Row: 18, Width: 30,
 				Get: func() string { return a.Sponsor },
 				Set: func(val string) error { a.Sponsor = val; return nil },
 			},
@@ -175,7 +180,7 @@ func (m *Model) fieldsMsgArea() []fieldDef {
 	case "netmail":
 		fields = append(fields,
 			fieldDef{
-				Label: "Network", Help: "FTN network key this netmail area serves (e.g. fsxnet)", Type: ftLookup, Col: 3, Row: 14, Width: 20,
+				Label: "Network", Help: "FTN network key this netmail area serves (e.g. fsxnet)", Type: ftLookup, Col: 3, Row: 15, Width: 20,
 				Get:         func() string { return a.Network },
 				Set:         func(val string) error { a.Network = val; return nil },
 				LookupItems: func() []LookupItem { return m.buildFTNNetworkLookupItems() },
@@ -184,13 +189,13 @@ func (m *Model) fieldsMsgArea() []fieldDef {
 	case "v3net":
 		fields = append(fields,
 			fieldDef{
-				Label: "Network", Help: "V3Net network name (e.g. felonynet)", Type: ftLookup, Col: 3, Row: 14, Width: 32,
+				Label: "Network", Help: "V3Net network name (e.g. felonynet)", Type: ftLookup, Col: 3, Row: 15, Width: 32,
 				Get:         func() string { return a.Network },
 				Set:         func(val string) error { a.Network = val; return nil },
 				LookupItems: func() []LookupItem { return m.buildV3NetNetworkLookupItems() },
 			},
 			fieldDef{
-				Label: "Echo Tag", Help: "V3Net area tag on the hub (e.g. fel.general)", Type: ftString, Col: 3, Row: 15, Width: 34,
+				Label: "Echo Tag", Help: "V3Net area tag on the hub (e.g. fel.general)", Type: ftString, Col: 3, Row: 16, Width: 34,
 				Get: func() string { return a.EchoTag },
 				Set: func(val string) error { a.EchoTag = val; return nil },
 			},

--- a/internal/menu/anon_posting_test.go
+++ b/internal/menu/anon_posting_test.go
@@ -1,0 +1,29 @@
+package menu
+
+import "testing"
+
+func TestAnonymousPostingAllowed(t *testing.T) {
+	yes, no := true, false
+	tests := []struct {
+		name                 string
+		userLevel, anonLevel int
+		area, conf           *bool
+		want                 bool
+	}{
+		{"below anon level", 5, 10, &yes, nil, false},
+		{"area unset defaults to no", 50, 10, nil, nil, false},
+		{"area explicitly no", 50, 10, &no, nil, false},
+		{"area yes, conf unset", 50, 10, &yes, nil, true},
+		{"area yes, conf yes", 50, 10, &yes, &yes, true},
+		{"area yes, conf no forbids", 50, 10, &yes, &no, false},
+		{"area no even if conf yes", 50, 10, &no, &yes, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := anonymousPostingAllowed(tc.userLevel, tc.anonLevel, tc.area, tc.conf); got != tc.want {
+				t.Errorf("anonymousPostingAllowed(%d,%d,%v,%v) = %v, want %v",
+					tc.userLevel, tc.anonLevel, tc.area, tc.conf, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/menu/executor_messages_compose.go
+++ b/internal/menu/executor_messages_compose.go
@@ -155,22 +155,13 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 
 	// 4. Prompt for Anonymous (if user level >= AnonymousLevel)
 	isAnonymous := false
-	allowAnon := currentUser.AccessLevel >= e.ServerCfg.AnonymousLevel
-	if allowAnon {
-		areaAllowsAnon := true
-		if area.AllowAnon != nil {
-			areaAllowsAnon = *area.AllowAnon
+	var confAllowAnon *bool
+	if e.ConferenceMgr != nil && area.ConferenceID != 0 {
+		if conf, ok := e.ConferenceMgr.GetByID(area.ConferenceID); ok {
+			confAllowAnon = conf.AllowAnon
 		}
-		confAllowsAnon := true
-		if e.ConferenceMgr != nil && area.ConferenceID != 0 {
-			if conf, ok := e.ConferenceMgr.GetByID(area.ConferenceID); ok {
-				if conf.AllowAnon != nil {
-					confAllowsAnon = *conf.AllowAnon
-				}
-			}
-		}
-		allowAnon = areaAllowsAnon && confAllowsAnon
 	}
+	allowAnon := anonymousPostingAllowed(currentUser.AccessLevel, e.ServerCfg.AnonymousLevel, area.AllowAnon, confAllowAnon)
 	if allowAnon {
 		anonPrompt := e.LoadedStrings.MsgAnonStr
 		if anonPrompt == "" {
@@ -278,4 +269,24 @@ func runComposeMessageWithIH(e *MenuExecutor, s ssh.Session, ih *editor.InputHan
 	time.Sleep(1 * time.Second)
 
 	return nil, "", nil
+}
+
+// anonymousPostingAllowed reports whether the anonymous-post prompt should be
+// offered. The user must meet the anonymous access level; the area must opt in
+// (an unset AllowAnon means no — anonymous is off unless an area enables it);
+// and the conference must not forbid it (an unset conference AllowAnon means
+// yes, so a conference only restricts when explicitly set to no).
+func anonymousPostingAllowed(userLevel, anonLevel int, area, conf *bool) bool {
+	if userLevel < anonLevel {
+		return false
+	}
+	areaAllows := false
+	if area != nil {
+		areaAllows = *area
+	}
+	confAllows := true
+	if conf != nil {
+		confAllows = *conf
+	}
+	return areaAllows && confAllows
 }

--- a/internal/message/types.go
+++ b/internal/message/types.go
@@ -11,7 +11,7 @@ type MessageArea struct {
 	Description  string `json:"description"`               // Longer description
 	ACSRead      string `json:"acs_read"`                  // ACS string required to read
 	ACSWrite     string `json:"acs_write"`                 // ACS string required to post
-	AllowAnon    *bool  `json:"allow_anonymous,omitempty"` // Optional: allow anonymous posts (nil defaults to true)
+	AllowAnon    *bool  `json:"allow_anonymous,omitempty"` // Optional: allow anonymous posts (nil = no; area must opt in)
 	RealNameOnly bool   `json:"real_name_only,omitempty"`  // Require real name for posts in this area
 	ConferenceID int    `json:"conference_id,omitempty"`   // Conference this area belongs to (0=ungrouped)
 	BasePath     string `json:"base_path"`                 // Relative path to JAM base (e.g., "msgbases/general")


### PR DESCRIPTION
Two `./config` changes.

## 1. Per-area "Allow Anonymous" (default No)

A new Y/N field on each message area controls whether anonymous posting is offered there at all — independent of the user's access level. A user who meets `AnonymousLevel` is now only shown the anonymous prompt in areas that allow it.

- The model's `AllowAnon` was already a `*bool`; the change is that an **unset value now means No** (areas opt in), where before it meant Yes. Comment and default updated.
- The anonymous decision moved into a small, testable `anonymousPostingAllowed(userLevel, anonLevel, area, conf)`: user must meet the level, the **area** must opt in (unset = no), and the **conference** must not forbid it (unset = yes, so a conference only restricts when explicitly set to no).
- The config-editor field reads an unset value as `N` and writes an explicit `Y`/`N`.

**Behavior note:** this flips the effective default — anonymous posting was allowed by default (for users at the level) and is now off until an area enables it. That's the requested "default No."

## 2. Drop the "[ESC] Cancel" label from the Yes/No dialog

Escape still cancels; the label was redundant next to the Yes/No buttons. The confirmation dialog loses that line (height 8 → 7).

## Testing

- `anonymousPostingAllowed` across the level / area / conference matrix (unset area = no, explicit no, area-yes with conf unset/yes/no, area-no overrides conf-yes).
- The config field's `unset → N`, `Y → &true`, `N → &false` mapping.
- `go build`, `go vet`, full `go test ./...` green.