### PR TITLE
feat(config): idle-gated deferred reload lane — file_areas.json and message_areas.json hot-reload at idle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,8 +64,9 @@ internal/configeditor/reload.now
 # SSH host keys (generated during setup, not tracked in git)
 /configs/ssh_host_*
 
-# Config reload semaphore (touched at runtime to signal a config reload)
+# Config reload semaphores (touched at runtime to signal a config reload)
 /configs/reload.now
+/configs/reload.force
 
 # Logs and debug files
 *.log

--- a/cmd/vision3/config_watcher.go
+++ b/cmd/vision3/config_watcher.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+	"github.com/ViSiON-3/vision-3-bbs/internal/file"
 	"github.com/ViSiON-3/vision-3-bbs/internal/logging"
 	"github.com/ViSiON-3/vision-3-bbs/internal/menu"
 	"github.com/ViSiON-3/vision-3-bbs/internal/scheduler"
@@ -59,14 +61,29 @@ type ConfigWatcher struct {
 	connTracker    *ConnectionTracker
 	scheduler      *scheduler.Scheduler // set via SetScheduler after startup; nil until then
 
-	interval     time.Duration
-	targets      []reloadTarget
-	sentinelPath string
+	interval          time.Duration
+	targets           []reloadTarget
+	deferredTargets   []deferredTarget
+	sentinelPath      string
+	forceSentinelPath string
 
-	mu     sync.Mutex           // guards mtimes and stop
-	mtimes map[string]time.Time // last-seen modification time per polled path
-	stop   chan struct{}
-	done   chan struct{}
+	mu      sync.Mutex           // guards mtimes, pending, and stop
+	mtimes  map[string]time.Time // last-seen modification time per polled path
+	pending map[string]bool      // deferred targets queued for the next idle window
+	stop    chan struct{}
+	done    chan struct{}
+}
+
+// deferredTarget is a watched file whose reload is structural: applying it
+// with callers online can pull state out from under a session, so a detected
+// change is validated immediately (the sysop hears about a bad file at save
+// time, not hours later) but applied only once the session registry reports
+// zero active sessions — or when the force sentinel demands it.
+type deferredTarget struct {
+	name     string // basename, for logging and pending listings
+	path     string
+	validate func() error // parse-only check, run at signal time
+	apply    func() error // the actual reload, run at the idle window
 }
 
 // NewConfigWatcher creates a configuration file watcher and starts polling.
