### PR TITLE
fix(ftn): stop writing a duplicate AREA kludge into exported echomail

### DIFF
--- a/docs/sysop/messages/jam-echomail.md
+++ b/docs/sysop/messages/jam-echomail.md
@@ -26,13 +26,15 @@ Logic lives in `internal/jam/msgtype.go` and is called by `internal/message/mana
 
 When writing **echomail** with `WriteMessageExt`, Vision3 automatically adds:
 
-- `AREA:` kludge
 - `MSGID` (unique serial per base), generated when the message has none
 - `PID`/`TID` identifiers
 - Tearline (`--- ViSiON/3 vX.Y.Z/Platform`, assigned by the software)
 - Origin line (`* Origin: ... (address)`)
 
-`SEEN-BY` and `PATH` are the tosser's job and are not added here.
+`SEEN-BY` and `PATH` are the tosser's job and are not added here. Neither is
+the `AREA:` line: the echo area is implicit in the message base, and the tosser
+writes the FTS-0004 `AREA:` line from the area's echo tag when it packs the
+message for export.
 
 **Netmail** takes none of the above: `WriteMessageExt` writes an `MSGID`
 subfield only when the message already carries one, and adds no kludges,

--- a/internal/ftn/packet.go
+++ b/internal/ftn/packet.go
@@ -369,16 +369,39 @@ type ParsedBody struct {
 	Path    []string // PATH lines (without "\x01PATH: " prefix)
 }
 
-// ParseAreaLine recognizes the echomail AREA line and returns its tag.
-// FTS-0004 puts "AREA:TAG" at the very start of the body with no SOH and no
-// space after the colon, but some tossers prefix it with SOH and/or pad it,
-// so both are accepted here. The tag is returned without surrounding spaces.
-func ParseAreaLine(line string) (string, bool) {
+// trimAreaPrefix strips the padding and optional SOH some tossers put in front
+// of the AREA line, reporting whether what remains is an AREA line and, if so,
+// the tag that follows the colon (which may be empty).
+func trimAreaPrefix(line string) (string, bool) {
+	line = strings.TrimLeft(line, " \t")
 	line = strings.TrimPrefix(line, "\x01")
+	line = strings.TrimLeft(line, " \t")
 	if len(line) < len("AREA:") || !strings.EqualFold(line[:len("AREA:")], "AREA:") {
 		return "", false
 	}
 	return strings.TrimSpace(line[len("AREA:"):]), true
+}
+
+// IsAreaLine reports whether a line is an echomail AREA line, including a
+// malformed one carrying no tag. Use it when discarding AREA lines; use
+// ParseAreaLine when the tag itself is needed.
+func IsAreaLine(line string) bool {
+	_, ok := trimAreaPrefix(line)
+	return ok
+}
+
+// ParseAreaLine recognizes the echomail AREA line and returns its tag.
+// FTS-0004 puts "AREA:TAG" at the very start of the body with no SOH and no
+// space after the colon, but some tossers prefix it with SOH and/or pad it, so
+// both are accepted here. The tag is returned without surrounding spaces; a
+// line with no tag at all is not treated as an AREA line, so it stays in the
+// body rather than being silently dropped.
+func ParseAreaLine(line string) (string, bool) {
+	tag, ok := trimAreaPrefix(line)
+	if !ok || tag == "" {
+		return "", false
+	}
+	return tag, true
 }
 
 // ParsePackedMessageBody separates an FTN message body into its components.

--- a/internal/ftn/packet.go
+++ b/internal/ftn/packet.go
@@ -369,6 +369,18 @@ type ParsedBody struct {
 	Path    []string // PATH lines (without "\x01PATH: " prefix)
 }
 
+// ParseAreaLine recognizes the echomail AREA line and returns its tag.
+// FTS-0004 puts "AREA:TAG" at the very start of the body with no SOH and no
+// space after the colon, but some tossers prefix it with SOH and/or pad it,
+// so both are accepted here. The tag is returned without surrounding spaces.
+func ParseAreaLine(line string) (string, bool) {
+	line = strings.TrimPrefix(line, "\x01")
+	if len(line) < len("AREA:") || !strings.EqualFold(line[:len("AREA:")], "AREA:") {
+		return "", false
+	}
+	return strings.TrimSpace(line[len("AREA:"):]), true
+}
+
 // ParsePackedMessageBody separates an FTN message body into its components.
 // Kludge lines start with \x01 (SOH), SEEN-BY/PATH are at the end.
 func ParsePackedMessageBody(body string) *ParsedBody {
@@ -389,9 +401,11 @@ func ParsePackedMessageBody(body string) *ParsedBody {
 		}
 
 		// Check for AREA: tag (first line)
-		if strings.HasPrefix(line, "AREA:") && result.Area == "" && len(textLines) == 0 {
-			result.Area = strings.TrimPrefix(line, "AREA:")
-			continue
+		if result.Area == "" && len(textLines) == 0 {
+			if tag, ok := ParseAreaLine(line); ok {
+				result.Area = tag
+				continue
+			}
 		}
 
 		// Check for kludge lines (\x01 prefix)

--- a/internal/ftn/packet_test.go
+++ b/internal/ftn/packet_test.go
@@ -339,3 +339,47 @@ func TestReadPacketRejectsOversizedInput(t *testing.T) {
 type zeroReader struct{}
 
 func (zeroReader) Read(p []byte) (int, error) { return len(p), nil }
+
+func TestParseAreaLine(t *testing.T) {
+	tests := []struct {
+		line    string
+		wantTag string
+		wantOK  bool
+	}{
+		{"AREA:FSX_TST", "FSX_TST", true},     // FTS-0004 form
+		{"AREA: FSX_TST", "FSX_TST", true},    // padded by some tossers
+		{"\x01AREA:FSX_TST", "FSX_TST", true}, // SOH-prefixed by some tossers
+		{"\x01AREA:  FSX_TST ", "FSX_TST", true},
+		{"area:fsx_tst", "fsx_tst", true},
+		{"AREAFIX", "", false},
+		{"MSGID: 21:4/158.1 6a6508de", "", false},
+		{"", "", false},
+	}
+	for _, tc := range tests {
+		gotTag, gotOK := ParseAreaLine(tc.line)
+		if gotOK != tc.wantOK || gotTag != tc.wantTag {
+			t.Errorf("ParseAreaLine(%q) = (%q, %v), want (%q, %v)",
+				tc.line, gotTag, gotOK, tc.wantTag, tc.wantOK)
+		}
+	}
+}
+
+// TestParseBodyTolerantAreaLine verifies that an inbound message whose AREA
+// line carries a SOH prefix and padding is still routed to its echo area
+// instead of being mistaken for netmail.
+func TestParseBodyTolerantAreaLine(t *testing.T) {
+	body := "\x01AREA: FSX_TST\r\x01MSGID: 21:4/158.1 6a6508de\rHello\r"
+	parsed := ParsePackedMessageBody(body)
+
+	if parsed.Area != "FSX_TST" {
+		t.Errorf("Area = %q, want %q", parsed.Area, "FSX_TST")
+	}
+	for _, k := range parsed.Kludges {
+		if _, isArea := ParseAreaLine(k); isArea {
+			t.Errorf("AREA line kept as a kludge: %q", parsed.Kludges)
+		}
+	}
+	if parsed.Text != "Hello" {
+		t.Errorf("Text = %q, want %q", parsed.Text, "Hello")
+	}
+}

--- a/internal/ftn/packet_test.go
+++ b/internal/ftn/packet_test.go
@@ -346,20 +346,37 @@ func TestParseAreaLine(t *testing.T) {
 		wantTag string
 		wantOK  bool
 	}{
-		{"AREA:FSX_TST", "FSX_TST", true},     // FTS-0004 form
-		{"AREA: FSX_TST", "FSX_TST", true},    // padded by some tossers
-		{"\x01AREA:FSX_TST", "FSX_TST", true}, // SOH-prefixed by some tossers
-		{"\x01AREA:  FSX_TST ", "FSX_TST", true},
+		{"AREA:FSX_TST", "FSX_TST", true},          // FTS-0004 form
+		{"AREA: FSX_TST", "FSX_TST", true},         // padded by some tossers
+		{"\x01AREA:FSX_TST", "FSX_TST", true},      // SOH-prefixed by some tossers
+		{" \x01 AREA:  FSX_TST ", "FSX_TST", true}, // padded around the SOH
 		{"area:fsx_tst", "fsx_tst", true},
 		{"AREAFIX", "", false},
 		{"MSGID: 21:4/158.1 6a6508de", "", false},
 		{"", "", false},
+		{"AREA:", "", false},    // no tag: keep the line, don't route on it
+		{"AREA:   ", "", false}, // same, padding only
 	}
 	for _, tc := range tests {
 		gotTag, gotOK := ParseAreaLine(tc.line)
 		if gotOK != tc.wantOK || gotTag != tc.wantTag {
 			t.Errorf("ParseAreaLine(%q) = (%q, %v), want (%q, %v)",
 				tc.line, gotTag, gotOK, tc.wantTag, tc.wantOK)
+		}
+	}
+}
+
+func TestIsAreaLine(t *testing.T) {
+	// IsAreaLine is the discard check, so it must also catch a tagless AREA
+	// line that ParseAreaLine deliberately rejects.
+	for _, line := range []string{"AREA:FSX_TST", "\x01AREA: FSX_TST", " \x01 area:fsx_tst", "AREA:", "AREA:  "} {
+		if !IsAreaLine(line) {
+			t.Errorf("IsAreaLine(%q) = false, want true", line)
+		}
+	}
+	for _, line := range []string{"", "AREAFIX", "MSGID: 21:4/158.1 6a6508de", "The AREA: is closed"} {
+		if IsAreaLine(line) {
+			t.Errorf("IsAreaLine(%q) = true, want false", line)
 		}
 	}
 }

--- a/internal/jam/echomail.go
+++ b/internal/jam/echomail.go
@@ -6,9 +6,20 @@ import (
 	"time"
 )
 
+// isAreaKludge reports whether a kludge line is an FTS-0004 AREA tag, with or
+// without the SOH prefix and padding some tossers add.
+func isAreaKludge(kludge string) bool {
+	kludge = strings.TrimPrefix(kludge, "\x01")
+	return len(kludge) >= len("AREA:") && strings.EqualFold(kludge[:len("AREA:")], "AREA:")
+}
+
 // WriteMessageExt writes a message with full echomail support. For echomail
-// messages it generates a MSGID, adds AREA/PID/TID kludges, tearline, and
-// origin line. DateProcessed is set to 0 so the tosser knows to export it.
+// messages it generates a MSGID, adds PID/TID kludges, tearline, and origin
+// line. DateProcessed is set to 0 so the tosser knows to export it.
+//
+// echoTag identifies the echo area but is not stored in the message: the area
+// is implicit in the base, and the tosser writes the FTS-0004 AREA line when
+// it packs the message for export.
 //
 // For local messages this behaves identically to WriteMessage.
 func (b *Base) WriteMessageExt(msg *Message, msgType MessageType, echoTag, originText string) (int, error) {
@@ -78,9 +89,6 @@ func (b *Base) WriteMessageExt(msg *Message, msgType MessageType, echoTag, origi
 				hdr.Subfields = append(hdr.Subfields, CreateSubfield(SfldMsgID, msg.MsgID))
 				hdr.MSGIDcrc = CRC32String(msg.MsgID)
 			}
-			if echoTag != "" {
-				hdr.Subfields = append(hdr.Subfields, CreateSubfield(SfldFTSKludge, "AREA:"+echoTag))
-			}
 			hdr.Subfields = append(hdr.Subfields, CreateSubfield(SfldPID, FormatPID()))
 			hdr.Subfields = append(hdr.Subfields, CreateSubfield(SfldFTSKludge, "TID: "+FormatTID()))
 
@@ -110,8 +118,14 @@ func (b *Base) WriteMessageExt(msg *Message, msgType MessageType, echoTag, origi
 			hdr.REPLYcrc = CRC32String(msg.ReplyID)
 		}
 
-		// Additional caller-provided kludges
+		// Additional caller-provided kludges. AREA is never stored: the echo
+		// area is implicit in the message base, and the tosser writes the
+		// AREA line from the area tag when it packs the message, so a stored
+		// copy would show up in the packed body twice.
 		for _, kludge := range msg.Kludges {
+			if isAreaKludge(kludge) {
+				continue
+			}
 			hdr.Subfields = append(hdr.Subfields, CreateSubfield(SfldFTSKludge, kludge))
 		}
 

--- a/internal/jam/echomail.go
+++ b/internal/jam/echomail.go
@@ -9,7 +9,9 @@ import (
 // isAreaKludge reports whether a kludge line is an FTS-0004 AREA tag, with or
 // without the SOH prefix and padding some tossers add.
 func isAreaKludge(kludge string) bool {
+	kludge = strings.TrimLeft(kludge, " \t")
 	kludge = strings.TrimPrefix(kludge, "\x01")
+	kludge = strings.TrimLeft(kludge, " \t")
 	return len(kludge) >= len("AREA:") && strings.EqualFold(kludge[:len("AREA:")], "AREA:")
 }
 

--- a/internal/jam/echomail_test.go
+++ b/internal/jam/echomail_test.go
@@ -203,3 +203,16 @@ func TestDetermineMessageType(t *testing.T) {
 		}
 	}
 }
+
+func TestIsAreaKludge(t *testing.T) {
+	for _, k := range []string{"AREA:FSX_GEN", "AREA: FSX_GEN", "\x01AREA:FSX_GEN", " \x01 area:fsx_gen", "AREA:"} {
+		if !isAreaKludge(k) {
+			t.Errorf("isAreaKludge(%q) = false, want true", k)
+		}
+	}
+	for _, k := range []string{"", "AREAFIX", "TID: ViSiON/3", "MSGID: 21:3/110 1234"} {
+		if isAreaKludge(k) {
+			t.Errorf("isAreaKludge(%q) = true, want false", k)
+		}
+	}
+}

--- a/internal/jam/echomail_test.go
+++ b/internal/jam/echomail_test.go
@@ -44,18 +44,19 @@ func TestWriteMessageExtEchomail(t *testing.T) {
 		t.Errorf("PID = %q, should start with ViSiON/3", got.PID)
 	}
 
-	// Verify kludges contain AREA and TID
+	// Verify kludges contain TID but not AREA — the echo area is implicit in
+	// the base, and the tosser writes the AREA line at export time.
 	var hasArea, hasTID bool
 	for _, k := range got.Kludges {
-		if k == "AREA:FSX_GEN" {
+		if isAreaKludge(k) {
 			hasArea = true
 		}
 		if strings.HasPrefix(k, "TID: ") {
 			hasTID = true
 		}
 	}
-	if !hasArea {
-		t.Error("missing AREA kludge")
+	if hasArea {
+		t.Errorf("AREA kludge should not be stored, kludges = %q", got.Kludges)
 	}
 	if !hasTID {
 		t.Error("missing TID kludge")

--- a/internal/tosser/export.go
+++ b/internal/tosser/export.go
@@ -525,7 +525,7 @@ func (t *Tosser) createOutboundPacket(link *linkConfig, msgs []pendingMsg) (int,
 func stripAreaKludges(kludges []string) []string {
 	out := make([]string, 0, len(kludges))
 	for _, k := range kludges {
-		if _, isArea := ftn.ParseAreaLine(k); isArea {
+		if ftn.IsAreaLine(k) {
 			continue
 		}
 		out = append(out, k)

--- a/internal/tosser/export.go
+++ b/internal/tosser/export.go
@@ -322,7 +322,7 @@ func (t *Tosser) createOutboundNetmailPacket(link *linkConfig, msgs []pendingNet
 		}
 		kludges = append(kludges, "MSGID: "+msgIDStr)
 		kludges = append(kludges, "PID: "+jam.FormatPID())
-		kludges = append(kludges, pm.msg.Kludges...)
+		kludges = append(kludges, stripAreaKludges(pm.msg.Kludges)...)
 
 		parsed := &ftn.ParsedBody{
 			Area:    "", // No AREA kludge for netmail
@@ -447,8 +447,11 @@ func (t *Tosser) createOutboundPacket(link *linkConfig, msgs []pendingMsg) (int,
 		// Add PID
 		parsed.Kludges = append(parsed.Kludges, "PID: "+jam.FormatPID())
 
-		// Existing kludges from the message
-		parsed.Kludges = append(parsed.Kludges, pm.msg.Kludges...)
+		// Existing kludges from the message. The AREA line is written from
+		// the area tag above, so any stored AREA kludge is dropped: older
+		// messages carry one in the JAM base and emitting it again would
+		// put the tag in the body twice.
+		parsed.Kludges = append(parsed.Kludges, stripAreaKludges(pm.msg.Kludges)...)
 
 		// SEEN-BY and PATH
 		if pm.msg.SeenBy != "" {
@@ -514,6 +517,20 @@ func (t *Tosser) createOutboundPacket(link *linkConfig, msgs []pendingMsg) (int,
 
 	slog.Info("exported messages", "count", len(packedMsgs), "file", finalName, "link", link.Address)
 	return len(packedMsgs), nil
+}
+
+// stripAreaKludges drops AREA lines from stored kludges. The exporter writes
+// the AREA line itself from the area tag (and netmail has none at all), so a
+// stored copy would only duplicate it.
+func stripAreaKludges(kludges []string) []string {
+	out := make([]string, 0, len(kludges))
+	for _, k := range kludges {
+		if _, isArea := ftn.ParseAreaLine(k); isArea {
+			continue
+		}
+		out = append(out, k)
+	}
+	return out
 }
 
 // linkMsgAttr returns the FTN packet attribute flags for a link's delivery flavour.

--- a/internal/tosser/integration_test.go
+++ b/internal/tosser/integration_test.go
@@ -871,3 +871,76 @@ func makeStagedPkt(t *testing.T) []byte {
 	}
 	return buf.Bytes()
 }
+
+// TestExportedEchomailHasSingleAreaLine verifies that a locally written
+// echomail is packed with exactly one FTS-0004 AREA line — bare, at the start
+// of the body, with no SOH-prefixed duplicate among the kludges.
+func TestExportedEchomailHasSingleAreaLine(t *testing.T) {
+	env := setupTestEnv(t)
+
+	base, err := env.msgMgr.GetBase(1)
+	if err != nil {
+		t.Fatalf("GetBase: %v", err)
+	}
+
+	msg := jam.NewMessage()
+	msg.From = "Local User"
+	msg.To = "All"
+	msg.Subject = "Area tag test"
+	msg.Text = "Testing the new setup...\r"
+	msg.OrigAddr = "21:4/158.1"
+	// A legacy base (or a sloppy remote) may already carry an AREA kludge;
+	// it must not survive into the packed body.
+	msg.Kludges = []string{"AREA:FSX_TEST"}
+
+	area, _ := env.msgMgr.GetAreaByTag("FSX_TEST")
+	msgType := jam.DetermineMessageType(area.AreaType, area.EchoTag)
+	if _, err = base.WriteMessageExt(msg, msgType, area.EchoTag, "TestBBS"); err != nil {
+		t.Fatalf("WriteMessageExt: %v", err)
+	}
+	base.Close()
+
+	tosser, err := New("testnet", env.netCfg, env.globalCfg, env.dupeDB, env.msgMgr)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if result := tosser.ScanAndExport(); result.MessagesExported != 1 {
+		t.Fatalf("expected 1 exported, got %d (errors: %v)", result.MessagesExported, result.Errors)
+	}
+
+	entries, _ := os.ReadDir(env.outboundDir)
+	var pktPath string
+	for _, e := range entries {
+		if strings.ToLower(filepath.Ext(e.Name())) == ".pkt" {
+			pktPath = filepath.Join(env.outboundDir, e.Name())
+		}
+	}
+	if pktPath == "" {
+		t.Fatal("no .PKT written to outbound")
+	}
+
+	f, err := os.Open(pktPath)
+	if err != nil {
+		t.Fatalf("open pkt: %v", err)
+	}
+	defer f.Close()
+
+	_, pktMsgs, err := ftn.ReadPacket(f)
+	if err != nil {
+		t.Fatalf("ReadPacket: %v", err)
+	}
+	if len(pktMsgs) != 1 {
+		t.Fatalf("expected 1 message in packet, got %d", len(pktMsgs))
+	}
+
+	body := pktMsgs[0].Body
+	if n := strings.Count(strings.ToUpper(body), "AREA:"); n != 1 {
+		t.Errorf("body has %d AREA lines, want 1: %q", n, body)
+	}
+	if !strings.HasPrefix(body, "AREA:FSX_TEST\r") {
+		t.Errorf("body must start with a bare AREA line, got %q", body)
+	}
+	if strings.Contains(body, "\x01AREA") {
+		t.Errorf("body has an SOH-prefixed AREA kludge: %q", body)
+	}
+}

--- a/internal/tosser/integration_test.go
+++ b/internal/tosser/integration_test.go
@@ -934,8 +934,14 @@ func TestExportedEchomailHasSingleAreaLine(t *testing.T) {
 	}
 
 	body := pktMsgs[0].Body
-	if n := strings.Count(strings.ToUpper(body), "AREA:"); n != 1 {
-		t.Errorf("body has %d AREA lines, want 1: %q", n, body)
+	var areaLines int
+	for _, line := range strings.Split(body, "\r") {
+		if ftn.IsAreaLine(line) {
+			areaLines++
+		}
+	}
+	if areaLines != 1 {
+		t.Errorf("body has %d AREA lines, want 1: %q", areaLines, body)
 	}
 	if !strings.HasPrefix(body, "AREA:FSX_TEST\r") {
 		t.Errorf("body must start with a bare AREA line, got %q", body)

--- a/internal/tosser/tosser_test.go
+++ b/internal/tosser/tosser_test.go
@@ -280,3 +280,25 @@ func TestReplyKludgeParsing(t *testing.T) {
 		})
 	}
 }
+
+func TestStripAreaKludges(t *testing.T) {
+	in := []string{
+		"MSGID: 21:4/158.1 6a6508de",
+		"AREA:FSX_TST",
+		"AREA: FSX_TST",
+		"\x01AREA:FSX_TST",
+		"area:fsx_tst",
+		"TID: ViSiON/3",
+	}
+	want := []string{"MSGID: 21:4/158.1 6a6508de", "TID: ViSiON/3"}
+
+	got := stripAreaKludges(in)
+	if len(got) != len(want) {
+		t.Fatalf("stripAreaKludges = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("kludge %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Reported by the fsxNet hub after a test post. The packed body carried the area tag twice:

```
00000000: 41 52 45 41 3a 46 53 58 5f 54 53 54 0d 01 4d 53 [AREA:FSX_TST..MS]
00000010: 47 49 44 3a 20 32 31 3a 34 2f 31 35 38 2e 31 20 [GID: 21:4/158.1 ]
00000020: 36 61 36 35 30 38 64 65 0d 01 50 49 44 3a 20 56 [6a6508de..PID: V]
00000030: 69 53 69 4f 4e 2f 33 20 76 30 2e 38 2e 32 2f 4c [iSiON/3 v0.8.2/L]
00000040: 69 6e 75 78 0d 01 41 52 45 41 3a 46 53 58 5f 54 [inux..AREA:FSX_T]
00000050: 53 54 0d 01 54 49 44 3a 20 56 69 53 69 4f 4e 2f [ST..TID: ViSiON/]
```

Once correctly as the bare FTS-0004 `AREA:` line at offset 0, and again at 0x44 as a SOH-prefixed kludge (quoted by readers as `@AREA:FSX_TST`).

Two layers each wrote it: `jam.WriteMessageExt` stored `AREA:<tag>` as an FTS kludge subfield in the JAM base, and the tosser writes the `AREA:` line itself from the area's echo tag, then appended every stored kludge verbatim.

## Changes

- **`internal/jam/echomail.go`** — no longer stores AREA as an FTS kludge subfield. The echo area is implicit in the message base. Caller-supplied AREA kludges are dropped too, so a malformed inbound message can't seed one on import.
- **`internal/tosser/export.go`** — `stripAreaKludges` filters stored AREA kludges out of both echomail and netmail export, so bases that already contain the bad kludge export cleanly with no rebuild.
- **`internal/ftn/packet.go`** — `ParseAreaLine` accepts an inbound AREA line with an optional SOH prefix and padding. Previously `AREA: FSX_TST` (with the space some tossers emit) parsed to a tag of `" FSX_TST"`, matched no area, and sent the message to BAD. We still emit the strict form: bare, leading, no space after the colon.

## Tests

- `ParseAreaLine` variants and tolerant body parsing (`internal/ftn/packet_test.go`)
- `stripAreaKludges` (`internal/tosser/tosser_test.go`)
- End-to-end export check that the packed body has exactly one AREA line, bare and leading, with no SOH-prefixed copy (`internal/tosser/integration_test.go`)
- `TestWriteMessageExtEchomail` updated to assert AREA is *not* stored

Full suite, `go vet`, and `gofmt` pass. Docs updated in `docs/sysop/messages/jam-echomail.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Echomail processing now recognizes `AREA:` lines with varied capitalization, spacing, and optional control-character prefixes.
  - Outbound echomail exports now include a single standardized `AREA:` line, preventing duplicate area tags.
  - Other message metadata, including `MSGID` and `TID`, remains preserved.

- **Bug Fixes**
  - Prevented `AREA:` metadata from being duplicated or misclassified as message text or unrelated metadata.

- **Documentation**
  - Clarified that area tags are added during export, while `SEEN-BY` and `PATH` remain tosser-managed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->