### PR TITLE
feat(newuser): async new-user notices for offline sysops + read-mail-now prompt

### DIFF
--- a/docs/sysop/getting-started/upgrading.md
+++ b/docs/sysop/getting-started/upgrading.md
@@ -360,3 +360,22 @@ This pairs well with leaving `autoValidateNewUsers` off: the signup-time message
 is your one chance to hear from a caller before you validate them, and the
 requirement now follows them across reconnects until they either introduce
 themselves or the account ages out.
+
+### New: new-user notices reach an offline SysOp, and a "read mail now?" prompt
+
+Two login-sequence quality-of-life changes. **Both require an edit to
+`configs/login.json` if you maintain your own** (installs without the file get
+them from the built-in default automatically):
+
+- **`SYSOPNOTICES`** — the "new user signed up" notice (`notifySysopNewUser`)
+  used to be a live page only, so it was lost whenever no SysOp was online at
+  signup time (which is most of the time). It is now also **queued and shown at
+  the SysOp's next login**. Add a `{"command": "SYSOPNOTICES"}` item to your
+  login sequence (a good spot is right after `NEWUSERVAL`). It is informational
+  and fires regardless of `autoValidateNewUsers` — unlike `NEWUSERVAL`, which is
+  silent when nothing is pending validation. Queued notices live in
+  `data/sysop_notices.json`.
+- **"Read it now?" after `NMAILSCAN`** — when the login mail scan reports new
+  private mail, the caller is now asked whether to read it immediately, dropping
+  them into the reader (reply/skip per message). No config change needed beyond
+  already having `NMAILSCAN` in your sequence.

--- a/docs/sysop/users/login-sequence.md
+++ b/docs/sysop/users/login-sequence.md
@@ -162,9 +162,10 @@ regardless of validation state, see `SYSOPNOTICES` below.
 
 Delivers any queued SysOp notices to a co-SysOp-or-above caller at login, then
 clears them. Today the only producer is the new-user notice: when someone signs
-up and no SysOp is online to be paged (`notifySysopNewUser`), the notice is
-queued for every co-SysOp+ account and shown here at their next login. It is
-purely informational — with `autoValidateNewUsers` on there is nothing to do
+up, `notifySysopNewUser` pages each co-SysOp+ account that is online and queues
+the notice for each one that is not — so an offline co-SysOp is caught up here
+even when another SysOp was online and paged in real time. It is purely
+informational — with `autoValidateNewUsers` on there is nothing to do
 but perhaps view the user; with it off, `NEWUSERVAL` (above) is where the
 validation actually happens.
 

