### PR TITLE
feat(files): add [C] Change Conference to the file menu, shared with messages (#304)

### DIFF
--- a/internal/menu/area_lightbar_conf.go
+++ b/internal/menu/area_lightbar_conf.go
@@ -109,16 +109,9 @@ func runChangeMsgConferenceLightbar(c *cmdCtx, args string) (*user.User, string,
 
 	p.onSelect = func(idx int) (bool, *user.User, string, error) {
 		chosen := confs[idx]
-		e.setUserMsgConference(currentUser, chosen.id)
-
-		firstArea := findFirstAccessibleAreaInConference(e, s, terminal, currentUser, chosen.id, sessionStartTime)
-		if firstArea != nil {
-			currentUser.CurrentMessageAreaID = firstArea.ID
-			currentUser.CurrentMessageAreaTag = firstArea.Tag
-		} else {
-			currentUser.CurrentMessageAreaID = 0
-			currentUser.CurrentMessageAreaTag = ""
-		}
+		// Joins the conference for both messages and files (#304), so the active
+		// conference stays in step across the two menus.
+		e.joinConferenceForBoth(s, terminal, currentUser, chosen.id, sessionStartTime)
 
 		if err := userManager.UpdateUser(currentUser); err != nil {
 			slog.Error("failed to save user after conference change", "node", nodeNumber, "error", err)

--- a/internal/menu/area_lightbar_conf.go
+++ b/internal/menu/area_lightbar_conf.go
@@ -110,11 +110,11 @@ func runChangeMsgConferenceLightbar(c *cmdCtx, args string) (*user.User, string,
 	p.onSelect = func(idx int) (bool, *user.User, string, error) {
 		chosen := confs[idx]
 		// Joins the conference for both messages and files (#304), so the active
-		// conference stays in step across the two menus.
-		e.joinConferenceForBoth(s, terminal, currentUser, chosen.id, sessionStartTime)
-
-		if err := userManager.UpdateUser(currentUser); err != nil {
-			slog.Error("failed to save user after conference change", "node", nodeNumber, "error", err)
+		// conference stays in step across the two menus. Reverts if the save
+		// fails rather than showing a change that won't survive the session.
+		if !e.commitConferenceJoin(s, terminal, userManager, currentUser, chosen.id, sessionStartTime) {
+			p.showConfirm("|12Could not save the conference change.|07")
+			return true, currentUser, "", nil
 		}
 
 		confName := chosen.name

--- a/internal/menu/area_lightbar_conf_file.go
+++ b/internal/menu/area_lightbar_conf_file.go
@@ -73,6 +73,45 @@ func (e *MenuExecutor) joinConferenceForBoth(s ssh.Session, terminal *term.Termi
 	}
 }
 
+// confSelection captures the conference/area fields joinConferenceForBoth
+// changes, so a failed save can be rolled back rather than leaving the session
+// showing a conference it did not persist (which would vanish on reconnect).
+type confSelection struct {
+	msgConfID, msgAreaID, fileConfID, fileAreaID     int
+	msgConfTag, msgAreaTag, fileConfTag, fileAreaTag string
+}
+
+func snapshotConfSelection(u *user.User) confSelection {
+	return confSelection{
+		msgConfID: u.CurrentMsgConferenceID, msgConfTag: u.CurrentMsgConferenceTag,
+		msgAreaID: u.CurrentMessageAreaID, msgAreaTag: u.CurrentMessageAreaTag,
+		fileConfID: u.CurrentFileConferenceID, fileConfTag: u.CurrentFileConferenceTag,
+		fileAreaID: u.CurrentFileAreaID, fileAreaTag: u.CurrentFileAreaTag,
+	}
+}
+
+func restoreConfSelection(u *user.User, s confSelection) {
+	u.CurrentMsgConferenceID, u.CurrentMsgConferenceTag = s.msgConfID, s.msgConfTag
+	u.CurrentMessageAreaID, u.CurrentMessageAreaTag = s.msgAreaID, s.msgAreaTag
+	u.CurrentFileConferenceID, u.CurrentFileConferenceTag = s.fileConfID, s.fileConfTag
+	u.CurrentFileAreaID, u.CurrentFileAreaTag = s.fileAreaID, s.fileAreaTag
+}
+
+// commitConferenceJoin joins a conference for both menus and persists it. If the
+// save fails it rolls the in-memory selection back to what it was and returns
+// false, so the caller does not report a change that will not survive the
+// session — the active conference stays consistent with what is on disk.
+func (e *MenuExecutor) commitConferenceJoin(s ssh.Session, terminal *term.Terminal, userManager *user.UserMgr, u *user.User, conferenceID int, sessionStartTime time.Time) bool {
+	prev := snapshotConfSelection(u)
+	e.joinConferenceForBoth(s, terminal, u, conferenceID, sessionStartTime)
+	if err := userManager.UpdateUser(u); err != nil {
+		restoreConfSelection(u, prev)
+		slog.Error("failed to save conference change; reverting selection", "handle", u.Handle, "error", err)
+		return false
+	}
+	return true
+}
+
 // runChangeFileConferenceLightbar is the file-menu counterpart to
 // runChangeMsgConferenceLightbar: it lets the caller pick a conference from the
 // same shared conference list and joins it for both files and messages. It
@@ -108,8 +147,10 @@ func runChangeFileConferenceLightbar(c *cmdCtx, args string) (*user.User, string
 	templateDir := filepath.Join(e.MenuSetPath, "templates")
 	topBytes, midBytes := loadFileConfTemplates(templateDir)
 	if topBytes == nil || midBytes == nil {
+		// Conferences may well exist — the templates are what's missing — so
+		// report a template error rather than "no conferences".
 		slog.Warn("FILECONF/MSGCONF templates unavailable for CHANGEFILECONF", "node", nodeNumber)
-		_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ConfNoConferences)), outputMode)
+		_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ConfTemplateError)), outputMode)
 		time.Sleep(1 * time.Second)
 		return currentUser, "", nil
 	}
@@ -166,10 +207,9 @@ func runChangeFileConferenceLightbar(c *cmdCtx, args string) (*user.User, string
 
 	p.onSelect = func(idx int) (bool, *user.User, string, error) {
 		chosen := confs[idx]
-		e.joinConferenceForBoth(s, terminal, currentUser, chosen.id, sessionStartTime)
-
-		if err := userManager.UpdateUser(currentUser); err != nil {
-			slog.Error("failed to save user after file conference change", "node", nodeNumber, "error", err)
+		if !e.commitConferenceJoin(s, terminal, userManager, currentUser, chosen.id, sessionStartTime) {
+			p.showConfirm("|12Could not save the conference change.|07")
+			return true, currentUser, "", nil
 		}
 
 		confName := chosen.name

--- a/internal/menu/area_lightbar_conf_file.go
+++ b/internal/menu/area_lightbar_conf_file.go
@@ -1,0 +1,206 @@
+package menu
+
+import (
+	"log/slog"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/file"
+	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+	"github.com/gliderlabs/ssh"
+	"golang.org/x/term"
+)
+
+// getAccessibleFileAreasInConference returns the file areas in a conference the
+// caller may list, ordered by ID (file areas have no explicit position field).
+func getAccessibleFileAreasInConference(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, currentUser *user.User, conferenceID int, sessionStartTime time.Time) []file.FileArea {
+	if e.FileMgr == nil {
+		return nil
+	}
+	var result []file.FileArea
+	for _, area := range e.FileMgr.ListAreas() {
+		if area.ConferenceID != conferenceID {
+			continue
+		}
+		if !checkACS(area.ACSList, currentUser, s, terminal, sessionStartTime) {
+			continue
+		}
+		result = append(result, area)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })
+	return result
+}
+
+// findFirstAccessibleFileAreaInConference returns the first file area the caller
+// can list in the conference, or nil when there is none.
+func findFirstAccessibleFileAreaInConference(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, currentUser *user.User, conferenceID int, sessionStartTime time.Time) *file.FileArea {
+	areas := getAccessibleFileAreasInConference(e, s, terminal, currentUser, conferenceID, sessionStartTime)
+	if len(areas) > 0 {
+		a := areas[0]
+		return &a
+	}
+	return nil
+}
+
+// joinConferenceForBoth makes a conference the caller's active conference for
+// both messages and files, moving them to the first accessible area on each
+// side (#304: a conference change in either the message or file menu applies to
+// both). A side with no accessible area in the conference has its current area
+// cleared rather than left pointing into the old conference. It does not save;
+// the caller persists the user record.
+func (e *MenuExecutor) joinConferenceForBoth(s ssh.Session, terminal *term.Terminal, u *user.User, conferenceID int, sessionStartTime time.Time) {
+	e.setUserMsgConference(u, conferenceID)
+	if area := findFirstAccessibleAreaInConference(e, s, terminal, u, conferenceID, sessionStartTime); area != nil {
+		u.CurrentMessageAreaID = area.ID
+		u.CurrentMessageAreaTag = area.Tag
+	} else {
+		u.CurrentMessageAreaID = 0
+		u.CurrentMessageAreaTag = ""
+	}
+
+	e.setUserFileConference(u, conferenceID)
+	if fa := findFirstAccessibleFileAreaInConference(e, s, terminal, u, conferenceID, sessionStartTime); fa != nil {
+		u.CurrentFileAreaID = fa.ID
+		u.CurrentFileAreaTag = fa.Tag
+	} else {
+		u.CurrentFileAreaID = 0
+		u.CurrentFileAreaTag = ""
+	}
+}
+
+// runChangeFileConferenceLightbar is the file-menu counterpart to
+// runChangeMsgConferenceLightbar: it lets the caller pick a conference from the
+// same shared conference list and joins it for both files and messages. It
+// reuses the MSGCONF templates when a menu set ships no FILECONF ones — the
+// conference list and layout are identical, and the shipped MSGCONF art is
+// generic ("Current Conference" / "# Conference Name Description").
+func runChangeFileConferenceLightbar(c *cmdCtx, args string) (*user.User, string, error) {
+	e := c.e
+	s := c.s
+	terminal := c.terminal
+	userManager := c.userManager
+	currentUser := c.currentUser
+	nodeNumber := c.nodeNumber
+	sessionStartTime := c.sessionStartTime
+	outputMode := c.outputMode
+
+	slog.Debug("running CHANGEFILECONF (lightbar)", "node", nodeNumber)
+
+	termWidth, termHeight := resolveTermDims(currentUser, c.termWidth, c.termHeight)
+
+	if currentUser == nil {
+		_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ConfLoginRequired)), outputMode)
+		time.Sleep(1 * time.Second)
+		return nil, "", nil
+	}
+
+	if e.ConferenceMgr == nil {
+		_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ConfNoConferences)), outputMode)
+		time.Sleep(1 * time.Second)
+		return currentUser, "", nil
+	}
+
+	templateDir := filepath.Join(e.MenuSetPath, "templates")
+	topBytes, midBytes := loadFileConfTemplates(templateDir)
+	if topBytes == nil || midBytes == nil {
+		slog.Warn("FILECONF/MSGCONF templates unavailable for CHANGEFILECONF", "node", nodeNumber)
+		_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ConfNoConferences)), outputMode)
+		time.Sleep(1 * time.Second)
+		return currentUser, "", nil
+	}
+
+	processedMidTemplate := string(ansi.ReplacePipeCodes(midBytes))
+
+	var confs []confPickItem
+	currentConfName := "None"
+	for _, conf := range e.ConferenceMgr.ListConferences() {
+		if !checkACS(conf.ACS, currentUser, s, terminal, sessionStartTime) {
+			continue
+		}
+		confs = append(confs, confPickItem{id: conf.ID, name: conf.Name, description: conf.Description})
+		if conf.ID == currentUser.CurrentFileConferenceID {
+			currentConfName = conf.Name
+		}
+	}
+
+	if len(confs) == 0 {
+		_ = terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ConfNoConferences)), outputMode)
+		time.Sleep(1 * time.Second)
+		return currentUser, "", nil
+	}
+
+	p := &areaLightbarPicker[confPickItem]{
+		e:           e,
+		terminal:    terminal,
+		outputMode:  outputMode,
+		currentUser: currentUser,
+		nodeNumber:  nodeNumber,
+		items:       confs,
+		buildItemLine: func(item confPickItem, displayIdx int) string {
+			line := processedMidTemplate
+			line = strings.ReplaceAll(line, "^CI", padRight(strconv.Itoa(displayIdx), 3))
+			line = strings.ReplaceAll(line, "^CN", padRight(truncateStr(item.name, 20), 20))
+			line = strings.ReplaceAll(line, "^CD", truncateStr(item.description, 53))
+			return strings.TrimRight(line, "\r\n")
+		},
+		hint:       "|08[ |15Up|08/|15Dn|08 ] Navigate  [ |15PgUp|08/|15PgDn|08 ] Page  [ |15Enter|08 ] Select  [ |15Q|08 ] Quit",
+		headerName: currentConfName,
+		topBytes:   topBytes,
+		hiColorSeq: resolveAreaHiColor(e, "MSGCONFHI", nodeNumber),
+		termWidth:  termWidth,
+		termHeight: termHeight,
+	}
+	p.computeLayout(measureAreaHeaderRows(e, topBytes, currentUser, nodeNumber))
+
+	for i, cf := range confs {
+		if cf.id == currentUser.CurrentFileConferenceID {
+			p.selectedIndex = i
+			break
+		}
+	}
+
+	p.onSelect = func(idx int) (bool, *user.User, string, error) {
+		chosen := confs[idx]
+		e.joinConferenceForBoth(s, terminal, currentUser, chosen.id, sessionStartTime)
+
+		if err := userManager.UpdateUser(currentUser); err != nil {
+			slog.Error("failed to save user after file conference change", "node", nodeNumber, "error", err)
+		}
+
+		confName := chosen.name
+		confTag := ""
+		if conf, ok := e.ConferenceMgr.GetByID(chosen.id); ok {
+			confName = conf.Name
+			confTag = conf.Tag
+		}
+
+		p.showConfirm("|08[ |15" + confName + " |08] |15Conference Joined!|07")
+
+		slog.Info("user changed file conference",
+			"node", nodeNumber, "handle", currentUser.Handle, "id", chosen.id, "tag", confTag, "fileArea", currentUser.CurrentFileAreaTag)
+		return true, currentUser, "", nil
+	}
+
+	return p.run(s)
+}
+
+// loadFileConfTemplates returns the top/mid templates for the file conference
+// picker, preferring FILECONF.* and falling back to the shipped MSGCONF.*.
+func loadFileConfTemplates(templateDir string) (top, mid []byte) {
+	top, errTop := readTemplateFile(filepath.Join(templateDir, "FILECONF.TOP"))
+	mid, errMid := readTemplateFile(filepath.Join(templateDir, "FILECONF.MID"))
+	if errTop == nil && errMid == nil {
+		return top, mid
+	}
+	top, errTop = readTemplateFile(filepath.Join(templateDir, "MSGCONF.TOP"))
+	mid, errMid = readTemplateFile(filepath.Join(templateDir, "MSGCONF.MID"))
+	if errTop != nil || errMid != nil {
+		return nil, nil
+	}
+	return top, mid
+}

