### PR TITLE
fix(ftn): registry URL liveness check + drop defunct SciNet

### DIFF
--- a/cmd/ini2ftnreg/main.go
+++ b/cmd/ini2ftnreg/main.go
@@ -67,7 +67,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Warning: no networks found in %s\n", *inPath)
 	}
 
-	applied, err := applyOverrides(networks)
+	networks, applied, err := applyOverrides(networks)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error applying overrides: %v\n", err)
 		os.Exit(1)

--- a/cmd/ini2ftnreg/overrides.go
+++ b/cmd/ini2ftnreg/overrides.go
@@ -29,6 +29,11 @@ type override struct {
 	Name   string `json:"name"`   // the network this zone is, for readability; not applied
 	Reason string `json:"reason"` // why upstream's value cannot be used; not applied
 
+	// Remove drops the network from the registry entirely — for a network that
+	// is defunct upstream (dead domain, no working list). Field overrides on the
+	// same entry are ignored when Remove is set.
+	Remove bool `json:"remove,omitempty"`
+
 	EcholistURL string `json:"echolist_url,omitempty"`
 	NodelistURL string `json:"nodelist_url,omitempty"`
 	PackURL     string `json:"pack_url,omitempty"`
@@ -37,15 +42,16 @@ type override struct {
 	HubHostname string `json:"hub_hostname,omitempty"`
 }
 
-// applyOverrides patches the parsed networks in place and reports what it
-// changed, so a build log shows which values did not come from upstream. An
+// applyOverrides patches the parsed networks and reports what it changed, so a
+// build log shows which values did not come from upstream. It returns the
+// (possibly filtered) network list — a `remove` override drops that network. An
 // override whose zone is absent from the ini is an error rather than a silent
 // no-op: it means upstream renumbered or dropped the network and the entry
 // needs revisiting.
-func applyOverrides(networks []Network) ([]string, error) {
+func applyOverrides(networks []Network) ([]Network, []string, error) {
 	var overrides []override
 	if err := json.Unmarshal(overridesJSON, &overrides); err != nil {
-		return nil, fmt.Errorf("parsing overrides.json: %w", err)
+		return nil, nil, fmt.Errorf("parsing overrides.json: %w", err)
 	}
 
 	byZone := make(map[int]*Network, len(networks))
@@ -54,11 +60,17 @@ func applyOverrides(networks []Network) ([]string, error) {
 	}
 
 	var applied []string
+	removeZones := make(map[int]bool)
 	for _, o := range overrides {
 		n, ok := byZone[o.Zone]
 		if !ok {
-			return nil, fmt.Errorf("override for zone %d matches no network in the ini "+
+			return nil, nil, fmt.Errorf("override for zone %d matches no network in the ini "+
 				"— upstream may have renumbered or dropped it, so the override needs revisiting", o.Zone)
+		}
+		if o.Remove {
+			removeZones[o.Zone] = true
+			applied = append(applied, fmt.Sprintf("zone %d (%s): removed", n.Zone, n.Name))
+			continue
 		}
 		for _, f := range []struct {
 			name string
@@ -79,7 +91,17 @@ func applyOverrides(networks []Network) ([]string, error) {
 			*f.dst = f.val
 		}
 	}
-	return applied, nil
+
+	if len(removeZones) == 0 {
+		return networks, applied, nil
+	}
+	kept := make([]Network, 0, len(networks))
+	for _, n := range networks {
+		if !removeZones[n.Zone] {
+			kept = append(kept, n)
+		}
+	}
+	return kept, applied, nil
 }
 
 // resetOverrides restores the embedded overrides after a test replaces them.

--- a/cmd/ini2ftnreg/overrides.json
+++ b/cmd/ini2ftnreg/overrides.json
@@ -93,5 +93,11 @@
     "reason": "init-fidonet.ini has no nodelist field at all, so every nodelist_url is curated here; without an entry, regenerating drops it. Upstream's value is unusable; corrected here. Upstream records the echolist as the bare filename \"tqwnet.na\", which cannot be fetched, so the wizard reports the area list as unavailable (ViSiON-3/vision-3-bbs#275). tqwNet does publish it, in the infopack repo. Note that repo also carries tqw_file.na, the *file* echo list; this is the echomail list.",
     "nodelist_url": "https://www.erb.pw/tqwinfo.zip",
     "echolist_url": "https://raw.githubusercontent.com/christiansacks/tqwnet_infopack/master/tqwnet.na"
+  },
+  {
+    "zone": 77,
+    "name": "SciNet",
+    "reason": "Defunct: scinet-ftn.org no longer resolves and the network is listed defunct in the community FTN listing. Dropped so the wizard does not show a network whose echolist and infopack are both gone.",
+    "remove": true
   }
 ]

--- a/cmd/ini2ftnreg/overrides_test.go
+++ b/cmd/ini2ftnreg/overrides_test.go
@@ -18,7 +18,7 @@ func TestOverridesApplyToParsedNetworks(t *testing.T) {
 	overridesJSON = []byte(`[{"zone":1337,"echolist_url":"https://example.org/real.na"}]`)
 	t.Cleanup(resetOverrides)
 
-	applied, err := applyOverrides(networks)
+	networks, applied, err := applyOverrides(networks)
 	if err != nil {
 		t.Fatalf("applyOverrides: %v", err)
 	}
@@ -44,7 +44,7 @@ func TestOverrideForMissingZoneIsAnError(t *testing.T) {
 	overridesJSON = []byte(`[{"zone":9999,"echolist_url":"https://example.org/x.na"}]`)
 	t.Cleanup(resetOverrides)
 
-	if _, err := applyOverrides([]Network{{Zone: 21}}); err == nil {
+	if _, _, err := applyOverrides([]Network{{Zone: 21}}); err == nil {
 		t.Fatal("an override matching no network should be an error, not a silent no-op")
 	}
 }
@@ -76,6 +76,17 @@ func TestEveryOverrideMatchesAShippedNetwork(t *testing.T) {
 	}
 
 	for _, o := range overrides {
+		if o.Remove {
+			// A removed network is intentionally absent from the shipped
+			// registry, so the presence check does not apply.
+			if _, present := zones[o.Zone]; present {
+				t.Errorf("zone %d (%s) is marked remove but is still in registry.json", o.Zone, o.Name)
+			}
+			if o.Reason == "" {
+				t.Errorf("remove override for zone %d (%s) has no reason recorded", o.Zone, o.Name)
+			}
+			continue
+		}
 		n, ok := zones[o.Zone]
 		if !ok {
 			t.Errorf("override for zone %d matches no network in registry.json", o.Zone)
@@ -107,5 +118,27 @@ func TestEveryOverrideMatchesAShippedNetwork(t *testing.T) {
 					o.Zone, n.Name, f.name, f.shipped, f.override)
 			}
 		}
+	}
+}
+
+// TestOverrideRemovesNetwork covers dropping a defunct network: the entry is
+// filtered out of the returned list, and other networks are untouched.
+func TestOverrideRemovesNetwork(t *testing.T) {
+	networks := []Network{
+		{Zone: 77, Name: "SciNet"},
+		{Zone: 21, Name: "fsxNet"},
+	}
+	overridesJSON = []byte(`[{"zone":77,"name":"SciNet","remove":true}]`)
+	t.Cleanup(resetOverrides)
+
+	kept, applied, err := applyOverrides(networks)
+	if err != nil {
+		t.Fatalf("applyOverrides: %v", err)
+	}
+	if len(kept) != 1 || kept[0].Zone != 21 {
+		t.Errorf("removed network still present: %+v", kept)
+	}
+	if len(applied) != 1 {
+		t.Errorf("removal should be logged, got %v", applied)
 	}
 }

--- a/internal/ftn/registry.json
+++ b/internal/ftn/registry.json
@@ -169,21 +169,6 @@
     "areatag_prefix": "CNT_"
   },
   {
-    "zone": 77,
-    "name": "SciNet",
-    "description": "Active network for the BBS scene",
-    "info_url": "https://scinet-ftn.org/",
-    "pack_url": "https://scinet-ftn.org/sciinfo.zip",
-    "coordinator": "Frank Linhares",
-    "coordinator_email": "scinet@diskshop.ca",
-    "coordinator_ftn": "1:229/101",
-    "hub_address": "77:1/100",
-    "hub_hostname": "bbs.diskshop.ca",
-    "dns_suffix": "scinet-ftn.org",
-    "echolist_url": "https://scinet-ftn.org/scinet.na",
-    "areatitle_prefix": "SciNet:"
-  },
-  {
     "zone": 256,
     "name": "DevNet",
     "description": "developer oriented network",

--- a/internal/ftn/registry_liveness_test.go
+++ b/internal/ftn/registry_liveness_test.go
@@ -1,0 +1,79 @@
+//go:build urlcheck
+
+// Registry URL liveness check. Network-dependent, so it is behind the urlcheck
+// build tag and never runs in the normal offline suite or CI. Run it by hand to
+// find dead entries the wizard would fail on:
+//
+//	go test -tags urlcheck ./internal/ftn/ -run TestRegistryURLsLive -v
+//
+// It fetches every http(s) URL in the registry and reports anything that is not
+// reachable, split into fetch-critical fields (echolist/nodelist/pack — the
+// files a sysop actually downloads) and info-only fields. It logs rather than
+// hard-fails, so one flaky host does not block a run; read the summary.
+package ftn
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestRegistryURLsLive(t *testing.T) {
+	networks, err := LoadRegistry()
+	if err != nil {
+		t.Fatalf("LoadRegistry: %v", err)
+	}
+
+	client := &http.Client{Timeout: 25 * time.Second}
+	live := func(url string) (int, error) {
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return 0, err
+		}
+		req.Header.Set("User-Agent", "vision3-registry-liveness/1")
+		resp, err := client.Do(req)
+		if err != nil {
+			return 0, err
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode, nil
+	}
+
+	type field struct {
+		name     string
+		url      string
+		critical bool
+	}
+	var deadCritical, deadInfo int
+	for _, n := range networks {
+		fields := []field{
+			{"echolist_url", n.EcholistURL, true},
+			{"nodelist_url", n.NodelistURL, true},
+			{"pack_url", n.PackURL, true},
+			{"info_url", n.InfoURL, false},
+		}
+		for _, f := range fields {
+			if len(f.url) < 4 || f.url[:4] != "http" {
+				continue // FTN-only lists and blanks are not web URLs
+			}
+			code, err := live(f.url)
+			ok := err == nil && code >= 200 && code < 400
+			if ok {
+				continue
+			}
+			status := "error"
+			if err == nil {
+				status = http.StatusText(code)
+			}
+			marker := " "
+			if f.critical {
+				marker = "*"
+				deadCritical++
+			} else {
+				deadInfo++
+			}
+			t.Logf("%s zone %d %-8s %-12s %-20s %s", marker, n.Zone, n.Name, f.name, status, f.url)
+		}
+	}
+	t.Logf("dead: %d fetch-critical (*), %d info-only", deadCritical, deadInfo)
+}


### PR DESCRIPTION
Addresses #285.

The FTN registry is inherited from Synchronet's `init-fidonet.ini`, and nothing checked whether its URLs still resolve. Several don't — a sysop only discovers it when the FTN wizard fails on that network.

## Liveness check (the core of the issue)

A `urlcheck`-tagged test fetches every http(s) URL in the registry and reports what's unreachable, split into fetch-critical fields (`echolist`/`nodelist`/`pack` — the files a sysop actually downloads) and info-only. It's behind a build tag so it never runs in the offline suite or CI (which must not depend on external hosts); a maintainer runs it by hand:

```
go test -tags urlcheck ./internal/ftn/ -run TestRegistryURLsLive -v
```

Right now it flags **6 fetch-critical** and **6 info-only** dead URLs — exactly what upstream's submission-driven, ~2-commits-a-year process structurally can't catch.

## Drop defunct SciNet (zone 77)

`scinet-ftn.org` no longer resolves, and the [community FTN listing](https://docs.google.com/spreadsheets/d/1zzR2A9rnQ1WhBlva_RaO2OMJ0aTWJdpRa2PMlwLPZx4/edit#gid=0) lists it **Defunct**, so its echolist and infopack are both gone. Since the registry is generated, `ini2ftnreg`'s overrides gain a `remove` flag that filters a network out after parsing. The shipped-registry guard skips removed zones; a unit test covers removal. Regenerating reproduces the committed registry exactly, minus SciNet (24 → 23 networks).

## Not fixed here (deliberately)

AmigaNet, WhisperNet, and HobbyNet are **active** networks whose fetch URLs are down, and their replacements from the community sheet are dead too — I couldn't verify a working URL for any of them. Rather than ship a guessed URL or blank a network's only pointer, they're left for the liveness check to keep flagging until an operator-provided URL turns up. The malformed DevNet/MusicNet `info_url` (prose in the field) is likewise left for a follow-up, since its host is also dead.

## Testing

`go build`, `go vet`, full offline `go test ./...` green. New: the liveness check (tagged), the `remove`-override unit test, and the updated shipped-registry guard. Verified regeneration from the upstream ini yields the committed registry (only SciNet removed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Override configuration can now remove obsolete networks from generated registries, with removal reasons recorded.
  - Updated network data ensures removed networks no longer appear in the setup wizard.

- **Bug Fixes**
  - Applied network overrides now correctly update the resulting registry.

- **Tests**
  - Added coverage for network removal and preservation of other networks.
  - Added optional checks to identify unreachable web addresses in registry data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->