--- a/docs/sysop/users/login-sequence.md
+++ b/docs/sysop/users/login-sequence.md
@@ -87,6 +87,11 @@ Scans the PRIVMAIL message area for unread private mail addressed to the current
 You have 3 new private mail message(s).
 ```
 
+When there is new mail, the caller is then asked **"Read it now?"** — answering
+yes drops them straight into the private-mail reader (where each message can be
+replied to with `R` or skipped with `N`), so they need not hunt for the mail
+menu. Answering no leaves the count as the only notice.
+
 ### DISPLAYFILE
 
 Displays an ANSI art file from the `menus/v3/ansi/` directory. The **data** field specifies the filename. Useful for bulletins, welcome screens, system news, or any custom display.
@@ -148,8 +153,30 @@ blank the screen on every quiet login. Use `VALIDATEUSER` on a menu when you
 want to open the queue deliberately — that one reports an empty queue and waits,
 which is right when a keystroke would otherwise appear to have done nothing.
 
-This covers the SysOp who was not online when someone signed up. For the case
-where they are, see `notifySysopNewUser` in
+`NEWUSERVAL` only speaks up when something is **pending validation** — so with
+`autoValidateNewUsers` on, where signups need no review, it stays silent and a
+SysOp never learns a user joined. For a "somebody joined" notice that fires
+regardless of validation state, see `SYSOPNOTICES` below.
+
+### SYSOPNOTICES
+
+Delivers any queued SysOp notices to a co-SysOp-or-above caller at login, then
+clears them. Today the only producer is the new-user notice: when someone signs
+up and no SysOp is online to be paged (`notifySysopNewUser`), the notice is
+queued for every co-SysOp+ account and shown here at their next login. It is
+purely informational — with `autoValidateNewUsers` on there is nothing to do
+but perhaps view the user; with it off, `NEWUSERVAL` (above) is where the
+validation actually happens.
+
+```json
+{"command": "SYSOPNOTICES"}
+```
+
+Silent for ordinary users and when the queue is empty — it checks co-SysOp
+access itself, so no `sec_level` is required (though you may set one to remove
+it for a SysOp who does not want it). This is the asynchronous half of
+`notifySysopNewUser`: online SysOps are paged in real time, offline ones catch
+up here. See `notifySysopNewUser` in
 [Configuration](configuration/configuration.md).
 
 ### CHECKNUV

--- a/internal/config/config_login.go
+++ b/internal/config/config_login.go
@@ -65,6 +65,9 @@ func defaultLoginSequence() []LoginItem {
 		// whether it has anything to say, so setting it would blank a sysop's
 		// screen on every quiet login for a command that then prints nothing.
 		{Command: "NEWUSERVAL"},
+		// Delivers queued sysop notices (e.g. a new user who signed up while no
+		// sysop was online). Self-gates on sysop ACS and is silent otherwise.
+		{Command: "SYSOPNOTICES"},
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -206,7 +206,7 @@ func TestLoadLoginSequence_MissingFile(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	// Should return default sequence
-	want := []string{"PRINTNEWS", "LASTCALLS", "ONELINERS", "USERSTATS", "NEWUSERVAL"}
+	want := []string{"PRINTNEWS", "LASTCALLS", "ONELINERS", "USERSTATS", "NEWUSERVAL", "SYSOPNOTICES"}
 	if len(result) != len(want) {
 		t.Fatalf("expected default %d-item sequence, got %d", len(want), len(result))
 	}

--- a/internal/menu/executor_login_steps.go
+++ b/internal/menu/executor_login_steps.go
@@ -1,7 +1,9 @@
 package menu
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -16,10 +18,13 @@ import (
 // runNewMailScan checks for new private mail and displays a count to the user.
 func runNewMailScan(c *cmdCtx, args string) (*user.User, string, error) {
 	e := c.e
+	s := c.s
 	terminal := c.terminal
 	currentUser := c.currentUser
 	nodeNumber := c.nodeNumber
 	outputMode := c.outputMode
+	termWidth := c.termWidth
+	termHeight := c.termHeight
 
 	if currentUser == nil {
 		return nil, "", nil
@@ -89,6 +94,21 @@ func runNewMailScan(c *cmdCtx, args string) (*user.User, string, error) {
 	if newMailCount > 0 {
 		mailMsg := fmt.Sprintf(e.LoadedStrings.ExecNewMailCount, newMailCount)
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(mailMsg)), outputMode)
+
+		// Offer to read it now rather than making the caller find the mail menu.
+		// Saying yes drops them straight into the private-mail reader, where they
+		// can reply to or skip each message; no leaves the count as the notice.
+		readNow, err := e.PromptYesNo(s, terminal, "|07Read it now? @", outputMode, nodeNumber, termWidth, termHeight, true)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil, "LOGOFF", io.EOF
+			}
+			slog.Warn("read-now prompt failed", "node", nodeNumber, "handle", currentUser.Handle, "error", err)
+			return currentUser, "", nil
+		}
+		if readNow {
+			return runReadPrivateMail(c, "")
+		}
 	} else {
 		msg := e.LoadedStrings.ExecNoNewMail
 		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(msg)), outputMode)

--- a/internal/menu/executor_runnables_registry.go
+++ b/internal/menu/executor_runnables_registry.go
@@ -152,6 +152,7 @@ func registerAppRunnables(registry map[string]RunnableFunc) { // Use local Runna
 	registry["PENDINGVALIDATIONNOTICE"] = runPendingValidationNotice // SysOp notice for new users awaiting validation
 	registry["VALIDATEUSER"] = runValidateUser                       // Validate user accounts from admin menu
 	registry["NEWUSERVAL"] = runNewUserValidation                    // Prompt to validate new users if any pending
+	registry["SYSOPNOTICES"] = runSysopNotices                       // Show queued sysop notices (e.g. new-user joins) at login
 	registry["UNVALIDATEUSER"] = runUnvalidateUser                   // Remove validation from user accounts
 	registry["BANUSER"] = runBanUser                                 // Quick-ban user accounts
 	registry["DELETEUSER"] = runDeleteUser                           // Soft-delete user accounts (data preserved)

--- a/internal/menu/newuser.go
+++ b/internal/menu/newuser.go
@@ -238,7 +238,7 @@ func (e *MenuExecutor) handleNewUserApplication(
 	// Tell any sysop who is online right now. Fires regardless of
 	// AutoValidateNewUsers: an auto-validated signup leaves nothing to review,
 	// but somebody joining is still worth knowing at the time it happens.
-	e.notifySysopsOfNewUser(newUser, nodeNumber)
+	e.notifySysopsOfNewUser(userManager, newUser, nodeNumber)
 
 	// Add to NUV queue if configured.
 	cfg := e.GetServerConfig()

--- a/internal/menu/newuser_notify.go
+++ b/internal/menu/newuser_notify.go
@@ -7,25 +7,26 @@ import (
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 )
 
-// notifySysopsOfNewUser queues a page on every online co-sysop-or-above session
-// telling them a signup just completed.
+// notifySysopsOfNewUser tells every co-sysop-or-above account that a signup just
+// completed. Online sysops are paged immediately; offline sysops get a
+// persistent notice queued for their next login, since a sysop is rarely online
+// at the moment someone signs up.
 //
-// It is deliberately independent of AutoValidateNewUsers. An auto-validated
-// signup raises nothing to review, but "somebody joined" is still news a sysop
-// wants at the time it happens rather than at their next login.
+// It is deliberately independent of AutoValidateNewUsers: an auto-validated
+// signup raises nothing to review, but "somebody joined" is still news worth
+// having — informational, not a call to action.
 //
-// Delivery uses the existing page queue, so the notice appears at the
-// recipient's next menu prompt rather than interrupting whatever they are in
-// the middle of. Nothing here blocks or fails the signup: a missing registry,
-// an absent string, or nobody online are all ordinary outcomes.
+// Nothing here blocks or fails the signup: a missing registry, an absent string,
+// nobody configured, or a write error are all ordinary, non-fatal outcomes.
 //
-// Returns the number of sessions paged, which the tests assert on.
-func (e *MenuExecutor) notifySysopsOfNewUser(newUser *user.User, nodeNumber int) int {
-	if newUser == nil || e.SessionRegistry == nil {
-		return 0
+// Returns (paged, queued): how many online sessions were paged and how many
+// offline accounts had a notice queued. The tests assert on both.
+func (e *MenuExecutor) notifySysopsOfNewUser(userManager *user.UserMgr, newUser *user.User, nodeNumber int) (paged, queued int) {
+	if newUser == nil {
+		return 0, 0
 	}
 	if !e.GetServerConfig().NotifySysopNewUser {
-		return 0
+		return 0, 0
 	}
 
 	format := e.LoadedStrings.NewUserSysopPage
@@ -33,35 +34,60 @@ func (e *MenuExecutor) notifySysopsOfNewUser(newUser *user.User, nodeNumber int)
 		// No configured text means no notice, rather than a blank line
 		// appearing at a sysop's prompt with no explanation.
 		slog.Debug("new-user sysop notice skipped: newUserSysopPage is empty", "node", nodeNumber)
-		return 0
+		return 0, 0
 	}
 	msg := fmt.Sprintf(format, newUser.Handle, nodeNumber)
 
-	paged := 0
-	for _, sess := range e.SessionRegistry.ListActive() {
-		if sess == nil {
-			continue
-		}
-		sess.Mutex.RLock()
-		target := sess.User
-		targetNode := sess.NodeID
-		sess.Mutex.RUnlock()
+	// Page online co-sysop+ sessions, and remember which accounts we reached so
+	// they are not also queued a login notice for the same event.
+	pagedIDs := map[int]bool{}
+	if e.SessionRegistry != nil {
+		for _, sess := range e.SessionRegistry.ListActive() {
+			if sess == nil {
+				continue
+			}
+			sess.Mutex.RLock()
+			target := sess.User
+			targetNode := sess.NodeID
+			sess.Mutex.RUnlock()
 
-		// Skip the node that just signed up. The new account cannot be a
-		// co-sysop, but the session is still mid-signup and its own arrival is
-		// not news to it.
-		if targetNode == nodeNumber {
-			continue
+			// Skip the node that just signed up: it is still mid-signup and its
+			// own arrival is not news to it.
+			if targetNode == nodeNumber {
+				continue
+			}
+			if !e.isCoSysOpOrAbove(target) {
+				continue
+			}
+			sess.AddPage(msg)
+			paged++
+			pagedIDs[target.ID] = true
 		}
-		if !e.isCoSysOpOrAbove(target) {
-			continue
-		}
-		sess.AddPage(msg)
-		paged++
 	}
 
-	if paged > 0 {
-		slog.Info("paged sysops about a new user", "node", nodeNumber, "handle", newUser.Handle, "recipients", paged)
+	// Queue a persistent notice for every co-sysop+ account that was not paged
+	// (i.e. offline), so the news survives to their next login.
+	if userManager != nil {
+		path := sysopNoticesPath(e.GetServerConfig().DataDir)
+		for _, u := range userManager.GetAllUsers() {
+			if u == nil || u.DeletedUser || u.ID == newUser.ID || pagedIDs[u.ID] {
+				continue
+			}
+			if !e.isCoSysOpOrAbove(u) {
+				continue
+			}
+			if err := enqueueSysopNotice(path, u.ID, msg); err != nil {
+				slog.Warn("failed to queue new-user notice for offline sysop",
+					"node", nodeNumber, "recipient", u.Handle, "error", err)
+				continue
+			}
+			queued++
+		}
 	}
-	return paged
+
+	if paged > 0 || queued > 0 {
+		slog.Info("notified sysops about a new user",
+			"node", nodeNumber, "handle", newUser.Handle, "paged", paged, "queued", queued)
+	}
+	return paged, queued
 }

--- a/internal/menu/newuser_notify_test.go
+++ b/internal/menu/newuser_notify_test.go
@@ -43,8 +43,9 @@ func TestNotifyPagesCoSysOpAndAbove(t *testing.T) {
 	cosysop := sess(3, 250)
 	e := notifyFixture(t, true, sysop, cosysop)
 
-	if got := e.notifySysopsOfNewUser(&user.User{Handle: "Newbie"}, 1); got != 2 {
-		t.Fatalf("paged %d sessions, want 2", got)
+	// nil userManager: this test is about paging online sessions only.
+	if paged, _ := e.notifySysopsOfNewUser(nil, &user.User{Handle: "Newbie"}, 1); paged != 2 {
+		t.Fatalf("paged %d sessions, want 2", paged)
 	}
 	for _, s := range []*session.BbsSession{sysop, cosysop} {
 		pages := s.DrainPages()
@@ -64,8 +65,8 @@ func TestNotifySkipsRegularUsers(t *testing.T) {
 	regular := sess(2, 25)
 	e := notifyFixture(t, true, regular)
 
-	if got := e.notifySysopsOfNewUser(&user.User{Handle: "Newbie"}, 1); got != 0 {
-		t.Errorf("paged %d sessions, want 0", got)
+	if paged, _ := e.notifySysopsOfNewUser(nil, &user.User{Handle: "Newbie"}, 1); paged != 0 {
+		t.Errorf("paged %d sessions, want 0", paged)
 	}
 	if pages := regular.DrainPages(); len(pages) != 0 {
 		t.Errorf("a regular user was told about the signup: %q", pages)
@@ -80,8 +81,8 @@ func TestNotifySkipsTheSigningUpNode(t *testing.T) {
 	own := sess(1, 255)
 	e := notifyFixture(t, true, own)
 
-	if got := e.notifySysopsOfNewUser(&user.User{Handle: "Newbie"}, 1); got != 0 {
-		t.Errorf("paged %d sessions, want 0", got)
+	if paged, _ := e.notifySysopsOfNewUser(nil, &user.User{Handle: "Newbie"}, 1); paged != 0 {
+		t.Errorf("paged %d sessions, want 0", paged)
 	}
 }
 
@@ -90,8 +91,8 @@ func TestNotifySkipsSessionsWithNoUser(t *testing.T) {
 	preAuth := sess(2, -1)
 	e := notifyFixture(t, true, preAuth)
 
-	if got := e.notifySysopsOfNewUser(&user.User{Handle: "Newbie"}, 1); got != 0 {
-		t.Errorf("paged %d sessions, want 0", got)
+	if paged, _ := e.notifySysopsOfNewUser(nil, &user.User{Handle: "Newbie"}, 1); paged != 0 {
+		t.Errorf("paged %d sessions, want 0", paged)
 	}
 }
 
@@ -99,8 +100,8 @@ func TestNotifyRespectsTheConfigFlag(t *testing.T) {
 	sysop := sess(2, 255)
 	e := notifyFixture(t, false, sysop)
 
-	if got := e.notifySysopsOfNewUser(&user.User{Handle: "Newbie"}, 1); got != 0 {
-		t.Errorf("paged %d sessions with notifySysopNewUser off, want 0", got)
+	if paged, _ := e.notifySysopsOfNewUser(nil, &user.User{Handle: "Newbie"}, 1); paged != 0 {
+		t.Errorf("paged %d sessions with notifySysopNewUser off, want 0", paged)
 	}
 }
 
@@ -114,8 +115,8 @@ func TestNotifyFiresRegardlessOfAutoValidate(t *testing.T) {
 		e.ServerCfg.AutoValidateNewUsers = autoValidate
 
 		newUser := &user.User{Handle: "Newbie", Validated: autoValidate}
-		if got := e.notifySysopsOfNewUser(newUser, 1); got != 1 {
-			t.Errorf("autoValidate=%v: paged %d sessions, want 1", autoValidate, got)
+		if paged, _ := e.notifySysopsOfNewUser(nil, newUser, 1); paged != 1 {
+			t.Errorf("autoValidate=%v: paged %d sessions, want 1", autoValidate, paged)
 		}
 	}
 }
@@ -127,8 +128,8 @@ func TestNotifySkipsWhenTheStringIsEmpty(t *testing.T) {
 	e := notifyFixture(t, true, sysop)
 	e.LoadedStrings.NewUserSysopPage = ""
 
-	if got := e.notifySysopsOfNewUser(&user.User{Handle: "Newbie"}, 1); got != 0 {
-		t.Errorf("paged %d sessions with no configured string, want 0", got)
+	if paged, queued := e.notifySysopsOfNewUser(nil, &user.User{Handle: "Newbie"}, 1); paged != 0 || queued != 0 {
+		t.Errorf("paged %d/queued %d with no configured string, want 0/0", paged, queued)
 	}
 	if pages := sysop.DrainPages(); len(pages) != 0 {
 		t.Errorf("queued %q with no configured string", pages)
@@ -138,11 +139,67 @@ func TestNotifySkipsWhenTheStringIsEmpty(t *testing.T) {
 // Nothing here may fail a signup.
 func TestNotifyToleratesMissingPieces(t *testing.T) {
 	e := notifyFixture(t, true)
-	if got := e.notifySysopsOfNewUser(nil, 1); got != 0 {
-		t.Errorf("nil user paged %d sessions", got)
+	if paged, _ := e.notifySysopsOfNewUser(nil, nil, 1); paged != 0 {
+		t.Errorf("nil user paged %d sessions", paged)
 	}
 	noReg := &MenuExecutor{ServerCfg: config.ServerConfig{NotifySysopNewUser: true}}
-	if got := noReg.notifySysopsOfNewUser(&user.User{Handle: "Newbie"}, 1); got != 0 {
-		t.Errorf("nil registry paged %d sessions", got)
+	if paged, _ := noReg.notifySysopsOfNewUser(nil, &user.User{Handle: "Newbie"}, 1); paged != 0 {
+		t.Errorf("nil registry paged %d sessions", paged)
+	}
+}
+
+// Offline sysops get a persistent notice queued for their next login, while
+// online ones (paged) and non-sysops do not.
+func TestNotifyQueuesForOfflineSysops(t *testing.T) {
+	e := notifyFixture(t, true) // empty registry: nobody online
+	e.ServerCfg.DataDir = t.TempDir()
+
+	offlineSysop := &user.User{ID: 1, Handle: "SysOp", AccessLevel: 255}
+	offlineCoSysop := &user.User{ID: 2, Handle: "Co", AccessLevel: 250}
+	regular := &user.User{ID: 3, Handle: "Reg", AccessLevel: 25}
+	deletedSysop := &user.User{ID: 4, Handle: "Gone", AccessLevel: 255, DeletedUser: true}
+	um := user.NewUserMgrForTest(offlineSysop, offlineCoSysop, regular, deletedSysop)
+
+	paged, queued := e.notifySysopsOfNewUser(um, &user.User{ID: 9, Handle: "Newbie"}, 1)
+	if paged != 0 {
+		t.Errorf("paged %d, want 0 (nobody online)", paged)
+	}
+	if queued != 2 {
+		t.Fatalf("queued %d, want 2 (the two live sysop accounts)", queued)
+	}
+
+	path := sysopNoticesPath(e.ServerCfg.DataDir)
+	for _, u := range []*user.User{offlineSysop, offlineCoSysop} {
+		notices, err := drainSysopNotices(path, u.ID)
+		if err != nil {
+			t.Fatalf("drain for %s: %v", u.Handle, err)
+		}
+		if len(notices) != 1 || !strings.Contains(notices[0].Text, "Newbie") {
+			t.Errorf("%s got %d notices (%v), want 1 naming the new user", u.Handle, len(notices), notices)
+		}
+	}
+	for _, u := range []*user.User{regular, deletedSysop} {
+		if notices, _ := drainSysopNotices(path, u.ID); len(notices) != 0 {
+			t.Errorf("%s got a notice but should not have", u.Handle)
+		}
+	}
+}
+
+// An online sysop is paged, not also queued a login notice for the same event.
+func TestNotifyDoesNotDoubleNotifyOnlineSysops(t *testing.T) {
+	onlineSysop := sess(2, 255)
+	onlineSysop.User.ID = 1
+	e := notifyFixture(t, true, onlineSysop)
+	e.ServerCfg.DataDir = t.TempDir()
+
+	sysopAccount := &user.User{ID: 1, Handle: "SysOp", AccessLevel: 255}
+	um := user.NewUserMgrForTest(sysopAccount)
+
+	paged, queued := e.notifySysopsOfNewUser(um, &user.User{ID: 9, Handle: "Newbie"}, 1)
+	if paged != 1 || queued != 0 {
+		t.Fatalf("paged %d/queued %d, want 1/0 (paged online sysop must not also be queued)", paged, queued)
+	}
+	if notices, _ := drainSysopNotices(sysopNoticesPath(e.ServerCfg.DataDir), 1); len(notices) != 0 {
+		t.Errorf("online sysop was also queued a login notice: %v", notices)
 	}
 }

--- a/internal/menu/sysop_notice.go
+++ b/internal/menu/sysop_notice.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/atomicfile"
 	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
 )
@@ -56,8 +57,9 @@ func loadSysopNotices(path string) (map[int][]sysopNotice, error) {
 	return m, nil
 }
 
-// saveSysopNotices writes the queues atomically (temp file + rename) so a crash
-// mid-write cannot corrupt the store.
+// saveSysopNotices writes the queues atomically so a crash mid-write cannot
+// corrupt the store. It uses the shared atomicfile helper, which also handles
+// the Windows case where the destination is briefly open.
 func saveSysopNotices(path string, m map[int][]sysopNotice) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
@@ -66,11 +68,7 @@ func saveSysopNotices(path string, m map[int][]sysopNotice) error {
 	if err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	return atomicfile.WriteFile(path, data, 0o644)
 }
 
 // enqueueSysopNotice appends a notice to one user's queue.
@@ -86,9 +84,9 @@ func enqueueSysopNotice(path string, userID int, text string) error {
 	return saveSysopNotices(path, m)
 }
 
-// drainSysopNotices returns and removes one user's queued notices, so each is
-// shown exactly once.
-func drainSysopNotices(path string, userID int) ([]sysopNotice, error) {
+// peekSysopNotices returns one user's queued notices without removing them, so a
+// caller can display them and clear the queue only once delivery has succeeded.
+func peekSysopNotices(path string, userID int) ([]sysopNotice, error) {
 	sysopNoticesMu.Lock()
 	defer sysopNoticesMu.Unlock()
 
@@ -96,12 +94,34 @@ func drainSysopNotices(path string, userID int) ([]sysopNotice, error) {
 	if err != nil {
 		return nil, err
 	}
-	notices := m[userID]
-	if len(notices) == 0 {
-		return nil, nil
+	return m[userID], nil
+}
+
+// clearSysopNotices removes one user's queued notices.
+func clearSysopNotices(path string, userID int) error {
+	sysopNoticesMu.Lock()
+	defer sysopNoticesMu.Unlock()
+
+	m, err := loadSysopNotices(path)
+	if err != nil {
+		return err
+	}
+	if _, ok := m[userID]; !ok {
+		return nil
 	}
 	delete(m, userID)
-	if err := saveSysopNotices(path, m); err != nil {
+	return saveSysopNotices(path, m)
+}
+
+// drainSysopNotices returns and removes one user's queued notices in a single
+// step. runSysopNotices deliberately does not use this — it peeks, displays,
+// then clears, so a disconnect mid-display does not drop undelivered notices.
+func drainSysopNotices(path string, userID int) ([]sysopNotice, error) {
+	notices, err := peekSysopNotices(path, userID)
+	if err != nil || len(notices) == 0 {
+		return notices, err
+	}
+	if err := clearSysopNotices(path, userID); err != nil {
 		return nil, err
 	}
 	return notices, nil
@@ -125,8 +145,14 @@ func runSysopNotices(c *cmdCtx, args string) (*user.User, string, error) {
 		return currentUser, "", nil
 	}
 
-	path := sysopNoticesPath(e.ServerCfg.DataDir)
-	notices, err := drainSysopNotices(path, currentUser.ID)
+	// Read config under lock: the executor hot-reloads it, so a direct field
+	// read would race an update (and trip the race detector).
+	path := sysopNoticesPath(e.GetServerConfig().DataDir)
+
+	// Peek, not drain: the queue is cleared only after the notices are actually
+	// written, so a disconnect or write error mid-display leaves them queued for
+	// the next login rather than losing them.
+	notices, err := peekSysopNotices(path, currentUser.ID)
 	if err != nil {
 		slog.Warn("failed to read sysop notices", "node", nodeNumber, "handle", currentUser.Handle, "error", err)
 		return currentUser, "", nil
@@ -135,10 +161,23 @@ func runSysopNotices(c *cmdCtx, args string) (*user.User, string, error) {
 		return currentUser, "", nil
 	}
 
-	terminalio.WriteProcessedBytes(terminal, []byte("\r\n"), outputMode)
+	if werr := terminalio.WriteProcessedBytes(terminal, []byte("\r\n"), outputMode); werr != nil {
+		return currentUser, "", nil // not delivered — leave queued
+	}
 	for _, n := range notices {
-		terminalio.WriteStringCP437(terminal, ansi.ReplacePipeCodes([]byte(n.Text)), outputMode)
-		terminalio.WriteProcessedBytes(terminal, []byte("\r\n"), outputMode)
+		if werr := terminalio.WriteStringCP437(terminal, ansi.ReplacePipeCodes([]byte(n.Text)), outputMode); werr != nil {
+			slog.Warn("failed to write a sysop notice; leaving the queue for next login",
+				"node", nodeNumber, "handle", currentUser.Handle, "error", werr)
+			return currentUser, "", nil
+		}
+		if werr := terminalio.WriteProcessedBytes(terminal, []byte("\r\n"), outputMode); werr != nil {
+			return currentUser, "", nil // leave queued
+		}
+	}
+
+	// Delivered — safe to clear now.
+	if cerr := clearSysopNotices(path, currentUser.ID); cerr != nil {
+		slog.Warn("failed to clear delivered sysop notices", "node", nodeNumber, "handle", currentUser.Handle, "error", cerr)
 	}
 	slog.Info("delivered queued sysop notices at login", "node", nodeNumber, "handle", currentUser.Handle, "count", len(notices))
 

--- a/internal/menu/sysop_notice.go
+++ b/internal/menu/sysop_notice.go
@@ -1,0 +1,149 @@
+package menu
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+// sysopNotice is one queued message for a sysop, waiting to be shown at their
+// next login. Text is fully rendered (pipe codes included) at enqueue time.
+type sysopNotice struct {
+	Text      string    `json:"text"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// sysopNoticesMu guards the on-disk notices file against concurrent node writes.
+var sysopNoticesMu sync.Mutex
+
+// sysopNoticesPath returns the notices file path for the given data dir, falling
+// back to the conventional "data" dir when none is configured.
+func sysopNoticesPath(dataDir string) string {
+	if strings.TrimSpace(dataDir) == "" {
+		dataDir = "data"
+	}
+	return filepath.Join(dataDir, "sysop_notices.json")
+}
+
+// loadSysopNotices reads the per-user notice queues. A missing or empty file is
+// an empty map, not an error, so first use needs no setup.
+func loadSysopNotices(path string) (map[int][]sysopNotice, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[int][]sysopNotice{}, nil
+		}
+		return nil, err
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return map[int][]sysopNotice{}, nil
+	}
+	var m map[int][]sysopNotice
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	if m == nil {
+		m = map[int][]sysopNotice{}
+	}
+	return m, nil
+}
+
+// saveSysopNotices writes the queues atomically (temp file + rename) so a crash
+// mid-write cannot corrupt the store.
+func saveSysopNotices(path string, m map[int][]sysopNotice) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// enqueueSysopNotice appends a notice to one user's queue.
+func enqueueSysopNotice(path string, userID int, text string) error {
+	sysopNoticesMu.Lock()
+	defer sysopNoticesMu.Unlock()
+
+	m, err := loadSysopNotices(path)
+	if err != nil {
+		return err
+	}
+	m[userID] = append(m[userID], sysopNotice{Text: text, CreatedAt: time.Now()})
+	return saveSysopNotices(path, m)
+}
+
+// drainSysopNotices returns and removes one user's queued notices, so each is
+// shown exactly once.
+func drainSysopNotices(path string, userID int) ([]sysopNotice, error) {
+	sysopNoticesMu.Lock()
+	defer sysopNoticesMu.Unlock()
+
+	m, err := loadSysopNotices(path)
+	if err != nil {
+		return nil, err
+	}
+	notices := m[userID]
+	if len(notices) == 0 {
+		return nil, nil
+	}
+	delete(m, userID)
+	if err := saveSysopNotices(path, m); err != nil {
+		return nil, err
+	}
+	return notices, nil
+}
+
+// runSysopNotices is the SYSOPNOTICES login-sequence handler: it shows any
+// queued notices for a co-sysop-or-above caller and clears them. It is quiet
+// (prints nothing, no pause) for ordinary users or when the queue is empty, so
+// it can sit in the login sequence without disturbing regular logins.
+func runSysopNotices(c *cmdCtx, args string) (*user.User, string, error) {
+	e := c.e
+	s := c.s
+	terminal := c.terminal
+	currentUser := c.currentUser
+	nodeNumber := c.nodeNumber
+	outputMode := c.outputMode
+	termWidth := c.termWidth
+	termHeight := c.termHeight
+
+	if currentUser == nil || !e.isCoSysOpOrAbove(currentUser) {
+		return currentUser, "", nil
+	}
+
+	path := sysopNoticesPath(e.ServerCfg.DataDir)
+	notices, err := drainSysopNotices(path, currentUser.ID)
+	if err != nil {
+		slog.Warn("failed to read sysop notices", "node", nodeNumber, "handle", currentUser.Handle, "error", err)
+		return currentUser, "", nil
+	}
+	if len(notices) == 0 {
+		return currentUser, "", nil
+	}
+
+	terminalio.WriteProcessedBytes(terminal, []byte("\r\n"), outputMode)
+	for _, n := range notices {
+		terminalio.WriteStringCP437(terminal, ansi.ReplacePipeCodes([]byte(n.Text)), outputMode)
+		terminalio.WriteProcessedBytes(terminal, []byte("\r\n"), outputMode)
+	}
+	slog.Info("delivered queued sysop notices at login", "node", nodeNumber, "handle", currentUser.Handle, "count", len(notices))
+
+	// Pause so the notices are not scrolled off by the rest of the login
+	// sequence before the sysop can read them.
+	e.holdScreen(s, terminal, outputMode, termWidth, termHeight)
+	return currentUser, "", nil
+}

