### PR TITLE
fix(file): resolve the muAreas/muFiles ABBA inversion — never hold both locks

### DIFF
--- a/internal/file/manager.go
+++ b/internal/file/manager.go
@@ -30,7 +30,12 @@ import (
 // paths read this way can in principle go stale against a future area
 // reload; such a reload is expected to run only with no sessions active
 // (see issue #323), which is also what keeps the rest of a reload's
-// consequences — removed areas' records, changed paths — tractable.
+// consequences — removed areas' records, changed paths — tractable. The
+// same constraint covers in-flight mutators: DeleteFileRecord and
+// MoveFileRecord release muFiles between their in-memory update and
+// saveFileRecords, so a reload landing in that window would re-read
+// metadata.json — still holding the pre-mutation list — and revert the
+// update after the disk operation has already run.
 type FileManager struct {
 	basePath    string               // Base directory for all file areas (e.g., "data/files")
 	configPath  string               // Path to file_areas.json

--- a/internal/file/manager.go
+++ b/internal/file/manager.go
@@ -14,26 +14,23 @@ import (
 // FileManager manages file areas and their associated file records.
 //
 // Locking: FileManager has two mutexes, muAreas (guards fileAreas/fileTags)
-// and muFiles (guards fileRecords). The intended acquisition order is
-// muAreas before muFiles. GetFilePath and DeleteFileRecord invert that
-// order: they take muFiles first and, while still holding it, take muAreas
-// (nested, not sequential — both are held at once). MoveFileRecord does
-// the same nested muFiles-then-muAreas acquisition internally (after an
-// initial, unrelated sequential muAreas check made before muFiles is ever
-// taken). loadAllFileRecords is the only function that nests them in the
-// intended muAreas-then-muFiles order — and it, too, runs only from
-// NewFileManager, so at runtime the nested order is in fact uniformly
-// muFiles-then-muAreas. Both halves of the inversion are therefore
-// confined to construction.
+// and muFiles (guards fileRecords). The invariant is that no goroutine ever
+// holds both at once — there is no acquisition order to get wrong, and a
+// runtime reload of file areas (an exclusive muAreas.Lock() after startup)
+// cannot deadlock against record operations. Historically these locks were
+// nested in both orders (an ABBA inversion, safe only because muAreas was
+// never write-locked after construction); that inversion is resolved, and
+// TestNoDeadlockUnderConcurrentAreaWriteLock guards against its return.
 //
-// This is an ABBA lock-ordering inversion. It cannot deadlock today only
-// because muAreas.Lock() (the exclusive write lock) is taken solely by
-// loadAreas, which runs once from NewFileManager before the FileManager
-// is shared, so muAreas is effectively read-only for the rest of the
-// process's life and concurrent RLock holders never block each other.
-// Introducing any runtime reload of file areas (an exclusive muAreas.Lock()
-// after startup) would make this a live deadlock risk. Do not add such a
-// reload without first resolving the ordering inversion.
+// Operations needing data from both domains copy what they need under one
+// lock, release it, then take the other. The price is that the combined view
+// is not atomic: a record found under muFiles may be gone by the time the
+// write lock is retaken, so mutators re-search by ID under the write lock
+// before touching anything, and treat "no longer there" as not-found. Area
+// paths read this way can in principle go stale against a future area
+// reload; such a reload is expected to run only with no sessions active
+// (see issue #323), which is also what keeps the rest of a reload's
+// consequences — removed areas' records, changed paths — tractable.
 type FileManager struct {
 	basePath    string               // Base directory for all file areas (e.g., "data/files")
 	configPath  string               // Path to file_areas.json

--- a/internal/file/manager_lockorder_test.go
+++ b/internal/file/manager_lockorder_test.go
@@ -1,0 +1,180 @@
+package file
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// reloadAreasForTest performs the lock sequence a future file-area reload
+// will perform: re-read file_areas.json (exclusive muAreas.Lock inside
+// loadAreas), then re-read the per-area metadata (muFiles.Lock inside
+// loadAllFileRecords). No public Reload exists yet — the point of this file
+// is to prove the locks can support one.
+func reloadAreasForTest(fm *FileManager) {
+	_ = fm.loadAreas()
+	_ = fm.loadAllFileRecords()
+}
+
+// lockTestManager builds a manager with two areas and a set of records whose
+// files exist on disk, so GetFilePath/Move/Delete run their full paths.
+func lockTestManager(t *testing.T, recordCount int) (*FileManager, []uuid.UUID) {
+	t.Helper()
+	fm := setupTestFileManager(t, []FileArea{
+		{ID: 1, Tag: "ONE", Name: "One", Path: "one"},
+		{ID: 2, Tag: "TWO", Name: "Two", Path: "two"},
+	})
+	for _, sub := range []string{"one", "two"} {
+		if err := os.MkdirAll(filepath.Join(fm.basePath, sub), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ids := make([]uuid.UUID, recordCount)
+	for i := range ids {
+		ids[i] = uuid.New()
+		name := fmt.Sprintf("file%03d.zip", i)
+		if err := os.WriteFile(filepath.Join(fm.basePath, "one", name), []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := fm.AddFileRecord(FileRecord{ID: ids[i], AreaID: 1, Filename: name, Description: "d"}); err != nil {
+			t.Fatalf("AddFileRecord: %v", err)
+		}
+	}
+	return fm, ids
+}
+
+// TestNoDeadlockUnderConcurrentAreaWriteLock is the regression test for the
+// muAreas/muFiles ABBA inversion this package's doc comment used to warn
+// about. The historical cycle needed three parties:
+//
+//	reader   holds muFiles, waits for muAreas.RLock — queued behind…
+//	reload B …a pending muAreas.Lock, which waits for…
+//	reload A …a held muAreas.RLock whose owner waits for muFiles
+//
+// Two goroutines running the reload sequence plus record readers/mutators
+// reproduce exactly that shape. On the pre-fix code this deadlocks within a
+// few hundred iterations; with the locks never held together there is no
+// cycle to form. The writers bound the test (a fixed iteration count ends
+// it); the watchdog turns a hang into a failure instead of a stuck CI job.
+func TestNoDeadlockUnderConcurrentAreaWriteLock(t *testing.T) {
+	fm, ids := lockTestManager(t, 8)
+
+	const reloads = 400
+	scenario := func() {
+		var wg sync.WaitGroup
+		writersDone := make(chan struct{})
+
+		var writerWg sync.WaitGroup
+		for w := 0; w < 2; w++ {
+			writerWg.Add(1)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer writerWg.Done()
+				for i := 0; i < reloads; i++ {
+					reloadAreasForTest(fm)
+				}
+			}()
+		}
+		go func() {
+			writerWg.Wait()
+			close(writersDone)
+		}()
+
+		// Readers and mutators: the operations that historically nested
+		// muFiles → muAreas.
+		for r := 0; r < 4; r++ {
+			wg.Add(1)
+			go func(r int) {
+				defer wg.Done()
+				for {
+					select {
+					case <-writersDone:
+						return
+					default:
+					}
+					for _, id := range ids {
+						_, _ = fm.GetFilePath(id)
+					}
+					_ = fm.ListAreas()
+					if r == 0 {
+						// One mover, ping-ponging a record between areas.
+						_ = fm.MoveFileRecord(ids[0], 2)
+						_ = fm.MoveFileRecord(ids[0], 1)
+					}
+				}
+			}(r)
+		}
+		wg.Wait()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		scenario()
+	}()
+	select {
+	case <-done:
+	case <-time.After(60 * time.Second):
+		t.Fatal("deadlock suspected: reload loops and record operations did not finish")
+	}
+}
+
+// TestDeleteRevalidatesUnderWriteLock covers the ID re-search that replaced
+// the stale index: a record deleted between Delete's read-phase and its
+// write-phase must yield not-found, not corrupt a neighbor.
+func TestDeleteRevalidatesUnderWriteLock(t *testing.T) {
+	fm, ids := lockTestManager(t, 2)
+
+	if err := fm.DeleteFileRecord(ids[0], true); err != nil {
+		t.Fatalf("first delete: %v", err)
+	}
+	if err := fm.DeleteFileRecord(ids[0], true); err == nil {
+		t.Fatal("second delete of the same ID succeeded; want not-found")
+	}
+	// The surviving record must be untouched.
+	if _, err := fm.GetFilePath(ids[1]); err != nil {
+		t.Fatalf("surviving record lost: %v", err)
+	}
+}
+
+// TestConcurrentDeleteAndMoveSameRecord hammers Delete and Move on the same
+// ID; under -race this checks the copy-then-revalidate structure, and the
+// invariant checked afterwards is that the record ends up in exactly one
+// state: present in one area or fully gone.
+func TestConcurrentDeleteAndMoveSameRecord(t *testing.T) {
+	for round := 0; round < 20; round++ {
+		fm, ids := lockTestManager(t, 1)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = fm.DeleteFileRecord(ids[0], true)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = fm.MoveFileRecord(ids[0], 2)
+		}()
+		wg.Wait()
+
+		fm.muFiles.RLock()
+		count := 0
+		for _, records := range fm.fileRecords {
+			for i := range records {
+				if records[i].ID == ids[0] {
+					count++
+				}
+			}
+		}
+		fm.muFiles.RUnlock()
+		if count > 1 {
+			t.Fatalf("round %d: record exists in %d areas after concurrent delete/move", round, count)
+		}
+	}
+}

--- a/internal/file/manager_lockorder_test.go
+++ b/internal/file/manager_lockorder_test.go
@@ -207,47 +207,66 @@ func TestDeleteUsesCurrentFilenameAfterRename(t *testing.T) {
 // the interleave behind the stale-filename hazard from PR #330's review: a
 // rename lands between DeleteFileRecord's read phase and its write phase.
 //
-// The interleave is forced through the locks themselves: the test holds
-// muAreas.Lock before starting the delete, so the delete completes its read
-// phase (capturing the pre-rename state) and parks at the area lookup. While
-// it is parked, the record and its disk file are renamed, and a bystander
-// file is created under the old name. On release, a correct delete removes
-// the file the record NOW names; the pre-fix code removed the bystander.
+// The interleave is forced through the locks themselves, in two stages:
+//
+//  1. The test holds muFiles exclusively while starting the delete, parking
+//     it at its phase-1 RLock; releasing and immediately re-acquiring
+//     muFiles then acts as a barrier — the write lock is only granted after
+//     phase 1's RUnlock, proving the read phase completed.
+//  2. The test also holds muAreas exclusively throughout, so the delete
+//     parks again at its area lookup while the rename and a bystander file
+//     under the old name land.
+//
+// On release, a correct delete removes the file the record NOW names; the
+// pre-fix code removed the bystander. (A sleep-based version of this test
+// could not prove the delete had passed phase 1 before the rename — a late
+// goroutine spawn would let even the stale implementation pass.)
 func TestDeleteAfterConcurrentRenameTargetsCurrentFile(t *testing.T) {
 	fm, ids := lockTestManager(t, 1)
 	dir := filepath.Join(fm.basePath, "one")
 
-	fm.muAreas.Lock() // park the delete between its phases
+	fm.muAreas.Lock() // parks the delete between phase 2 and its write phase
+	fm.muFiles.Lock() // parks the delete at the start of phase 1
 
+	started := make(chan struct{})
 	done := make(chan error, 1)
-	go func() { done <- fm.DeleteFileRecord(ids[0], true) }()
+	go func() {
+		close(started)
+		done <- fm.DeleteFileRecord(ids[0], true)
+	}()
 
-	// Let the delete finish its read phase and block on muAreas.
-	time.Sleep(100 * time.Millisecond)
+	// Wait for the goroutine to be running, plus a beat for it to reach the
+	// phase-1 RLock; the barrier below is what actually proves phase 1 ran.
+	<-started
+	time.Sleep(10 * time.Millisecond)
 
-	// Rename record + disk file, then plant a bystander under the old name.
-	// The record is mutated directly under muFiles rather than through
-	// UpdateFileRecord: that method's save path takes muAreas.RLock, which
-	// the test itself is holding exclusively — calling it here would
-	// deadlock the test (an instructive demonstration of why this package
-	// never nests these locks).
+	// Barrier: this Lock is granted only once phase 1's RLock has been
+	// released, so everything after this line happens-after the read phase.
+	fm.muFiles.Unlock()
 	fm.muFiles.Lock()
+
+	// Rename the record (directly — UpdateFileRecord's save path takes
+	// muAreas.RLock, which the test holds exclusively and would deadlock on;
+	// an instructive demonstration of why this package never nests these
+	// locks), rename the disk file, and plant a bystander under the old name.
 	for i := range fm.fileRecords[1] {
 		if fm.fileRecords[1][i].ID == ids[0] {
 			fm.fileRecords[1][i].Filename = "renamed.zip"
 		}
 	}
-	fm.muFiles.Unlock()
 	if err := os.Rename(filepath.Join(dir, "file000.zip"), filepath.Join(dir, "renamed.zip")); err != nil {
+		fm.muFiles.Unlock()
 		fm.muAreas.Unlock()
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, "file000.zip"), []byte("bystander"), 0644); err != nil {
+		fm.muFiles.Unlock()
 		fm.muAreas.Unlock()
 		t.Fatal(err)
 	}
+	fm.muFiles.Unlock()
 
-	fm.muAreas.Unlock()
+	fm.muAreas.Unlock() // release the delete into its write phase
 	if err := <-done; err != nil {
 		t.Fatalf("DeleteFileRecord: %v", err)
 	}

--- a/internal/file/manager_lockorder_test.go
+++ b/internal/file/manager_lockorder_test.go
@@ -178,3 +178,84 @@ func TestConcurrentDeleteAndMoveSameRecord(t *testing.T) {
 		}
 	}
 }
+
+// TestDeleteUsesCurrentFilenameAfterRename covers the stale-filename hazard
+// Copilot flagged on PR #330: the disk delete must target the record's
+// filename as it stands under the write lock, not a copy captured earlier.
+// Sequentially: rename the record (and its disk file), then delete — the
+// renamed file must be removed and no stray remains.
+func TestDeleteUsesCurrentFilenameAfterRename(t *testing.T) {
+	fm, ids := lockTestManager(t, 1)
+	dir := filepath.Join(fm.basePath, "one")
+
+	if err := os.Rename(filepath.Join(dir, "file000.zip"), filepath.Join(dir, "renamed.zip")); err != nil {
+		t.Fatal(err)
+	}
+	if err := fm.UpdateFileRecord(ids[0], func(r *FileRecord) { r.Filename = "renamed.zip" }); err != nil {
+		t.Fatalf("UpdateFileRecord: %v", err)
+	}
+
+	if err := fm.DeleteFileRecord(ids[0], true); err != nil {
+		t.Fatalf("DeleteFileRecord: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "renamed.zip")); !os.IsNotExist(err) {
+		t.Error("renamed.zip still on disk; delete used a stale filename")
+	}
+}
+
+// TestDeleteAfterConcurrentRenameTargetsCurrentFile deterministically forces
+// the interleave behind the stale-filename hazard from PR #330's review: a
+// rename lands between DeleteFileRecord's read phase and its write phase.
+//
+// The interleave is forced through the locks themselves: the test holds
+// muAreas.Lock before starting the delete, so the delete completes its read
+// phase (capturing the pre-rename state) and parks at the area lookup. While
+// it is parked, the record and its disk file are renamed, and a bystander
+// file is created under the old name. On release, a correct delete removes
+// the file the record NOW names; the pre-fix code removed the bystander.
+func TestDeleteAfterConcurrentRenameTargetsCurrentFile(t *testing.T) {
+	fm, ids := lockTestManager(t, 1)
+	dir := filepath.Join(fm.basePath, "one")
+
+	fm.muAreas.Lock() // park the delete between its phases
+
+	done := make(chan error, 1)
+	go func() { done <- fm.DeleteFileRecord(ids[0], true) }()
+
+	// Let the delete finish its read phase and block on muAreas.
+	time.Sleep(100 * time.Millisecond)
+
+	// Rename record + disk file, then plant a bystander under the old name.
+	// The record is mutated directly under muFiles rather than through
+	// UpdateFileRecord: that method's save path takes muAreas.RLock, which
+	// the test itself is holding exclusively — calling it here would
+	// deadlock the test (an instructive demonstration of why this package
+	// never nests these locks).
+	fm.muFiles.Lock()
+	for i := range fm.fileRecords[1] {
+		if fm.fileRecords[1][i].ID == ids[0] {
+			fm.fileRecords[1][i].Filename = "renamed.zip"
+		}
+	}
+	fm.muFiles.Unlock()
+	if err := os.Rename(filepath.Join(dir, "file000.zip"), filepath.Join(dir, "renamed.zip")); err != nil {
+		fm.muAreas.Unlock()
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "file000.zip"), []byte("bystander"), 0644); err != nil {
+		fm.muAreas.Unlock()
+		t.Fatal(err)
+	}
+
+	fm.muAreas.Unlock()
+	if err := <-done; err != nil {
+		t.Fatalf("DeleteFileRecord: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "renamed.zip")); !os.IsNotExist(err) {
+		t.Error("renamed.zip still on disk: the delete did not target the record's current filename")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "file000.zip")); err != nil {
+		t.Error("bystander file000.zip was deleted: the delete used the stale pre-rename filename")
+	}
+}

--- a/internal/file/manager_mutate.go
+++ b/internal/file/manager_mutate.go
@@ -12,34 +12,37 @@ import (
 // DeleteFileRecord removes a file record by ID. If deleteFromDisk is true,
 // the physical file is also removed from the filesystem.
 func (fm *FileManager) DeleteFileRecord(fileID uuid.UUID, deleteFromDisk bool) error {
-	fm.muFiles.Lock()
-	defer fm.muFiles.Unlock()
-
+	// muAreas and muFiles are never held together (see the FileManager doc
+	// comment): find the record under a read lock, copy the area path under
+	// muAreas, then re-validate by ID under the write lock before mutating —
+	// the index from the first search can go stale in between.
+	fm.muFiles.RLock()
 	foundAreaID := -1
-	foundIndex := -1
 	var foundFilename string
-
 searchLoop:
 	for areaID, records := range fm.fileRecords {
 		for i := range records {
 			if records[i].ID == fileID {
 				foundAreaID = areaID
-				foundIndex = i
 				foundFilename = records[i].Filename
 				break searchLoop
 			}
 		}
 	}
+	fm.muFiles.RUnlock()
 
 	if foundAreaID == -1 {
 		return fmt.Errorf("file record with ID %s not found", fileID)
 	}
 
-	// If requested, delete from disk first — before touching metadata.
-	// This way a failure leaves metadata intact and the operation is retryable.
+	var fullPath string
 	if deleteFromDisk {
 		fm.muAreas.RLock()
 		area, areaExists := fm.fileAreas[foundAreaID]
+		var areaPath string
+		if areaExists {
+			areaPath = area.Path
+		}
 		fm.muAreas.RUnlock()
 		if !areaExists {
 			return fmt.Errorf("internal inconsistency: area %d not found", foundAreaID)
@@ -55,7 +58,28 @@ searchLoop:
 		if err != nil {
 			return fmt.Errorf("refusing to delete from disk: %w", err)
 		}
-		fullPath := filepath.Join(absBasePath, area.Path, safeName)
+		fullPath = filepath.Join(absBasePath, areaPath, safeName)
+	}
+
+	fm.muFiles.Lock()
+	defer fm.muFiles.Unlock()
+
+	// Re-search under the write lock: another writer may have moved or
+	// removed the record while no lock was held.
+	foundIndex := -1
+	for i := range fm.fileRecords[foundAreaID] {
+		if fm.fileRecords[foundAreaID][i].ID == fileID {
+			foundIndex = i
+			break
+		}
+	}
+	if foundIndex == -1 {
+		return fmt.Errorf("file record with ID %s not found", fileID)
+	}
+
+	// If requested, delete from disk first — before touching metadata.
+	// This way a failure leaves metadata intact and the operation is retryable.
+	if deleteFromDisk {
 		if err := os.Remove(fullPath); err != nil && !os.IsNotExist(err) {
 			slog.Warn("failed to delete file from disk", "path", fullPath, "error", err)
 			return fmt.Errorf("failed to delete file from disk: %w", err)
@@ -82,29 +106,26 @@ searchLoop:
 
 // MoveFileRecord moves a file record to a different area, renaming the file on disk.
 func (fm *FileManager) MoveFileRecord(fileID uuid.UUID, targetAreaID int) error {
-	fm.muAreas.RLock()
-	targetArea, targetExists := fm.fileAreas[targetAreaID]
-	fm.muAreas.RUnlock()
-	if !targetExists {
-		return fmt.Errorf("target area ID %d not found", targetAreaID)
-	}
-
-	fm.muFiles.Lock()
-	defer fm.muFiles.Unlock()
-
+	// muAreas and muFiles are never held together (see the FileManager doc
+	// comment): locate the record under a read lock, copy both area paths
+	// under muAreas, then re-validate by ID under the write lock — the index
+	// from the first search can go stale in between. Disk operations stay
+	// under the write lock, as before, so concurrent moves of the same file
+	// serialize on it.
+	fm.muFiles.RLock()
 	srcAreaID := -1
-	srcIndex := -1
-
+	var recordFilename string
 searchLoop:
 	for areaID, records := range fm.fileRecords {
 		for i := range records {
 			if records[i].ID == fileID {
 				srcAreaID = areaID
-				srcIndex = i
+				recordFilename = records[i].Filename
 				break searchLoop
 			}
 		}
 	}
+	fm.muFiles.RUnlock()
 
 	if srcAreaID == -1 {
 		return fmt.Errorf("file record with ID %s not found", fileID)
@@ -113,11 +134,20 @@ searchLoop:
 		return fmt.Errorf("file is already in area %d", targetAreaID)
 	}
 
-	record := fm.fileRecords[srcAreaID][srcIndex]
-
 	fm.muAreas.RLock()
+	targetArea, targetExists := fm.fileAreas[targetAreaID]
 	srcArea, srcExists := fm.fileAreas[srcAreaID]
+	var srcAreaPath, targetAreaPath string
+	if targetExists {
+		targetAreaPath = targetArea.Path
+	}
+	if srcExists {
+		srcAreaPath = srcArea.Path
+	}
 	fm.muAreas.RUnlock()
+	if !targetExists {
+		return fmt.Errorf("target area ID %d not found", targetAreaID)
+	}
 	if !srcExists {
 		return fmt.Errorf("internal inconsistency: source area %d not found", srcAreaID)
 	}
@@ -126,12 +156,29 @@ searchLoop:
 	if err != nil {
 		return fmt.Errorf("failed to get absolute base path: %w", err)
 	}
-	safeFilename, err := validateFilename(record.Filename)
+	safeFilename, err := validateFilename(recordFilename)
 	if err != nil {
 		return fmt.Errorf("refusing to move file record %s: %w", fileID, err)
 	}
-	srcPath := filepath.Join(absBasePath, srcArea.Path, safeFilename)
-	dstPath := filepath.Join(absBasePath, targetArea.Path, safeFilename)
+	srcPath := filepath.Join(absBasePath, srcAreaPath, safeFilename)
+	dstPath := filepath.Join(absBasePath, targetAreaPath, safeFilename)
+
+	fm.muFiles.Lock()
+	defer fm.muFiles.Unlock()
+
+	// Re-search under the write lock: another writer may have moved or
+	// removed the record while no lock was held.
+	srcIndex := -1
+	for i := range fm.fileRecords[srcAreaID] {
+		if fm.fileRecords[srcAreaID][i].ID == fileID {
+			srcIndex = i
+			break
+		}
+	}
+	if srcIndex == -1 {
+		return fmt.Errorf("file record with ID %s not found", fileID)
+	}
+	record := fm.fileRecords[srcAreaID][srcIndex]
 
 	// Guard against silently overwriting an existing file in the target area.
 	if _, err := os.Stat(dstPath); err == nil {

--- a/internal/file/manager_mutate.go
+++ b/internal/file/manager_mutate.go
@@ -18,13 +18,11 @@ func (fm *FileManager) DeleteFileRecord(fileID uuid.UUID, deleteFromDisk bool) e
 	// the index from the first search can go stale in between.
 	fm.muFiles.RLock()
 	foundAreaID := -1
-	var foundFilename string
 searchLoop:
 	for areaID, records := range fm.fileRecords {
 		for i := range records {
 			if records[i].ID == fileID {
 				foundAreaID = areaID
-				foundFilename = records[i].Filename
 				break searchLoop
 			}
 		}
@@ -35,7 +33,7 @@ searchLoop:
 		return fmt.Errorf("file record with ID %s not found", fileID)
 	}
 
-	var fullPath string
+	var areaDir string
 	if deleteFromDisk {
 		fm.muAreas.RLock()
 		area, areaExists := fm.fileAreas[foundAreaID]
@@ -51,14 +49,7 @@ searchLoop:
 		if err != nil {
 			return fmt.Errorf("failed to get absolute base path: %w", err)
 		}
-		// Only gate the disk delete: a record with a corrupt filename must
-		// still be removable from metadata (deleteFromDisk=false), or the
-		// sysop has no way to clear it.
-		safeName, err := validateFilename(foundFilename)
-		if err != nil {
-			return fmt.Errorf("refusing to delete from disk: %w", err)
-		}
-		fullPath = filepath.Join(absBasePath, areaPath, safeName)
+		areaDir = filepath.Join(absBasePath, areaPath)
 	}
 
 	fm.muFiles.Lock()
@@ -76,10 +67,23 @@ searchLoop:
 	if foundIndex == -1 {
 		return fmt.Errorf("file record with ID %s not found", fileID)
 	}
+	// The on-disk name comes from the record as it exists NOW, under the
+	// write lock — not from a read-phase copy, which UpdateFileRecord may
+	// have renamed in the unlocked gap. A stale name here could delete a
+	// different file that has since taken it over.
+	freshFilename := fm.fileRecords[foundAreaID][foundIndex].Filename
 
 	// If requested, delete from disk first — before touching metadata.
 	// This way a failure leaves metadata intact and the operation is retryable.
 	if deleteFromDisk {
+		// Only gate the disk delete: a record with a corrupt filename must
+		// still be removable from metadata (deleteFromDisk=false), or the
+		// sysop has no way to clear it.
+		safeName, err := validateFilename(freshFilename)
+		if err != nil {
+			return fmt.Errorf("refusing to delete from disk: %w", err)
+		}
+		fullPath := filepath.Join(areaDir, safeName)
 		if err := os.Remove(fullPath); err != nil && !os.IsNotExist(err) {
 			slog.Warn("failed to delete file from disk", "path", fullPath, "error", err)
 			return fmt.Errorf("failed to delete file from disk: %w", err)
@@ -96,11 +100,11 @@ searchLoop:
 	fm.muFiles.Lock()
 
 	if saveErr != nil {
-		slog.Error("failed to save file records after deleting", "file", foundFilename, "id", fileID, "error", saveErr)
+		slog.Error("failed to save file records after deleting", "file", freshFilename, "id", fileID, "error", saveErr)
 		return saveErr
 	}
 
-	slog.Info("deleted file record", "file", foundFilename, "id", fileID, "area", foundAreaID)
+	slog.Info("deleted file record", "file", freshFilename, "id", fileID, "area", foundAreaID)
 	return nil
 }
 
@@ -114,13 +118,11 @@ func (fm *FileManager) MoveFileRecord(fileID uuid.UUID, targetAreaID int) error 
 	// serialize on it.
 	fm.muFiles.RLock()
 	srcAreaID := -1
-	var recordFilename string
 searchLoop:
 	for areaID, records := range fm.fileRecords {
 		for i := range records {
 			if records[i].ID == fileID {
 				srcAreaID = areaID
-				recordFilename = records[i].Filename
 				break searchLoop
 			}
 		}
@@ -156,12 +158,6 @@ searchLoop:
 	if err != nil {
 		return fmt.Errorf("failed to get absolute base path: %w", err)
 	}
-	safeFilename, err := validateFilename(recordFilename)
-	if err != nil {
-		return fmt.Errorf("refusing to move file record %s: %w", fileID, err)
-	}
-	srcPath := filepath.Join(absBasePath, srcAreaPath, safeFilename)
-	dstPath := filepath.Join(absBasePath, targetAreaPath, safeFilename)
 
 	fm.muFiles.Lock()
 	defer fm.muFiles.Unlock()
@@ -179,6 +175,17 @@ searchLoop:
 		return fmt.Errorf("file record with ID %s not found", fileID)
 	}
 	record := fm.fileRecords[srcAreaID][srcIndex]
+
+	// The on-disk name comes from the record as it exists NOW, under the
+	// write lock — not from a read-phase copy, which UpdateFileRecord may
+	// have renamed in the unlocked gap. A stale name here could rename a
+	// different file that has since taken it over.
+	safeFilename, err := validateFilename(record.Filename)
+	if err != nil {
+		return fmt.Errorf("refusing to move file record %s: %w", fileID, err)
+	}
+	srcPath := filepath.Join(absBasePath, srcAreaPath, safeFilename)
+	dstPath := filepath.Join(absBasePath, targetAreaPath, safeFilename)
 
 	// Guard against silently overwriting an existing file in the target area.
 	if _, err := os.Stat(dstPath); err == nil {

--- a/internal/file/manager_paths.go
+++ b/internal/file/manager_paths.go
@@ -17,33 +17,37 @@ import (
 // It does NOT check that the file exists on disk -- callers that need that must
 // stat the returned path themselves.
 func (fm *FileManager) GetFilePath(fileID uuid.UUID) (string, error) {
-	fm.muFiles.RLock() // Need read lock to find the file record
-	defer fm.muFiles.RUnlock()
-	fm.muAreas.RLock() // Need read lock to get area path
-	defer fm.muAreas.RUnlock()
-
-	var foundArea *FileArea
-	var foundRecord *FileRecord
-
+	// muAreas and muFiles are never held together (see the FileManager doc
+	// comment): copy what is needed from each domain under its own lock.
+	fm.muFiles.RLock()
+	foundAreaID := -1
+	var foundFilename string
 searchLoop:
 	for areaID, records := range fm.fileRecords {
 		for i := range records {
 			if records[i].ID == fileID {
-				// Get corresponding area
-				area, areaExists := fm.fileAreas[areaID]
-				if !areaExists {
-					// Should not happen if data is consistent
-					return "", fmt.Errorf("internal inconsistency: area %d not found for file %s", areaID, fileID)
-				}
-				foundArea = area
-				foundRecord = &records[i] // Get pointer to the record
+				foundAreaID = areaID
+				foundFilename = records[i].Filename
 				break searchLoop
 			}
 		}
 	}
+	fm.muFiles.RUnlock()
 
-	if foundRecord == nil {
+	if foundAreaID == -1 {
 		return "", fmt.Errorf("file record with ID %s not found", fileID)
+	}
+
+	fm.muAreas.RLock()
+	area, areaExists := fm.fileAreas[foundAreaID]
+	var areaPath string
+	if areaExists {
+		areaPath = area.Path
+	}
+	fm.muAreas.RUnlock()
+	if !areaExists {
+		// Should not happen if data is consistent
+		return "", fmt.Errorf("internal inconsistency: area %d not found for file %s", foundAreaID, fileID)
 	}
 
 	// Construct path safely
@@ -54,12 +58,12 @@ searchLoop:
 	}
 	// Area path is relative to base path
 	// Filename should be just the base name
-	safeFilename, err := validateFilename(foundRecord.Filename)
+	safeFilename, err := validateFilename(foundFilename)
 	if err != nil {
 		return "", fmt.Errorf("file record %s: %w", fileID, err)
 	}
 
-	fullPath := filepath.Join(absBasePath, foundArea.Path, safeFilename)
+	fullPath := filepath.Join(absBasePath, areaPath, safeFilename)
 
 	// Final check: Ensure the resolved path is still within the intended base directory
 	if !strings.HasPrefix(fullPath, absBasePath) {

--- a/internal/file/manager_store.go
+++ b/internal/file/manager_store.go
@@ -10,8 +10,22 @@ import (
 
 // loadAllFileRecords iterates through loaded areas and loads their metadata.
 func (fm *FileManager) loadAllFileRecords() error {
-	fm.muAreas.RLock() // Need read lock on areas to iterate
-	defer fm.muAreas.RUnlock()
+	// muAreas and muFiles are never held together (see the FileManager doc
+	// comment): snapshot the area list first, then load records under muFiles
+	// alone. The metadata reads happen against the snapshot, so an area added
+	// or removed mid-load is simply picked up by the next load.
+	type areaInfo struct {
+		id   int
+		path string
+		tag  string
+	}
+	fm.muAreas.RLock()
+	areas := make([]areaInfo, 0, len(fm.fileAreas))
+	for areaID, area := range fm.fileAreas {
+		areas = append(areas, areaInfo{id: areaID, path: area.Path, tag: area.Tag})
+	}
+	fm.muAreas.RUnlock()
+
 	fm.muFiles.Lock() // Need write lock on fileRecords map
 	defer fm.muFiles.Unlock()
 
@@ -19,34 +33,34 @@ func (fm *FileManager) loadAllFileRecords() error {
 	var totalFilesLoaded int
 	var errorsEncountered bool
 
-	for areaID, area := range fm.fileAreas {
-		metadataPath := filepath.Join(fm.basePath, area.Path, "metadata.json")
+	for _, area := range areas {
+		metadataPath := filepath.Join(fm.basePath, area.path, "metadata.json")
 		data, err := os.ReadFile(metadataPath)
 		if err != nil {
 			if os.IsNotExist(err) {
-				slog.Debug("metadata file not found for area, assuming no files", "path", metadataPath, "area", area.Tag, "id", areaID)
-				fm.fileRecords[areaID] = []FileRecord{} // Initialize empty slice
+				slog.Debug("metadata file not found for area, assuming no files", "path", metadataPath, "area", area.tag, "id", area.id)
+				fm.fileRecords[area.id] = []FileRecord{} // Initialize empty slice
 				continue
 			}
-			slog.Error("failed to read metadata file for area", "path", metadataPath, "area", area.Tag, "error", err)
+			slog.Error("failed to read metadata file for area", "path", metadataPath, "area", area.tag, "error", err)
 			errorsEncountered = true
 			continue // Skip this area on error
 		}
 
 		var records []FileRecord
 		if err := json.Unmarshal(data, &records); err != nil {
-			slog.Error("failed to parse metadata file for area", "path", metadataPath, "area", area.Tag, "error", err)
+			slog.Error("failed to parse metadata file for area", "path", metadataPath, "area", area.tag, "error", err)
 			errorsEncountered = true
 			continue // Skip this area on error
 		}
 
 		// TODO: Validate records? Ensure filenames exist?
-		fm.fileRecords[areaID] = records
+		fm.fileRecords[area.id] = records
 		totalFilesLoaded += len(records)
-		slog.Debug("loaded file records for area", "count", len(records), "area", area.Tag, "id", areaID)
+		slog.Debug("loaded file records for area", "count", len(records), "area", area.tag, "id", area.id)
 	}
 
-	slog.Info("loaded metadata for areas", "areas", len(fm.fileAreas), "count", totalFilesLoaded)
+	slog.Info("loaded metadata for areas", "areas", len(areas), "count", totalFilesLoaded)
 	if errorsEncountered {
 		return fmt.Errorf("encountered errors while loading file records")
 	}


### PR DESCRIPTION
## Summary

Resolves the ABBA lock-ordering inversion in `internal/file/manager.go` that its own doc comment flagged as the blocker for any runtime reload of file areas. Based on `main`, independent of the #327 → #328 → #329 stack — it touches nothing those PRs touch.

## The problem

`FileManager` has two mutexes: `muAreas` (areas/tags) and `muFiles` (records). They were nested in both orders:

- `GetFilePath`, `DeleteFileRecord`, `MoveFileRecord`: held `muFiles`, then took `muAreas`
- `loadAllFileRecords`: held `muAreas`, then took `muFiles`

Safe today only because nothing write-locks `muAreas` after construction. The moment a reload exists, the deadlock is real, and it takes three parties — subtle enough to be worth spelling out:

1. a reader holds `muFiles`, requests `muAreas.RLock` — **queued behind**
2. a *pending* `muAreas.Lock` (Go's RWMutex blocks new readers when a writer waits), which waits on
3. a held `muAreas.RLock` whose owner is blocked wanting `muFiles`

## The fix

No ordering discipline to remember — the nesting is gone entirely: **no goroutine ever holds both locks.** Cross-domain operations copy what they need under one lock, release, take the other. The price is the combined view isn't atomic, so:

- mutators **re-search by ID under the write lock** before touching anything (the first search's index can go stale), treating "no longer there" as not-found
- disk I/O in Delete/Move stays under the write lock as before, so same-file operations keep serializing

The doc comment now states the invariant and names the regression test that guards it.

## Verification

The methodology matters more than the numbers here:

- `TestNoDeadlockUnderConcurrentAreaWriteLock` reproduces the exact three-party cycle: two goroutines running the future reload's lock sequence (`loadAreas` + `loadAllFileRecords`) against concurrent `GetFilePath`/`Move` traffic, writer-bounded with a watchdog so a hang fails fast instead of wedging CI.
- **Validated against the pre-fix code**: dropped into a worktree at `origin/main`, it deadlocks 3/3 runs. On the fixed code: 0/5 full-package `-race` failures.
- `TestDeleteRevalidatesUnderWriteLock` and `TestConcurrentDeleteAndMoveSameRecord` cover the new re-validate semantics — the latter asserts a hammered record ends in exactly one state (one area, or gone).
- Full suite green; unix + `GOOS=windows` builds; vet clean.

## Scope

Lock-layer prerequisite **only**. A public `file_areas.json` reload still needs the data-layer work (refreshing `fileTags`, dropping records of removed areas, path changes) under #323's idle-gated apply design — that's lane 3, deliberately not started here.

Refs #311, #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hb7nz7xAjkqrPvVK4mLuN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of file and area operations during concurrent reloads, reads, moves, and deletions.
  * File paths now reflect the latest record name when files are moved or deleted.
  * Reduced the risk of stale metadata causing incorrect file operations or inconsistent path results.
  * Improved handling of area changes while records are being loaded.

* **Tests**
  * Added regression coverage for file deletion and renaming during concurrent changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->