### PR TITLE
feat(files): mirror message-menu area/conference navigation in the file menu

### DIFF
--- a/internal/menu/conference_menu.go
+++ b/internal/menu/conference_menu.go
@@ -505,20 +505,11 @@ func navigateMsgConf(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, us
 	}
 
 	newConf := accessibleConfs[newIdx]
-	e.setUserMsgConference(currentUser, newConf.ID)
-
-	// Set first accessible area in the new conference
-	firstArea := findFirstAccessibleAreaInConference(e, s, terminal, currentUser, newConf.ID, sessionStartTime)
-	if firstArea != nil {
-		currentUser.CurrentMessageAreaID = firstArea.ID
-		currentUser.CurrentMessageAreaTag = firstArea.Tag
-	} else {
-		currentUser.CurrentMessageAreaID = 0
-		currentUser.CurrentMessageAreaTag = ""
-	}
-
-	if err := userManager.UpdateUser(currentUser); err != nil {
-		slog.Error("failed to save user after conference change", "node", nodeNumber, "error", err)
+	// Join for both messages and files (#304), reverting on a save failure.
+	if !e.commitConferenceJoin(s, terminal, userManager, currentUser, newConf.ID, sessionStartTime) {
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|12Could not save the conference change.|07\r\n")), outputMode)
+		time.Sleep(1 * time.Second)
+		return currentUser, "", nil
 	}
 
 	msg := e.LoadedStrings.ConfCurrentConfFormat

--- a/internal/menu/executor_runnables_registry.go
+++ b/internal/menu/executor_runnables_registry.go
@@ -172,6 +172,10 @@ func registerAppRunnables(registry map[string]RunnableFunc) { // Use local Runna
 	registry["SELECTMSGAREA"] = runSelectMessageAreaLightbar         // Register message area selection runnable (lightbar)
 	registry["CHANGEMSGCONF"] = runChangeMsgConferenceLightbar       // Change message conference (lightbar)
 	registry["CHANGEFILECONF"] = runChangeFileConferenceLightbar     // Change file conference (lightbar); joins for both menus
+	registry["NEXTFILEAREA"] = runNextFileArea                       // Next file area in the current conference
+	registry["PREVFILEAREA"] = runPrevFileArea                       // Previous file area in the current conference
+	registry["NEXTFILECONF"] = runNextFileConf                       // Next file conference (joins for both menus)
+	registry["PREVFILECONF"] = runPrevFileConf                       // Previous file conference (joins for both menus)
 	registry["NEXTMSGAREA"] = runNextMsgArea                         // Navigate to next message area
 	registry["PREVMSGAREA"] = runPrevMsgArea                         // Navigate to previous message area
 	registry["NEXTMSGCONF"] = runNextMsgConf                         // Navigate to next message conference

--- a/internal/menu/file_nav.go
+++ b/internal/menu/file_nav.go
@@ -1,0 +1,133 @@
+package menu
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
+	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+// File-menu area/conference navigation, mirroring the message menu's
+// NEXT/PREVMSGAREA and NEXT/PREVMSGCONF so the two menus behave the same way.
+// Conference moves join for both menus (#304), keeping the active conference in
+// step across messages and files.
+
+func runNextFileArea(c *cmdCtx, args string) (*user.User, string, error) {
+	return navigateFileArea(c, true)
+}
+
+func runPrevFileArea(c *cmdCtx, args string) (*user.User, string, error) {
+	return navigateFileArea(c, false)
+}
+
+func navigateFileArea(c *cmdCtx, forward bool) (*user.User, string, error) {
+	e, s, terminal := c.e, c.s, c.terminal
+	currentUser, nodeNumber := c.currentUser, c.nodeNumber
+	sessionStartTime, outputMode := c.sessionStartTime, c.outputMode
+
+	if currentUser == nil {
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ConfNavLoginRequired)), outputMode)
+		time.Sleep(1 * time.Second)
+		return nil, "", nil
+	}
+
+	areas := getAccessibleFileAreasInConference(e, s, terminal, currentUser, currentUser.CurrentFileConferenceID, sessionStartTime)
+	if len(areas) == 0 {
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ConfNoAccessibleAreas)), outputMode)
+		time.Sleep(1 * time.Second)
+		return currentUser, "", nil
+	}
+
+	currentIdx := -1
+	for i, area := range areas {
+		if area.ID == currentUser.CurrentFileAreaID {
+			currentIdx = i
+			break
+		}
+	}
+	newIdx := stepIndex(currentIdx, len(areas), forward)
+
+	newArea := areas[newIdx]
+	currentUser.CurrentFileAreaID = newArea.ID
+	currentUser.CurrentFileAreaTag = newArea.Tag
+	if err := c.userManager.UpdateUser(currentUser); err != nil {
+		slog.Error("failed to save user after file area change", "node", nodeNumber, "error", err)
+	}
+
+	terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes(
+		[]byte(fmt.Sprintf(e.LoadedStrings.ConfCurrentAreaFormat, newArea.Name, newArea.Tag))), outputMode)
+	slog.Info("user navigated to file area", "node", nodeNumber, "handle", currentUser.Handle, "id", newArea.ID, "tag", newArea.Tag)
+	return currentUser, "", nil
+}
+
+func runNextFileConf(c *cmdCtx, args string) (*user.User, string, error) {
+	return navigateFileConf(c, true)
+}
+
+func runPrevFileConf(c *cmdCtx, args string) (*user.User, string, error) {
+	return navigateFileConf(c, false)
+}
+
+func navigateFileConf(c *cmdCtx, forward bool) (*user.User, string, error) {
+	e, s, terminal := c.e, c.s, c.terminal
+	currentUser, nodeNumber := c.currentUser, c.nodeNumber
+	sessionStartTime, outputMode := c.sessionStartTime, c.outputMode
+
+	if currentUser == nil {
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ConfNavLoginRequired)), outputMode)
+		time.Sleep(1 * time.Second)
+		return nil, "", nil
+	}
+	if e.ConferenceMgr == nil {
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ConfNoConferences)), outputMode)
+		time.Sleep(1 * time.Second)
+		return currentUser, "", nil
+	}
+
+	confs := getAccessibleConferences(e, s, terminal, currentUser, sessionStartTime)
+	if len(confs) == 0 {
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.LoadedStrings.ConfNoAccessibleConfs)), outputMode)
+		time.Sleep(1 * time.Second)
+		return currentUser, "", nil
+	}
+
+	currentIdx := -1
+	for i, conf := range confs {
+		if conf.ID == currentUser.CurrentFileConferenceID {
+			currentIdx = i
+			break
+		}
+	}
+	newConf := confs[stepIndex(currentIdx, len(confs), forward)]
+
+	// Join for both menus (#304); revert on a save failure rather than showing a
+	// move that will not survive the session.
+	if !e.commitConferenceJoin(s, terminal, c.userManager, currentUser, newConf.ID, sessionStartTime) {
+		terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|12Could not save the conference change.|07\r\n")), outputMode)
+		time.Sleep(1 * time.Second)
+		return currentUser, "", nil
+	}
+
+	msg := e.LoadedStrings.ConfCurrentConfFormat
+	if msg == "" {
+		msg = "\r\n|07(|15%s|07) [|14%s|07]\r\n"
+	}
+	terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(fmt.Sprintf(msg, newConf.Name, newConf.Tag))), outputMode)
+	slog.Info("user navigated to file conference", "node", nodeNumber, "handle", currentUser.Handle, "id", newConf.ID, "tag", newConf.Tag)
+	return currentUser, "", nil
+}
+
+// stepIndex advances (or retreats) an index within [0,n) with wraparound. A
+// starting index of -1 (current item not in the list) lands on the first item.
+func stepIndex(current, n int, forward bool) int {
+	if current == -1 {
+		return 0
+	}
+	if forward {
+		return (current + 1) % n
+	}
+	return (current - 1 + n) % n
+}

