### PR TITLE
feat(gate): make the challenge stray-key limit configurable

### DIFF
--- a/docs/sysop/configuration/security.md
+++ b/docs/sysop/configuration/security.md
@@ -92,7 +92,21 @@ it.
 | Challenge Key | `challengeGateKey` | `ESC` | The key the caller must press. Use the literal string `ESC` for the Escape key, or a single character (e.g. `*`). |
 | Timeout Secs | `challengeGateTimeoutSeconds` | `20` | Seconds the caller has to complete the challenge before the connection is dropped. |
 | Req Presses | `challengeGateRequiredPresses` | `2` | Number of times the key must be pressed to pass. |
+| Stray Keys | `challengeGateStrayLimit` | `8` | Number of wrong (non-challenge) keys that drops the caller immediately instead of waiting out the timeout. Set to `1` to hang up on the first wrong key. See the note below before going that low. |
 | Live Countdown | `challengeGateLiveCountdown` | `true` | Animates the countdown once per second in the art file. Turn this **off** for web-based telnet clients that garble absolute cursor repositioning — with it off, the starting number is drawn once and stays static instead of ticking down. |
+
+**Stray keys and the timeout:** the gate drops the caller as soon as it has
+seen `challengeGateStrayLimit` keys that are not the challenge key, so a
+scanner that fires a payload at the prompt is rejected without tying up the
+node for the full timeout. Two things to weigh before lowering it to `1`:
+
+- Many callers press **Enter** the moment they connect, before they have
+  read the prompt. With the limit at `1` that Enter is the stray key and they
+  are hung up on. A value of `2` or `3` still cuts off most scripted junk
+  while forgiving a single reflexive keystroke.
+- A bot that connects and sends **nothing** never trips the stray-key rule.
+  That hold is bounded only by `challengeGateTimeoutSeconds`, so if idle
+  connections are what's occupying your nodes, lower the timeout instead.
 
 **The `##` countdown placeholder:** in the gate art file, a run of `#`
 characters marks where the countdown is drawn. The number of `#` characters