@@ -82,18 +99,20 @@ func NewConfigWatcher(rootConfigPath, menuSetPath string, menuExecutor *menu.Men
 	}
 
 	cw := &ConfigWatcher{
-		rootConfigPath: rootConfigPath,
-		menuSetPath:    menuSetPath,
-		menuExecutor:   menuExecutor,
-		userMgr:        userMgr,
-		serverConfig:   serverConfig,
-		serverConfigMu: serverConfigMu,
-		connTracker:    connTracker,
-		interval:       defaultPollInterval,
-		sentinelPath:   config.ReloadSentinelPath(rootConfigPath),
-		mtimes:         make(map[string]time.Time),
-		stop:           make(chan struct{}),
-		done:           make(chan struct{}),
+		rootConfigPath:    rootConfigPath,
+		menuSetPath:       menuSetPath,
+		menuExecutor:      menuExecutor,
+		userMgr:           userMgr,
+		serverConfig:      serverConfig,
+		serverConfigMu:    serverConfigMu,
+		connTracker:       connTracker,
+		interval:          defaultPollInterval,
+		sentinelPath:      config.ReloadSentinelPath(rootConfigPath),
+		forceSentinelPath: config.ReloadForceSentinelPath(rootConfigPath),
+		mtimes:            make(map[string]time.Time),
+		pending:           make(map[string]bool),
+		stop:              make(chan struct{}),
+		done:              make(chan struct{}),
 	}
 
 	cw.targets = []reloadTarget{
@@ -105,6 +124,14 @@ func NewConfigWatcher(rootConfigPath, menuSetPath string, menuExecutor *menu.Men
 		{name: "protocols.json", path: filepath.Join(rootConfigPath, "protocols.json"), reload: cw.reloadProtocols},
 		{name: "events.json", path: filepath.Join(rootConfigPath, "events.json"), reload: cw.reloadEvents},
 		{name: "conferences.json", path: filepath.Join(rootConfigPath, "conferences.json"), reload: cw.reloadConferences},
+	}
+	cw.deferredTargets = []deferredTarget{
+		{
+			name:     "file_areas.json",
+			path:     filepath.Join(rootConfigPath, "file_areas.json"),
+			validate: cw.validateFileAreas,
+			apply:    cw.applyFileAreas,
+		},
 	}
 
 	// Record current timestamps so the first poll does not reload everything
@@ -124,9 +151,12 @@ func (cw *ConfigWatcher) seed() {
 	cw.mu.Lock()
 	defer cw.mu.Unlock()
 
-	paths := make([]string, 0, len(cw.targets)+1)
-	paths = append(paths, cw.sentinelPath)
+	paths := make([]string, 0, len(cw.targets)+len(cw.deferredTargets)+2)
+	paths = append(paths, cw.sentinelPath, cw.forceSentinelPath)
 	for _, t := range cw.targets {
+		paths = append(paths, t.path)
+	}
+	for _, t := range cw.deferredTargets {
 		paths = append(paths, t.path)
 	}
 	for _, p := range paths {
@@ -173,6 +203,20 @@ func (cw *ConfigWatcher) pollLoop() {
 // poll reloads every configuration file whose timestamp changed since the last
 // check. A touched sentinel reloads everything regardless of timestamps.
 func (cw *ConfigWatcher) poll() {
+	if cw.changed(cw.forceSentinelPath) {
+		slog.Warn("force sentinel touched: applying all configuration now, including deferred structural changes",
+			"path", cw.forceSentinelPath, "active_sessions", cw.activeSessions())
+		for _, t := range cw.targets {
+			cw.changed(t.path)
+		}
+		cw.ReloadAll()
+		for _, t := range cw.deferredTargets {
+			cw.changed(t.path)
+			cw.applyDeferred(t)
+		}
+		return
+	}
+
 	if cw.changed(cw.sentinelPath) {
 		slog.Info("reload sentinel touched, reloading all configuration",
 			"path", cw.sentinelPath)
@@ -183,6 +227,15 @@ func (cw *ConfigWatcher) poll() {
 			cw.changed(t.path)
 		}
 		cw.ReloadAll()
+		// Deferred targets covered by the save are queued, not applied: the
+		// sentinel is touched automatically by v3config on every save, and
+		// automatic saves must not bypass the idle gate.
+		for _, t := range cw.deferredTargets {
+			if cw.changed(t.path) {
+				cw.queueDeferred(t)
+			}
+		}
+		cw.applyPendingIfIdle()
 		return
 	}
 
@@ -192,6 +245,118 @@ func (cw *ConfigWatcher) poll() {
 			t.reload()
 		}
 	}
+	for _, t := range cw.deferredTargets {
+		if cw.changed(t.path) {
+			cw.queueDeferred(t)
+		}
+	}
+	cw.applyPendingIfIdle()
+}
+
+// activeSessions reports how many callers are online, or 0 when no session
+// registry is wired (tests, tools) — in which case there is nobody to
+// protect and deferral degrades to immediate application.
+func (cw *ConfigWatcher) activeSessions() int {
+	if cw.menuExecutor == nil || cw.menuExecutor.SessionRegistry == nil {
+		return 0
+	}
+	return cw.menuExecutor.SessionRegistry.ActiveCount()
+}
+
+// queueDeferred validates a changed structural config now and, if it parses,
+// queues it for the next idle window. A file that fails validation is not
+// queued: the error is the sysop's immediate feedback, and fixing the file
+// changes its timestamp, which queues it afresh.
+func (cw *ConfigWatcher) queueDeferred(t deferredTarget) {
+	if err := t.validate(); err != nil {
+		slog.Error("changed config failed validation and will not be applied",
+			"file", t.name, "error", err)
+		return
+	}
+	cw.mu.Lock()
+	cw.pending[t.name] = true
+	cw.mu.Unlock()
+	if n := cw.activeSessions(); n > 0 {
+		slog.Info("structural config change queued; applies when no callers are online",
+			"file", t.name, "active_sessions", n,
+			"hint", "touch configs/"+config.ReloadForceSentinelName+" to apply now")
+	}
+}
+
+// applyPendingIfIdle applies every queued structural reload once the board
+// is idle. Called on each poll tick, so the reload lands within one poll
+// interval of the last caller logging off.
+func (cw *ConfigWatcher) applyPendingIfIdle() {
+	cw.mu.Lock()
+	anyPending := len(cw.pending) > 0
+	cw.mu.Unlock()
+	if !anyPending || cw.activeSessions() > 0 {
+		return
+	}
+	for _, t := range cw.deferredTargets {
+		cw.mu.Lock()
+		isPending := cw.pending[t.name]
+		cw.mu.Unlock()
+		if isPending {
+			cw.applyDeferred(t)
+		}
+	}
+}
+
+// applyDeferred runs a deferred target's reload and clears its pending mark.
+// The mark is cleared even on failure: the apply re-reads the file, so a
+// failure means the file changed again and went bad, and the fix will arrive
+// as a fresh timestamp change that re-queues it.
+func (cw *ConfigWatcher) applyDeferred(t deferredTarget) {
+	cw.mu.Lock()
+	delete(cw.pending, t.name)
+	cw.mu.Unlock()
+	if err := t.apply(); err != nil {
+		slog.Error("failed to apply deferred config reload", "file", t.name, "error", err)
+		return
+	}
+	slog.Info("deferred config reload applied", "file", t.name)
+}
+
+// PendingReloads lists the structural configs queued for the next idle
+// window, for surfacing on the WFC console.
+func (cw *ConfigWatcher) PendingReloads() []string {
+	cw.mu.Lock()
+	defer cw.mu.Unlock()
+	if len(cw.pending) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(cw.pending))
+	for _, t := range cw.deferredTargets {
+		if cw.pending[t.name] {
+			names = append(names, t.name)
+		}
+	}
+	return names
+}
+
+// validateFileAreas is the signal-time check for file_areas.json: parse only,
+// touch nothing.
+func (cw *ConfigWatcher) validateFileAreas() error {
+	data, err := os.ReadFile(filepath.Join(cw.rootConfigPath, "file_areas.json"))
+	if err != nil {
+		return err
+	}
+	var areas []file.FileArea
+	if err := json.Unmarshal(data, &areas); err != nil {
+		return fmt.Errorf("parsing file_areas.json: %w", err)
+	}
+	return nil
+}
+
+// applyFileAreas reloads the file manager from disk. Runs only at an idle
+// window (or under the force sentinel), per the reload constraint documented
+// on FileManager.
+func (cw *ConfigWatcher) applyFileAreas() error {
+	if cw.menuExecutor == nil || cw.menuExecutor.FileMgr == nil {
+		return fmt.Errorf("file manager not running")
+	}
+	return cw.menuExecutor.FileMgr.Reload()
 }
 
 // changed reports whether path's modification time differs from the one last

--- a/cmd/vision3/config_watcher.go
+++ b/cmd/vision3/config_watcher.go
@@ -276,6 +276,12 @@ func (cw *ConfigWatcher) activeSessions() int {
 // changes its timestamp, which queues it afresh.
 func (cw *ConfigWatcher) queueDeferred(t deferredTarget) {
 	if err := t.validate(); err != nil {
+		// Also clear any pending mark from an earlier, still-valid edit:
+		// the file's CURRENT content is what an apply would read, and it
+		// is invalid — applying the queue now would fail against it.
+		cw.mu.Lock()
+		delete(cw.pending, t.name)
+		cw.mu.Unlock()
 		slog.Error("changed config failed validation and will not be applied",
 			"file", t.name, "error", err)
 		return
@@ -301,6 +307,18 @@ func (cw *ConfigWatcher) applyPendingIfIdle() {
 		return
 	}
 	for _, t := range cw.deferredTargets {
+		// Re-check right before each apply: a caller may have connected while
+		// an earlier target in this pass was reloading. A session can still
+		// register in the instant between this check and the apply — that
+		// residual window is benign, not ignored: the managers' reloads take
+		// their write locks, so a just-admitted session's first structural
+		// operation serializes after the swap, and the mutators re-validate
+		// by ID under the write lock (see #330). The gate exists to keep
+		// reloads away from sessions mid-flight in longer operations, and a
+		// session admitted microseconds ago has none.
+		if cw.activeSessions() > 0 {
+			return
+		}
 		cw.mu.Lock()
 		isPending := cw.pending[t.name]
 		cw.mu.Unlock()
@@ -310,18 +328,21 @@ func (cw *ConfigWatcher) applyPendingIfIdle() {
 	}
 }
 
-// applyDeferred runs a deferred target's reload and clears its pending mark.
-// The mark is cleared even on failure: the apply re-reads the file, so a
-// failure means the file changed again and went bad, and the fix will arrive
-// as a fresh timestamp change that re-queues it.
+// applyDeferred runs a deferred target's reload, clearing its pending mark
+// only on success. A failed apply stays queued and retries on subsequent
+// polls: validation already gated what enters the queue, so an apply failure
+// is a transient problem (I/O, permissions) or a broken runtime dependency,
+// and either way silently de-queuing would strand the change until the file
+// happened to be touched again. The recurring error log while it retries is
+// deliberate visibility, not noise.
 func (cw *ConfigWatcher) applyDeferred(t deferredTarget) {
+	if err := t.apply(); err != nil {
+		slog.Error("failed to apply deferred config reload; will retry", "file", t.name, "error", err)
+		return
+	}
 	cw.mu.Lock()
 	delete(cw.pending, t.name)
 	cw.mu.Unlock()
-	if err := t.apply(); err != nil {
-		slog.Error("failed to apply deferred config reload", "file", t.name, "error", err)
-		return
-	}
 	slog.Info("deferred config reload applied", "file", t.name)
 }
 

--- a/cmd/vision3/config_watcher.go
+++ b/cmd/vision3/config_watcher.go
@@ -395,6 +395,11 @@ func (cw *ConfigWatcher) validateMessageAreas() error {
 		return err
 	}
 	var areas []message.MessageArea
+	// An empty file is a supported state — loadMessageAreas defines it as
+	// "no areas" — and json.Unmarshal would reject it.
+	if len(data) == 0 {
+		return nil
+	}
 	if err := json.Unmarshal(data, &areas); err != nil {
 		return fmt.Errorf("parsing message_areas.json: %w", err)
 	}

--- a/cmd/vision3/config_watcher.go
+++ b/cmd/vision3/config_watcher.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ViSiON-3/vision-3-bbs/internal/file"
 	"github.com/ViSiON-3/vision-3-bbs/internal/logging"
 	"github.com/ViSiON-3/vision-3-bbs/internal/menu"
+	"github.com/ViSiON-3/vision-3-bbs/internal/message"
 	"github.com/ViSiON-3/vision-3-bbs/internal/scheduler"
 	"github.com/ViSiON-3/vision-3-bbs/internal/transfer"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
@@ -131,6 +132,12 @@ func NewConfigWatcher(rootConfigPath, menuSetPath string, menuExecutor *menu.Men
 			path:     filepath.Join(rootConfigPath, "file_areas.json"),
 			validate: cw.validateFileAreas,
 			apply:    cw.applyFileAreas,
+		},
+		{
+			name:     "message_areas.json",
+			path:     filepath.Join(rootConfigPath, "message_areas.json"),
+			validate: cw.validateMessageAreas,
+			apply:    cw.applyMessageAreas,
 		},
 	}
 
@@ -357,6 +364,30 @@ func (cw *ConfigWatcher) applyFileAreas() error {
 		return fmt.Errorf("file manager not running")
 	}
 	return cw.menuExecutor.FileMgr.Reload()
+}
+
+// validateMessageAreas is the signal-time check for message_areas.json:
+// parse only, touch nothing.
+func (cw *ConfigWatcher) validateMessageAreas() error {
+	data, err := os.ReadFile(filepath.Join(cw.rootConfigPath, "message_areas.json"))
+	if err != nil {
+		return err
+	}
+	var areas []message.MessageArea
+	if err := json.Unmarshal(data, &areas); err != nil {
+		return fmt.Errorf("parsing message_areas.json: %w", err)
+	}
+	return nil
+}
+
+// applyMessageAreas reloads the message manager's area definitions. Runs
+// only at an idle window (or under the force sentinel), per the reload
+// constraint documented on MessageManager.Reload.
+func (cw *ConfigWatcher) applyMessageAreas() error {
+	if cw.menuExecutor == nil || cw.menuExecutor.MessageMgr == nil {
+		return fmt.Errorf("message manager not running")
+	}
+	return cw.menuExecutor.MessageMgr.Reload()
 }
 
 // changed reports whether path's modification time differs from the one last

--- a/cmd/vision3/config_watcher_deferred_test.go
+++ b/cmd/vision3/config_watcher_deferred_test.go
@@ -290,3 +290,69 @@ func TestMessageAreasReloadEndToEnd(t *testing.T) {
 		t.Error("new message area not visible after the board went idle")
 	}
 }
+
+// TestDeferredApplyFailureRetries pins the review fix on #331: a transient
+// apply failure must stay queued and retry on a later poll, not be silently
+// de-queued until the file happens to change again.
+func TestDeferredApplyFailureRetries(t *testing.T) {
+	cw, dir, rec, _ := newDeferredTestWatcher(t)
+
+	failing := true
+	cw.deferredTargets[0].apply = func() error {
+		if failing {
+			return os.ErrPermission
+		}
+		rec.hit("structural.json")()
+		return nil
+	}
+
+	touch(t, filepath.Join(dir, "structural.json"), time.Second)
+	cw.poll() // idle board: applies immediately — and fails
+	if got := cw.PendingReloads(); len(got) != 1 {
+		t.Fatalf("failed apply was de-queued: PendingReloads() = %v", got)
+	}
+
+	cw.poll() // still failing: still pending
+	if got := cw.PendingReloads(); len(got) != 1 {
+		t.Fatalf("pending lost across a retry: %v", got)
+	}
+
+	failing = false
+	cw.poll()
+	if got := rec.count("structural.json"); got != 1 {
+		t.Errorf("applied %d times after the failure cleared, want 1", got)
+	}
+	if got := cw.PendingReloads(); got != nil {
+		t.Errorf("PendingReloads() = %v after success, want nil", got)
+	}
+}
+
+// TestDeferredInvalidEditClearsStalePending pins the second review fix: a
+// valid edit queues, then a second INVALID edit arrives before the board
+// goes idle — the stale pending mark must clear, or the idle window would
+// apply the invalid file.
+func TestDeferredInvalidEditClearsStalePending(t *testing.T) {
+	cw, dir, _, reg := newDeferredTestWatcher(t)
+	reg.Register(&session.BbsSession{ID: 1, NodeID: 1})
+
+	valid := true
+	cw.deferredTargets[0].validate = func() error {
+		if valid {
+			return nil
+		}
+		return os.ErrInvalid
+	}
+
+	touch(t, filepath.Join(dir, "structural.json"), time.Second)
+	cw.poll()
+	if got := cw.PendingReloads(); len(got) != 1 {
+		t.Fatalf("valid edit not queued: %v", got)
+	}
+
+	valid = false
+	touch(t, filepath.Join(dir, "structural.json"), 2*time.Second)
+	cw.poll()
+	if got := cw.PendingReloads(); got != nil {
+		t.Fatalf("stale pending survived an invalid follow-up edit: %v", got)
+	}
+}

--- a/cmd/vision3/config_watcher_deferred_test.go
+++ b/cmd/vision3/config_watcher_deferred_test.go
@@ -356,3 +356,16 @@ func TestDeferredInvalidEditClearsStalePending(t *testing.T) {
 		t.Fatalf("stale pending survived an invalid follow-up edit: %v", got)
 	}
 }
+
+// TestValidateMessageAreasAcceptsEmptyFile: an emptied message_areas.json is
+// a supported "no areas" state and must queue, not be rejected at validation.
+func TestValidateMessageAreasAcceptsEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "message_areas.json"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	cw := &ConfigWatcher{rootConfigPath: dir}
+	if err := cw.validateMessageAreas(); err != nil {
+		t.Errorf("validateMessageAreas rejected an empty file: %v", err)
+	}
+}

