### PR TITLE
fix(ftn): exit non-zero on quarantined backlog and warn on a point without its boss link

### DIFF
--- a/cmd/v3mail/cmd_ftn.go
+++ b/cmd/v3mail/cmd_ftn.go
@@ -110,7 +110,11 @@ func cmdToss(args []string) {
 		}
 	}
 
-	if hadErrors {
+	// A persistent backlog — mail unclaimed long enough to be quarantined —
+	// exits non-zero so a scheduler surfaces it. Freshly unclaimed files only
+	// warn (exit 0): they are usually a network briefly misconfigured and will
+	// toss once it is fixed, so failing on them would be noise.
+	if hadErrors || len(unclaimed.Quarantined) > 0 {
 		os.Exit(1)
 	}
 }

--- a/internal/config/config_ftn.go
+++ b/internal/config/config_ftn.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/jam"
 )
 
 // FTNLinkConfig defines an FTN link (uplink/downlink node).
@@ -161,12 +163,50 @@ func LoadFTNConfig(configPath string) (FTNConfig, error) {
 		if net.InternalTosserEnabled {
 			enabledCount++
 			slog.Info("ftn network internal tosser enabled", "network", name, "address", net.OwnAddress)
+			warnPointWithoutBossLink(name, net)
 		}
 	}
 	slog.Info("loaded FTN configuration", "networks", len(config.Networks), "tosserEnabled", enabledCount)
 
 	applyBinkdDefaults(&config.Binkd)
 	return config, nil
+}
+
+// warnPointWithoutBossLink logs a warning when a network posts from a point
+// address (e.g. 1337:3/123.1) whose boss node (1337:3/123) is not among its
+// links. Inbound echomail arrives from the boss node, so if it is not a link
+// the tosser matches nothing and the mail piles up unclaimed — the exact
+// misconfiguration behind #276, surfaced here at load instead of silently at
+// toss time. Point-numbers and a mismatched boss are common enough to warn,
+// not fail: the config still loads.
+func warnPointWithoutBossLink(name string, net FTNNetworkConfig) {
+	if !pointBossMissing(net) {
+		return
+	}
+	own, _ := jam.ParseAddress(net.OwnAddress)
+	slog.Warn("ftn network posts from a point but its boss node is not a link — "+
+		"inbound mail from the boss will match no link and pile up unclaimed; add it under Echomail Links",
+		"network", name,
+		"own_address", net.OwnAddress,
+		"boss_node", fmt.Sprintf("%d:%d/%d", own.Zone, own.Net, own.Node))
+}
+
+// pointBossMissing reports whether the network's own_address is a point whose
+// boss node matches none of its links. Link matching compares zone/net/node
+// and ignores the point, the same way the tosser matches an inbound packet's
+// origin, so a link recorded as another point of the boss node still counts.
+func pointBossMissing(net FTNNetworkConfig) bool {
+	own, err := jam.ParseAddress(net.OwnAddress)
+	if err != nil || own.Point == 0 {
+		return false // not a point, or unparseable (validated elsewhere)
+	}
+	for _, l := range net.Links {
+		la, err := jam.ParseAddress(l.Address)
+		if err == nil && la.Zone == own.Zone && la.Net == own.Net && la.Node == own.Node {
+			return false // the boss node is a configured link
+		}
+	}
+	return true
 }
 
 // ValidateFTNConfig checks that all required global path fields are set for any

--- a/internal/config/ftn_boss_warn_test.go
+++ b/internal/config/ftn_boss_warn_test.go
@@ -1,0 +1,33 @@
+package config
+
+import "testing"
+
+// TestPointWithoutBossLink covers the #276 startup guard: a network posting
+// from a point whose boss node is not a link is the misconfiguration that made
+// inbound mail pile up unclaimed. warnPointWithoutBossLink only logs, so this
+// asserts the detection predicate via the same parse/compare logic.
+func TestPointWithoutBossLink(t *testing.T) {
+	tests := []struct {
+		name        string
+		own         string
+		links       []string
+		wantMissing bool
+	}{
+		{"point, boss not a link", "1337:3/123.1", []string{"1337:3/100"}, true},
+		{"point, boss is a link", "1337:3/123.1", []string{"1337:3/123"}, false},
+		{"point, boss among several", "1337:3/123.1", []string{"1337:3/100", "1337:3/123"}, false},
+		{"not a point", "21:4/158", []string{"21:1/100"}, false},
+		{"point, boss link carries its own point", "1337:3/123.1", []string{"1337:3/123.9"}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			net := FTNNetworkConfig{OwnAddress: tc.own}
+			for _, l := range tc.links {
+				net.Links = append(net.Links, FTNLinkConfig{Address: l})
+			}
+			if got := pointBossMissing(net); got != tc.wantMissing {
+				t.Errorf("pointBossMissing(%s, %v) = %v, want %v", tc.own, tc.links, got, tc.wantMissing)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Completes #276. #281 added the corrupt-packet quarantine and unclaimed-mail reporting; these are the two remaining finishers.

## Changes

**`v3mail toss` exits non-zero on a persistent backlog.** When unclaimed mail has aged past the stale threshold and been quarantined, the command now exits 1 so a scheduler (cron/systemd) surfaces it. Freshly unclaimed files still only warn and exit 0 — those are usually a network briefly misconfigured that will toss cleanly once fixed, so failing on them would be noise.

**Startup warning for a point without its boss link.** `LoadFTNConfig` now warns when a network's `own_address` is a point (e.g. `1337:3/123.1`) whose boss node (`1337:3/123`) is not among its links. That is the exact misconfiguration behind this issue: inbound echomail arrives from the boss node, so if the boss is not a link the tosser matches nothing and the mail piles up unclaimed. Surfacing it at load beats discovering it silently at toss time. It warns rather than fails — the config still loads.

The detection is a `pointBossMissing` predicate that matches by zone/net/node and ignores the point, the same way the tosser matches an inbound packet's origin (so a link recorded as another point of the boss node still counts). Covered by `TestPointWithoutBossLink`.

## Testing
- `go build ./...`
- `go test ./internal/config/ ./internal/tosser/` — all pass, including the new `TestPointWithoutBossLink` (5 cases).

Fixes #276