--- a/internal/menu/sysop_notice_test.go
+++ b/internal/menu/sysop_notice_test.go
@@ -1,0 +1,46 @@
+package menu
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestSysopNoticeQueueRoundTrip covers enqueue → drain: notices accumulate per
+// user, drain returns them in order and clears the queue, and a second drain is
+// empty. A missing file drains empty rather than erroring.
+func TestSysopNoticeQueueRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sysop_notices.json")
+
+	// Draining a never-written store is empty, not an error.
+	if got, err := drainSysopNotices(path, 1); err != nil || len(got) != 0 {
+		t.Fatalf("drain of empty store = (%v, %v), want (nil, no error)", got, err)
+	}
+
+	for _, text := range []string{"first", "second"} {
+		if err := enqueueSysopNotice(path, 1, text); err != nil {
+			t.Fatalf("enqueue %q: %v", text, err)
+		}
+	}
+	// A different user's queue is independent.
+	if err := enqueueSysopNotice(path, 2, "other"); err != nil {
+		t.Fatalf("enqueue for user 2: %v", err)
+	}
+
+	got, err := drainSysopNotices(path, 1)
+	if err != nil {
+		t.Fatalf("drain user 1: %v", err)
+	}
+	if len(got) != 2 || got[0].Text != "first" || got[1].Text != "second" {
+		t.Fatalf("drain user 1 = %v, want [first second] in order", got)
+	}
+
+	// Draining again yields nothing — each notice is shown once.
+	if again, _ := drainSysopNotices(path, 1); len(again) != 0 {
+		t.Errorf("second drain returned %v, want empty", again)
+	}
+
+	// User 2's queue is untouched by user 1's drain.
+	if other, _ := drainSysopNotices(path, 2); len(other) != 1 || other[0].Text != "other" {
+		t.Errorf("user 2 drain = %v, want [other]", other)
+	}
+}

