### PR TITLE
feat(v3net): live subscription changes — area browser applies instantly, hand edits ride the idle lane

### DIFF
--- a/cmd/vision3/config_watcher.go
+++ b/cmd/vision3/config_watcher.go
@@ -139,6 +139,12 @@ func NewConfigWatcher(rootConfigPath, menuSetPath string, menuExecutor *menu.Men
 			validate: cw.validateMessageAreas,
 			apply:    cw.applyMessageAreas,
 		},
+		{
+			name:     "v3net.json",
+			path:     filepath.Join(rootConfigPath, "v3net.json"),
+			validate: cw.validateV3Net,
+			apply:    cw.applyV3Net,
+		},
 	}
 
 	// Record current timestamps so the first poll does not reload everything
@@ -388,6 +394,25 @@ func (cw *ConfigWatcher) applyMessageAreas() error {
 		return fmt.Errorf("message manager not running")
 	}
 	return cw.menuExecutor.MessageMgr.Reload()
+}
+
+// validateV3Net is the signal-time check for v3net.json: parse only.
+func (cw *ConfigWatcher) validateV3Net() error {
+	_, err := config.LoadV3NetConfig(cw.rootConfigPath)
+	return err
+}
+
+// applyV3Net rebuilds the leaf subscriptions from v3net.json via the hook
+// main wires when the V3Net service is running. Deferred to an idle window
+// for hand edits because a rebuild cancels any chat riding a leaf; the area
+// browser's own subscribe/unsubscribe applies immediately instead, as an
+// explicit sysop action. Hub settings and the enabled flag still require a
+// restart.
+func (cw *ConfigWatcher) applyV3Net() error {
+	if cw.menuExecutor == nil || cw.menuExecutor.V3NetReload == nil {
+		return fmt.Errorf("V3Net service not running, restart required to apply v3net.json")
+	}
+	return cw.menuExecutor.V3NetReload()
 }
 
 // changed reports whether path's modification time differs from the one last