--- a/cmd/vision3/config_watcher_deferred_test.go
+++ b/cmd/vision3/config_watcher_deferred_test.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+	"github.com/ViSiON-3/vision-3-bbs/internal/file"
+	"github.com/ViSiON-3/vision-3-bbs/internal/menu"
+	"github.com/ViSiON-3/vision-3-bbs/internal/session"
+)
+
+// newDeferredTestWatcher builds a watcher with one fake deferred target and a
+// real session registry, driving poll() by hand.
+func newDeferredTestWatcher(t *testing.T) (*ConfigWatcher, string, *recorder, *session.SessionRegistry) {
+	t.Helper()
+	dir := t.TempDir()
+	rec := newRecorder()
+	reg := session.NewSessionRegistry()
+
+	cw := &ConfigWatcher{
+		rootConfigPath:    dir,
+		menuExecutor:      &menu.MenuExecutor{SessionRegistry: reg},
+		interval:          defaultPollInterval,
+		sentinelPath:      config.ReloadSentinelPath(dir),
+		forceSentinelPath: config.ReloadForceSentinelPath(dir),
+		mtimes:            make(map[string]time.Time),
+		pending:           make(map[string]bool),
+		stop:              make(chan struct{}),
+		done:              make(chan struct{}),
+	}
+	path := filepath.Join(dir, "structural.json")
+	if err := os.WriteFile(path, []byte(`[]`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cw.deferredTargets = []deferredTarget{{
+		name:     "structural.json",
+		path:     path,
+		validate: func() error { return nil },
+		apply:    func() error { rec.hit("structural.json")(); return nil },
+	}}
+	cw.seed()
+	return cw, dir, rec, reg
+}
+
+// TestDeferredWaitsForIdle: a structural change with callers online queues
+// and does not apply; it applies within one poll of the board going idle.
+func TestDeferredWaitsForIdle(t *testing.T) {
+	cw, dir, rec, reg := newDeferredTestWatcher(t)
+	reg.Register(&session.BbsSession{ID: 1, NodeID: 1})
+
+	touch(t, filepath.Join(dir, "structural.json"), time.Second)
+	cw.poll()
+
+	if got := rec.count("structural.json"); got != 0 {
+		t.Fatalf("applied %d times with a caller online, want 0", got)
+	}
+	if got := cw.PendingReloads(); len(got) != 1 || got[0] != "structural.json" {
+		t.Fatalf("PendingReloads() = %v, want [structural.json]", got)
+	}
+
+	// Still online, further polls change nothing.
+	cw.poll()
+	if got := rec.count("structural.json"); got != 0 {
+		t.Fatalf("applied %d times while still online, want 0", got)
+	}
+
+	reg.Unregister(1)
+	cw.poll()
+	if got := rec.count("structural.json"); got != 1 {
+		t.Errorf("applied %d times after going idle, want 1", got)
+	}
+	if got := cw.PendingReloads(); got != nil {
+		t.Errorf("PendingReloads() = %v after apply, want nil", got)
+	}
+}
+
+// TestDeferredAppliesImmediatelyWhenIdle: with nobody online the deferred
+// lane degrades to the immediate one.
+func TestDeferredAppliesImmediatelyWhenIdle(t *testing.T) {
+	cw, dir, rec, _ := newDeferredTestWatcher(t)
+
+	touch(t, filepath.Join(dir, "structural.json"), time.Second)
+	cw.poll()
+
+	if got := rec.count("structural.json"); got != 1 {
+		t.Errorf("applied %d times on an idle board, want 1", got)
+	}
+}
+
+// TestDeferredValidationFailureDoesNotQueue: a bad save is reported at
+// signal time and never queued; fixing the file queues it afresh.
+func TestDeferredValidationFailureDoesNotQueue(t *testing.T) {
+	cw, dir, rec, reg := newDeferredTestWatcher(t)
+	reg.Register(&session.BbsSession{ID: 1, NodeID: 1})
+
+	valid := true
+	cw.deferredTargets[0].validate = func() error {
+		if valid {
+			return nil
+		}
+		return os.ErrInvalid
+	}
+
+	valid = false
+	touch(t, filepath.Join(dir, "structural.json"), time.Second)
+	cw.poll()
+	if got := cw.PendingReloads(); got != nil {
+		t.Fatalf("invalid change queued: %v", got)
+	}
+
+	valid = true
+	touch(t, filepath.Join(dir, "structural.json"), 2*time.Second)
+	cw.poll()
+	if got := cw.PendingReloads(); len(got) != 1 {
+		t.Fatalf("fixed change not queued: %v", got)
+	}
+
+	reg.Unregister(1)
+	cw.poll()
+	if got := rec.count("structural.json"); got != 1 {
+		t.Errorf("applied %d times, want 1", got)
+	}
+}
+
+// TestForceSentinelBypassesIdleGate: touching reload.force applies deferred
+// targets with callers still online.
+func TestForceSentinelBypassesIdleGate(t *testing.T) {
+	cw, dir, rec, reg := newDeferredTestWatcher(t)
+	reg.Register(&session.BbsSession{ID: 1, NodeID: 1})
+
+	touch(t, filepath.Join(dir, "structural.json"), time.Second)
+	cw.poll()
+	if got := rec.count("structural.json"); got != 0 {
+		t.Fatalf("applied %d times before force, want 0", got)
+	}
+
+	touch(t, config.ReloadForceSentinelPath(dir), 2*time.Second)
+	cw.poll()
+	if got := rec.count("structural.json"); got != 1 {
+		t.Errorf("applied %d times after force, want 1", got)
+	}
+	if got := cw.PendingReloads(); got != nil {
+		t.Errorf("PendingReloads() = %v after force, want nil", got)
+	}
+}
+
+// TestSaveSentinelDoesNotBypassIdleGate: reload.now is touched automatically
+// by v3config on every save; it must queue structural changes, never apply
+// them over live callers.
+func TestSaveSentinelDoesNotBypassIdleGate(t *testing.T) {
+	cw, dir, rec, reg := newDeferredTestWatcher(t)
+	reg.Register(&session.BbsSession{ID: 1, NodeID: 1})
+
+	touch(t, filepath.Join(dir, "structural.json"), time.Second)
+	if err := config.TouchReloadSentinel(dir); err != nil {
+		t.Fatal(err)
+	}
+	cw.poll()
+
+	if got := rec.count("structural.json"); got != 0 {
+		t.Fatalf("save sentinel applied a structural change over a live caller (%d times)", got)
+	}
+	if got := cw.PendingReloads(); len(got) != 1 {
+		t.Fatalf("save sentinel did not queue the structural change: %v", got)
+	}
+}
+
+// TestFileAreasReloadEndToEnd drives the real file_areas.json target through
+// the watcher: queued while online, applied at idle, new area visible.
+func TestFileAreasReloadEndToEnd(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "configs")
+	dataDir := filepath.Join(tmp, "data")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "file_areas.json"),
+		[]byte(`[{"id":1,"tag":"ONE","name":"One","path":"one"}]`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	fileMgr, err := file.NewFileManager(dataDir, configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reg := session.NewSessionRegistry()
+	e := &menu.MenuExecutor{SessionRegistry: reg, FileMgr: fileMgr}
+
+	cw := &ConfigWatcher{
+		rootConfigPath:    configDir,
+		menuExecutor:      e,
+		interval:          defaultPollInterval,
+		sentinelPath:      config.ReloadSentinelPath(configDir),
+		forceSentinelPath: config.ReloadForceSentinelPath(configDir),
+		mtimes:            make(map[string]time.Time),
+		pending:           make(map[string]bool),
+		stop:              make(chan struct{}),
+		done:              make(chan struct{}),
+	}
+	cw.deferredTargets = []deferredTarget{{
+		name:     "file_areas.json",
+		path:     filepath.Join(configDir, "file_areas.json"),
+		validate: cw.validateFileAreas,
+		apply:    cw.applyFileAreas,
+	}}
+	cw.seed()
+
+	reg.Register(&session.BbsSession{ID: 1, NodeID: 1})
+	if err := os.WriteFile(filepath.Join(configDir, "file_areas.json"),
+		[]byte(`[{"id":1,"tag":"ONE","name":"One","path":"one"},{"id":2,"tag":"TWO","name":"Two","path":"two"}]`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	ts := time.Now().Add(time.Second)
+	if err := os.Chtimes(filepath.Join(configDir, "file_areas.json"), ts, ts); err != nil {
+		t.Fatal(err)
+	}
+
+	cw.poll()
+	if _, ok := fileMgr.GetAreaByTag("TWO"); ok {
+		t.Fatal("new area visible while a caller was online")
+	}
+
+	reg.Unregister(1)
+	cw.poll()
+	if _, ok := fileMgr.GetAreaByTag("TWO"); !ok {
+		t.Error("new area not visible after the board went idle")
+	}
+}

--- a/cmd/vision3/config_watcher_deferred_test.go
+++ b/cmd/vision3/config_watcher_deferred_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ViSiON-3/vision-3-bbs/internal/config"
 	"github.com/ViSiON-3/vision-3-bbs/internal/file"
 	"github.com/ViSiON-3/vision-3-bbs/internal/menu"
+	"github.com/ViSiON-3/vision-3-bbs/internal/message"
 	"github.com/ViSiON-3/vision-3-bbs/internal/session"
 )
 
@@ -226,5 +227,66 @@ func TestFileAreasReloadEndToEnd(t *testing.T) {
 	cw.poll()
 	if _, ok := fileMgr.GetAreaByTag("TWO"); !ok {
 		t.Error("new area not visible after the board went idle")
+	}
+}
+
+// TestMessageAreasReloadEndToEnd drives the real message_areas.json target
+// through the watcher: queued while online, applied at idle.
+func TestMessageAreasReloadEndToEnd(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "configs")
+	dataDir := filepath.Join(tmp, "data")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "message_areas.json"),
+		[]byte(`[{"id":1,"tag":"GEN","name":"General"}]`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	msgMgr, err := message.NewMessageManager(dataDir, configDir, "TestBBS", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reg := session.NewSessionRegistry()
+	e := &menu.MenuExecutor{SessionRegistry: reg, MessageMgr: msgMgr}
+
+	cw := &ConfigWatcher{
+		rootConfigPath:    configDir,
+		menuExecutor:      e,
+		interval:          defaultPollInterval,
+		sentinelPath:      config.ReloadSentinelPath(configDir),
+		forceSentinelPath: config.ReloadForceSentinelPath(configDir),
+		mtimes:            make(map[string]time.Time),
+		pending:           make(map[string]bool),
+		stop:              make(chan struct{}),
+		done:              make(chan struct{}),
+	}
+	cw.deferredTargets = []deferredTarget{{
+		name:     "message_areas.json",
+		path:     filepath.Join(configDir, "message_areas.json"),
+		validate: cw.validateMessageAreas,
+		apply:    cw.applyMessageAreas,
+	}}
+	cw.seed()
+
+	reg.Register(&session.BbsSession{ID: 1, NodeID: 1})
+	if err := os.WriteFile(filepath.Join(configDir, "message_areas.json"),
+		[]byte(`[{"id":1,"tag":"GEN","name":"General"},{"id":2,"tag":"TECH","name":"Tech"}]`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	ts := time.Now().Add(time.Second)
+	if err := os.Chtimes(filepath.Join(configDir, "message_areas.json"), ts, ts); err != nil {
+		t.Fatal(err)
+	}
+
+	cw.poll()
+	if _, ok := msgMgr.GetAreaByTag("TECH"); ok {
+		t.Fatal("new message area visible while a caller was online")
+	}
+
+	reg.Unregister(1)
+	cw.poll()
+	if _, ok := msgMgr.GetAreaByTag("TECH"); !ok {
+		t.Error("new message area not visible after the board went idle")
 	}
 }

--- a/cmd/vision3/main.go
+++ b/cmd/vision3/main.go
@@ -1795,20 +1795,6 @@ func main() {
 	// Initialize session registry for who's online tracking
 	sessionRegistry = session.NewSessionRegistry()
 
-	// Initialize and start the WFC admin server.
-	// adminMinLevel is a live getter so config hot-reloads take effect immediately.
-	adminMinLevel = func() int { return menuExecutor.GetServerConfig().CoSysOpLevel }
-	wfcEnabled = func() bool { return menuExecutor.GetServerConfig().WFCEnabled }
-	adminServer = admin.NewServer(admin.ServerConfig{
-		Reg:        sessionRegistry,
-		SystemName: serverConfig.BoardName,
-		StartedAt:  time.Now(),
-		Refresh:    time.Second,
-		MaxEvents:  200,
-		CallsToday: func() int { return -1 },
-	})
-	go adminServer.Run(context.Background())
-
 	// Load transfer protocol configuration
 	var loadedProtocols []transfer.ProtocolConfig
 	protocolsPath := filepath.Join(rootConfigPath, "protocols.json")
@@ -1832,6 +1818,28 @@ func main() {
 		defer configWatcher.Stop()
 		slog.Info("configuration hot reload enabled")
 	}
+
+	// Initialize and start the WFC admin server. Created after the menu
+	// executor and config watcher so its getters bind to objects that
+	// already exist — the closures are live so config hot-reloads take
+	// effect immediately, and the pending-reload queue reaches the console.
+	adminMinLevel = func() int { return menuExecutor.GetServerConfig().CoSysOpLevel }
+	wfcEnabled = func() bool { return menuExecutor.GetServerConfig().WFCEnabled }
+	adminServer = admin.NewServer(admin.ServerConfig{
+		Reg:        sessionRegistry,
+		SystemName: serverConfig.BoardName,
+		StartedAt:  time.Now(),
+		Refresh:    time.Second,
+		MaxEvents:  200,
+		CallsToday: func() int { return -1 },
+		PendingReloads: func() []string {
+			if configWatcher == nil {
+				return nil
+			}
+			return configWatcher.PendingReloads()
+		},
+	})
+	go adminServer.Run(context.Background())
 
 	if ftnErr == nil && len(ftnConfig.Networks) > 0 && !ftnConfig.Binkd.Enabled {
 		slog.Info("internal FTN tosser disabled, use v3mail for toss/scan or enable the binkd mailer")

--- a/docs/sysop/configuration/configuration.md
+++ b/docs/sysop/configuration/configuration.md
@@ -985,6 +985,9 @@ seconds of the last caller logging off:
 
 - `configs/file_areas.json` — areas added, removed, or re-pathed; each
   area's file records are re-read from its `metadata.json`
+- `configs/message_areas.json` — areas added, removed, or re-pathed; the
+  message bases on disk are untouched. V3Net area routing is bound at
+  startup, so changing a V3Net-subscribed area still needs a restart
 
 A queued change is logged when it queues and again when it applies. The
 change is validated the moment you save — a file that doesn't parse is
@@ -1007,7 +1010,7 @@ difference is that nothing touches it automatically, so it is the explicit
 - SSH host keys
 - The QWK API listener
 - Logging directory and rolling settings (the log *level* is applied live)
-- `configs/message_areas.json`, `configs/v3net.json`
+- `configs/v3net.json`
 
 ### Triggering a reload by hand
 

--- a/docs/sysop/configuration/configuration.md
+++ b/docs/sysop/configuration/configuration.md
@@ -977,6 +977,29 @@ Reloading `events.json` replaces the cron schedule. Events already mid-run
 finish undisturbed, and `run_at_startup` events belong to process startup —
 saving the file does not re-fire them.
 
+**Applied when the board is idle:**
+
+Structural changes can pull state out from under a caller mid-session, so
+they queue instead of applying immediately, and land within a couple of
+seconds of the last caller logging off:
+
+- `configs/file_areas.json` — areas added, removed, or re-pathed; each
+  area's file records are re-read from its `metadata.json`
+
+A queued change is logged when it queues and again when it applies. The
+change is validated the moment you save — a file that doesn't parse is
+reported immediately and never queued, and the running config stays as it
+was. To apply queued changes right now, without waiting for the board to
+empty:
+
+```bash
+touch configs/reload.force
+```
+
+`reload.force` also re-reads everything else, like `reload.now` — the
+difference is that nothing touches it automatically, so it is the explicit
+"I know callers are online, do it anyway".
+
 **Still requires a restart:**
 
 - Listening ports and hosts (`sshPort`, `sshHost`, `telnetPort`, `telnetHost`)
@@ -984,7 +1007,7 @@ saving the file does not re-fire them.
 - SSH host keys
 - The QWK API listener
 - Logging directory and rolling settings (the log *level* is applied live)
-- `configs/message_areas.json`, `configs/file_areas.json`, `configs/v3net.json`
+- `configs/message_areas.json`, `configs/v3net.json`
 
 ### Triggering a reload by hand
 

--- a/internal/admin/client.go
+++ b/internal/admin/client.go
@@ -49,6 +49,9 @@ type SystemSnapshot struct {
 	UptimeSecs int64       `json:"uptimeSecs"`
 	Nodes      []NodeState `json:"nodes"`
 	Counters   Counters    `json:"counters"`
+	// PendingReloads names structural config files whose reload is queued
+	// for the next idle window (empty when nothing is pending).
+	PendingReloads []string `json:"pendingReloads,omitempty"`
 }
 
 // EventType enumerates diff-synthesized event kinds.

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -18,6 +18,9 @@ type ServerConfig struct {
 	Refresh    time.Duration
 	MaxEvents  int
 	CallsToday func() int // returns -1 if unavailable; may be nil
+	// PendingReloads lists structural config reloads queued for the next
+	// idle window; may be nil.
+	PendingReloads func() []string
 }
 
 // Server polls SessionRegistry, keeps the latest snapshot, and fans out
@@ -93,7 +96,12 @@ func (s *Server) tickLocked(now time.Time) {
 	if s.cfg.CallsToday != nil {
 		calls = s.cfg.CallsToday()
 	}
+	var pending []string
+	if s.cfg.PendingReloads != nil {
+		pending = s.cfg.PendingReloads()
+	}
 	snap := BuildSnapshot(s.cfg.Reg, s.cfg.SystemName, s.cfg.StartedAt, now, calls)
+	snap.PendingReloads = pending
 
 	s.mu.Lock()
 	events := DiffSnapshots(s.prev, snap)

--- a/internal/config/reload_signal.go
+++ b/internal/config/reload_signal.go
@@ -55,3 +55,21 @@ func TouchReloadSentinel(configPath string) error {
 	}
 	return nil
 }
+
+// ReloadForceSentinelName is the semaphore a sysop touches to apply DEFERRED
+// configuration changes immediately, without waiting for the board to go
+// idle, and to re-read everything else at the same time:
+//
+//	touch configs/reload.force
+//
+// Unlike ReloadSentinelName, no tool touches this automatically — structural
+// changes (file areas, and eventually message areas) normally wait for zero
+// active sessions because applying them mid-session can pull state out from
+// under a caller. The force sentinel is the explicit "I know, do it now".
+const ReloadForceSentinelName = "reload.force"
+
+// ReloadForceSentinelPath returns the full path to the force sentinel within
+// the given config directory.
+func ReloadForceSentinelPath(configPath string) string {
+	return filepath.Join(configPath, ReloadForceSentinelName)
+}

--- a/internal/file/manager.go
+++ b/internal/file/manager.go
@@ -72,6 +72,35 @@ func NewFileManager(baseDataPath, baseConfigPath string) (*FileManager, error) {
 	return fm, nil
 }
 
+// Reload re-reads file_areas.json and every area's metadata, replacing the
+// in-memory definitions and records. Areas removed from the file lose their
+// records; added areas get theirs loaded; tag lookups follow the new file. A
+// file_areas.json that fails to read or parse leaves the current definitions
+// in place (loadAreas mutates nothing before a successful parse).
+//
+// Callers must ensure no sessions are active. Per the reload constraint in
+// the type comment: with callers online, area paths copied before the swap
+// can go stale, and a reload landing between an in-flight mutator's
+// in-memory update and its save would revert the update from stale
+// metadata.json. The config watcher enforces this by deferring the reload
+// until the session registry reports zero active sessions.
+func (fm *FileManager) Reload() error {
+	if err := fm.loadAreas(); err != nil {
+		return fmt.Errorf("reloading file areas: %w", err)
+	}
+	if err := fm.loadAllFileRecords(); err != nil {
+		// Area definitions swapped but some metadata failed to read; the
+		// affected areas simply list as empty until the next reload.
+		return fmt.Errorf("reloading file records: %w", err)
+	}
+
+	fm.muAreas.RLock()
+	count := len(fm.fileAreas)
+	fm.muAreas.RUnlock()
+	slog.Info("file areas reloaded", "count", count)
+	return nil
+}
+
 // loadAreas loads the FileArea definitions from the configuration file.
 func (fm *FileManager) loadAreas() error {
 	fm.muAreas.Lock()

--- a/internal/file/manager.go
+++ b/internal/file/manager.go
@@ -85,6 +85,15 @@ func NewFileManager(baseDataPath, baseConfigPath string) (*FileManager, error) {
 // metadata.json. The config watcher enforces this by deferring the reload
 // until the session registry reports zero active sessions.
 func (fm *FileManager) Reload() error {
+	// A missing config is a reload ERROR, not the fresh-install case it is at
+	// construction. loadAreas would helpfully create an empty file_areas.json
+	// and report success with the old definitions still in memory — and the
+	// created file's fresh timestamp would then queue a follow-up reload that
+	// wipes every area. Refuse instead, keeping the running definitions and
+	// the sysop's ability to restore the file.
+	if _, err := os.Stat(fm.configPath); err != nil {
+		return fmt.Errorf("reloading file areas: %w", err)
+	}
 	if err := fm.loadAreas(); err != nil {
 		return fmt.Errorf("reloading file areas: %w", err)
 	}

--- a/internal/file/manager.go
+++ b/internal/file/manager.go
@@ -57,7 +57,7 @@ func NewFileManager(baseDataPath, baseConfigPath string) (*FileManager, error) {
 	}
 
 	slog.Info("loading file areas", "path", fm.configPath)
-	if err := fm.loadAreas(); err != nil {
+	if err := fm.loadAreas(createIfMissing); err != nil {
 		return nil, fmt.Errorf("failed to load file areas: %w", err)
 	}
 
@@ -85,16 +85,14 @@ func NewFileManager(baseDataPath, baseConfigPath string) (*FileManager, error) {
 // metadata.json. The config watcher enforces this by deferring the reload
 // until the session registry reports zero active sessions.
 func (fm *FileManager) Reload() error {
-	// A missing config is a reload ERROR, not the fresh-install case it is at
-	// construction. loadAreas would helpfully create an empty file_areas.json
-	// and report success with the old definitions still in memory — and the
-	// created file's fresh timestamp would then queue a follow-up reload that
-	// wipes every area. Refuse instead, keeping the running definitions and
-	// the sysop's ability to restore the file.
-	if _, err := os.Stat(fm.configPath); err != nil {
-		return fmt.Errorf("reloading file areas: %w", err)
-	}
-	if err := fm.loadAreas(); err != nil {
+	// errIfMissing: a missing config is a reload ERROR, not the
+	// fresh-install case it is at construction. Creating an empty
+	// file_areas.json here and reporting success would leave the old
+	// definitions in memory — and the created file's fresh timestamp would
+	// then queue a follow-up reload that wipes every area. The policy lives
+	// inside loadAreas' own read, so there is no check-then-read gap for a
+	// concurrent deletion to slip through.
+	if err := fm.loadAreas(errIfMissing); err != nil {
 		return fmt.Errorf("reloading file areas: %w", err)
 	}
 	if err := fm.loadAllFileRecords(); err != nil {
@@ -110,14 +108,24 @@ func (fm *FileManager) Reload() error {
 	return nil
 }
 
+// missingFilePolicy selects what loadAreas does when file_areas.json does
+// not exist: construction treats it as a fresh install and creates an empty
+// one; a reload treats it as an error and keeps the running definitions.
+type missingFilePolicy int
+
+const (
+	createIfMissing missingFilePolicy = iota
+	errIfMissing
+)
+
 // loadAreas loads the FileArea definitions from the configuration file.
-func (fm *FileManager) loadAreas() error {
+func (fm *FileManager) loadAreas(onMissing missingFilePolicy) error {
 	fm.muAreas.Lock()
 	defer fm.muAreas.Unlock()
 
 	data, err := os.ReadFile(fm.configPath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if os.IsNotExist(err) && onMissing == createIfMissing {
 			slog.Warn("file areas config not found, no file areas loaded", "path", fm.configPath)
 			// Create an empty file?
 			emptyJSON := []byte("[]")

--- a/internal/file/manager_lockorder_test.go
+++ b/internal/file/manager_lockorder_test.go
@@ -11,14 +11,11 @@ import (
 	"github.com/google/uuid"
 )
 
-// reloadAreasForTest performs the lock sequence a future file-area reload
-// will perform: re-read file_areas.json (exclusive muAreas.Lock inside
-// loadAreas), then re-read the per-area metadata (muFiles.Lock inside
-// loadAllFileRecords). No public Reload exists yet — the point of this file
-// is to prove the locks can support one.
+// reloadAreasForTest exercises the public Reload, which performs exactly the
+// lock sequence this file exists to prove safe: exclusive muAreas.Lock inside
+// loadAreas, then muFiles.Lock inside loadAllFileRecords.
 func reloadAreasForTest(fm *FileManager) {
-	_ = fm.loadAreas()
-	_ = fm.loadAllFileRecords()
+	_ = fm.Reload()
 }
 
 // lockTestManager builds a manager with two areas and a set of records whose

--- a/internal/file/manager_reload_test.go
+++ b/internal/file/manager_reload_test.go
@@ -99,3 +99,26 @@ func TestReloadRereadsRecordsFromDisk(t *testing.T) {
 		t.Errorf("externally added record not visible after reload: %v", err)
 	}
 }
+
+// TestReloadErrorsOnMissingFile pins the review fix on #331: a missing
+// file_areas.json is a reload error keeping the old definitions — not a
+// silent success that recreates an empty file whose fresh timestamp would
+// later wipe every area.
+func TestReloadErrorsOnMissingFile(t *testing.T) {
+	fm := setupTestFileManager(t, []FileArea{
+		{ID: 1, Tag: "KEEP", Name: "Keep", Path: "keep"},
+	})
+
+	if err := os.Remove(fm.configPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := fm.Reload(); err == nil {
+		t.Fatal("Reload succeeded with file_areas.json missing")
+	}
+	if _, ok := fm.GetAreaByTag("KEEP"); !ok {
+		t.Error("definitions lost after a refused reload")
+	}
+	if _, err := os.Stat(fm.configPath); !os.IsNotExist(err) {
+		t.Error("a refused reload recreated file_areas.json")
+	}
+}

--- a/internal/file/manager_reload_test.go
+++ b/internal/file/manager_reload_test.go
@@ -1,0 +1,101 @@
+package file
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// writeAreas rewrites file_areas.json in the manager's config path.
+func writeAreas(t *testing.T, fm *FileManager, areas []FileArea) {
+	t.Helper()
+	data, err := json.Marshal(areas)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fm.configPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReloadReplacesAreasAndRecords(t *testing.T) {
+	fm := setupTestFileManager(t, []FileArea{
+		{ID: 1, Tag: "OLD", Name: "Old", Path: "old"},
+	})
+
+	// A record in the area that is about to be removed.
+	if err := os.MkdirAll(filepath.Join(fm.basePath, "old"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	id := uuid.New()
+	if err := fm.AddFileRecord(FileRecord{ID: id, AreaID: 1, Filename: "gone.zip", Description: "d"}); err != nil {
+		t.Fatal(err)
+	}
+
+	writeAreas(t, fm, []FileArea{
+		{ID: 2, Tag: "NEW", Name: "New", Path: "new"},
+	})
+	if err := fm.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	if _, ok := fm.GetAreaByTag("OLD"); ok {
+		t.Error("removed area OLD still resolvable by tag")
+	}
+	if _, ok := fm.GetAreaByTag("NEW"); !ok {
+		t.Error("added area NEW not resolvable by tag")
+	}
+	if _, err := fm.GetFilePath(id); err == nil {
+		t.Error("record of a removed area still resolvable after reload")
+	}
+}
+
+// TestReloadKeepsOldOnBadFile: a malformed save must not wipe the running
+// definitions.
+func TestReloadKeepsOldOnBadFile(t *testing.T) {
+	fm := setupTestFileManager(t, []FileArea{
+		{ID: 1, Tag: "KEEP", Name: "Keep", Path: "keep"},
+	})
+
+	if err := os.WriteFile(fm.configPath, []byte("{not json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := fm.Reload(); err == nil {
+		t.Fatal("Reload succeeded on a malformed file")
+	}
+	if _, ok := fm.GetAreaByTag("KEEP"); !ok {
+		t.Error("area KEEP lost after a failed reload; old definitions must survive")
+	}
+}
+
+// TestReloadRereadsRecordsFromDisk: records edited on disk (another tool, a
+// restore) are picked up, which is the point of re-reading metadata rather
+// than carrying the in-memory set across.
+func TestReloadRereadsRecordsFromDisk(t *testing.T) {
+	fm := setupTestFileManager(t, []FileArea{
+		{ID: 1, Tag: "A", Name: "A", Path: "a"},
+	})
+
+	id := uuid.New()
+	records := []FileRecord{{ID: id, AreaID: 1, Filename: "ext.zip", Description: "added externally"}}
+	data, err := json.MarshalIndent(records, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(fm.basePath, "a"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fm.basePath, "a", "metadata.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fm.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if _, err := fm.GetFilePath(id); err != nil {
+		t.Errorf("externally added record not visible after reload: %v", err)
+	}
+}

--- a/internal/message/manager_areas_store.go
+++ b/internal/message/manager_areas_store.go
@@ -34,6 +34,12 @@ func (mm *MessageManager) loadMessageAreas() error {
 	mm.areasByID = make(map[int]*MessageArea)
 	mm.areasByTag = make(map[string]*MessageArea)
 	mm.areasByEchoTag = make(map[string]*MessageArea)
+	// The cached indexes are keyed by area ID and validated against the base
+	// they were built from; they reset in the SAME critical section as the
+	// map swap, or a concurrent lookup could pair the new areas with an index
+	// built for a previous BasePath. At construction this is a no-op.
+	mm.threadIndex = make(map[int]*threadIndex)
+	mm.msgidIndex = make(map[int]*msgidIndex)
 
 	for _, area := range areasList {
 		if area == nil {
@@ -112,9 +118,10 @@ func (mm *MessageManager) loadMessageAreas() error {
 	return nil
 }
 
-// Reload re-reads message_areas.json, replacing the in-memory definitions
-// and dropping the cached thread/MSGID indexes — an area's BasePath may have
-// changed, and a stale index would answer for the wrong base. JAM bases are
+// Reload re-reads message_areas.json, replacing the in-memory definitions.
+// The cached thread/MSGID indexes drop in the same critical section as the
+// map swap (inside loadMessageAreas) — an area's BasePath may have changed,
+// and a stale index would answer for the wrong base. JAM bases are
 // opened on demand and never cached, so there are no handles to invalidate;
 // a message being posted concurrently holds its own area pointer and its own
 // open base, and at worst lands in an area removed a moment earlier (the JAM
@@ -131,11 +138,9 @@ func (mm *MessageManager) Reload() error {
 		return fmt.Errorf("reloading message areas: %w", err)
 	}
 
-	mm.mu.Lock()
-	mm.threadIndex = make(map[int]*threadIndex)
-	mm.msgidIndex = make(map[int]*msgidIndex)
+	mm.mu.RLock()
 	count := len(mm.areasByID)
-	mm.mu.Unlock()
+	mm.mu.RUnlock()
 
 	slog.Info("message areas reloaded", "count", count)
 	return nil

--- a/internal/message/manager_areas_store.go
+++ b/internal/message/manager_areas_store.go
@@ -18,12 +18,13 @@ func (mm *MessageManager) loadMessageAreas() error {
 	if err != nil {
 		return err
 	}
-	if len(data) == 0 {
-		return nil
-	}
-
 	var areasList []*MessageArea
-	if err := json.Unmarshal(data, &areasList); err != nil {
+	if len(data) == 0 {
+		// An empty file means no areas. Falling through with a nil list
+		// (rather than returning early) matters on reload: the maps below
+		// must be rebuilt empty, not left holding the previous contents.
+		slog.Info("message areas file is empty; none loaded", "path", mm.areasPath)
+	} else if err := json.Unmarshal(data, &areasList); err != nil {
 		return fmt.Errorf("failed to unmarshal areas from %s: %w", mm.areasPath, err)
 	}
 
@@ -108,6 +109,35 @@ func (mm *MessageManager) loadMessageAreas() error {
 		slog.Info("auto-assigned message area positions (migration)", "count", len(sorted))
 	}
 
+	return nil
+}
+
+// Reload re-reads message_areas.json, replacing the in-memory definitions
+// and dropping the cached thread/MSGID indexes — an area's BasePath may have
+// changed, and a stale index would answer for the wrong base. JAM bases are
+// opened on demand and never cached, so there are no handles to invalidate;
+// a message being posted concurrently holds its own area pointer and its own
+// open base, and at worst lands in an area removed a moment earlier (the JAM
+// files on disk are untouched by a reload). A message_areas.json that fails
+// to read or parse leaves the current definitions in place.
+//
+// Callers must ensure no sysop session is mid-edit in the area editor: its
+// whole-file SaveAreas would clobber (or be clobbered by) the sysop's edit.
+// The config watcher defers this reload to an idle window, which guarantees
+// that. V3Net area routing is bound at startup and is NOT rewired by a
+// reload; changing a V3Net-subscribed area still needs a restart.
+func (mm *MessageManager) Reload() error {
+	if err := mm.loadMessageAreas(); err != nil {
+		return fmt.Errorf("reloading message areas: %w", err)
+	}
+
+	mm.mu.Lock()
+	mm.threadIndex = make(map[int]*threadIndex)
+	mm.msgidIndex = make(map[int]*msgidIndex)
+	count := len(mm.areasByID)
+	mm.mu.Unlock()
+
+	slog.Info("message areas reloaded", "count", count)
 	return nil
 }
 

--- a/internal/message/manager_reload_test.go
+++ b/internal/message/manager_reload_test.go
@@ -1,0 +1,141 @@
+package message
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeMsgAreas(t *testing.T, configDir, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(configDir, "message_areas.json"), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReloadReplacesAreas(t *testing.T) {
+	dataDir, configDir := t.TempDir(), t.TempDir()
+	writeMsgAreas(t, configDir, `[{"id":1,"tag":"OLD","name":"Old"}]`)
+
+	mm, err := NewMessageManager(dataDir, configDir, "TestBBS", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := mm.GetAreaByTag("OLD"); !ok {
+		t.Fatal("area OLD missing after initial load")
+	}
+
+	writeMsgAreas(t, configDir, `[{"id":2,"tag":"NEW","name":"New","echo_tag":"NEW_ECHO","network":"testnet"}]`)
+	if err := mm.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	if _, ok := mm.GetAreaByTag("OLD"); ok {
+		t.Error("removed area OLD still resolvable")
+	}
+	if _, ok := mm.GetAreaByTag("NEW"); !ok {
+		t.Error("added area NEW not resolvable")
+	}
+	if _, ok := mm.GetAreaByEchoTag("NEW_ECHO"); !ok {
+		t.Error("added area's echo tag not resolvable")
+	}
+}
+
+func TestReloadKeepsOldOnBadFile(t *testing.T) {
+	dataDir, configDir := t.TempDir(), t.TempDir()
+	writeMsgAreas(t, configDir, `[{"id":1,"tag":"KEEP","name":"Keep"}]`)
+
+	mm, err := NewMessageManager(dataDir, configDir, "TestBBS", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writeMsgAreas(t, configDir, `{not json`)
+	if err := mm.Reload(); err == nil {
+		t.Fatal("Reload succeeded on a malformed file")
+	}
+	if _, ok := mm.GetAreaByTag("KEEP"); !ok {
+		t.Error("area KEEP lost after a failed reload")
+	}
+}
+
+func TestReloadEmptyFileClearsAreas(t *testing.T) {
+	dataDir, configDir := t.TempDir(), t.TempDir()
+	writeMsgAreas(t, configDir, `[{"id":1,"tag":"GONE","name":"Gone"}]`)
+
+	mm, err := NewMessageManager(dataDir, configDir, "TestBBS", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writeMsgAreas(t, configDir, ``)
+	if err := mm.Reload(); err != nil {
+		t.Fatalf("Reload of an empty file: %v", err)
+	}
+	if got := len(mm.ListAreas()); got != 0 {
+		t.Errorf("ListAreas() = %d after emptying the file, want 0", got)
+	}
+}
+
+// TestReloadDropsCachedIndexes: an area's BasePath can change across a
+// reload, and a stale thread/MSGID index would answer for the wrong base.
+func TestReloadDropsCachedIndexes(t *testing.T) {
+	dataDir, configDir := t.TempDir(), t.TempDir()
+	writeMsgAreas(t, configDir, `[{"id":1,"tag":"A","name":"A"}]`)
+
+	mm, err := NewMessageManager(dataDir, configDir, "TestBBS", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed fake cache entries directly; building real ones needs a JAM base
+	// and the property under test is only that Reload drops whatever is there.
+	mm.mu.Lock()
+	mm.threadIndex[1] = &threadIndex{}
+	mm.msgidIndex[1] = &msgidIndex{}
+	mm.mu.Unlock()
+
+	if err := mm.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	mm.mu.RLock()
+	ti, mi := len(mm.threadIndex), len(mm.msgidIndex)
+	mm.mu.RUnlock()
+	if ti != 0 || mi != 0 {
+		t.Errorf("cached indexes survived reload: thread=%d msgid=%d, want 0/0", ti, mi)
+	}
+}
+
+// TestReloadRaceWithReaders proves the map swap is safe against concurrent
+// lookups under -race.
+func TestReloadRaceWithReaders(t *testing.T) {
+	dataDir, configDir := t.TempDir(), t.TempDir()
+	writeMsgAreas(t, configDir, `[{"id":1,"tag":"GEN","name":"General"}]`)
+
+	mm, err := NewMessageManager(dataDir, configDir, "TestBBS", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 300; i++ {
+			if err := mm.Reload(); err != nil {
+				t.Errorf("Reload: %v", err)
+				return
+			}
+		}
+	}()
+	for {
+		select {
+		case <-done:
+			return
+		default:
+		}
+		_, _ = mm.GetAreaByTag("GEN")
+		_, _ = mm.GetAreaByID(1)
+		_ = mm.ListAreas()
+	}
+}

--- a/internal/wfcui/view.go
+++ b/internal/wfcui/view.go
@@ -153,6 +153,12 @@ func (m Model) renderHeader(st colorSet) string {
 	now := time.Now().Format("15:04:05")
 	header := fmt.Sprintf(" %s  |  Nodes: %d  |  Calls Today: %s  |  Uptime: %s  |  %s",
 		sysName, activeNodes, callsTodayStr, uptime, now)
+	if m.snapshot != nil && len(m.snapshot.PendingReloads) > 0 {
+		// A structural config change is queued for the next idle window;
+		// the sysop should know saves are pending rather than silently held.
+		header += fmt.Sprintf("  |  RELOAD PENDING: %s",
+			sanitizeTerminal(strings.Join(m.snapshot.PendingReloads, ", ")))
+	}
 	return st.header.Render(header)
 }
 

--- a/internal/wfcui/view_test.go
+++ b/internal/wfcui/view_test.go
@@ -67,6 +67,30 @@ func TestViewListContainsNodeHandle(t *testing.T) {
 }
 
 // TestViewListNilSnapshot renders without panic.
+// TestViewShowsPendingReloads: a queued structural reload must be visible on
+// the console, or a deferred save looks like a save that did nothing.
+func TestViewShowsPendingReloads(t *testing.T) {
+	m := makeModel(Options{NoColor: true, ASCII: true}, 120, 30)
+	m.mode = modeList
+	m.snapshot = &admin.SystemSnapshot{
+		SystemName:     "TestBBS",
+		Time:           time.Now(),
+		Nodes:          []admin.NodeState{{NodeID: 1, Handle: "Caller", Status: admin.StatusOnline}},
+		Counters:       admin.Counters{ActiveNodes: 1, CallsToday: 1},
+		PendingReloads: []string{"file_areas.json"},
+	}
+	got := m.View()
+	if !strings.Contains(got, "RELOAD PENDING") || !strings.Contains(got, "file_areas.json") {
+		t.Errorf("header missing pending-reload notice; got:\n%s", got)
+	}
+
+	// And absent when nothing is pending.
+	m.snapshot.PendingReloads = nil
+	if strings.Contains(m.View(), "RELOAD PENDING") {
+		t.Error("pending-reload notice shown with an empty queue")
+	}
+}
+
 func TestViewListNilSnapshot(t *testing.T) {
 	m := makeModel(Options{NoColor: true, ASCII: true}, 100, 30)
 	m.mode = modeList


### PR DESCRIPTION
## Summary

Lane 3 of #323: the **idle-gated deferred reload lane**, with `file_areas.json` as its first target — the piece #330's lock work existed to unblock. Based on `main`, everything else from the roadmap already merged.

## How it works

Structural configs — those whose reload can pull state out from under a live session — get a third treatment, between "hot" and "restart":

1. **Validate at signal time.** A changed file is parsed the moment the watcher sees it. A file that doesn't parse is reported immediately and never queued; the running config stays as it was, and fixing the file re-queues it via its fresh timestamp. The sysop hears about a bad save at save time, not hours later when the board happens to empty.
2. **Queue until idle.** The reload applies on the first poll tick with zero active sessions. Sessions register at connect (before login), so `ActiveCount() == 0` genuinely means nobody is anywhere in the system — including the matrix screen.
3. **Two escape hatches, deliberately different in power:**
   - `configs/reload.now` (touched **automatically** by `v3config` on every save) *queues* structural changes but never applies them over live callers — an automatic save must not bypass the gate. `TestSaveSentinelDoesNotBypassIdleGate` pins exactly this.
   - `configs/reload.force` (touched by **nobody** automatically) is the explicit "I know callers are online, do it now": applies queued structural changes immediately and re-reads everything else besides.

## file_areas.json

`FileManager.Reload` is `loadAreas` + `loadAllFileRecords`: both lookup maps rebuilt, removed areas' records dropped, added areas' records read from their `metadata.json`. A malformed file keeps the old definitions (`loadAreas` parses before mutating). The method documents the no-active-sessions constraint from the type comment — the idle gate is what discharges it. The #330 lock-order regression test now exercises the real `Reload` instead of its stand-in helper.

## Verification

- New tests: queue-while-online → apply-at-idle (within one poll of the last logoff), immediate application on an idle board, validation failure not queued + re-queue on fix, force sentinel bypassing the gate, save sentinel *not* bypassing it, and an end-to-end run through the real `FileManager` (new area invisible while a caller is online, visible after logoff)
- `FileManager.Reload` tests: area add/remove with records following, malformed file keeps old, externally edited `metadata.json` picked up
- Full suite green under `-race`; unix + `GOOS=windows` builds; vet clean

## Left for follow-ups

- `message_areas.json` — same lane, but adds cached JAM base handles and the in-process mailer to the picture
- WFC surfacing of the queue — `PendingReloads()` exists and is tested; the console display is its own change
- #323 lane 2 (per-session snapshots) and the `v3net.json` restructuring

Refs #311, #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8bsBNQ533XxwP1Z2ph5Lr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File-area and message-area configuration changes now reload automatically when the board is idle.
  * Changes are validated and queued while sessions are active, then applied when the board becomes idle.
  * Administrators can force pending configuration changes immediately using `configs/reload.force`.
  * Reloaded areas and metadata reflect external updates, removals, and empty configurations.
  * The interface displays pending configuration reloads.

* **Bug Fixes**
  * Existing area definitions are preserved when configuration files are missing or invalid.

* **Documentation**
  * Updated configuration guidance for automatic, deferred, validated, and forced reloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->