--- a/templates/configs/login.json
+++ b/templates/configs/login.json
@@ -28,6 +28,9 @@
         "sec_level": 255
     },
     {
+        "command": "SYSOPNOTICES"
+    },
+    {
         "command": "CHECKNUV"
     }
 ]


### PR DESCRIPTION
## Summary

Makes the "new user signed up" sysop notice **asynchronous**, and adds a **"read mail now?"** prompt at login. Addresses the observation that a sysop is rarely online at signup time, so the old live-only page was almost always lost.

## New-user notice: online → page, offline → queued for next login

`notifySysopNewUser` used to page only co-sysop+ sessions that were **online at the moment of signup** (skipping the signing-up node). If no sysop was online, the news vanished — and with `autoValidateNewUsers` on, `NEWUSERVAL` shows nothing either (nothing pending), so the sysop never learned a user joined.

Now:
- Online co-sysop+ sessions are **paged** immediately (unchanged).
- Offline co-sysop+ accounts get a **persistent notice** queued to `data/sysop_notices.json`, delivered and cleared at their **next login** via a new `SYSOPNOTICES` login step.
- An online sysop who was paged is **not** also queued for the same event (no double delivery).
- The notice is **informational** and fires regardless of `autoValidateNewUsers` — with auto-approve on there's nothing to validate, so it's just "somebody joined, maybe view them." It self-gates on co-sysop ACS (silent for everyone else and when the queue is empty).

