### PR TITLE
fix(messages): default to the clean style-1 message header (#301)

### DIFF
--- a/internal/menu/message_reader.go
+++ b/internal/menu/message_reader.go
@@ -22,8 +22,10 @@ import (
 	"golang.org/x/term"
 )
 
-// Default message header style if user hasn't selected one
-const defaultMsgHdrStyle = 5
+// Default message header style if user hasn't selected one. Style 1 is the
+// clean "ViSiON/3 Message Header"; the previous default (5) shipped with
+// alignment glitches ("Sent To" and an empty, misplaced "Total Msg"). See #301.
+const defaultMsgHdrStyle = 1
 
 // Message reader navigation options (Pascal's 10-option bar)
 var msgReaderOptions = []MsgLightbarOption{


### PR DESCRIPTION
Addresses the main ask in #301: **change the default message header to `[1] - ViSiON/3 Message Header`.**

The default was style **5**, whose template (`MSGHDR.5.ans`) is the one in the screenshot — it has a stray dot in the `Sent To` label and a `Total Msg` label with **no value placeholder** positioned after it (only `@#@ of @N@` sits on the `Msg` row), so `Total Msg`'s value renders empty. Style **1** (`MSGHDR.1.ans`, "ViSiON/3 Message Header") is clean, so the default now points there. Users who explicitly picked another style are unaffected.

## Scope note
Repairing style 5's template itself (the stray dot + adding the missing `Total Msg` value) is **not** in this PR — it's careful cursor-position surgery in a binary ANSI file, and style 5 is no longer the default. Happy to do it as a follow-up if you want style 5 kept usable.

## Testing
`go build ./...`, `gofmt`, `go test ./internal/menu/` pass.

Refs #301