--- a/internal/menu/area_lightbar_conf_file_test.go
+++ b/internal/menu/area_lightbar_conf_file_test.go
@@ -1,0 +1,60 @@
+package menu
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/file"
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+// newTestFileMgr builds a real FileManager from a temp file_areas.json.
+func newTestFileMgr(t *testing.T, areas string) *file.FileManager {
+	t.Helper()
+	dataDir := t.TempDir()
+	cfgDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cfgDir, "file_areas.json"), []byte(areas), 0o644); err != nil {
+		t.Fatalf("write file_areas.json: %v", err)
+	}
+	fm, err := file.NewFileManager(dataDir, cfgDir)
+	if err != nil {
+		t.Fatalf("NewFileManager: %v", err)
+	}
+	return fm
+}
+
+func TestFileAreasInConference(t *testing.T) {
+	// Areas across two conferences, out of ID order in the file, one gated.
+	fm := newTestFileMgr(t, `[
+	  {"id": 30, "tag": "B30", "name": "Beta", "conference_id": 1, "acs_list": "*"},
+	  {"id": 10, "tag": "A10", "name": "Alpha", "conference_id": 1, "acs_list": "*"},
+	  {"id": 20, "tag": "S20", "name": "Secret", "conference_id": 1, "acs_list": "S255"},
+	  {"id": 40, "tag": "C40", "name": "Gamma", "conference_id": 2, "acs_list": "*"}
+	]`)
+	e := &MenuExecutor{FileMgr: fm}
+	u := &user.User{ID: 2, Handle: "u", AccessLevel: 10}
+
+	got := getAccessibleFileAreasInConference(e, nil, nil, u, 1, time.Time{})
+	// Conference 1, ACS-visible only (S20 gated out for a level-10 user), sorted by ID.
+	if len(got) != 2 || got[0].ID != 10 || got[1].ID != 30 {
+		t.Fatalf("conf 1 accessible = %+v, want IDs [10 30]", got)
+	}
+
+	first := findFirstAccessibleFileAreaInConference(e, nil, nil, u, 1, time.Time{})
+	if first == nil || first.ID != 10 || first.Tag != "A10" {
+		t.Fatalf("first accessible = %+v, want ID 10 tag A10", first)
+	}
+
+	// Conference 2 has one area; a conference with none returns nil.
+	if first := findFirstAccessibleFileAreaInConference(e, nil, nil, u, 2, time.Time{}); first == nil || first.ID != 40 {
+		t.Fatalf("conf 2 first = %+v, want ID 40", first)
+	}
+	if got := getAccessibleFileAreasInConference(e, nil, nil, u, 99, time.Time{}); got != nil {
+		t.Fatalf("empty conference returned %+v, want nil", got)
+	}
+	if first := findFirstAccessibleFileAreaInConference(e, nil, nil, u, 99, time.Time{}); first != nil {
+		t.Fatalf("empty conference first = %+v, want nil", first)
+	}
+}

