### PR TITLE
fix(lastcallers): hide invisible logins from every viewer

### DIFF
--- a/internal/menu/executor_lastcallers.go
+++ b/internal/menu/executor_lastcallers.go
@@ -22,7 +22,6 @@ func runLastCallers(c *cmdCtx, args string) (*user.User, string, error) {
 	s := c.s
 	terminal := c.terminal
 	userManager := c.userManager
-	currentUser := c.currentUser
 	nodeNumber := c.nodeNumber
 	outputMode := c.outputMode
 	termWidth := c.termWidth
@@ -72,17 +71,7 @@ func runLastCallers(c *cmdCtx, args string) (*user.User, string, error) {
 	// --- END Template Processing ---
 
 	// 2. Get last callers data from UserManager
-	lastCallers := userManager.GetLastCallers()
-	// Filter out invisible call records for non-CoSysOp viewers
-	if !e.isCoSysOpOrAbove(currentUser) {
-		filtered := make([]user.CallRecord, 0, len(lastCallers))
-		for _, rec := range lastCallers {
-			if !rec.Invisible {
-				filtered = append(filtered, rec)
-			}
-		}
-		lastCallers = filtered
-	}
+	lastCallers := visibleCallRecords(userManager.GetLastCallers())
 	users := userManager.GetAllUsers()
 	totalUsers := len(users)
 	userNotesByID := make(map[int]string, len(users))
@@ -197,4 +186,18 @@ func runLastCallers(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	return nil, "", nil // Success
+}
+
+// visibleCallRecords drops call records made by users who declined the
+// "add this login to the last caller list?" prompt. The exclusion applies to
+// every viewer, including the SysOp: the caller asked not to be listed, so the
+// login must not appear on the screen no matter who is looking (issue #334).
+func visibleCallRecords(records []user.CallRecord) []user.CallRecord {
+	visible := make([]user.CallRecord, 0, len(records))
+	for _, rec := range records {
+		if !rec.Invisible {
+			visible = append(visible, rec)
+		}
+	}
+	return visible
 }

--- a/internal/menu/executor_lastcallers_test.go
+++ b/internal/menu/executor_lastcallers_test.go
@@ -1,0 +1,41 @@
+package menu
+
+import (
+	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/user"
+)
+
+// TestVisibleCallRecords_HidesInvisibleForEveryViewer covers issue #334: a
+// login recorded as invisible must be dropped from the last callers list
+// regardless of who is viewing it. The filter takes no viewer, so a SysOp
+// looking at the list gets exactly the same rows as any other user.
+func TestVisibleCallRecords_HidesInvisibleForEveryViewer(t *testing.T) {
+	records := []user.CallRecord{
+		{UserID: 1, Handle: "sysop", Invisible: true},
+		{UserID: 2, Handle: "alice"},
+		{UserID: 1, Handle: "sysop", Invisible: true},
+		{UserID: 3, Handle: "bob"},
+	}
+
+	got := visibleCallRecords(records)
+
+	if len(got) != 2 {
+		t.Fatalf("visibleCallRecords returned %d records, want 2: %+v", len(got), got)
+	}
+	if got[0].Handle != "alice" || got[1].Handle != "bob" {
+		t.Errorf("visibleCallRecords order/content wrong: got %q, %q", got[0].Handle, got[1].Handle)
+	}
+	for _, rec := range got {
+		if rec.Invisible {
+			t.Errorf("invisible record %q leaked into the visible list", rec.Handle)
+		}
+	}
+}
+
+func TestVisibleCallRecords_EmptyInputIsEmptyNonNil(t *testing.T) {
+	got := visibleCallRecords(nil)
+	if got == nil || len(got) != 0 {
+		t.Fatalf("visibleCallRecords(nil) = %v, want empty non-nil slice", got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #334.

A user at or above the invisible level who answers "no" to the last-caller-list prompt is recorded with the `Invisible` flag. The last callers screen only dropped those records for viewers below CoSysOp level, so the SysOp kept seeing their own hidden logins accumulate on every login.

The filter now applies to every viewer. The prompt asks whether to add the login to the list, so a "no" should mean the login never appears, no matter who is looking.

## Changes

- `internal/menu/executor_lastcallers.go`: replace the viewer-level branch with a `visibleCallRecords` helper that drops invisible records unconditionally. The now-unused `currentUser` local is removed.
- `internal/menu/executor_lastcallers_test.go`: new tests covering the filter and the empty-input case.

## Not changed

The call is still written to the history file with the flag set, so the global call number and the on-disk history are unaffected. Only the display changes.

## Verification

- `go vet ./internal/menu/` clean
- `go test ./internal/menu/ ./internal/user/` pass
- `go build ./...` succeeds