--- a/internal/config/config_server.go
+++ b/internal/config/config_server.go
@@ -64,6 +64,7 @@ type ServerConfig struct {
 	ChallengeGateKey             string `json:"challengeGateKey"`             // "ESC" or a single character
 	ChallengeGateTimeoutSeconds  int    `json:"challengeGateTimeoutSeconds"`  // seconds to complete the challenge
 	ChallengeGateRequiredPresses int    `json:"challengeGateRequiredPresses"` // presses of the key to pass
+	ChallengeGateStrayLimit      int    `json:"challengeGateStrayLimit"`      // non-matching keys that reject (1 = first stray key drops)
 	ChallengeGateLiveCountdown   bool   `json:"challengeGateLiveCountdown"`   // live per-second countdown vs static
 
 	// Connection-rate limiter — temp-ban IPs that reconnect too rapidly.
@@ -195,6 +196,7 @@ func LoadServerConfig(configPath string) (ServerConfig, error) {
 		ChallengeGateKey:             "ESC",
 		ChallengeGateTimeoutSeconds:  20,
 		ChallengeGateRequiredPresses: 2,
+		ChallengeGateStrayLimit:      8,
 		ChallengeGateLiveCountdown:   true,
 		EnableConnRateLimit:          false,
 		ConnRateLimitHits:            20,
@@ -278,6 +280,9 @@ func (c *ServerConfig) SanitizeChallengeGate() {
 	}
 	if c.ChallengeGateRequiredPresses < 1 {
 		c.ChallengeGateRequiredPresses = 2
+	}
+	if c.ChallengeGateStrayLimit < 1 {
+		c.ChallengeGateStrayLimit = 8
 	}
 	if c.ConnRateLimitHits < 0 {
 		c.ConnRateLimitHits = 0

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -939,6 +939,9 @@ func TestLoadServerConfigChallengeGateDefaults(t *testing.T) {
 	if !cfg.ChallengeGateLiveCountdown {
 		t.Errorf("ChallengeGateLiveCountdown default = false, want true")
 	}
+	if cfg.ChallengeGateStrayLimit != 8 {
+		t.Errorf("ChallengeGateStrayLimit = %d, want 8", cfg.ChallengeGateStrayLimit)
+	}
 	if cfg.ConnRateLimitHits != 20 || cfg.ConnRateLimitWindowSeconds != 10 || cfg.ConnRateLimitBanMinutes != 90 {
 		t.Errorf("rate-limit defaults = %d/%d/%d, want 20/10/90",
 			cfg.ConnRateLimitHits, cfg.ConnRateLimitWindowSeconds, cfg.ConnRateLimitBanMinutes)
@@ -946,13 +949,16 @@ func TestLoadServerConfigChallengeGateDefaults(t *testing.T) {
 }
 
 func TestSanitizeChallengeGate(t *testing.T) {
-	cfg := ServerConfig{ChallengeGateTimeoutSeconds: 0, ChallengeGateRequiredPresses: 0, ChallengeGateFile: "", ChallengeGateKey: ""}
+	cfg := ServerConfig{ChallengeGateTimeoutSeconds: 0, ChallengeGateRequiredPresses: 0, ChallengeGateStrayLimit: 0, ChallengeGateFile: "", ChallengeGateKey: ""}
 	cfg.SanitizeChallengeGate()
 	if cfg.ChallengeGateTimeoutSeconds != 20 {
 		t.Errorf("timeout not defaulted: %d", cfg.ChallengeGateTimeoutSeconds)
 	}
 	if cfg.ChallengeGateRequiredPresses != 2 {
 		t.Errorf("presses not defaulted: %d", cfg.ChallengeGateRequiredPresses)
+	}
+	if cfg.ChallengeGateStrayLimit != 8 {
+		t.Errorf("stray limit not defaulted: %d", cfg.ChallengeGateStrayLimit)
 	}
 	if cfg.ChallengeGateFile != "BOTCHECK.ASC" {
 		t.Errorf("file not defaulted: %q", cfg.ChallengeGateFile)

--- a/internal/configeditor/fields_security_defense.go
+++ b/internal/configeditor/fields_security_defense.go
@@ -55,17 +55,29 @@ func sysFieldsBotDefense(cfg *config.ServerConfig) []fieldDef {
 			},
 		},
 		{
-			Label: "Live Countdown", Help: "Animate the ## countdown (off = static)", Type: ftYesNo, Col: 3, Row: 6, Width: 1,
+			Label: "Stray Keys", Help: "Wrong keys before the caller is dropped (1 = first)", Type: ftInteger, Col: 3, Row: 6, Width: 3, Min: 1, Max: 99,
+			Get: func() string { return strconv.Itoa(cfg.ChallengeGateStrayLimit) },
+			Set: func(val string) error {
+				n, err := strconv.Atoi(val)
+				if err != nil {
+					return err
+				}
+				cfg.ChallengeGateStrayLimit = n
+				return nil
+			},
+		},
+		{
+			Label: "Live Countdown", Help: "Animate the ## countdown (off = static)", Type: ftYesNo, Col: 3, Row: 7, Width: 1,
 			Get: func() string { return uitext.BoolToYN(cfg.ChallengeGateLiveCountdown) },
 			Set: func(val string) error { cfg.ChallengeGateLiveCountdown = uitext.YNToBool(val); return nil },
 		},
 		{
-			Label: "Rate Limit", Help: "Temp-ban IPs that reconnect too fast", Type: ftYesNo, Col: 3, Row: 7, Width: 1,
+			Label: "Rate Limit", Help: "Temp-ban IPs that reconnect too fast", Type: ftYesNo, Col: 3, Row: 8, Width: 1,
 			Get: func() string { return uitext.BoolToYN(cfg.EnableConnRateLimit) },
 			Set: func(val string) error { cfg.EnableConnRateLimit = uitext.YNToBool(val); return nil },
 		},
 		{
-			Label: "Rate Hits", Help: "Attempts within the window that trigger a ban", Type: ftInteger, Col: 3, Row: 8, Width: 4, Min: 0, Max: 9999,
+			Label: "Rate Hits", Help: "Attempts within the window that trigger a ban", Type: ftInteger, Col: 3, Row: 9, Width: 4, Min: 0, Max: 9999,
 			Get: func() string { return strconv.Itoa(cfg.ConnRateLimitHits) },
 			Set: func(val string) error {
 				n, err := strconv.Atoi(val)
@@ -77,7 +89,7 @@ func sysFieldsBotDefense(cfg *config.ServerConfig) []fieldDef {
 			},
 		},
 		{
-			Label: "Rate Window", Help: "Sliding window in seconds", Type: ftInteger, Col: 3, Row: 9, Width: 4, Min: 1, Max: 9999,
+			Label: "Rate Window", Help: "Sliding window in seconds", Type: ftInteger, Col: 3, Row: 10, Width: 4, Min: 1, Max: 9999,
 			Get: func() string { return strconv.Itoa(cfg.ConnRateLimitWindowSeconds) },
 			Set: func(val string) error {
 				n, err := strconv.Atoi(val)
@@ -89,7 +101,7 @@ func sysFieldsBotDefense(cfg *config.ServerConfig) []fieldDef {
 			},
 		},
 		{
-			Label: "Ban Minutes", Help: "Temp-ban duration in minutes", Type: ftInteger, Col: 3, Row: 10, Width: 5, Min: 1, Max: 99999,
+			Label: "Ban Minutes", Help: "Temp-ban duration in minutes", Type: ftInteger, Col: 3, Row: 11, Width: 5, Min: 1, Max: 99999,
 			Get: func() string { return strconv.Itoa(cfg.ConnRateLimitBanMinutes) },
 			Set: func(val string) error {
 				n, err := strconv.Atoi(val)

--- a/internal/configeditor/fields_system_test.go
+++ b/internal/configeditor/fields_system_test.go
@@ -149,8 +149,8 @@ func TestMenuItemBuildersNonEmpty(t *testing.T) {
 func TestSysFieldsBotDefenseRoundTrip(t *testing.T) {
 	cfg := &config.ServerConfig{}
 	fields := sysFieldsBotDefense(cfg)
-	if len(fields) != 10 {
-		t.Fatalf("got %d fields, want 10", len(fields))
+	if len(fields) != 11 {
+		t.Fatalf("got %d fields, want 11", len(fields))
 	}
 	byLabel := map[string]fieldDef{}
 	for _, f := range fields {
@@ -164,6 +164,9 @@ func TestSysFieldsBotDefenseRoundTrip(t *testing.T) {
 	}
 	if err := byLabel["Timeout Secs"].Set("30"); err != nil || cfg.ChallengeGateTimeoutSeconds != 30 {
 		t.Errorf("Timeout Set failed: %d", cfg.ChallengeGateTimeoutSeconds)
+	}
+	if err := byLabel["Stray Keys"].Set("1"); err != nil || cfg.ChallengeGateStrayLimit != 1 {
+		t.Errorf("Stray Keys Set failed: %d", cfg.ChallengeGateStrayLimit)
 	}
 	if got := byLabel["Enable Gate"].Get(); got != "Y" {
 		t.Errorf("Enable Gate Get = %q, want Y", got)

--- a/internal/menu/challenge_gate.go
+++ b/internal/menu/challenge_gate.go
@@ -14,11 +14,6 @@ import (
 	"golang.org/x/term"
 )
 
-// challengeStrayLimit is the number of non-matching keys that trips the
-// fail-fast scripted-payload rejection: the loop rejects on the Nth stray key
-// (8 or more), mirroring botgate's stray-key flood rule.
-const challengeStrayLimit = 8
-
 // fallbackGatePrompt is used when the configured art file cannot be read. It
 // keeps the "{KEY}"/"{PRESSES}"/"{TIMES}" tokens and the "##" countdown field
 // intact, so substituteGateTokens and the live countdown work the same as for
@@ -62,6 +57,13 @@ func (e *MenuExecutor) RunChallengeGate(
 	if timeout < 1 {
 		timeout = 1
 	}
+	// Non-matching keys that trip the fail-fast rejection: the loop drops the
+	// caller on the Nth stray key. The default of 8 mirrors botgate's
+	// stray-key flood rule; 1 drops on the first wrong key.
+	strayLimit := cfg.ChallengeGateStrayLimit
+	if strayLimit < 1 {
+		strayLimit = 8
+	}
 
 	prompt := gatePromptOrFallback(e, cfg.ChallengeGateFile, nodeNumber)
 	prompt = substituteGateTokens(prompt, cfg.ChallengeGateKey, required)
@@ -76,7 +78,7 @@ func (e *MenuExecutor) RunChallengeGate(
 	}
 	writeGateArt(terminal, draw, outputMode)
 
-	slog.Info("challenge gate presented", "node", nodeNumber, "key", cfg.ChallengeGateKey, "required", required, "timeout_s", timeout)
+	slog.Info("challenge gate presented", "node", nodeNumber, "key", cfg.ChallengeGateKey, "required", required, "stray_limit", strayLimit, "timeout_s", timeout)
 
 	deadline := time.Now().Add(time.Duration(timeout) * time.Second)
 	remaining := timeout
@@ -92,7 +94,7 @@ func (e *MenuExecutor) RunChallengeGate(
 		terminalio.WriteProcessedBytes(terminal, []byte(upd), outputMode)
 	}
 
-	passed, err := runChallengeLoop(getSessionIH(s), time.Now, deadline, matchKey, required, challengeStrayLimit, time.Second, onTick)
+	passed, err := runChallengeLoop(getSessionIH(s), time.Now, deadline, matchKey, required, strayLimit, time.Second, onTick)
 	terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 	if err != nil {
 		if errors.Is(err, io.EOF) {

--- a/internal/menu/challenge_gate_helpers_test.go
+++ b/internal/menu/challenge_gate_helpers_test.go
@@ -230,6 +230,23 @@ func TestRunChallengeLoopFloodFails(t *testing.T) {
 	}
 }
 
+// A stray limit of 1 drops the caller on the very first wrong key, even
+// though the matching keys that follow would otherwise have passed.
+func TestRunChallengeLoopStrayLimitOneDropsOnFirstStray(t *testing.T) {
+	in := &scriptedInput{events: []struct {
+		key int
+		err error
+	}{key('a'), key(editor.KeyEsc), key(editor.KeyEsc)}}
+	now := func() time.Time { return time.Unix(0, 0) }
+	passed, err := runChallengeLoop(in, now, time.Unix(100, 0), editor.KeyEsc, 2, 1, time.Second, func() {})
+	if err != nil || passed {
+		t.Fatalf("passed=%v err=%v; want false/nil (first stray key)", passed, err)
+	}
+	if in.i != 1 {
+		t.Errorf("loop read %d keys before rejecting, want 1", in.i)
+	}
+}
+
 func TestRunChallengeLoopTimeout(t *testing.T) {
 	in := &scriptedInput{} // always idle-timeout
 	ticks := 0

--- a/templates/configs/config.json
+++ b/templates/configs/config.json
@@ -31,6 +31,7 @@
   "challengeGateKey": "ESC",
   "challengeGateTimeoutSeconds": 20,
   "challengeGateRequiredPresses": 2,
+  "challengeGateStrayLimit": 8,
   "challengeGateLiveCountdown": true,
   "enableConnRateLimit": false,
   "connRateLimitHits": 20,


### PR DESCRIPTION
Closes #338

## What

The Challenge Gate rejected a caller on the 8th non-matching key but otherwise held the node until the timeout expired. This makes that limit a config setting so a sysop can hang up sooner, down to the first wrong key.

- New `challengeGateStrayLimit` on `ServerConfig`, default 8, minimum 1, filled in by `SanitizeChallengeGate`.
- New **Stray Keys** field on the Bot Defense TUI screen (rows below it shift down one).
- `RunChallengeGate` passes the configured value into `runChallengeLoop`; the `challengeStrayLimit` constant is gone. The "challenge gate presented" log line now includes `stray_limit`.
- `templates/configs/config.json` carries the new key.
- Docs: a table row for the setting plus a note on why `1` is aggressive (Enter-on-connect callers get dropped; silent connections are still bounded only by the timeout).

## Behaviour change

None at the default. Existing configs without the key sanitize to 8, which is the previous hard-coded value.

## Tests

- Config: default and sanitize cover the new field.
- TUI: field count is 11 and Stray Keys round-trips.
- Gate loop: a limit of 1 rejects on the first stray key and reads exactly one key before doing so.

`go build ./...`, `go vet`, and `go test` on config, configeditor, and menu all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable limit for incorrect keys during the challenge gate.
  - The default limit is 8; values below 1 are reset to 8.
  - Added a **Stray Keys** setting to the security configuration editor.
  - Reaching the configured limit now disconnects the caller immediately.

- **Documentation**
  - Documented the new setting, including behavior and considerations when configured to 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->