--- a/internal/menu/file_nav_test.go
+++ b/internal/menu/file_nav_test.go
@@ -1,0 +1,30 @@
+package menu
+
+import "testing"
+
+// TestStepIndex covers the wraparound used by file (and mirrors message) area /
+// conference next-prev navigation, including the "current item not found" case.
+func TestStepIndex(t *testing.T) {
+	tests := []struct {
+		name       string
+		current, n int
+		forward    bool
+		want       int
+	}{
+		{"forward mid", 1, 4, true, 2},
+		{"forward wraps at end", 3, 4, true, 0},
+		{"backward mid", 2, 4, false, 1},
+		{"backward wraps at start", 0, 4, false, 3},
+		{"not found goes first (forward)", -1, 4, true, 0},
+		{"not found goes first (backward)", -1, 4, false, 0},
+		{"single item forward", 0, 1, true, 0},
+		{"single item backward", 0, 1, false, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stepIndex(tc.current, tc.n, tc.forward); got != tc.want {
+				t.Errorf("stepIndex(%d,%d,%v) = %d, want %d", tc.current, tc.n, tc.forward, got, tc.want)
+			}
+		})
+	}
+}

--- a/menus/v3/cfg/FILEM.CFG
+++ b/menus/v3/cfg/FILEM.CFG
@@ -21,6 +21,34 @@
         "NODE_ACTIVITY": "Changing Conference"
     },
     {
+        "KEYS": "]",
+        "CMD": "RUN:NEXTFILEAREA",
+        "ACS": "*",
+        "HIDDEN": false,
+        "NODE_ACTIVITY": "Changing File Area"
+    },
+    {
+        "KEYS": "[",
+        "CMD": "RUN:PREVFILEAREA",
+        "ACS": "*",
+        "HIDDEN": false,
+        "NODE_ACTIVITY": "Changing File Area"
+    },
+    {
+        "KEYS": "}",
+        "CMD": "RUN:NEXTFILECONF",
+        "ACS": "*",
+        "HIDDEN": false,
+        "NODE_ACTIVITY": "Changing Conference"
+    },
+    {
+        "KEYS": "{",
+        "CMD": "RUN:PREVFILECONF",
+        "ACS": "*",
+        "HIDDEN": false,
+        "NODE_ACTIVITY": "Changing Conference"
+    },
+    {
         "KEYS": "D",
         "CMD": "RUN:DOWNLOADFILE",
         "ACS": "",


### PR DESCRIPTION
Follow-up to #304: bring the file menu's navigation keys to parity with the message menu.

## Added
| Key | File menu | Mirrors |
|---|---|---|
| `]` / `[` | Next / Prev **file area** (in current conference) | `NEXTMSGAREA` / `PREVMSGAREA` |
| `}` / `{` | Next / Prev **file conference** | `NEXTMSGCONF` / `PREVMSGCONF` |

New runnables `NEXTFILEAREA` / `PREVFILEAREA` / `NEXTFILECONF` / `PREVFILECONF`, wired into `FILEM.CFG`. Conference moves **join for both menus** (#304) and revert on a save failure, consistent with the pickers.

Already in place from #304/#309: `A` (area change), `C` (conference change), `N` (newscan), `Z` (set scan areas).

For consistency with #304, the **message** conference next/prev (`}`/`{`) now also joins both menus (previously message-only).

## Not mirrored — `U` (Set Scan Date)
Two reasons, both structural:
1. In the **file** menu, `U` is **Upload** — a core action that can't be displaced.
2. File newscan has **no per-area read pointer or scan-date state**; it scans "since your previous logon" (`newscanSince` → `PreviousLogin`). There's nothing for a set-scan-date to adjust without introducing a new persistent per-user field.

If you want true parity here, I can add a persistent file-newscan cutoff (a new user field the file newscan honors, plus a set-date prompt) as a separate change — happy to, just flagging the scope since it's more than a menu remap.

## Testing
`stepIndex` (the wrap helper) is unit-tested; `go build`, `go vet`, `gofmt`, full `go test ./...` pass.

Refs #304