### PR TITLE
fix(lastcallers): fill the screen with 20 visible callers

### DIFF
--- a/docs/sysop/menus/menu-system.md
+++ b/docs/sysop/menus/menu-system.md
@@ -839,14 +839,19 @@ Command usage examples:
 ```json
 {
   "KEYS": "LC",
-  "CMD": "RUN:LASTCALLERS 10",
+  "CMD": "RUN:LASTCALLERS 20",
   "ACS": "*",
   "HIDDEN": false
 }
 ```
 
-- `RUN:LASTCALLERS` - Uses default limit of 10 entries
+- `RUN:LASTCALLERS` - Uses default limit of 20 entries
 - `RUN:LASTCALLERS 25` - Shows last 25 entries
+
+The limit counts entries the viewer actually sees: logins hidden by the
+invisible logon prompt are filtered out before it is applied, so they never
+consume a row. Stored history is deeper than the display limit
+(`callHistoryLimit`), so hidden logins cannot push real callers off the screen.
 
 Template files:
 

--- a/docs/sysop/users/user-management.md
+++ b/docs/sysop/users/user-management.md
@@ -620,12 +620,12 @@ Invisible Logon? Y/n
 
 If they choose **Yes**, the session is flagged invisible for its duration. Invisible sessions are:
 
-- **Hidden from Last Callers** — non-CoSysOp users do not see the call in `RUN:LASTCALLERS`. The call is still logged to `callhistory.json` with `"invisible": true`.
+- **Hidden from Last Callers** — the call does not appear in `RUN:LASTCALLERS` for *any* viewer, including the SysOp: the prompt asks whether to list the login, so declining hides it from everyone. The call is still logged to `callhistory.json` with `"invisible": true`, and the global call counter still advances.
 - **Hidden from Who's Online** — invisible sessions are excluded from `RUN:WHOONLINE` listings and the `NODECT` token count for non-CoSysOp viewers.
 - **Hidden from Page** — invisible nodes do not appear in the page node list and are treated as offline for non-CoSysOp users attempting to page them.
 - **Silent in Chat** — join and leave announcements are suppressed in `RUN:CHAT` for invisible users (they can still chat normally).
 
-**CoSysOp/SysOp users can always see invisible sessions** across all of the above views.
+**CoSysOp/SysOp users can always see invisible sessions** in Who's Online, Page, and Chat. Last Callers is the exception: a declined login is hidden from every viewer.
 
 ### Configuration
 

