### PR TITLE
fix(jam): remap lastread pointers when a pack renumbers messages

### DIFF
--- a/docs/sysop/messages/v3mail.md
+++ b/docs/sysop/messages/v3mail.md
@@ -9,7 +9,7 @@
 | Command    | Description                                                                  |
 | ---------- | ---------------------------------------------------------------------------- |
 | `stats`    | Display message counts, base sizes, and metadata for one or all areas        |
-| `pack`     | Defragment a base — physically removes deleted messages and compacts storage |
+| `pack`     | Defragment a base — physically removes deleted messages and compacts storage. Surviving messages are renumbered from 1, and each user's lastread pointer is moved with them, so a pack never marks unread mail as read |
 | `purge`    | Delete messages exceeding per-area `max_messages` or `max_age` limits        |
 | `fix`      | Verify base integrity; use `--repair` to automatically fix corrupt headers   |
 | `link`     | Build reply-thread chains (`ReplyTo` / `Reply1st` / `ReplyNext` JAM fields)  |

--- a/docs/sysop/messages/v3mail.md
+++ b/docs/sysop/messages/v3mail.md
@@ -9,7 +9,7 @@
 | Command    | Description                                                                  |
 | ---------- | ---------------------------------------------------------------------------- |
 | `stats`    | Display message counts, base sizes, and metadata for one or all areas        |
-| `pack`     | Defragment a base — physically removes deleted messages and compacts storage. Surviving messages are renumbered from 1, and each user's lastread pointer is moved with them, so a pack never marks unread mail as read |
+| `pack`     | Defragment a base — physically removes deleted messages and compacts storage. Surviving messages are renumbered from 1, and each user's lastread pointer is moved with them so it keeps naming the same message rather than leaving unread mail looking read |
 | `purge`    | Delete messages exceeding per-area `max_messages` or `max_age` limits        |
 | `fix`      | Verify base integrity; use `--repair` to automatically fix corrupt headers   |
 | `link`     | Build reply-thread chains (`ReplyTo` / `Reply1st` / `ReplyNext` JAM fields)  |

--- a/internal/jam/lastread.go
+++ b/internal/jam/lastread.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 )
 
@@ -229,4 +230,64 @@ func (b *Base) GetUnreadCount(username string) (int, error) {
 		unread = 0
 	}
 	return unread, nil
+}
+
+// remapLastReadLocked rewrites every lastread pointer from the pre-pack
+// numbering to the post-pack numbering. survivors holds the old message numbers
+// that were kept, in ascending order.
+//
+// Packing renumbers surviving messages from 1, so a pointer left alone silently
+// changes meaning: after messages are removed, "I have read up to #3" starts
+// describing a message the user has never seen — or, once the base is smaller
+// than the pointer, every message in it. The login mail scan counts from
+// lastread+1, so a stranded pointer reports no new mail no matter what arrives,
+// and new private mail becomes invisible.
+//
+// A pointer at old message N becomes the number of survivors at or below N: the
+// user has still read everything up to that point, whatever it is now numbered.
+// Pointers past the end of the old base (already stale) collapse to the new
+// message count, and a base packed empty leaves every pointer at 0, which is
+// correct — there is nothing left to have read.
+//
+// The caller must hold b.mu and have the base open on the packed files.
+func (b *Base) remapLastReadLocked(survivors []int) error {
+	if !b.isOpen {
+		return ErrBaseNotOpen
+	}
+
+	info, err := b.jlrFile.Stat()
+	if err != nil {
+		return fmt.Errorf("jam: failed to stat .jlr: %w", err)
+	}
+	if info.Size()%LastReadSize != 0 {
+		return fmt.Errorf("jam: invalid .jlr size %d (not aligned to record size %d)", info.Size(), LastReadSize)
+	}
+	recordCount := info.Size() / LastReadSize
+
+	// remap counts the survivors at or below an old message number. survivors is
+	// ascending, so that is where old+1 would be inserted.
+	remap := func(old uint32) uint32 {
+		return uint32(sort.SearchInts(survivors, int(old)+1))
+	}
+
+	for i := int64(0); i < recordCount; i++ {
+		pos := i * LastReadSize
+		buf := make([]byte, LastReadSize)
+		if _, err := b.jlrFile.ReadAt(buf, pos); err != nil && err != io.EOF {
+			return fmt.Errorf("jam: read failed in .jlr: %w", err)
+		}
+		lastRead := binary.LittleEndian.Uint32(buf[8:12])
+		highRead := binary.LittleEndian.Uint32(buf[12:16])
+
+		newLastRead, newHighRead := remap(lastRead), remap(highRead)
+		if newLastRead == lastRead && newHighRead == highRead {
+			continue
+		}
+		binary.LittleEndian.PutUint32(buf[8:12], newLastRead)
+		binary.LittleEndian.PutUint32(buf[12:16], newHighRead)
+		if _, err := b.jlrFile.WriteAt(buf, pos); err != nil {
+			return fmt.Errorf("jam: write failed in .jlr: %w", err)
+		}
+	}
+	return nil
 }