## "Read it now?" after the login mail scan

When `NMAILSCAN` reports new private mail, the caller is now asked **"Read it now?"** — yes drops them into the private-mail reader (per-message **R** reply / **N** skip), instead of making them find the mail menu. (This reader already existed on the Email menu; the login scan just never offered it.)

## Wiring
- `SYSOPNOTICES` registered as a runnable, added to the built-in default login sequence and the shipped `templates/configs/login.json` (after `NEWUSERVAL`).
- **Existing installs with a custom `login.json` must add `{"command":"SYSOPNOTICES"}`** — documented in the upgrade guide and login-sequence reference.

## Testing
- New store unit-tested (`TestSysopNoticeQueueRoundTrip`): enqueue/drain ordering, drain-clears-once, per-user isolation, missing-file safety.
- Notify split tested: `TestNotifyQueuesForOfflineSysops` (offline queued, regular/deleted skipped) and `TestNotifyDoesNotDoubleNotifyOnlineSysops`.
- `go build ./...`, `go vet ./...`, `gofmt`, and full `go test ./...` all pass.

## Docs
- Login-sequence reference: new `SYSOPNOTICES` section; `NMAILSCAN` read-now note; `NEWUSERVAL` cross-reference clarifying the auto-validate gap.
- Upgrade guide: how to add `SYSOPNOTICES` to a custom `login.json`.

## Notes
- This is *not* issue #206 — that's real-time cross-node login/logoff announcements, a separate larger feature. This is the async sysop-alert gap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SysOps now receive queued notices, including offline new-user signup notifications, when they next log in.
  * New users can be notified to online SysOps immediately while offline notices are saved for later.
  * When new private mail is detected, users can open the mail reader immediately.

* **Documentation**
  * Updated login and upgrade guidance to describe these behaviors and required configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->