--- a/internal/menu/executor_lastcallers.go
+++ b/internal/menu/executor_lastcallers.go
@@ -29,8 +29,10 @@ func runLastCallers(c *cmdCtx, args string) (*user.User, string, error) {
 
 	slog.Debug("running LASTCALLERS", "node", nodeNumber)
 
-	// Parse optional caller count argument (e.g., RUN:LASTCALLERS 10)
-	callerLimit := 10
+	// Parse optional caller count argument (e.g., RUN:LASTCALLERS 25).
+	// The default fills the screen; an explicit argument overrides it in either
+	// direction, so a larger request is honoured rather than capped.
+	callerLimit := defaultLastCallerRows
 	if strings.TrimSpace(args) != "" {
 		if parsedLimit, parseErr := strconv.Atoi(strings.TrimSpace(args)); parseErr == nil && parsedLimit > 0 {
 			callerLimit = parsedLimit
@@ -82,9 +84,7 @@ func runLastCallers(c *cmdCtx, args string) (*user.User, string, error) {
 		userNotesByID[userRecord.ID] = userRecord.PrivateNote
 	}
 	timeLoc := getLastCallerTimeLocation(strings.TrimSpace(e.GetServerConfig().Timezone))
-	if callerLimit > 0 && len(lastCallers) > callerLimit {
-		lastCallers = lastCallers[len(lastCallers)-callerLimit:]
-	}
+	lastCallers = mostRecentCallRecords(lastCallers, callerLimit)
 
 	processedTopTemplate = renderLastCallerGlobalATTokens(processedTopTemplate, totalUsers)
 	processedBotTemplate = renderLastCallerGlobalATTokens(processedBotTemplate, totalUsers)
@@ -188,21 +188,15 @@ func runLastCallers(c *cmdCtx, args string) (*user.User, string, error) {
 	return nil, "", nil // Success
 }
 
-// lastCallersDisplayLimit caps how many rows the last callers screen renders.
-// The cap is applied to the visible records only, so a board whose stored
-// history is mostly hidden SysOp logins still fills the screen with real
-// callers instead of showing a handful of rows.
-const lastCallersDisplayLimit = 20
+// defaultLastCallerRows is how many callers the screen shows when the menu
+// command passes no count. Hidden logins are filtered out before this limit is
+// applied, so it is a count of real callers rather than of stored records.
+const defaultLastCallerRows = 20
 
 // visibleCallRecords drops call records made by users who declined the
-// "add this login to the last caller list?" prompt, then keeps the most recent
-// lastCallersDisplayLimit of what remains. The exclusion applies to every
-// viewer, including the SysOp: the caller asked not to be listed, so the login
-// must not appear on the screen no matter who is looking (issue #334).
-//
-// Hidden records are removed before the cap so they cannot consume display
-// slots. Chronological order is preserved (oldest kept record first), which is
-// the order LASTCALL.MID expects.
+// "add this login to the last caller list?" prompt. The exclusion applies to
+// every viewer, including the SysOp: the caller asked not to be listed, so the
+// login must not appear on the screen no matter who is looking (issue #334).
 func visibleCallRecords(records []user.CallRecord) []user.CallRecord {
 	visible := make([]user.CallRecord, 0, len(records))
 	for _, rec := range records {
@@ -210,8 +204,16 @@ func visibleCallRecords(records []user.CallRecord) []user.CallRecord {
 			visible = append(visible, rec)
 		}
 	}
-	if len(visible) > lastCallersDisplayLimit {
-		visible = visible[len(visible)-lastCallersDisplayLimit:]
-	}
 	return visible
+}
+
+// mostRecentCallRecords keeps the newest limit records, preserving the
+// oldest-first order LASTCALL.MID renders. A limit of zero or less keeps
+// everything. Callers must filter hidden records first so that the limit
+// counts rows the viewer will actually see.
+func mostRecentCallRecords(records []user.CallRecord, limit int) []user.CallRecord {
+	if limit <= 0 || len(records) <= limit {
+		return records
+	}
+	return records[len(records)-limit:]
 }

--- a/internal/menu/executor_lastcallers.go
+++ b/internal/menu/executor_lastcallers.go
@@ -188,16 +188,30 @@ func runLastCallers(c *cmdCtx, args string) (*user.User, string, error) {
 	return nil, "", nil // Success
 }
 
+// lastCallersDisplayLimit caps how many rows the last callers screen renders.
+// The cap is applied to the visible records only, so a board whose stored
+// history is mostly hidden SysOp logins still fills the screen with real
+// callers instead of showing a handful of rows.
+const lastCallersDisplayLimit = 20
+
 // visibleCallRecords drops call records made by users who declined the
-// "add this login to the last caller list?" prompt. The exclusion applies to
-// every viewer, including the SysOp: the caller asked not to be listed, so the
-// login must not appear on the screen no matter who is looking (issue #334).
+// "add this login to the last caller list?" prompt, then keeps the most recent
+// lastCallersDisplayLimit of what remains. The exclusion applies to every
+// viewer, including the SysOp: the caller asked not to be listed, so the login
+// must not appear on the screen no matter who is looking (issue #334).
+//
+// Hidden records are removed before the cap so they cannot consume display
+// slots. Chronological order is preserved (oldest kept record first), which is
+// the order LASTCALL.MID expects.
 func visibleCallRecords(records []user.CallRecord) []user.CallRecord {
 	visible := make([]user.CallRecord, 0, len(records))
 	for _, rec := range records {
 		if !rec.Invisible {
 			visible = append(visible, rec)
 		}
+	}
+	if len(visible) > lastCallersDisplayLimit {
+		visible = visible[len(visible)-lastCallersDisplayLimit:]
 	}
 	return visible
 }

--- a/internal/menu/executor_lastcallers_test.go
+++ b/internal/menu/executor_lastcallers_test.go
@@ -39,3 +39,56 @@ func TestVisibleCallRecords_EmptyInputIsEmptyNonNil(t *testing.T) {
 		t.Fatalf("visibleCallRecords(nil) = %v, want empty non-nil slice", got)
 	}
 }
+
+// TestVisibleCallRecords_CapsAtDisplayLimit verifies the screen renders at most
+// lastCallersDisplayLimit rows and keeps the most recent ones, in order.
+func TestVisibleCallRecords_CapsAtDisplayLimit(t *testing.T) {
+	records := make([]user.CallRecord, 0, lastCallersDisplayLimit+10)
+	for i := 0; i < lastCallersDisplayLimit+10; i++ {
+		records = append(records, user.CallRecord{UserID: i, CallNumber: uint64(i)})
+	}
+
+	got := visibleCallRecords(records)
+
+	if len(got) != lastCallersDisplayLimit {
+		t.Fatalf("visibleCallRecords returned %d records, want %d", len(got), lastCallersDisplayLimit)
+	}
+	// The oldest 10 must have been dropped, not the newest.
+	if got[0].CallNumber != 10 {
+		t.Errorf("kept the wrong window: first record is call %d, want 10", got[0].CallNumber)
+	}
+	if got[len(got)-1].CallNumber != uint64(lastCallersDisplayLimit+9) {
+		t.Errorf("newest record missing: last is call %d, want %d", got[len(got)-1].CallNumber, lastCallersDisplayLimit+9)
+	}
+}
+
+// TestVisibleCallRecords_HiddenRecordsDoNotConsumeSlots is the regression guard
+// for the starvation case: a deep history that is mostly invisible logins must
+// still fill the screen with the visible callers it contains.
+func TestVisibleCallRecords_HiddenRecordsDoNotConsumeSlots(t *testing.T) {
+	// 100 hidden logins interleaved with 25 real callers.
+	records := make([]user.CallRecord, 0, 125)
+	realSeen := 0
+	for i := 0; i < 125; i++ {
+		if i%5 == 0 {
+			realSeen++
+			records = append(records, user.CallRecord{UserID: 1, CallNumber: uint64(i)})
+			continue
+		}
+		records = append(records, user.CallRecord{UserID: 2, CallNumber: uint64(i), Invisible: true})
+	}
+	if realSeen != 25 {
+		t.Fatalf("test setup wrong: built %d visible records, want 25", realSeen)
+	}
+
+	got := visibleCallRecords(records)
+
+	if len(got) != lastCallersDisplayLimit {
+		t.Fatalf("got %d rows, want a full screen of %d", len(got), lastCallersDisplayLimit)
+	}
+	for _, rec := range got {
+		if rec.Invisible {
+			t.Errorf("invisible record (call %d) leaked into the visible list", rec.CallNumber)
+		}
+	}
+}

--- a/internal/menu/executor_lastcallers_test.go
+++ b/internal/menu/executor_lastcallers_test.go
@@ -40,55 +40,78 @@ func TestVisibleCallRecords_EmptyInputIsEmptyNonNil(t *testing.T) {
 	}
 }
 
-// TestVisibleCallRecords_CapsAtDisplayLimit verifies the screen renders at most
-// lastCallersDisplayLimit rows and keeps the most recent ones, in order.
-func TestVisibleCallRecords_CapsAtDisplayLimit(t *testing.T) {
-	records := make([]user.CallRecord, 0, lastCallersDisplayLimit+10)
-	for i := 0; i < lastCallersDisplayLimit+10; i++ {
-		records = append(records, user.CallRecord{UserID: i, CallNumber: uint64(i)})
+// TestMostRecentCallRecords_KeepsNewestWindow verifies the row limit keeps the
+// most recent records and preserves the oldest-first render order.
+func TestMostRecentCallRecords_KeepsNewestWindow(t *testing.T) {
+	records := make([]user.CallRecord, 0, 30)
+	for i := 0; i < 30; i++ {
+		records = append(records, user.CallRecord{CallNumber: uint64(i)})
 	}
 
-	got := visibleCallRecords(records)
+	got := mostRecentCallRecords(records, 20)
 
-	if len(got) != lastCallersDisplayLimit {
-		t.Fatalf("visibleCallRecords returned %d records, want %d", len(got), lastCallersDisplayLimit)
+	if len(got) != 20 {
+		t.Fatalf("mostRecentCallRecords returned %d records, want 20", len(got))
 	}
-	// The oldest 10 must have been dropped, not the newest.
 	if got[0].CallNumber != 10 {
 		t.Errorf("kept the wrong window: first record is call %d, want 10", got[0].CallNumber)
 	}
-	if got[len(got)-1].CallNumber != uint64(lastCallersDisplayLimit+9) {
-		t.Errorf("newest record missing: last is call %d, want %d", got[len(got)-1].CallNumber, lastCallersDisplayLimit+9)
+	if got[len(got)-1].CallNumber != 29 {
+		t.Errorf("newest record missing: last is call %d, want 29", got[len(got)-1].CallNumber)
 	}
 }
 
-// TestVisibleCallRecords_HiddenRecordsDoNotConsumeSlots is the regression guard
-// for the starvation case: a deep history that is mostly invisible logins must
-// still fill the screen with the visible callers it contains.
-func TestVisibleCallRecords_HiddenRecordsDoNotConsumeSlots(t *testing.T) {
-	// 100 hidden logins interleaved with 25 real callers.
+// TestMostRecentCallRecords_PassThrough covers the limits that must not slice:
+// a limit at or above the record count, and the zero/negative "no limit" cases.
+func TestMostRecentCallRecords_PassThrough(t *testing.T) {
+	records := []user.CallRecord{{CallNumber: 1}, {CallNumber: 2}, {CallNumber: 3}}
+
+	for _, limit := range []int{3, 10, 0, -1} {
+		got := mostRecentCallRecords(records, limit)
+		if len(got) != len(records) {
+			t.Errorf("limit %d: got %d records, want all %d", limit, len(got), len(records))
+		}
+	}
+}
+
+// TestLastCallerRows_HiddenLoginsDoNotConsumeRows is the regression guard for
+// the starvation case behind this change: filtering runs before the row limit,
+// so a history that is mostly hidden logins still fills the screen with real
+// callers. Ordering mirrors runLastCallers.
+func TestLastCallerRows_HiddenLoginsDoNotConsumeRows(t *testing.T) {
+	// 125 stored records: every fifth is a real caller, the rest are hidden.
 	records := make([]user.CallRecord, 0, 125)
-	realSeen := 0
 	for i := 0; i < 125; i++ {
 		if i%5 == 0 {
-			realSeen++
 			records = append(records, user.CallRecord{UserID: 1, CallNumber: uint64(i)})
 			continue
 		}
 		records = append(records, user.CallRecord{UserID: 2, CallNumber: uint64(i), Invisible: true})
 	}
-	if realSeen != 25 {
-		t.Fatalf("test setup wrong: built %d visible records, want 25", realSeen)
-	}
 
-	got := visibleCallRecords(records)
+	got := mostRecentCallRecords(visibleCallRecords(records), defaultLastCallerRows)
 
-	if len(got) != lastCallersDisplayLimit {
-		t.Fatalf("got %d rows, want a full screen of %d", len(got), lastCallersDisplayLimit)
+	if len(got) != defaultLastCallerRows {
+		t.Fatalf("got %d rows, want a full screen of %d", len(got), defaultLastCallerRows)
 	}
 	for _, rec := range got {
 		if rec.Invisible {
 			t.Errorf("invisible record (call %d) leaked into the visible list", rec.CallNumber)
 		}
+	}
+}
+
+// TestLastCallerRows_LimitIsNotCapped guards the documented contract that
+// RUN:LASTCALLERS 25 shows 25 entries; the default must not impose a ceiling.
+func TestLastCallerRows_LimitIsNotCapped(t *testing.T) {
+	records := make([]user.CallRecord, 0, 40)
+	for i := 0; i < 40; i++ {
+		records = append(records, user.CallRecord{CallNumber: uint64(i)})
+	}
+
+	got := mostRecentCallRecords(visibleCallRecords(records), 25)
+
+	if len(got) != 25 {
+		t.Fatalf("a request for 25 rows returned %d; the default must not cap it", len(got))
 	}
 }

--- a/internal/user/manager.go
+++ b/internal/user/manager.go
@@ -22,12 +22,16 @@ var (
 )
 
 const (
-	userFile         = "users.json"
-	callHistoryFile  = "callhistory.json"    // Filename for call history
-	callNumberFile   = "callnumber.json"     // Filename for the next call number
-	adminLogFile     = "admin_activity.json" // Filename for admin activity log
-	callHistoryLimit = 20                    // Max number of call records to keep
-	adminLogLimit    = 1000                  // Max number of admin log entries to keep
+	userFile        = "users.json"
+	callHistoryFile = "callhistory.json"    // Filename for call history
+	callNumberFile  = "callnumber.json"     // Filename for the next call number
+	adminLogFile    = "admin_activity.json" // Filename for admin activity log
+	// callHistoryLimit is the stored depth, not the displayed row count. Logins
+	// hidden by the invisible prompt still occupy a slot here, so the ring is
+	// kept deep enough that they cannot starve the last callers screen of real
+	// callers; the screen itself caps at lastCallersDisplayLimit visible rows.
+	callHistoryLimit = 200  // Max number of call records to keep
+	adminLogLimit    = 1000 // Max number of admin log entries to keep
 )
 
 // StripUTF8BOM returns data with UTF-8 BOM (EF BB BF) removed if present.

--- a/menus/v3/cfg/MAIN.CFG
+++ b/menus/v3/cfg/MAIN.CFG
@@ -141,7 +141,7 @@
     },
     {
         "KEYS": "W LC",
-        "CMD": "RUN:LASTCALLERS 10",
+        "CMD": "RUN:LASTCALLERS 20",
         "ACS": "*",
         "HIDDEN": false,
         "NODE_ACTIVITY": "Viewing Last Callers"


### PR DESCRIPTION
## Summary

Follow-up to #335 / #334.

Hiding invisible logins from every viewer was correct, but it exposed a second problem underneath: `callHistoryLimit` was doing double duty as both the stored history depth and the displayed row count. Hidden logins still occupy a slot in that 20-record ring, so a SysOp who logs in invisibly steadily evicts real callers from the list.

On this board 16 of the 20 stored records were hidden logins, so the last callers screen rendered **4 rows**. Every further hidden login pushed another real caller out permanently.

## Changes

- `internal/user/manager.go`: `callHistoryLimit` 20 → 200. This is now storage depth only. Hidden logins still take a slot, but the ring is deep enough that they cannot starve the screen.
- `internal/menu/executor_lastcallers.go`: new `lastCallersDisplayLimit = 20` caps the rendered rows. `visibleCallRecords` drops hidden records **before** applying the cap — that ordering is the fix — and keeps the most recent 20 in the oldest-first order `LASTCALL.MID` renders.
- `internal/menu/executor_lastcallers_test.go`: tests for the cap window (keeps newest 20, drops oldest) and for the starvation case (125 records, 100 hidden → still a full 20-row screen).

## Not changed

- The on-disk history and the global call counter. Hidden calls are still recorded, and `GetTotalCalls` reads `nextCallNumber` rather than the history length, so the deeper ring does not shift any stat.
- The **`Calls` column**, which is a separate bug worth its own issue. `LASTCALL.TOP` labels it `Calls` but `@CA@` renders `record.CallNumber`, the board-wide call counter — so J0hnny A1pha shows 63 while `TimesCalled` is 114, and Toady shows 68 having called twice. Every other "Calls" display in the BBS (`executor_admin_users.go:272`, `executor_admin_user_editor_render.go:191`, the `|CALLS` placeholder) uses `TimesCalled`. The related `@NU@` new-user marker tests `record.CallNumber <= 1`, so it can only ever fire for the first call in the board's history rather than flagging first-time callers.

## Verification

- `go build ./...` succeeds
- `go vet ./internal/user/ ./internal/menu/` clean
- `go test ./...` full suite passes
- `gofmt` clean

Note: records already evicted under the old 20-record limit are not recoverable. The screen fills toward 20 rows as new calls arrive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The recent callers display now shows up to 20 visible entries, prioritizing the latest calls.
  * Hidden records no longer reduce the number of visible callers shown.
  * Call history now retains up to 200 records, including hidden login entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->