--- a/internal/jam/lastread.go
+++ b/internal/jam/lastread.go
@@ -265,16 +265,29 @@ func (b *Base) remapLastReadLocked(survivors []int) error {
 	recordCount := info.Size() / LastReadSize
 
 	// remap counts the survivors at or below an old message number. survivors is
-	// ascending, so that is where old+1 would be inserted.
+	// ascending, so that is the first position holding a larger number.
+	//
+	// The search key stays a uint32: a stale pointer can hold any value the file
+	// happens to contain, and converting one above math.MaxInt32 to int would
+	// wrap negative on a 32-bit build and collapse the pointer to zero.
 	remap := func(old uint32) uint32 {
-		return uint32(sort.SearchInts(survivors, int(old)+1))
+		return uint32(sort.Search(len(survivors), func(i int) bool {
+			return uint32(survivors[i]) > old
+		}))
 	}
 
+	buf := make([]byte, LastReadSize)
 	for i := int64(0); i < recordCount; i++ {
 		pos := i * LastReadSize
-		buf := make([]byte, LastReadSize)
-		if _, err := b.jlrFile.ReadAt(buf, pos); err != nil && err != io.EOF {
+		n, err := b.jlrFile.ReadAt(buf, pos)
+		if err != nil && err != io.EOF {
 			return fmt.Errorf("jam: read failed in .jlr: %w", err)
+		}
+		// A short read would leave stale bytes in the reused buffer, and the
+		// record is written back below — remapping partial data would corrupt a
+		// pointer rather than merely misplace it.
+		if n != int(LastReadSize) {
+			return fmt.Errorf("jam: short read in .jlr: got %d bytes", n)
 		}
 		lastRead := binary.LittleEndian.Uint32(buf[8:12])
 		highRead := binary.LittleEndian.Uint32(buf[12:16])

--- a/internal/jam/pack.go
+++ b/internal/jam/pack.go
@@ -80,8 +80,9 @@ func (b *Base) ResetLastRead(username string) error {
 }
 
 // Pack defragments the message base by rewriting all non-deleted messages
-// to new files, then atomically replacing the originals. The .jlr file
-// is preserved as-is.
+// to new files, then atomically replacing the originals. Lastread pointers in
+// the .jlr are remapped to the new numbering — see remapLastReadLocked — since
+// packing renumbers the messages they point at.
 func (b *Base) Pack() (PackResult, error) {
 	return b.packWithReplyIDCleanup(false)
 }
@@ -167,6 +168,9 @@ func (b *Base) packWithReplyIDCleanup(cleanReplyIDs bool) (PackResult, error) {
 
 	activeCount := 0
 	newMsgNum := uint32(0)
+	// The old message numbers that survive, ascending, so lastread pointers can
+	// be moved onto the new numbering once the packed files are in place.
+	survivors := make([]int, 0, totalCount)
 
 	for n := 1; n <= totalCount; n++ {
 		idx, err := b.readIndexRecordLocked(n)
@@ -267,6 +271,7 @@ func (b *Base) packWithReplyIDCleanup(cleanReplyIDs bool) (PackResult, error) {
 		}
 
 		activeCount++
+		survivors = append(survivors, n)
 	}
 
 	// Update final ActiveMsgs in the fixed header
@@ -358,6 +363,13 @@ func (b *Base) packWithReplyIDCleanup(cleanReplyIDs bool) (PackResult, error) {
 			return result, fmt.Errorf("jam: failed to stat file after pack: %w", err)
 		}
 		result.BytesAfter += info.Size()
+	}
+
+	// Move lastread pointers onto the new numbering. This runs after the packed
+	// files are in place and reopened, so a failure here leaves a valid packed
+	// base with pointers still on the old numbering rather than losing the pack.
+	if err := b.remapLastReadLocked(survivors); err != nil {
+		return result, fmt.Errorf("jam: packed, but lastread pointers were not remapped: %w", err)
 	}
 
 	result.MessagesAfter = activeCount

--- a/internal/jam/pack.go
+++ b/internal/jam/pack.go
@@ -365,6 +365,13 @@ func (b *Base) packWithReplyIDCleanup(cleanReplyIDs bool) (PackResult, error) {
 		result.BytesAfter += info.Size()
 	}
 
+	// The pack itself is committed, so the counts describe the base on disk
+	// whatever happens next. They are set before the remap so the error path
+	// below does not hand the caller zeroes alongside a base that really was
+	// packed.
+	result.MessagesAfter = activeCount
+	result.DeletedRemoved = totalCount - activeCount
+
 	// Move lastread pointers onto the new numbering. This runs after the packed
 	// files are in place and reopened, so a failure here leaves a valid packed
 	// base with pointers still on the old numbering rather than losing the pack.
@@ -372,8 +379,6 @@ func (b *Base) packWithReplyIDCleanup(cleanReplyIDs bool) (PackResult, error) {
 		return result, fmt.Errorf("jam: packed, but lastread pointers were not remapped: %w", err)
 	}
 
-	result.MessagesAfter = activeCount
-	result.DeletedRemoved = totalCount - activeCount
 	return result, nil
 }
 

--- a/internal/jam/pack_test.go
+++ b/internal/jam/pack_test.go
@@ -183,9 +183,6 @@ func TestPackPreservesLastread(t *testing.T) {
 	b.WriteMessage(msg)
 	b.SetLastRead("testuser", 1, 1)
 
-	// Get .jlr contents before pack
-	jlrBefore, _ := os.ReadFile(basePath + ".jlr")
-
 	result, err := b.Pack()
 	if err != nil {
 		t.Fatalf("Pack: %v", err)
@@ -194,17 +191,10 @@ func TestPackPreservesLastread(t *testing.T) {
 		t.Errorf("MessagesAfter: got %d, want 1", result.MessagesAfter)
 	}
 
-	// Verify .jlr is unchanged
-	jlrAfter, _ := os.ReadFile(basePath + ".jlr")
-	if len(jlrBefore) != len(jlrAfter) {
-		t.Errorf(".jlr size changed: before=%d after=%d", len(jlrBefore), len(jlrAfter))
-	}
-	for i := range jlrBefore {
-		if jlrBefore[i] != jlrAfter[i] {
-			t.Error(".jlr contents changed after pack")
-			break
-		}
-	}
+	// Nothing was removed, so the numbering is untouched and the pointer keeps
+	// its value. What matters is that it still names the same message, which the
+	// check below asserts -- a pack that dropped messages would have to move the
+	// pointer to keep that true. See TestPackRemapsLastreadOntoNewNumbering.
 
 	// Verify lastread still works
 	lr, err := b.GetLastRead("testuser")
@@ -307,4 +297,136 @@ func TestPackRenameFailureMarksBaseClosed(t *testing.T) {
 	if b.IsOpen() {
 		t.Error("base claims open after failed rename recovery; want IsOpen() == false")
 	}
+}
+
+// TestPackRemapsLastreadOntoNewNumbering covers the pointer bug behind
+// "new private mail was never announced": packing renumbers surviving messages
+// from 1, so a pointer left on the old numbering stops describing what the user
+// has actually read. Once the base is smaller than the pointer, the login mail
+// scan (which counts from lastread+1) reports nothing no matter what arrives.
+func TestPackRemapsLastreadOntoNewNumbering(t *testing.T) {
+	write := func(t *testing.T, b *Base, subject string) {
+		t.Helper()
+		m := NewMessage()
+		m.From, m.To, m.Subject, m.Text = "someone", "sysop", subject, "body"
+		if _, err := b.WriteMessage(m); err != nil {
+			t.Fatalf("WriteMessage(%s): %v", subject, err)
+		}
+	}
+
+	t.Run("pointer follows its message when earlier ones are packed away", func(t *testing.T) {
+		b, err := Open(filepath.Join(t.TempDir(), "follow"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer b.Close()
+
+		for _, s := range []string{"one", "two", "three", "four"} {
+			write(t, b, s)
+		}
+		// Read up to #3, then #1 and #2 are removed: "three" becomes #1.
+		if err := b.SetLastRead("sysop", 3, 3); err != nil {
+			t.Fatal(err)
+		}
+		for _, n := range []int{1, 2} {
+			if err := b.DeleteMessage(n); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if _, err := b.Pack(); err != nil {
+			t.Fatal(err)
+		}
+
+		lr, err := b.GetLastRead("sysop")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if lr.LastReadMsg != 1 || lr.HighReadMsg != 1 {
+			t.Fatalf("lastread = %d/%d, want 1/1 — the message read as #3 is now #1", lr.LastReadMsg, lr.HighReadMsg)
+		}
+		// "four" is the only message left unread, and must still read as unread.
+		count, err := b.GetMessageCount()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if unread := count - int(lr.LastReadMsg); unread != 1 {
+			t.Errorf("unread count = %d, want 1 (\"four\")", unread)
+		}
+	})
+
+	t.Run("mail arriving after an emptying pack is seen as new", func(t *testing.T) {
+		b, err := Open(filepath.Join(t.TempDir(), "empty"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer b.Close()
+
+		// The board's case: every old private mail read, then removed.
+		for _, s := range []string{"old one", "old two", "old three"} {
+			write(t, b, s)
+		}
+		if err := b.SetLastRead("sysop", 3, 3); err != nil {
+			t.Fatal(err)
+		}
+		for n := 1; n <= 3; n++ {
+			if err := b.DeleteMessage(n); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if _, err := b.Pack(); err != nil {
+			t.Fatal(err)
+		}
+
+		lr, err := b.GetLastRead("sysop")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if lr.LastReadMsg != 0 || lr.HighReadMsg != 0 {
+			t.Fatalf("lastread = %d/%d, want 0/0 — nothing survives to have been read", lr.LastReadMsg, lr.HighReadMsg)
+		}
+
+		// A new-user application arrives and becomes #1.
+		write(t, b, "New user application")
+		count, err := b.GetMessageCount()
+		if err != nil {
+			t.Fatal(err)
+		}
+		lr, err = b.GetLastRead("sysop")
+		if err != nil {
+			t.Fatal(err)
+		}
+		// This is the login mail scan's loop bound.
+		newMail := 0
+		for n := int(lr.LastReadMsg) + 1; n <= count; n++ {
+			newMail++
+		}
+		if newMail != 1 {
+			t.Errorf("login scan would report %d new messages, want 1 — the mail is invisible", newMail)
+		}
+	})
+
+	t.Run("a pointer already past the end collapses to the new count", func(t *testing.T) {
+		b, err := Open(filepath.Join(t.TempDir(), "stale"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer b.Close()
+
+		write(t, b, "only")
+		// A pointer stranded by an earlier pack, naming messages that never
+		// existed in this numbering.
+		if err := b.SetLastRead("sysop", 9, 9); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := b.Pack(); err != nil {
+			t.Fatal(err)
+		}
+		lr, err := b.GetLastRead("sysop")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if lr.LastReadMsg != 1 || lr.HighReadMsg != 1 {
+			t.Errorf("lastread = %d/%d, want 1/1 — clamped to what the base actually holds", lr.LastReadMsg, lr.HighReadMsg)
+		}
+	})
 }

--- a/internal/jam/pack_test.go
+++ b/internal/jam/pack_test.go
@@ -3,6 +3,7 @@ package jam
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -429,4 +430,39 @@ func TestPackRemapsLastreadOntoNewNumbering(t *testing.T) {
 			t.Errorf("lastread = %d/%d, want 1/1 — clamped to what the base actually holds", lr.LastReadMsg, lr.HighReadMsg)
 		}
 	})
+}
+
+// TestPackRemapsHugeStalePointer covers a pointer holding a value above
+// math.MaxInt32. Remapping searches with the key as a uint32 for this reason:
+// converting one to int on a 32-bit build wraps negative, which would collapse
+// the pointer to zero and re-present the whole base as unread.
+func TestPackRemapsHugeStalePointer(t *testing.T) {
+	b, err := Open(filepath.Join(t.TempDir(), "huge"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Close()
+
+	for i := 0; i < 2; i++ {
+		m := NewMessage()
+		m.From, m.To, m.Subject, m.Text = "someone", "sysop", "msg", "body"
+		if _, err := b.WriteMessage(m); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := b.SetLastRead("sysop", math.MaxUint32, math.MaxUint32); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Pack(); err != nil {
+		t.Fatal(err)
+	}
+
+	lr, err := b.GetLastRead("sysop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lr.LastReadMsg != 2 || lr.HighReadMsg != 2 {
+		t.Errorf("lastread = %d/%d, want 2/2 — clamped to the message count, not wrapped to 0",
+			lr.LastReadMsg, lr.HighReadMsg)
+	}
 }


### PR DESCRIPTION
## The bug

A new user signed up, left the required introduction mail for the SysOp — and the SysOp was never told it was there. The message showed as **already read** without having been opened.

`Pack` renumbers surviving messages from 1 (`pack.go`: `hdr.MessageNumber = newMsgNum + b.fixedHeader.BaseMsgNum - 1`) but left the `.jlr` alone. The doc comment said so outright — *"The .jlr file is preserved as-is"* — and `TestPackPreservesLastread` asserted the file was unchanged byte for byte.

A pointer left on the old numbering stops describing what the user has read. Once the base is smaller than the pointer, it covers every message in it. The login mail scan counts from `lastread + 1`:

```go
for msgNum := lastRead + 1; msgNum <= totalMessages; msgNum++
```

so a stranded pointer reports no new mail no matter what arrives.

On the affected board the nightly purge and pack emptied PRIVMAIL at 02:15/02:30. The new user's mail arrived at 04:56 as message **#1**, against a pointer still reading 1 or higher. `2 > 1`, the loop never ran, no count was printed and the `Read it now?` prompt never appeared.

This is not specific to new-user mail or to one account: **any** user whose pointer outlives a pack silently stops being told about new mail in that area, until enough messages arrive to push the count back past the stale pointer.

## The fix

`Pack` already walks the base in order, so it now records which old message numbers survive and remaps every pointer once the packed files are in place:

> A pointer at old message N becomes the number of survivors at or below N.

It still means "read everything up to here", whatever those messages are now numbered. Pointers past the end of the old base (already stranded by an earlier pack) collapse to the new message count, and a base packed empty leaves every pointer at 0 — correct, since nothing survives to have been read.

The remap runs after the atomic replace and reopen, so a failure there leaves a valid packed base with pointers on the old numbering — the status quo — rather than failing a pack that already succeeded.

## Tests

`TestPackRemapsLastreadOntoNewNumbering` covers three cases, each verified to fail without the fix:

| Case | Without the fix |
|---|---|
| Pointer follows its message when earlier ones are packed away | `lastread = 3/3, want 1/1` |
| Mail arriving after an emptying pack is seen as new | `lastread = 3/3, want 0/0` |
| A pointer already past the end collapses to the new count | `lastread = 9/9, want 1/1` |

The second reproduces the board failure end to end: three read messages, deleted, packed, then one new arrival — and asserts the login scan's own loop bound reports it.

`TestPackPreservesLastread` now asserts the pointer still names the same message rather than that the bytes did not move. Its scenario deletes nothing, so the numbering is untouched and the pointer keeps its value either way.

## Note for existing boards

This fixes future packs. Pointers already stranded by past packs stay stranded until that area is packed again, which will now clamp them to the real message count. `v3mail lastread` can reset one by hand in the meantime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Packing mailboxes now correctly remaps last-read and high-read pointers after deleted messages are removed and remaining messages are renumbered.
  - Handles empty mailboxes, newly arrived mail, and outdated read pointers without losing pointer consistency.

- **Documentation**
  - Clarified that packing removes deleted messages, renumbers remaining messages, and preserves users’ read positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->