### PR TITLE
feat(config): hot-reload ftn.json origin lines — the last item from #311's table

### DIFF
--- a/cmd/vision3/config_watcher.go
+++ b/cmd/vision3/config_watcher.go
@@ -125,6 +125,7 @@ func NewConfigWatcher(rootConfigPath, menuSetPath string, menuExecutor *menu.Men
 		{name: "protocols.json", path: filepath.Join(rootConfigPath, "protocols.json"), reload: cw.reloadProtocols},
 		{name: "events.json", path: filepath.Join(rootConfigPath, "events.json"), reload: cw.reloadEvents},
 		{name: "conferences.json", path: filepath.Join(rootConfigPath, "conferences.json"), reload: cw.reloadConferences},
+		{name: "ftn.json", path: filepath.Join(rootConfigPath, "ftn.json"), reload: cw.reloadFTNOrigins},
 	}
 	cw.deferredTargets = []deferredTarget{
 		{
@@ -600,6 +601,27 @@ func (cw *ConfigWatcher) reloadEvents() {
 	slog.Info("events.json reloaded", "count", len(newEvents.Events))
 }
 
+// reloadFTNOrigins re-reads ftn.json and applies the per-network origin
+// overrides to the message manager. That is the only piece of ftn.json the
+// BBS process itself consumes at runtime — the binkd mailer re-reads the
+// file on its own export/respawn cycle, so its settings need no push from
+// here.
+func (cw *ConfigWatcher) reloadFTNOrigins() {
+	slog.Info("reloading ftn.json network origins")
+
+	if cw.menuExecutor == nil || cw.menuExecutor.MessageMgr == nil {
+		slog.Warn("message manager not running, restart required to apply ftn.json origins")
+		return
+	}
+	ftnCfg, err := config.LoadFTNConfig(cw.rootConfigPath)
+	if err != nil {
+		slog.Error("failed to reload ftn.json", "error", err)
+		return
+	}
+	cw.menuExecutor.MessageMgr.SetNetworkOrigins(ftnCfg.NetworkOrigins())
+	slog.Info("ftn.json network origins reloaded", "count", len(ftnCfg.NetworkOrigins()))
+}
+
 // reloadServerConfig reloads the server configuration.
 func (cw *ConfigWatcher) reloadServerConfig() {
 	slog.Info("reloading config.json")
@@ -629,6 +651,11 @@ func (cw *ConfigWatcher) reloadServerConfig() {
 		slog.Info("updated new user level", "level", newServerConfig.NewUserLevel)
 		cw.userMgr.SetAutoValidateNewUsers(newServerConfig.AutoValidateNewUsers)
 		slog.Info("updated auto-validate new users", "enabled", newServerConfig.AutoValidateNewUsers)
+	}
+
+	// Keep the message manager's fallback origin (the board name) current.
+	if cw.menuExecutor.MessageMgr != nil {
+		cw.menuExecutor.MessageMgr.SetBoardName(newServerConfig.BoardName)
 	}
 
 	// Push connection-security settings into the tracker. Without this the

--- a/cmd/vision3/config_watcher_deferred_test.go
+++ b/cmd/vision3/config_watcher_deferred_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -370,9 +371,12 @@ func TestValidateMessageAreasAcceptsEmptyFile(t *testing.T) {
 	}
 }
 
-// TestReloadFTNOriginsUpdatesMessageManager: an ftn.json origin edit reaches
-// the message manager's origin resolution without a restart.
-func TestReloadFTNOriginsUpdatesMessageManager(t *testing.T) {
+// TestReloadFTNOriginsThroughWatcher: an ftn.json origin edit reaches the
+// message manager's origin resolution without a restart — driven through the
+// real watcher construction and its polling path, so a regression that
+// unwires the ftn.json target fails here rather than passing on a direct
+// method call.
+func TestReloadFTNOriginsThroughWatcher(t *testing.T) {
 	tmp := t.TempDir()
 	configDir := filepath.Join(tmp, "configs")
 	if err := os.MkdirAll(configDir, 0755); err != nil {
@@ -382,19 +386,101 @@ func TestReloadFTNOriginsUpdatesMessageManager(t *testing.T) {
 		[]byte(`[{"id":1,"tag":"GEN","name":"General","network":"fidonet"}]`), 0644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(configDir, "ftn.json"),
+		[]byte(`{"networks":{"fidonet":{"origin":"Boot Origin"}}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
 	msgMgr, err := message.NewMessageManager(filepath.Join(tmp, "data"), configDir, "TestBBS", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	cw := &ConfigWatcher{rootConfigPath: configDir, menuExecutor: &menu.MenuExecutor{MessageMgr: msgMgr}}
 
+	var serverCfg config.ServerConfig
+	var serverCfgMu sync.RWMutex
+	e := &menu.MenuExecutor{MessageMgr: msgMgr}
+	cw, err := NewConfigWatcher(configDir, tmp, e, nil, &serverCfg, &serverCfgMu, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cw.Stop()
+
+	touchAt := func(path string, age time.Duration) {
+		t.Helper()
+		ts := time.Now().Add(age)
+		if err := os.Chtimes(path, ts, ts); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Edit ftn.json and let the real poll pick it up via its timestamp.
 	if err := os.WriteFile(filepath.Join(configDir, "ftn.json"),
 		[]byte(`{"networks":{"fidonet":{"origin":"Fresh Origin"}}}`), 0644); err != nil {
 		t.Fatal(err)
 	}
-	cw.reloadFTNOrigins()
+	touchAt(filepath.Join(configDir, "ftn.json"), time.Second)
+	cw.poll()
 
 	if got := msgMgr.OriginTextForNetwork("fidonet"); got != "Fresh Origin" {
-		t.Errorf("OriginTextForNetwork = %q after reload, want Fresh Origin", got)
+		t.Errorf("OriginTextForNetwork = %q after watcher poll, want Fresh Origin", got)
+	}
+
+	// And through the save sentinel, as v3config signals it.
+	if err := os.WriteFile(filepath.Join(configDir, "ftn.json"),
+		[]byte(`{"networks":{"fidonet":{"origin":"Sentinel Origin"}}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	touchAt(filepath.Join(configDir, "ftn.json"), 2*time.Second)
+	if err := config.TouchReloadSentinel(configDir); err != nil {
+		t.Fatal(err)
+	}
+	cw.poll()
+	if got := msgMgr.OriginTextForNetwork("fidonet"); got != "Sentinel Origin" {
+		t.Errorf("OriginTextForNetwork = %q after sentinel poll, want Sentinel Origin", got)
+	}
+}
+
+// TestServerConfigReloadUpdatesBoardNameFallback: a config.json boardName
+// edit reaches the message manager's fallback origin through the watcher's
+// reloadServerConfig wiring.
+func TestServerConfigReloadUpdatesBoardNameFallback(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "configs")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "message_areas.json"), []byte(`[]`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	msgMgr, err := message.NewMessageManager(filepath.Join(tmp, "data"), configDir, "OldBoard", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var serverCfg config.ServerConfig
+	var serverCfgMu sync.RWMutex
+	e := &menu.MenuExecutor{MessageMgr: msgMgr}
+	cw := &ConfigWatcher{
+		rootConfigPath: configDir,
+		menuExecutor:   e,
+		serverConfig:   &serverCfg,
+		serverConfigMu: &serverCfgMu,
+	}
+
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"),
+		[]byte(`{"boardName":"New Board"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cw.reloadServerConfig()
+	if got := msgMgr.OriginTextForNetwork("any"); got != "New Board" {
+		t.Errorf("fallback origin = %q after config.json reload, want New Board", got)
+	}
+
+	// A malformed config.json must leave the fallback untouched.
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{broken`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cw.reloadServerConfig()
+	if got := msgMgr.OriginTextForNetwork("any"); got != "New Board" {
+		t.Errorf("fallback origin = %q after malformed reload, want New Board (unchanged)", got)
 	}
 }

--- a/cmd/vision3/config_watcher_deferred_test.go
+++ b/cmd/vision3/config_watcher_deferred_test.go
@@ -369,3 +369,32 @@ func TestValidateMessageAreasAcceptsEmptyFile(t *testing.T) {
 		t.Errorf("validateMessageAreas rejected an empty file: %v", err)
 	}
 }
+
+// TestReloadFTNOriginsUpdatesMessageManager: an ftn.json origin edit reaches
+// the message manager's origin resolution without a restart.
+func TestReloadFTNOriginsUpdatesMessageManager(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "configs")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "message_areas.json"),
+		[]byte(`[{"id":1,"tag":"GEN","name":"General","network":"fidonet"}]`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	msgMgr, err := message.NewMessageManager(filepath.Join(tmp, "data"), configDir, "TestBBS", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cw := &ConfigWatcher{rootConfigPath: configDir, menuExecutor: &menu.MenuExecutor{MessageMgr: msgMgr}}
+
+	if err := os.WriteFile(filepath.Join(configDir, "ftn.json"),
+		[]byte(`{"networks":{"fidonet":{"origin":"Fresh Origin"}}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cw.reloadFTNOrigins()
+
+	if got := msgMgr.OriginTextForNetwork("fidonet"); got != "Fresh Origin" {
+		t.Errorf("OriginTextForNetwork = %q after reload, want Fresh Origin", got)
+	}
+}

--- a/cmd/vision3/main.go
+++ b/cmd/vision3/main.go
@@ -1924,7 +1924,12 @@ func main() {
 				if strings.HasPrefix(body, "\x01V3NETUUID: ") {
 					return
 				}
-				msg := v3net.BuildWireMessage(binding.Network, area.Tag, svc.NodeID(), serverConfig.BoardName, from, to, subject, body, binding.Origin)
+				// Read through the executor's atomic snapshot, not the shared
+				// serverConfig var: this closure runs at post time, racing the
+				// config watcher's reload writes. It also means a renamed
+				// board flows into wire messages, matching the message
+				// manager's now-live fallback origin.
+				msg := v3net.BuildWireMessage(binding.Network, area.Tag, svc.NodeID(), menuExecutor.GetServerConfig().BoardName, from, to, subject, body, binding.Origin)
 				if err := svc.SendMessage(binding.Network, msg); err != nil {
 					slog.Error("V3Net: failed to send message", "network", binding.Network, "error", err)
 					return
@@ -1955,7 +1960,10 @@ func main() {
 				if lerr != nil {
 					return lerr
 				}
-				return svc.ReloadLeaves(fresh.Leaves, messageMgr, confMgr, serverConfig.BoardName)
+				// Atomic snapshot, not the shared var: this hook runs at
+				// reload time, and the current board name is the right
+				// default origin for freshly built leaf bindings.
+				return svc.ReloadLeaves(fresh.Leaves, messageMgr, confMgr, menuExecutor.GetServerConfig().BoardName)
 			}
 			slog.Info("V3Net service started",
 				"node_id", v3netService.NodeID(),

--- a/cmd/vision3/main.go
+++ b/cmd/vision3/main.go
@@ -1896,10 +1896,20 @@ func main() {
 			// ReloadLeaves can rebuild them and these callbacks pick up the
 			// new set on their next call.
 			nodeID := svc.NodeID()
-			svc.ConfigureLeaves(v3netConfig.Leaves, messageMgr, serverConfig.BoardName)
+			svc.ConfigureLeaves(v3netConfig.Leaves, messageMgr)
 
 			// Append tearline/origin to local JAM copy for V3Net areas so
 			// the user sees the origin on locally-created messages too.
+			// v3netOrigin resolves a binding's origin, applying the board-name
+			// fallback at use time (through the executor's atomic snapshot)
+			// so a renamed board reaches blank-origin areas immediately.
+			v3netOrigin := func(binding v3net.AreaBinding) string {
+				if binding.Origin != "" {
+					return binding.Origin
+				}
+				return menuExecutor.GetServerConfig().BoardName
+			}
+
 			messageMgr.BodyTransform = func(areaID int, body string) string {
 				binding, ok := svc.AreaBindingFor(areaID)
 				if !ok {
@@ -1911,7 +1921,7 @@ func main() {
 				if strings.Contains(body, "\n--- ") || strings.HasPrefix(body, "--- ") {
 					return body
 				}
-				return v3net.AppendV3NetOrigin(body, v3net.DefaultTearline(), binding.Origin, nodeID)
+				return v3net.AppendV3NetOrigin(body, v3net.DefaultTearline(), v3netOrigin(binding), nodeID)
 			}
 
 			// Hook message posts to forward to V3Net when posted to a networked area.
@@ -1929,7 +1939,7 @@ func main() {
 				// config watcher's reload writes. It also means a renamed
 				// board flows into wire messages, matching the message
 				// manager's now-live fallback origin.
-				msg := v3net.BuildWireMessage(binding.Network, area.Tag, svc.NodeID(), menuExecutor.GetServerConfig().BoardName, from, to, subject, body, binding.Origin)
+				msg := v3net.BuildWireMessage(binding.Network, area.Tag, svc.NodeID(), menuExecutor.GetServerConfig().BoardName, from, to, subject, body, v3netOrigin(binding))
 				if err := svc.SendMessage(binding.Network, msg); err != nil {
 					slog.Error("V3Net: failed to send message", "network", binding.Network, "error", err)
 					return
@@ -1960,10 +1970,7 @@ func main() {
 				if lerr != nil {
 					return lerr
 				}
-				// Atomic snapshot, not the shared var: this hook runs at
-				// reload time, and the current board name is the right
-				// default origin for freshly built leaf bindings.
-				return svc.ReloadLeaves(fresh.Leaves, messageMgr, confMgr, menuExecutor.GetServerConfig().BoardName)
+				return svc.ReloadLeaves(fresh.Leaves, messageMgr, confMgr)
 			}
 			slog.Info("V3Net service started",
 				"node_id", v3netService.NodeID(),

--- a/cmd/vision3/main.go
+++ b/cmd/vision3/main.go
@@ -1735,18 +1735,7 @@ func main() {
 	if ftnErr != nil {
 		slog.Error("failed to load FTN config, echomail disabled", "error", ftnErr)
 	}
-	networkOrigins := make(map[string]string)
-	if ftnErr == nil {
-		for name, netCfg := range ftnConfig.Networks {
-			if strings.TrimSpace(netCfg.Origin) == "" {
-				continue
-			}
-			networkOrigins[strings.ToLower(strings.TrimSpace(name))] = netCfg.Origin
-		}
-	}
-	if len(networkOrigins) == 0 {
-		networkOrigins = nil
-	}
+	networkOrigins := ftnConfig.NetworkOrigins()
 
 	// Oneliners are loaded by the runnable; start with an empty list here.
 	oneliners := []string{}

--- a/docs/sysop/configuration/configuration.md
+++ b/docs/sysop/configuration/configuration.md
@@ -965,7 +965,7 @@ the TUI signals the BBS once every file in the save has been written.
 | `configs/conferences.json` | A caller whose conference was removed sees "None" and re-selects |
 | `configs/archivers.json` | Re-read on each archive operation |
 | IP blocklist/allowlist files | Watched separately, reloaded on save |
-| `configs/ftn.json` | Origin lines apply on save; the binkd mailer picks up the rest on its next cycle |
+| `configs/ftn.json` | Origin lines apply on save; the mailer's runtime settings (port, log level, links) apply on its next cycle. Enabling or disabling the binkd mailer itself still requires a restart |
 
 Connection-security settings in `config.json` — `maxNodes`, `maxConnectionsPerIP`,
 `maxFailedLogins`, `lockoutMinutes`, the connection rate limiter, and the
@@ -1010,8 +1010,11 @@ difference is that nothing touches it automatically, so it is the explicit
 **Still requires a restart:**
 
 - Listening ports and hosts (`sshPort`, `sshHost`, `telnetPort`, `telnetHost`)
-- `boardName`'s startup copies: the WFC header, V3Net identity, and QWK packet
-  headers (new message origin lines pick up a renamed board immediately)
+- `boardName`'s startup copies: the WFC header, the V3Net identity sent in
+  subscribe requests, and the QWK **API** service's packet headers.
+  Everything else follows a rename immediately: message origin lines,
+  V3Net wire messages and blank-origin tearlines, and interactive QWK
+  packets (built fresh per operation)
 - Enabling or disabling a protocol (`sshEnabled`, `telnetEnabled`)
 - SSH host keys
 - The QWK API listener

--- a/docs/sysop/configuration/configuration.md
+++ b/docs/sysop/configuration/configuration.md
@@ -965,7 +965,7 @@ the TUI signals the BBS once every file in the save has been written.
 | `configs/conferences.json` | A caller whose conference was removed sees "None" and re-selects |
 | `configs/archivers.json` | Re-read on each archive operation |
 | IP blocklist/allowlist files | Watched separately, reloaded on save |
-| `configs/ftn.json` | Picked up by the binkd mailer on its next cycle |
+| `configs/ftn.json` | Origin lines apply on save; the binkd mailer picks up the rest on its next cycle |
 
 Connection-security settings in `config.json` — `maxNodes`, `maxConnectionsPerIP`,
 `maxFailedLogins`, `lockoutMinutes`, the connection rate limiter, and the
@@ -1010,6 +1010,8 @@ difference is that nothing touches it automatically, so it is the explicit
 **Still requires a restart:**
 
 - Listening ports and hosts (`sshPort`, `sshHost`, `telnetPort`, `telnetHost`)
+- `boardName`'s startup copies: the WFC header, V3Net identity, and QWK packet
+  headers (new message origin lines pick up a renamed board immediately)
 - Enabling or disabling a protocol (`sshEnabled`, `telnetEnabled`)
 - SSH host keys
 - The QWK API listener

--- a/internal/config/config_ftn.go
+++ b/internal/config/config_ftn.go
@@ -259,3 +259,21 @@ func (c *FTNConfig) ResolvePaths(root string) {
 		c.DupeDBPath = resolve(c.DupeDBPath)
 	}
 }
+
+// NetworkOrigins collects each network's origin-line override, keyed by
+// lower-cased network name. Networks with no origin set are omitted; an
+// empty result returns nil. Shared by startup and the ftn.json reload so
+// both build the same map.
+func (c FTNConfig) NetworkOrigins() map[string]string {
+	origins := make(map[string]string)
+	for name, netCfg := range c.Networks {
+		if strings.TrimSpace(netCfg.Origin) == "" {
+			continue
+		}
+		origins[strings.ToLower(strings.TrimSpace(name))] = netCfg.Origin
+	}
+	if len(origins) == 0 {
+		return nil
+	}
+	return origins
+}

--- a/internal/message/manager.go
+++ b/internal/message/manager.go
@@ -129,16 +129,37 @@ func normalizeNetworkOrigins(input map[string]string) map[string]string {
 	return out
 }
 
-// originTextForNetwork returns the origin line text for an area on the given
+// OriginTextForNetwork returns the origin line text for an area on the given
 // network, falling back to the board name when the network sets none.
-func (mm *MessageManager) originTextForNetwork(network string) string {
+func (mm *MessageManager) OriginTextForNetwork(network string) string {
 	key := strings.ToLower(strings.TrimSpace(network))
+	mm.mu.RLock()
+	defer mm.mu.RUnlock()
 	if key != "" && mm.networkOrigins != nil {
 		if origin := mm.networkOrigins[key]; origin != "" {
 			return origin
 		}
 	}
 	return mm.boardName
+}
+
+// SetNetworkOrigins replaces the per-network origin overrides, applied when
+// ftn.json is reloaded. Messages already being posted keep the origin they
+// resolved; subsequent posts use the new set.
+func (mm *MessageManager) SetNetworkOrigins(origins map[string]string) {
+	normalized := normalizeNetworkOrigins(origins)
+	mm.mu.Lock()
+	mm.networkOrigins = normalized
+	mm.mu.Unlock()
+}
+
+// SetBoardName replaces the fallback origin text, applied when config.json's
+// boardName is reloaded. Other boardName consumers (the WFC header, V3Net
+// identity, QWK packet headers) still read theirs at startup.
+func (mm *MessageManager) SetBoardName(name string) {
+	mm.mu.Lock()
+	mm.boardName = name
+	mm.mu.Unlock()
 }
 
 // Close is a no-op now that bases are opened on-demand.

--- a/internal/message/manager_post.go
+++ b/internal/message/manager_post.go
@@ -72,7 +72,7 @@ func (mm *MessageManager) addMessage(areaID int, from, to, subject, body, replyT
 	var msgNum int
 	if msgType.IsEchomail() || msgType.IsNetmail() {
 		msg.OrigAddr = area.OriginAddr
-		msgNum, err = b.WriteMessageExt(msg, msgType, area.EchoTag, mm.originTextForNetwork(area.Network))
+		msgNum, err = b.WriteMessageExt(msg, msgType, area.EchoTag, mm.OriginTextForNetwork(area.Network))
 	} else {
 		msgNum, err = b.WriteMessage(msg)
 	}

--- a/internal/message/origins_test.go
+++ b/internal/message/origins_test.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"strings"
 	"sync"
 	"testing"
 )
@@ -77,4 +78,47 @@ func TestOriginSettersRaceWithReads(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// TestEchomailPostCarriesOrigin posts real echomail through addMessage's
+// WriteMessageExt path and reads the JAM text back, so the integration point
+// between the manager and the origin line is covered — not just the
+// OriginTextForNetwork accessor. It then updates the origins and the board
+// name and posts again, proving the hot-reload path reaches actual messages.
+func TestEchomailPostCarriesOrigin(t *testing.T) {
+	dataDir, configDir := t.TempDir(), t.TempDir()
+	// origin_addr matters: the JAM writer only appends " * Origin:" when the
+	// area has an FTN address to stamp it with.
+	writeMsgAreas(t, configDir, `[{"id":1,"tag":"ECHO","name":"Echo","area_type":"echomail","echo_tag":"TEST_ECHO","network":"fidonet","origin_addr":"21:3/110"}]`)
+	mm, err := NewMessageManager(dataDir, configDir, "Fallback Board", map[string]string{"fidonet": "Configured Origin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	postAndRead := func(subject string) string {
+		t.Helper()
+		msgNum, err := mm.AddMessage(1, "Alice", "All", subject, "hello there", "")
+		if err != nil {
+			t.Fatalf("AddMessage: %v", err)
+		}
+		msg, err := mm.GetMessage(1, msgNum)
+		if err != nil {
+			t.Fatalf("GetMessage: %v", err)
+		}
+		return msg.Body
+	}
+
+	if body := postAndRead("first"); !strings.Contains(body, "Configured Origin") {
+		t.Errorf("posted echomail body missing configured origin:\n%s", body)
+	}
+
+	mm.SetNetworkOrigins(nil) // drop the override: fallback takes over
+	if body := postAndRead("second"); !strings.Contains(body, "Fallback Board") {
+		t.Errorf("posted echomail body missing board-name fallback:\n%s", body)
+	}
+
+	mm.SetBoardName("Renamed Board")
+	if body := postAndRead("third"); !strings.Contains(body, "Renamed Board") {
+		t.Errorf("posted echomail body missing renamed fallback:\n%s", body)
+	}
 }

--- a/internal/message/origins_test.go
+++ b/internal/message/origins_test.go
@@ -1,0 +1,80 @@
+package message
+
+import (
+	"sync"
+	"testing"
+)
+
+func originsTestManager(t *testing.T) *MessageManager {
+	t.Helper()
+	dataDir, configDir := t.TempDir(), t.TempDir()
+	writeMsgAreas(t, configDir, `[{"id":1,"tag":"GEN","name":"General","network":"fidonet"}]`)
+	mm, err := NewMessageManager(dataDir, configDir, "InitialBoard", map[string]string{"fidonet": "Initial Origin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return mm
+}
+
+func TestSetNetworkOriginsApplies(t *testing.T) {
+	mm := originsTestManager(t)
+
+	if got := mm.OriginTextForNetwork("fidonet"); got != "Initial Origin" {
+		t.Fatalf("initial origin = %q", got)
+	}
+
+	mm.SetNetworkOrigins(map[string]string{"FidoNet ": "New Origin"}) // normalization applies
+	if got := mm.OriginTextForNetwork("fidonet"); got != "New Origin" {
+		t.Errorf("origin after SetNetworkOrigins = %q, want New Origin", got)
+	}
+
+	// Clearing the overrides falls back to the board name.
+	mm.SetNetworkOrigins(nil)
+	if got := mm.OriginTextForNetwork("fidonet"); got != "InitialBoard" {
+		t.Errorf("origin after clearing = %q, want InitialBoard", got)
+	}
+}
+
+func TestSetBoardNameAppliesToFallback(t *testing.T) {
+	mm := originsTestManager(t)
+	mm.SetNetworkOrigins(nil)
+
+	mm.SetBoardName("Renamed BBS")
+	if got := mm.OriginTextForNetwork("unlisted-net"); got != "Renamed BBS" {
+		t.Errorf("fallback origin = %q, want Renamed BBS", got)
+	}
+}
+
+// TestOriginSettersRaceWithReads proves the newly-mutable fields are safe
+// against the post path's reads under -race.
+func TestOriginSettersRaceWithReads(t *testing.T) {
+	mm := originsTestManager(t)
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(done)
+		for i := 0; i < 2000; i++ {
+			mm.SetNetworkOrigins(map[string]string{"fidonet": "Origin A"})
+			mm.SetBoardName("Board B")
+		}
+	}()
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				_ = mm.OriginTextForNetwork("fidonet")
+				_ = mm.OriginTextForNetwork("other")
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/v3net/reload_test.go
+++ b/internal/v3net/reload_test.go
@@ -72,7 +72,7 @@ func leafCfg(network, board string) config.V3NetLeafConfig {
 // running, and the area bindings follow.
 func TestReloadLeavesSwapsSubscriptions(t *testing.T) {
 	svc, mm := newReloadFixture(t, "ALPHA", "BETA")
-	svc.ConfigureLeaves([]config.V3NetLeafConfig{leafCfg("net-a", "ALPHA")}, mm, "TestBBS")
+	svc.ConfigureLeaves([]config.V3NetLeafConfig{leafCfg("net-a", "ALPHA")}, mm)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	started := make(chan struct{})
@@ -93,7 +93,7 @@ func TestReloadLeavesSwapsSubscriptions(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- svc.ReloadLeaves([]config.V3NetLeafConfig{leafCfg("net-b", "BETA")}, mm, nil, "TestBBS")
+		done <- svc.ReloadLeaves([]config.V3NetLeafConfig{leafCfg("net-b", "BETA")}, mm, nil)
 	}()
 	select {
 	case err := <-done:
@@ -111,8 +111,8 @@ func TestReloadLeavesSwapsSubscriptions(t *testing.T) {
 		t.Errorf("old binding survived reload: NetworkForArea(ALPHA) = %q", got)
 	}
 	betaArea, _ := mm.GetAreaByTag("BETA")
-	if b, ok := svc.AreaBindingFor(betaArea.ID); !ok || b.Network != "net-b" || b.Origin != "TestBBS" {
-		t.Errorf("AreaBindingFor(BETA) = %+v ok=%v, want net-b/TestBBS", b, ok)
+	if b, ok := svc.AreaBindingFor(betaArea.ID); !ok || b.Network != "net-b" || b.Origin != "" {
+		t.Errorf("AreaBindingFor(BETA) = %+v ok=%v, want net-b with empty origin (fallback applies at use time)", b, ok)
 	}
 
 	// SendMessage to the removed network is a silent no-op, matching the
@@ -128,9 +128,9 @@ func TestReloadLeavesSwapsSubscriptions(t *testing.T) {
 // swaps configuration without starting anything.
 func TestReloadLeavesBeforeStart(t *testing.T) {
 	svc, mm := newReloadFixture(t, "ALPHA", "BETA")
-	svc.ConfigureLeaves([]config.V3NetLeafConfig{leafCfg("net-a", "ALPHA")}, mm, "TestBBS")
+	svc.ConfigureLeaves([]config.V3NetLeafConfig{leafCfg("net-a", "ALPHA")}, mm)
 
-	if err := svc.ReloadLeaves([]config.V3NetLeafConfig{leafCfg("net-b", "BETA")}, mm, nil, "TestBBS"); err != nil {
+	if err := svc.ReloadLeaves([]config.V3NetLeafConfig{leafCfg("net-b", "BETA")}, mm, nil); err != nil {
 		t.Fatalf("ReloadLeaves before Start: %v", err)
 	}
 	if got := svc.LeafNetworks(); len(got) != 1 || got[0] != "net-b" {
@@ -151,7 +151,7 @@ func TestReloadLeavesRaceWithReaders(t *testing.T) {
 			if i%2 == 1 {
 				cfgs = []config.V3NetLeafConfig{leafCfg("net-b", "BETA")}
 			}
-			if err := svc.ReloadLeaves(cfgs, mm, nil, "TestBBS"); err != nil {
+			if err := svc.ReloadLeaves(cfgs, mm, nil); err != nil {
 				t.Errorf("ReloadLeaves: %v", err)
 				return
 			}

--- a/internal/v3net/service.go
+++ b/internal/v3net/service.go
@@ -57,7 +57,10 @@ type Service struct {
 }
 
 // AreaBinding ties a message area to the V3Net network it is subscribed on
-// and the origin line its outbound messages carry.
+// and the origin line its outbound messages carry. Origin is the leaf
+// config's value verbatim and may be EMPTY: the board-name fallback is
+// applied by the consumer at use time, not baked in here, so a renamed
+// board reaches blank-origin areas without a reload.
 type AreaBinding struct {
 	Network string
 	Origin  string
@@ -506,16 +509,13 @@ func (s *Service) ConfigPath() string {
 // ConfigureLeaves builds and registers a leaf client for every subscription
 // in leafCfgs: board tags are resolved against the message manager, a JAM
 // router is wired per network, and each resolved area is bound to its
-// network and origin. Unresolvable boards and networks with no resolvable
-// boards are skipped with a warning, matching historical startup behavior.
-// If the service is already running, new leaves start immediately.
-func (s *Service) ConfigureLeaves(leafCfgs []config.V3NetLeafConfig, mgr *message.MessageManager, defaultOrigin string) {
+// network and configured origin (possibly empty — see AreaBinding).
+// Unresolvable boards and networks with no resolvable boards are skipped
+// with a warning, matching historical startup behavior. If the service is
+// already running, new leaves start immediately.
+func (s *Service) ConfigureLeaves(leafCfgs []config.V3NetLeafConfig, mgr *message.MessageManager) {
 	for _, lcfg := range leafCfgs {
 		router := NewJAMRouter()
-		origin := lcfg.Origin
-		if origin == "" {
-			origin = defaultOrigin
-		}
 		var resolvedBoards []string
 		for _, tag := range lcfg.Boards {
 			area, ok := mgr.GetAreaByTag(tag)
@@ -525,7 +525,7 @@ func (s *Service) ConfigureLeaves(leafCfgs []config.V3NetLeafConfig, mgr *messag
 			}
 			router.Add(tag, NewJAMAdapter(mgr, area.ID))
 			resolvedBoards = append(resolvedBoards, tag)
-			s.RegisterArea(area.ID, lcfg.Network, origin)
+			s.RegisterArea(area.ID, lcfg.Network, lcfg.Origin)
 		}
 		if len(resolvedBoards) == 0 {
 			slog.Warn("V3Net leaf: no resolvable boards, skipping", "network", lcfg.Network)
@@ -552,7 +552,7 @@ func (s *Service) ConfigureLeaves(leafCfgs []config.V3NetLeafConfig, mgr *messag
 //
 // Hub settings, the enabled flag, and keystore/dedup paths are NOT touched;
 // those still require a restart.
-func (s *Service) ReloadLeaves(leafCfgs []config.V3NetLeafConfig, mgr *message.MessageManager, confMgr *conference.ConferenceManager, defaultOrigin string) error {
+func (s *Service) ReloadLeaves(leafCfgs []config.V3NetLeafConfig, mgr *message.MessageManager, confMgr *conference.ConferenceManager) error {
 	s.reloadMu.Lock()
 	defer s.reloadMu.Unlock()
 
@@ -575,7 +575,7 @@ func (s *Service) ReloadLeaves(leafCfgs []config.V3NetLeafConfig, mgr *message.M
 	}
 	slog.Info("v3net: leaf subscriptions stopped for reload", "count", len(old))
 
-	s.ConfigureLeaves(leafCfgs, mgr, defaultOrigin)
+	s.ConfigureLeaves(leafCfgs, mgr)
 
 	s.mu.RLock()
 	count := len(s.leaves)


### PR DESCRIPTION
## Summary

Closes the one gap a post-completion audit found against #311's ranked list: **`ftn.json` origin lines** (the "medium tier" `networkOrigins` item) never landed. Per-network origin overrides — and `boardName`, their fallback — were snapshotted into the message manager at boot, so editing an origin line or renaming the board didn't reach new messages' origin lines until a restart.

## Changes

- `MessageManager` gains `SetNetworkOrigins` / `SetBoardName` under its existing lock; the post path's origin read (previously unguarded, safe only while the fields were immutable) now takes `RLock`
- The origins-map construction moves from a loop in `main` onto `config.FTNConfig.NetworkOrigins()`, so startup and reload build the same map by definition
- `ftn.json` joins the watcher's **immediate** targets for exactly this one field — the binkd mailer already re-reads the file on its own export/respawn cycle, so nothing else needs a push (the reload handler's comment says so, to head off "why doesn't this reload everything" confusion)
- `config.json` reloads propagate `boardName` to the message manager's fallback
- Docs: the `ftn.json` row now says origins apply on save; the restart-required list gains an honest entry for `boardName`'s other startup copies (WFC header, V3Net identity, QWK packet headers), which the docs previously implied were live

## Verification

- Origin swap, normalization, and clear-to-fallback tests; a setter-vs-post-path race test under `-race`; a watcher end-to-end test (`ftn.json` edit → `OriginTextForNetwork` returns the new origin)
- Full suite green; unix + `GOOS=windows` builds; vet clean

With this, the #311 table is genuinely complete rather than complete-minus-one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FTN network-origin text now updates immediately when configuration changes are saved.
  * Message origins support configurable network-specific text, with the board name as a fallback.
  * Server configuration reloads now apply updated board names to newly generated message origins.

* **Documentation**
  * Clarified which FTN settings apply immediately and which require a restart or the next binkd cycle.

* **Tests**
  * Added coverage for configuration reloads, origin fallbacks, normalization, and concurrent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->