--- a/cmd/vision3/main.go
+++ b/cmd/vision3/main.go
@@ -1902,47 +1902,17 @@ func main() {
 			// Auto-create message areas for V3Net subscriptions if missing.
 			v3net.SyncAreas(v3netConfig.Leaves, messageMgr, confMgr)
 
-			// Configure leaf clients for each subscribed network.
-			type v3netAreaInfo struct {
-				Network string
-				Origin  string
-			}
-			v3netAreaMap := make(map[int]v3netAreaInfo) // area ID → network info
+			// Configure leaf clients for each subscribed network. The area
+			// bindings live in the service (not a local map) so that
+			// ReloadLeaves can rebuild them and these callbacks pick up the
+			// new set on their next call.
 			nodeID := svc.NodeID()
-			for _, lcfg := range v3netConfig.Leaves {
-				router := v3net.NewJAMRouter()
-				origin := lcfg.Origin
-				if origin == "" {
-					origin = serverConfig.BoardName
-				}
-				var resolvedBoards []string
-				for _, tag := range lcfg.Boards {
-					area, ok := messageMgr.GetAreaByTag(tag)
-					if !ok {
-						slog.Warn("V3Net leaf: message area not found, skipping", "network", lcfg.Network, "area", tag)
-						continue
-					}
-					router.Add(tag, v3net.NewJAMAdapter(messageMgr, area.ID))
-					resolvedBoards = append(resolvedBoards, tag)
-					v3netAreaMap[area.ID] = v3netAreaInfo{Network: lcfg.Network, Origin: origin}
-					svc.RegisterArea(area.ID, lcfg.Network)
-				}
-				if len(resolvedBoards) == 0 {
-					slog.Warn("V3Net leaf: no resolvable boards, skipping", "network", lcfg.Network)
-					continue
-				}
-				leafCfg := lcfg
-				leafCfg.Boards = resolvedBoards
-				if err := v3netService.AddLeaf(leafCfg, router, nil); err != nil {
-					slog.Error("V3Net leaf error", "network", lcfg.Network, "error", err)
-					continue
-				}
-			}
+			svc.ConfigureLeaves(v3netConfig.Leaves, messageMgr, serverConfig.BoardName)
 
 			// Append tearline/origin to local JAM copy for V3Net areas so
 			// the user sees the origin on locally-created messages too.
 			messageMgr.BodyTransform = func(areaID int, body string) string {
-				info, ok := v3netAreaMap[areaID]
+				binding, ok := svc.AreaBindingFor(areaID)
 				if !ok {
 					return body
 				}
@@ -1952,22 +1922,22 @@ func main() {
 				if strings.Contains(body, "\n--- ") || strings.HasPrefix(body, "--- ") {
 					return body
 				}
-				return v3net.AppendV3NetOrigin(body, v3net.DefaultTearline(), info.Origin, nodeID)
+				return v3net.AppendV3NetOrigin(body, v3net.DefaultTearline(), binding.Origin, nodeID)
 			}
 
 			// Hook message posts to forward to V3Net when posted to a networked area.
 			// Skip messages imported from V3Net (contain the UUID kludge) to prevent feedback loops.
 			messageMgr.OnMessagePosted = func(area *message.MessageArea, msgNum int, from, to, subject, body string) {
-				info, ok := v3netAreaMap[area.ID]
+				binding, ok := svc.AreaBindingFor(area.ID)
 				if !ok {
 					return
 				}
 				if strings.HasPrefix(body, "\x01V3NETUUID: ") {
 					return
 				}
-				msg := v3net.BuildWireMessage(info.Network, area.Tag, svc.NodeID(), serverConfig.BoardName, from, to, subject, body, info.Origin)
-				if err := svc.SendMessage(info.Network, msg); err != nil {
-					slog.Error("V3Net: failed to send message", "network", info.Network, "error", err)
+				msg := v3net.BuildWireMessage(binding.Network, area.Tag, svc.NodeID(), serverConfig.BoardName, from, to, subject, body, binding.Origin)
+				if err := svc.SendMessage(binding.Network, msg); err != nil {
+					slog.Error("V3Net: failed to send message", "network", binding.Network, "error", err)
 					return
 				}
 				// Mark the local JAM copy as sent so the reader shows "V3NET SENT".
@@ -1988,6 +1958,16 @@ func main() {
 			go v3netService.Start(v3netCtx)
 			menuExecutor.V3NetStatus = v3netService
 			menuExecutor.ChatLeaves = v3netChatProvider(v3netService)
+			// Live subscription apply: re-read v3net.json and rebuild the
+			// leaf set. Used by the area browser after a subscribe or
+			// unsubscribe, and by the config watcher for hand edits.
+			menuExecutor.V3NetReload = func() error {
+				fresh, lerr := config.LoadV3NetConfig(rootConfigPath)
+				if lerr != nil {
+					return lerr
+				}
+				return svc.ReloadLeaves(fresh.Leaves, messageMgr, confMgr, serverConfig.BoardName)
+			}
 			slog.Info("V3Net service started",
 				"node_id", v3netService.NodeID(),
 				"hub", v3netService.HubActive(),

--- a/docs/sysop/configuration/configuration.md
+++ b/docs/sysop/configuration/configuration.md
@@ -986,8 +986,12 @@ seconds of the last caller logging off:
 - `configs/file_areas.json` — areas added, removed, or re-pathed; each
   area's file records are re-read from its `metadata.json`
 - `configs/message_areas.json` — areas added, removed, or re-pathed; the
-  message bases on disk are untouched. V3Net area routing is bound at
-  startup, so changing a V3Net-subscribed area still needs a restart
+  message bases on disk are untouched
+- `configs/v3net.json` — leaf subscriptions are torn down and rebuilt
+  (a caller mid-chat on a V3Net leaf loses that chat's stream). Subscribing
+  from the in-BBS area browser applies immediately instead of waiting for
+  idle. Hub settings, the `enabled` flag, and keystore/dedup paths still
+  require a restart
 
 A queued change is logged when it queues and again when it applies. The
 change is validated the moment you save — a file that doesn't parse is
@@ -1010,7 +1014,6 @@ difference is that nothing touches it automatically, so it is the explicit
 - SSH host keys
 - The QWK API listener
 - Logging directory and rolling settings (the log *level* is applied live)
-- `configs/v3net.json`
 
 ### Triggering a reload by hand
 

--- a/internal/menu/executor.go
+++ b/internal/menu/executor.go
@@ -68,6 +68,7 @@ type MenuExecutor struct {
 	IPLockoutCheck  IPLockoutChecker              // IP-based authentication lockout checker
 	SessionRegistry *session.SessionRegistry      // Session registry for who's online
 	ChatLeaves      ChatLeafProvider              // V3Net chat leaf provider (nil = local only)
+	V3NetReload     func() error                  // Applies v3net.json subscription changes live (nil = restart required)
 	V3NetStatus     V3NetStatusProvider           // V3Net service status (nil if disabled)
 
 	// Hot-reloadable configuration.

--- a/internal/menu/v3net_areas.go
+++ b/internal/menu/v3net_areas.go
@@ -325,6 +325,13 @@ func runV3NetAreas(c *cmdCtx, args string) (*user.User, string, error) {
 					ent.subscribed = false
 					subSet[ent.network+":"+ent.area.Tag] = false
 					statusMsg = fmt.Sprintf("|10Unsubscribed from %s. Restart to apply.|07", ent.area.Tag)
+					if e.V3NetReload != nil {
+						if rerr := e.V3NetReload(); rerr != nil {
+							statusMsg = fmt.Sprintf("|10Unsubscribed from %s.|07 |04Live apply failed (%s); restart to apply.|07", ent.area.Tag, rerr)
+						} else {
+							statusMsg = fmt.Sprintf("|10Unsubscribed from %s. Now inactive.|07", ent.area.Tag)
+						}
+					}
 				}
 			} else {
 				// Subscribe: add leaf config + create message area.
@@ -345,6 +352,13 @@ func runV3NetAreas(c *cmdCtx, args string) (*user.User, string, error) {
 					ent.subscribed = true
 					subSet[ent.network+":"+ent.area.Tag] = true
 					statusMsg = fmt.Sprintf("|10Subscribed to %s. Restart to activate.|07", ent.area.Tag)
+					if e.V3NetReload != nil {
+						if rerr := e.V3NetReload(); rerr != nil {
+							statusMsg = fmt.Sprintf("|10Subscribed to %s.|07 |04Live apply failed (%s); restart to activate.|07", ent.area.Tag, rerr)
+						} else {
+							statusMsg = fmt.Sprintf("|10Subscribed to %s. Now active.|07", ent.area.Tag)
+						}
+					}
 				}
 			}
 			needFullRedraw = true

--- a/internal/message/manager_areas_store.go
+++ b/internal/message/manager_areas_store.go
@@ -124,8 +124,9 @@ func (mm *MessageManager) loadMessageAreas() error {
 // Callers must ensure no sysop session is mid-edit in the area editor: its
 // whole-file SaveAreas would clobber (or be clobbered by) the sysop's edit.
 // The config watcher defers this reload to an idle window, which guarantees
-// that. V3Net area routing is bound at startup and is NOT rewired by a
-// reload; changing a V3Net-subscribed area still needs a restart.
+// that. V3Net area bindings are NOT rewired by this reload alone; a
+// v3net.json reload (or an area-browser subscription change) rebuilds them
+// against the current areas.
 func (mm *MessageManager) Reload() error {
 	if err := mm.loadMessageAreas(); err != nil {
 		return fmt.Errorf("reloading message areas: %w", err)

--- a/internal/v3net/reload_test.go
+++ b/internal/v3net/reload_test.go
@@ -1,0 +1,180 @@
+package v3net_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+	"github.com/ViSiON-3/vision-3-bbs/internal/message"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/keystore"
+	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/protocol"
+)
+
+// newReloadFixture builds a leaf-only service plus a message manager holding
+// the given area tags. Hub URLs point at an unroutable address, so leaves sit
+// in their subscribe-retry loop — which is exactly the state a stop must be
+// able to interrupt.
+func newReloadFixture(t *testing.T, tags ...string) (*v3net.Service, *message.MessageManager) {
+	t.Helper()
+	dir := t.TempDir()
+	keystorePath := filepath.Join(dir, "v3net.key")
+	if _, _, err := keystore.Load(keystorePath); err != nil {
+		t.Fatal(err)
+	}
+	svc, err := v3net.New(config.V3NetConfig{
+		Enabled:      true,
+		KeystorePath: keystorePath,
+		DedupDBPath:  filepath.Join(dir, "dedup.sqlite"),
+		ConfigPath:   dir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = svc.Close() })
+
+	configDir := filepath.Join(dir, "configs")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	body := "["
+	for i, tag := range tags {
+		if i > 0 {
+			body += ","
+		}
+		body += `{"id":` + itoa(i+1) + `,"tag":"` + tag + `","name":"` + tag + `"}`
+	}
+	body += "]"
+	if err := os.WriteFile(filepath.Join(configDir, "message_areas.json"), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mm, err := message.NewMessageManager(filepath.Join(dir, "data"), configDir, "TestBBS", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return svc, mm
+}
+
+func itoa(n int) string {
+	if n < 10 {
+		return string(rune('0' + n))
+	}
+	return string(rune('0'+n/10)) + string(rune('0'+n%10))
+}
+
+func leafCfg(network, board string) config.V3NetLeafConfig {
+	return config.V3NetLeafConfig{
+		Network: network,
+		HubURL:  "http://127.0.0.1:1", // unroutable: leaves park in subscribe retry
+		Boards:  []string{board},
+	}
+}
+
+// TestReloadLeavesSwapsSubscriptions covers the whole contract: the old
+// leaf set stops (even mid-subscribe-backoff), the new set is configured and
+// running, and the area bindings follow.
+func TestReloadLeavesSwapsSubscriptions(t *testing.T) {
+	svc, mm := newReloadFixture(t, "ALPHA", "BETA")
+	svc.ConfigureLeaves([]config.V3NetLeafConfig{leafCfg("net-a", "ALPHA")}, mm, "TestBBS")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	go func() {
+		close(started)
+		svc.Start(ctx)
+	}()
+	<-started
+	time.Sleep(20 * time.Millisecond) // let the leaf enter its retry loop
+
+	if got := svc.LeafNetworks(); len(got) != 1 || got[0] != "net-a" {
+		t.Fatalf("LeafNetworks() = %v, want [net-a]", got)
+	}
+	alphaArea, _ := mm.GetAreaByTag("ALPHA")
+	if got := svc.NetworkForArea(alphaArea.ID); got != "net-a" {
+		t.Fatalf("NetworkForArea(ALPHA) = %q, want net-a", got)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.ReloadLeaves([]config.V3NetLeafConfig{leafCfg("net-b", "BETA")}, mm, nil, "TestBBS")
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ReloadLeaves: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("ReloadLeaves hung — stopping a leaf mid-backoff did not interrupt it")
+	}
+
+	if got := svc.LeafNetworks(); len(got) != 1 || got[0] != "net-b" {
+		t.Errorf("LeafNetworks() = %v after reload, want [net-b]", got)
+	}
+	if got := svc.NetworkForArea(alphaArea.ID); got != "" {
+		t.Errorf("old binding survived reload: NetworkForArea(ALPHA) = %q", got)
+	}
+	betaArea, _ := mm.GetAreaByTag("BETA")
+	if b, ok := svc.AreaBindingFor(betaArea.ID); !ok || b.Network != "net-b" || b.Origin != "TestBBS" {
+		t.Errorf("AreaBindingFor(BETA) = %+v ok=%v, want net-b/TestBBS", b, ok)
+	}
+
+	// SendMessage to the removed network is a silent no-op, matching the
+	// unconfigured-network contract.
+	if err := svc.SendMessage("net-a", protocol.Message{}); err != nil {
+		t.Errorf("SendMessage to removed network errored: %v", err)
+	}
+
+	cancel()
+}
+
+// TestReloadLeavesBeforeStart: a reload while the service has never started
+// swaps configuration without starting anything.
+func TestReloadLeavesBeforeStart(t *testing.T) {
+	svc, mm := newReloadFixture(t, "ALPHA", "BETA")
+	svc.ConfigureLeaves([]config.V3NetLeafConfig{leafCfg("net-a", "ALPHA")}, mm, "TestBBS")
+
+	if err := svc.ReloadLeaves([]config.V3NetLeafConfig{leafCfg("net-b", "BETA")}, mm, nil, "TestBBS"); err != nil {
+		t.Fatalf("ReloadLeaves before Start: %v", err)
+	}
+	if got := svc.LeafNetworks(); len(got) != 1 || got[0] != "net-b" {
+		t.Errorf("LeafNetworks() = %v, want [net-b]", got)
+	}
+}
+
+// TestReloadLeavesRaceWithReaders proves the swap is safe against the
+// accessors real callers use, under -race.
+func TestReloadLeavesRaceWithReaders(t *testing.T) {
+	svc, mm := newReloadFixture(t, "ALPHA", "BETA")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 60; i++ {
+			cfgs := []config.V3NetLeafConfig{leafCfg("net-a", "ALPHA")}
+			if i%2 == 1 {
+				cfgs = []config.V3NetLeafConfig{leafCfg("net-b", "BETA")}
+			}
+			if err := svc.ReloadLeaves(cfgs, mm, nil, "TestBBS"); err != nil {
+				t.Errorf("ReloadLeaves: %v", err)
+				return
+			}
+		}
+	}()
+	for {
+		select {
+		case <-done:
+			return
+		default:
+		}
+		_ = svc.LeafNetworks()
+		_ = svc.LeafCount()
+		_ = svc.Leaves()
+		_ = svc.NetworkForArea(1)
+		_, _ = svc.AreaBindingFor(2)
+		_ = svc.SendMessage("net-a", protocol.Message{})
+		svc.SendLogon("caller")
+	}
+}

--- a/internal/v3net/reload_test.go
+++ b/internal/v3net/reload_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -45,7 +46,7 @@ func newReloadFixture(t *testing.T, tags ...string) (*v3net.Service, *message.Me
 		if i > 0 {
 			body += ","
 		}
-		body += `{"id":` + itoa(i+1) + `,"tag":"` + tag + `","name":"` + tag + `"}`
+		body += `{"id":` + strconv.Itoa(i+1) + `,"tag":"` + tag + `","name":"` + tag + `"}`
 	}
 	body += "]"
 	if err := os.WriteFile(filepath.Join(configDir, "message_areas.json"), []byte(body), 0644); err != nil {
@@ -56,13 +57,6 @@ func newReloadFixture(t *testing.T, tags ...string) (*v3net.Service, *message.Me
 		t.Fatal(err)
 	}
 	return svc, mm
-}
-
-func itoa(n int) string {
-	if n < 10 {
-		return string(rune('0' + n))
-	}
-	return string(rune('0'+n/10)) + string(rune('0'+n%10))
 }
 
 func leafCfg(network, board string) config.V3NetLeafConfig {
@@ -163,7 +157,7 @@ func TestReloadLeavesRaceWithReaders(t *testing.T) {
 			}
 		}
 	}()
-	for {
+	for i := 0; ; i++ {
 		select {
 		case <-done:
 			return
@@ -175,6 +169,10 @@ func TestReloadLeavesRaceWithReaders(t *testing.T) {
 		_ = svc.NetworkForArea(1)
 		_, _ = svc.AreaBindingFor(2)
 		_ = svc.SendMessage("net-a", protocol.Message{})
-		svc.SendLogon("caller")
+		if i%64 == 0 {
+			// SendLogon spawns a goroutine per leaf per call; unthrottled it
+			// churns thousands of goroutines for no extra lock coverage.
+			svc.SendLogon("caller")
+		}
 	}
 }

--- a/internal/v3net/service.go
+++ b/internal/v3net/service.go
@@ -10,7 +10,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/conference"
 	"github.com/ViSiON-3/vision-3-bbs/internal/config"
+	"github.com/ViSiON-3/vision-3-bbs/internal/message"
 	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/dedup"
 	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/hub"
 	"github.com/ViSiON-3/vision-3-bbs/internal/v3net/keystore"
@@ -22,27 +24,57 @@ import (
 
 // Service manages V3Net hub and leaf lifecycle.
 //
-// leaves, leafByNetwork, and areaToNetwork are populated during initialization
-// (via AddLeaf/RegisterArea) before Start() is called, and are read-only after
-// that point. No mutex is needed for concurrent read access.
+// Leaf subscriptions and area bindings were historically populated before
+// Start() and read-only afterwards; ReloadLeaves changed that, so mu now
+// guards them. The hub, keystore, and dedup index remain fixed for the life
+// of the process — reconfiguring those still requires a restart.
 type Service struct {
 	cfg      config.V3NetConfig
 	ks       *keystore.Keystore
 	dedupIdx *dedup.Index
 	hub      *hub.Hub
-	leaves   []*leaf.Leaf
 
-	// leafByNetwork maps network name to its leaf for message sending.
-	// Populated at init time only; read-only after Start().
-	leafByNetwork map[string]*leaf.Leaf
+	// mu guards leaves, leafByNetwork, areaBindings, and runCtx.
+	mu     sync.RWMutex
+	leaves []*leafRun
 
-	// areaToNetwork maps message area ID to its V3Net network name.
-	// Populated at init time only; read-only after Start().
-	areaToNetwork map[int]string
+	// leafByNetwork maps network name to its running leaf for message sending.
+	leafByNetwork map[string]*leafRun
+
+	// areaBindings maps message area ID to its V3Net network and origin line.
+	areaBindings map[int]AreaBinding
+
+	// runCtx is the context Start was called with; nil until then. A leaf
+	// added while the service runs is started against a child of it.
+	runCtx context.Context
+
+	// reloadMu serializes ReloadLeaves calls; it is never held together with mu.
+	reloadMu sync.Mutex
 
 	// BBSName and BBSHost are sent in subscribe requests.
 	BBSName string
 	BBSHost string
+}
+
+// AreaBinding ties a message area to the V3Net network it is subscribed on
+// and the origin line its outbound messages carry.
+type AreaBinding struct {
+	Network string
+	Origin  string
+}
+
+// leafRun is a leaf plus its runtime handles. cancel and done are nil until
+// the leaf is started; stopping cancels the leaf's own context and waits for
+// its goroutine, so a stop never strands a mid-backoff subscribe or an open
+// SSE stream.
+type leafRun struct {
+	l      *leaf.Leaf
+	cancel context.CancelFunc
+	done   chan struct{}
+	// stop makes stopping idempotent and concurrency-safe: shutdown, Close,
+	// and a reload can all try to stop the same run, and sync.Once blocks
+	// the latecomers until the first stop has fully completed.
+	stop sync.Once
 }
 
 // hubAutoInit performs idempotent hub initialization steps:
@@ -160,8 +192,8 @@ func New(cfg config.V3NetConfig) (*Service, error) {
 		cfg:           cfg,
 		ks:            ks,
 		dedupIdx:      ix,
-		leafByNetwork: make(map[string]*leaf.Leaf),
-		areaToNetwork: make(map[int]string),
+		leafByNetwork: make(map[string]*leafRun),
+		areaBindings:  make(map[int]AreaBinding),
 	}
 
 	// Initialize hub if enabled.
@@ -220,40 +252,88 @@ func (s *Service) AddLeaf(lcfg config.V3NetLeafConfig, writer JAMWriter, onEvent
 		BBSHost:      s.BBSHost,
 	})
 
-	s.leaves = append(s.leaves, l)
-	s.leafByNetwork[lcfg.Network] = l
+	run := &leafRun{l: l}
+	s.mu.Lock()
+	s.leaves = append(s.leaves, run)
+	s.leafByNetwork[lcfg.Network] = run
+	if s.runCtx != nil {
+		// The service is already running (a reload added this leaf); start it
+		// now rather than waiting for a Start that already happened.
+		s.startLeafLocked(run)
+	}
+	s.mu.Unlock()
 	return nil
 }
 
-// Start launches the hub (if enabled) and all leaf clients. Blocks until ctx is cancelled.
-func (s *Service) Start(ctx context.Context) {
-	var wg sync.WaitGroup
+// startLeafLocked launches a leaf against a child of the service context.
+// Caller must hold s.mu, and s.runCtx must be set.
+func (s *Service) startLeafLocked(run *leafRun) {
+	lctx, cancel := context.WithCancel(s.runCtx)
+	run.cancel = cancel
+	run.done = make(chan struct{})
+	go func() {
+		defer close(run.done)
+		run.l.Start(lctx)
+	}()
+}
 
+// stopLeaf cancels a running leaf, waits for its goroutine to exit, and
+// closes its idle connections. Safe on a leaf that was never started. Must
+// be called without holding s.mu — the wait can take as long as the leaf's
+// current HTTP request.
+func (s *Service) stopLeaf(run *leafRun) {
+	run.stop.Do(func() {
+		if run.cancel != nil {
+			run.cancel()
+			<-run.done
+		}
+		run.l.Close()
+	})
+}
+
+// Start launches the hub (if enabled) and all leaf clients, then blocks
+// until ctx is cancelled, at which point every running leaf is stopped and
+// waited for.
+func (s *Service) Start(ctx context.Context) {
+	hubDone := make(chan struct{})
 	if s.hub != nil {
-		wg.Add(1)
 		go func() {
-			defer wg.Done()
+			defer close(hubDone)
 			if err := s.hub.Start(ctx); err != nil {
 				slog.Error("v3net: hub error", "error", err)
 			}
 		}()
+	} else {
+		close(hubDone)
 	}
 
-	for _, l := range s.leaves {
-		wg.Add(1)
-		go func(lf *leaf.Leaf) {
-			defer wg.Done()
-			lf.Start(ctx)
-		}(l)
+	s.mu.Lock()
+	s.runCtx = ctx
+	for _, run := range s.leaves {
+		if run.done == nil {
+			s.startLeafLocked(run)
+		}
 	}
+	s.mu.Unlock()
 
-	wg.Wait()
+	<-ctx.Done()
+
+	s.mu.Lock()
+	running := append([]*leafRun(nil), s.leaves...)
+	s.mu.Unlock()
+	for _, run := range running {
+		s.stopLeaf(run)
+	}
+	<-hubDone
 }
 
 // Close releases resources held by the service.
 func (s *Service) Close() error {
-	for _, l := range s.leaves {
-		l.Close()
+	s.mu.Lock()
+	running := append([]*leafRun(nil), s.leaves...)
+	s.mu.Unlock()
+	for _, run := range running {
+		s.stopLeaf(run)
 	}
 	if s.hub != nil {
 		_ = s.hub.Close() // best-effort shutdown
@@ -271,11 +351,13 @@ func (s *Service) NodeID() string {
 // Also marks the message as seen in the dedup index so the local leaf
 // does not re-import it when polling.
 func (s *Service) SendMessage(network string, msg protocol.Message) error {
-	l, ok := s.leafByNetwork[network]
+	s.mu.RLock()
+	run, ok := s.leafByNetwork[network]
+	s.mu.RUnlock()
 	if !ok {
 		return nil
 	}
-	if err := l.SendMessage(msg); err != nil {
+	if err := run.l.SendMessage(msg); err != nil {
 		return err
 	}
 	// Mark as seen so our own leaf won't write it back to JAM.
@@ -288,24 +370,24 @@ func (s *Service) SendMessage(network string, msg protocol.Message) error {
 // SendLogon notifies all connected hubs of a user logon.
 // Runs asynchronously so it never blocks the caller's session.
 func (s *Service) SendLogon(handle string) {
-	for _, l := range s.leaves {
+	for _, lf := range s.Leaves() {
 		go func(lf *leaf.Leaf) {
 			if err := lf.SendLogon(handle); err != nil {
 				slog.Warn("v3net: SendLogon failed", "error", err)
 			}
-		}(l)
+		}(lf)
 	}
 }
 
 // SendLogoff notifies all connected hubs of a user logoff.
 // Runs asynchronously so it never blocks the caller's session.
 func (s *Service) SendLogoff(handle string) {
-	for _, l := range s.leaves {
+	for _, lf := range s.Leaves() {
 		go func(lf *leaf.Leaf) {
 			if err := lf.SendLogoff(handle); err != nil {
 				slog.Warn("v3net: SendLogoff failed", "error", err)
 			}
-		}(l)
+		}(lf)
 	}
 }
 
@@ -316,11 +398,15 @@ func (s *Service) HubActive() bool {
 
 // LeafCount returns the number of configured leaf subscriptions.
 func (s *Service) LeafCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return len(s.leaves)
 }
 
 // LeafNetworks returns the names of all subscribed networks.
 func (s *Service) LeafNetworks() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	var names []string
 	for name := range s.leafByNetwork {
 		names = append(names, name)
@@ -333,49 +419,75 @@ func (s *Service) Hub() *hub.Hub {
 	return s.hub
 }
 
-// Leaves returns all configured leaf clients (read-only after Start).
+// Leaves returns a snapshot of the current leaf clients. The slice is the
+// caller's to keep; a reload does not mutate it.
 func (s *Service) Leaves() []*leaf.Leaf {
-	return s.leaves
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]*leaf.Leaf, 0, len(s.leaves))
+	for _, run := range s.leaves {
+		out = append(out, run.l)
+	}
+	return out
 }
 
-// RegisterArea associates a message area ID with a V3Net network name.
-// Called during startup so the message reader can identify V3Net areas.
-func (s *Service) RegisterArea(areaID int, network string) {
+// RegisterArea associates a message area ID with a V3Net network name and
+// the origin line its outbound messages carry.
+func (s *Service) RegisterArea(areaID int, network, origin string) {
 	slog.Info("v3net: registering area", "area_id", areaID, "network", network)
-	s.areaToNetwork[areaID] = network
+	s.mu.Lock()
+	s.areaBindings[areaID] = AreaBinding{Network: network, Origin: origin}
+	s.mu.Unlock()
 }
 
 // NetworkForArea returns the V3Net network name for a message area, or empty
 // string if the area is not a V3Net-networked area.
 func (s *Service) NetworkForArea(areaID int) string {
-	return s.areaToNetwork[areaID]
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.areaBindings[areaID].Network
+}
+
+// AreaBindingFor returns the full binding for a message area, and whether
+// the area is V3Net-networked at all.
+func (s *Service) AreaBindingFor(areaID int) (AreaBinding, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	b, ok := s.areaBindings[areaID]
+	return b, ok
 }
 
 // ProposeArea submits an area proposal to the hub for the given network.
 func (s *Service) ProposeArea(network string, req protocol.AreaProposalRequest) (*protocol.ProposalResponse, error) {
-	l, ok := s.leafByNetwork[network]
+	s.mu.RLock()
+	run, ok := s.leafByNetwork[network]
+	s.mu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("v3net: no leaf configured for network %q", network)
 	}
-	return l.ProposeArea(req)
+	return run.l.ProposeArea(req)
 }
 
 // FetchNALForNetwork fetches and verifies the NAL for the given network.
 func (s *Service) FetchNALForNetwork(ctx context.Context, network string) (*protocol.NAL, error) {
-	l, ok := s.leafByNetwork[network]
+	s.mu.RLock()
+	run, ok := s.leafByNetwork[network]
+	s.mu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("v3net: no leaf configured for network %q", network)
 	}
-	return l.FetchNAL(ctx)
+	return run.l.FetchNAL(ctx)
 }
 
 // HubURLForNetwork returns the hub URL for the given network, or empty string.
 func (s *Service) HubURLForNetwork(network string) string {
-	l, ok := s.leafByNetwork[network]
+	s.mu.RLock()
+	run, ok := s.leafByNetwork[network]
+	s.mu.RUnlock()
 	if !ok {
 		return ""
 	}
-	return l.HubURL()
+	return run.l.HubURL()
 }
 
 // RegistryURL returns the configured registry URL, or the default if not set.
@@ -389,4 +501,85 @@ func (s *Service) RegistryURL() string {
 // ConfigPath returns the path used to load the V3Net config (for saving).
 func (s *Service) ConfigPath() string {
 	return s.cfg.KeystorePath // parent dir derived at call site
+}
+
+// ConfigureLeaves builds and registers a leaf client for every subscription
+// in leafCfgs: board tags are resolved against the message manager, a JAM
+// router is wired per network, and each resolved area is bound to its
+// network and origin. Unresolvable boards and networks with no resolvable
+// boards are skipped with a warning, matching historical startup behavior.
+// If the service is already running, new leaves start immediately.
+func (s *Service) ConfigureLeaves(leafCfgs []config.V3NetLeafConfig, mgr *message.MessageManager, defaultOrigin string) {
+	for _, lcfg := range leafCfgs {
+		router := NewJAMRouter()
+		origin := lcfg.Origin
+		if origin == "" {
+			origin = defaultOrigin
+		}
+		var resolvedBoards []string
+		for _, tag := range lcfg.Boards {
+			area, ok := mgr.GetAreaByTag(tag)
+			if !ok {
+				slog.Warn("V3Net leaf: message area not found, skipping", "network", lcfg.Network, "area", tag)
+				continue
+			}
+			router.Add(tag, NewJAMAdapter(mgr, area.ID))
+			resolvedBoards = append(resolvedBoards, tag)
+			s.RegisterArea(area.ID, lcfg.Network, origin)
+		}
+		if len(resolvedBoards) == 0 {
+			slog.Warn("V3Net leaf: no resolvable boards, skipping", "network", lcfg.Network)
+			continue
+		}
+		leafCfg := lcfg
+		leafCfg.Boards = resolvedBoards
+		if err := s.AddLeaf(leafCfg, router, nil); err != nil {
+			slog.Error("V3Net leaf error", "network", lcfg.Network, "error", err)
+		}
+	}
+}
+
+// ReloadLeaves replaces the running leaf subscriptions with those in
+// leafCfgs: message areas for new subscriptions are auto-created (as at
+// startup), every current leaf is stopped and waited for, the area bindings
+// are cleared, and the new set is configured and started.
+//
+// This is a full stop-and-rebuild rather than a per-network diff — a
+// subscription change is a rare, sysop-initiated event, and rebuilding is
+// the simplest shape that cannot leave a half-old, half-new set behind. The
+// visible costs: unchanged networks re-subscribe to their hub (idempotent),
+// and a caller mid-chat on a V3Net leaf has that chat's stream cancelled.
+//
+// Hub settings, the enabled flag, and keystore/dedup paths are NOT touched;
+// those still require a restart.
+func (s *Service) ReloadLeaves(leafCfgs []config.V3NetLeafConfig, mgr *message.MessageManager, confMgr *conference.ConferenceManager, defaultOrigin string) error {
+	s.reloadMu.Lock()
+	defer s.reloadMu.Unlock()
+
+	if created := SyncAreas(leafCfgs, mgr, confMgr); created > 0 {
+		slog.Info("v3net: created message areas for new subscriptions", "count", created)
+	}
+
+	// Detach the current set under the lock, then stop it outside the lock —
+	// waiting for a leaf mid-request while holding mu would stall SendMessage
+	// and the status providers.
+	s.mu.Lock()
+	old := s.leaves
+	s.leaves = nil
+	s.leafByNetwork = make(map[string]*leafRun)
+	s.areaBindings = make(map[int]AreaBinding)
+	s.mu.Unlock()
+
+	for _, run := range old {
+		s.stopLeaf(run)
+	}
+	slog.Info("v3net: leaf subscriptions stopped for reload", "count", len(old))
+
+	s.ConfigureLeaves(leafCfgs, mgr, defaultOrigin)
+
+	s.mu.RLock()
+	count := len(s.leaves)
+	s.mu.RUnlock()
+	slog.Info("v3net: leaf subscriptions reloaded", "count", count)
+	return nil
 }


### PR DESCRIPTION
## Summary

`v3net.json` subscription changes now apply live — the last file from #311's table, and the one with the most direct sysop pain: the in-BBS area browser writes the file and then says **"Restart to activate."** It now activates.

Stacked on #331 (base `feat/deferred-config-reload`) because the hand-edit path rides its deferred lane; the diff here shows only the v3net work. Implements the design the earlier session posted on #311.

## The three structural changes

**1. Leaves get individual lifecycles.** Each leaf runs against a child of the service context with its own cancel + done channel, so one leaf can be stopped — including mid-subscribe-backoff or mid-SSE-stream — and *waited for*, without touching the others. Stops are guarded by a per-run `sync.Once`: shutdown, `Close`, and a reload can all reach the same leaf, and latecomers block until the first stop completes. (The first version raced exactly there; `-race` caught it, and the test that hung on it now asserts a stop interrupts a leaf parked in its retry loop.)

**2. The service drops its read-only-after-Start contract.** `leaves`, `leafByNetwork`, and the area bindings move behind a mutex — the same treatment #321 gave the menu executor, at a scale where a mutex is the right tool (a dozen accessors, all in one file). Bindings now carry the origin line, so the tearline and message-forwarding callbacks in `main` read through `svc.AreaBindingFor()` instead of closing over a map built once at boot. `ConfigureLeaves` absorbs `main`'s leaf-building loop: startup and reload share one implementation.

**3. `ReloadLeaves` is a full stop-and-rebuild, not a per-network diff.** Subscription changes are rare sysop actions; rebuilding is the simplest shape that cannot leave a half-old, half-new set behind. Costs stated where they land: unchanged networks re-subscribe (idempotent), and a caller mid-chat on a V3Net leaf loses that stream.

## Two entry points, same split as the rest of the reload system

- **Area browser** (subscribe/unsubscribe): applies **immediately** — explicit sysop action. Messages become "Subscribed to X. Now active." / "Now inactive.", falling back to the restart text if the live apply fails or the service isn't running.
- **Hand edits to `v3net.json`**: watcher-detected, validated at signal time, applied through #331's **idle-gated deferred lane** — because a rebuild cancels chats, and a hand edit carries no "do it now" intent the way a browser action does.

**Still restart-only:** hub settings, the `enabled` flag, keystore/dedup paths.

## Verification

- `TestReloadLeavesSwapsSubscriptions`: old network stopped (with a hang-detector proving a mid-backoff leaf is interruptible), new network running, bindings swapped, sends to the removed network silently no-op per the unconfigured-network contract
- Reload-before-Start, and a reader-race test over every accessor real callers use, under `-race` at `-count=3`
- Full suite green; unix + `GOOS=windows` builds; vet clean
- Docs: `v3net.json` moves to the idle-applied table with its caveats; the "V3Net needs restart" note on message-area reloads updated to point at the rebind path

With this, **every configuration file from #311's original table hot-reloads** — the last restart-only items are listener ports/hosts, SSH keys, protocol enables, the QWK API listener, logging dir/rolling, and V3Net's hub/identity settings, all deliberately so.

Refs #311, #323. Stacked on #331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8bsBNQ533XxwP1Z2ph5Lr