--- a/internal/menu/conference_menu.go
+++ b/internal/menu/conference_menu.go
@@ -125,21 +125,13 @@ func runChangeMsgConference(c *cmdCtx, args string) (*user.User, string, error) 
 			continue
 		}
 
-		// Update user conference
-		e.setUserMsgConference(currentUser, confID)
-
-		// Find first accessible area in new conference
-		firstArea := findFirstAccessibleAreaInConference(e, s, terminal, currentUser, confID, sessionStartTime)
-		if firstArea != nil {
-			currentUser.CurrentMessageAreaID = firstArea.ID
-			currentUser.CurrentMessageAreaTag = firstArea.Tag
-		} else {
-			currentUser.CurrentMessageAreaID = 0
-			currentUser.CurrentMessageAreaTag = ""
-		}
-
-		if err := userManager.UpdateUser(currentUser); err != nil {
-			slog.Error("failed to save user after conference change", "node", nodeNumber, "error", err)
+		// Join the conference for both messages and files (#304), persisting it
+		// and reverting on a save failure. The text-mode path must share this
+		// behavior with the lightbar path or the two menus can desync.
+		if !e.commitConferenceJoin(s, terminal, userManager, currentUser, confID, sessionStartTime) {
+			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|12Could not save the conference change.|07\r\n")), outputMode)
+			time.Sleep(1 * time.Second)
+			return currentUser, "", nil
 		}
 
 		// Display confirmation

--- a/internal/menu/executor_runnables_registry.go
+++ b/internal/menu/executor_runnables_registry.go
@@ -171,6 +171,7 @@ func registerAppRunnables(registry map[string]RunnableFunc) { // Use local Runna
 	registry["SELECTFILEAREA"] = runSelectFileAreaDispatch           // File area selection (dispatches by fileListingMode)
 	registry["SELECTMSGAREA"] = runSelectMessageAreaLightbar         // Register message area selection runnable (lightbar)
 	registry["CHANGEMSGCONF"] = runChangeMsgConferenceLightbar       // Change message conference (lightbar)
+	registry["CHANGEFILECONF"] = runChangeFileConferenceLightbar     // Change file conference (lightbar); joins for both menus
 	registry["NEXTMSGAREA"] = runNextMsgArea                         // Navigate to next message area
 	registry["PREVMSGAREA"] = runPrevMsgArea                         // Navigate to previous message area
 	registry["NEXTMSGCONF"] = runNextMsgConf                         // Navigate to next message conference

--- a/menus/v3/cfg/FILEM.CFG
+++ b/menus/v3/cfg/FILEM.CFG
@@ -18,7 +18,7 @@
         "CMD": "RUN:CHANGEFILECONF",
         "ACS": "",
         "HIDDEN": false,
-        "NODE_ACTIVITY": "Changing File Conference"
+        "NODE_ACTIVITY": "Changing Conference"
     },
     {
         "KEYS": "D",
@@ -129,7 +129,7 @@
         "CMD": "RUN:FILENEWSCANCONFIG",
         "ACS": "",
         "HIDDEN": false,
-        "NODE_ACTIVITY": "Configuring File NewScan"
+        "NODE_ACTIVITY": "Configuring Newscan"
     },
     {
         "KEYS": "-",

--- a/menus/v3/cfg/FILEM.CFG
+++ b/menus/v3/cfg/FILEM.CFG
@@ -15,10 +15,10 @@
     },
     {
         "KEYS": "C",
-        "CMD": "RUN:FILENEWSCANCONFIG",
+        "CMD": "RUN:CHANGEFILECONF",
         "ACS": "",
         "HIDDEN": false,
-        "NODE_ACTIVITY": "Configuring File Newscan"
+        "NODE_ACTIVITY": "Changing File Conference"
     },
     {
         "KEYS": "D",
@@ -126,10 +126,10 @@
     },
     {
         "KEYS": "Z",
-        "CMD": "RUN:FILE_NEWSCAN",
+        "CMD": "RUN:FILENEWSCANCONFIG",
         "ACS": "",
         "HIDDEN": false,
-        "NODE_ACTIVITY": "Scanning New Files"
+        "NODE_ACTIVITY": "Configuring File NewScan"
     },
     {
         "KEYS": "-",


### PR DESCRIPTION
Closes #304.

The file/transfer menu had **Change Area** but no **Change Conference**, and the message vs. file "current conference" tracked independently.

## What's added
- **`CHANGEFILECONF`** — a lightbar conference picker mirroring `CHANGEMSGCONF`. Reuses the shipped `MSGCONF.*` templates when a menu set has no `FILECONF.*` ones (same conference list; the MSGCONF art is generic — "Current Conference" / "# Conference Name Description"), so it works out of the box and a sysop can drop in `FILECONF.TOP`/`.MID` to customize.
- **Shared active conference (item 2)** — `joinConferenceForBoth` sets the active conference for **both** messages and files and moves the caller to the first accessible area on each side. Both the message and file conference-change commands call it, so changing conference in either menu applies to both. A side with no accessible area in the conference has its current area cleared rather than left dangling in the old one.
- **Helpers** `getAccessibleFileAreasInConference` / `findFirstAccessibleFileAreaInConference` (ordered by ID — file areas have no position field), unit-tested against a real `FileManager` built from a temp `file_areas.json`.
- **`FILEM.CFG`**: `[C]` → `CHANGEFILECONF`, and `[Z]` (previously a duplicate of `[N]` `FILE_NEWSCAN`) → `FILENEWSCANCONFIG`, mirroring the message menu's C/Z layout.

## Testing
`TestFileAreasInConference` covers conference filtering, ACS gating, ID ordering, and the empty-conference case. `go build ./...`, `go vet`, `gofmt`, and full `go test ./...` pass.

## Deploy note
Prod's `FILEM.CFG` is a separate copy; it'll get the `[C]`/`[Z]` remap at deploy.

Fixes #304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a file conference selector to the file menu.
  * File conference changes now synchronize the active message and file areas.
  * File areas are filtered based on access permissions, with the first available area selected automatically.
  * Added fallback support for conference menu templates and clearer handling of unavailable options.

* **Bug Fixes**
  * Corrected file-menu commands for configuration and new-file scanning actions.
  * Conference changes now roll back when saving fails and display an error instead of a success confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->