### PR TITLE
chore(release): v0.9.2 — version bump + upgrade guide

### DIFF
--- a/docs/sysop/README.md
+++ b/docs/sysop/README.md
@@ -2,7 +2,7 @@
 
 Welcome, SysOp. This wiki covers everything you need to install, configure, and run a l33t ViSiON/3 BBS like it's 1992 all over again.
 
-> **Current Version: v0.9.0** | [GitHub Releases](https://github.com/ViSiON-3/vision-3-bbs/releases)
+> **Current Version: v0.9.2** | [GitHub Releases](https://github.com/ViSiON-3/vision-3-bbs/releases)
 >
 > ⚠️ **Early Development:** ViSiON/3 is under active development and not yet feature-complete. Expect rough edges and missing features. Use at your own risk.
 

--- a/docs/sysop/getting-started/README.md
+++ b/docs/sysop/getting-started/README.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-> **Current Version: v0.9.0** — [GitHub Releases](https://github.com/ViSiON-3/vision-3-bbs/releases)
+> **Current Version: v0.9.2** — [GitHub Releases](https://github.com/ViSiON-3/vision-3-bbs/releases)
 >
 > ⚠️ **Early Development:** ViSiON/3 is under active development and not yet feature-complete. Use at your own risk.
 

--- a/docs/sysop/getting-started/installation.md
+++ b/docs/sysop/getting-started/installation.md
@@ -1,6 +1,6 @@
 # ViSiON/3 Installation Guide
 
-> **Current Version: v0.9.0** — [GitHub Releases](https://github.com/ViSiON-3/vision-3-bbs/releases)
+> **Current Version: v0.9.2** — [GitHub Releases](https://github.com/ViSiON-3/vision-3-bbs/releases)
 >
 > ⚠️ **Early Development:** ViSiON/3 is under active development and not yet feature-complete. Expect rough edges and missing features. Use at your own risk. Check the [releases page](https://github.com/ViSiON-3/vision-3-bbs/releases) and the [README](https://github.com/ViSiON-3/vision-3-bbs) for the current status of features.
 

--- a/docs/sysop/getting-started/upgrading.md
+++ b/docs/sysop/getting-started/upgrading.md
@@ -415,3 +415,64 @@ of `export_interval_seconds` applies live; other binkd settings apply on binkd's
 next (re)launch — and, importantly, the supervisor no longer overwrites a newer
 `binkd.conf` with stale boot-time values. No action needed; it just stops
 silently reverting your changes.
+
+## Worked example: upgrading to v0.9.2
+
+v0.9.2 is almost entirely automatic: deploy the new bundle, restart, and the
+fixes and the new live config reload are active. The one thing that needs your
+hand is a **customized `login.json`** — and even that is only an ordering edit.
+
+### Custom `login.json`: put SYSOPNOTICES and NMAILSCAN first
+
+Two things changed around the login sequence:
+
+- `SYSOPNOTICES` now actually runs at login. It was silently dead — the login
+  sequence dispatcher never knew the command, so queued "new user joined"
+  notices piled up undelivered (you'd see `unknown login sequence command`
+  warnings in the log). Any notices already queued are delivered on your next
+  login after the upgrade.
+- The shipped sequences now lead with `SYSOPNOTICES` then `NMAILSCAN`, **above**
+  `FASTLOGIN`. A `FASTLOGIN` jump ends the sequence, so anything below it is
+  skipped for callers who take the shortcut — which is how sysop notices and
+  the new-mail scan were being missed.
+
+An upgrade never touches your `login.json`, so if you maintain a custom one,
+reorder it so `SYSOPNOTICES` and `NMAILSCAN` are the first two items, above
+`FASTLOGIN`. (Earlier docs suggested adding `SYSOPNOTICES` after `NEWUSERVAL`,
+which lands below `FASTLOGIN` — move it up.)
+
+### Config edits now apply to the running BBS
+
+Saving from `./config` (or editing a config file by hand) no longer needs a
+restart for most files — see
+[Configuration](../configuration/configuration.md) for the full live-vs-restart
+table and how the `configs/reload.now` / `configs/reload.force` semaphore files
+and `SIGHUP` work. Structural files (`file_areas.json`, `message_areas.json`,
+`v3net.json` hand edits) are validated on save and applied the moment the board
+is empty, so live callers are never yanked around. Nothing to migrate — this is
+just a behavior change to know about.
+
+### Stranded "already read" mail heals on the next pack
+
+If mail ever showed as already-read without being opened (typically after the
+nightly purge/pack emptied an area), that was a stale lastread pointer left on
+the old message numbering by `Pack`. Packs now remap pointers, so the problem
+stops recurring — and pointers stranded by *past* packs are clamped back into
+range the next time that area is packed. `v3mail lastread` can reset one by
+hand if you don't want to wait.
+
+### Optional: hang up bot connections sooner
+
+The challenge gate's stray-key limit (previously hard-coded at 8) is now
+**Stray Keys** on the Bot Defense screen (`challengeGateStrayLimit` in
+`config.json`, minimum 1). Existing configs without the key keep the old
+behavior. Setting it to `1` drops a caller on the first wrong key — aggressive,
+since callers who lean on Enter at connect get dropped too.
+
+### Last callers list
+
+Invisible logins are now hidden from **every** viewer (before, CoSysOp+ still
+saw them), and they no longer crowd real callers off the screen — the list
+always shows up to 20 visible callers. Real callers evicted from the old,
+shallower history are gone for good; the screen refills as calls arrive. No
+action needed.

--- a/docs/sysop/getting-started/upgrading.md
+++ b/docs/sysop/getting-started/upgrading.md
@@ -420,7 +420,7 @@ silently reverting your changes.
 
 v0.9.2 is almost entirely automatic: deploy the new bundle, restart, and the
 fixes and the new live config reload are active. The one thing that needs your
-hand is a **customized `login.json`** — and even that is only an ordering edit.
+hand is a **customized `login.json`** — and even that is only a small edit.
 
 ### Custom `login.json`: put SYSOPNOTICES and NMAILSCAN first
 
@@ -436,21 +436,33 @@ Two things changed around the login sequence:
   skipped for callers who take the shortcut — which is how sysop notices and
   the new-mail scan were being missed.
 
-An upgrade never touches your `login.json`, so if you maintain a custom one,
-reorder it so `SYSOPNOTICES` and `NMAILSCAN` are the first two items, above
-`FASTLOGIN`. (Earlier docs suggested adding `SYSOPNOTICES` after `NEWUSERVAL`,
-which lands below `FASTLOGIN` — move it up.)
+An upgrade never touches your `login.json`, so if you maintain a custom one:
+
+1. **Add whichever of the two is missing.** Older custom files may have neither
+   (`NMAILSCAN` is new to the built-in default too). An item is just
+   `{ "command": "SYSOPNOTICES" }` — copy the first two entries from the
+   shipped `templates/configs/login.json` if in doubt.
+2. **Make them the first two items**, `SYSOPNOTICES` then `NMAILSCAN`, above
+   `FASTLOGIN`. (Earlier docs suggested adding `SYSOPNOTICES` after
+   `NEWUSERVAL`, which lands below `FASTLOGIN` — move it up.)
 
 ### Config edits now apply to the running BBS
 
 Saving from `./config` (or editing a config file by hand) no longer needs a
 restart for most files — see
-[Configuration](../configuration/configuration.md) for the full live-vs-restart
+[Configuration](configuration/configuration.md) for the full live-vs-restart
 table and how the `configs/reload.now` / `configs/reload.force` semaphore files
 and `SIGHUP` work. Structural files (`file_areas.json`, `message_areas.json`,
 `v3net.json` hand edits) are validated on save and applied the moment the board
-is empty, so live callers are never yanked around. Nothing to migrate — this is
-just a behavior change to know about.
+is empty, so live callers are never yanked around — unless you explicitly
+`touch configs/reload.force`, which applies queued structural changes with
+callers online. Nothing to migrate — this is just a behavior change to know
+about.
+
+> **Note:** the earlier worked examples on this page predate live reload —
+> where they say to restart after a config edit (e.g. `message_areas.json` in
+> the v0.9.1 section), that advice is superseded on v0.9.2 by the table linked
+> above.
 
 ### Stranded "already read" mail heals on the next pack
 
@@ -473,6 +485,7 @@ since callers who lean on Enter at connect get dropped too.
 
 Invisible logins are now hidden from **every** viewer (before, CoSysOp+ still
 saw them), and they no longer crowd real callers off the screen — the list
-always shows up to 20 visible callers. Real callers evicted from the old,
-shallower history are gone for good; the screen refills as calls arrive. No
-action needed.
+shows up to 20 visible callers by default (a `RUN:LASTCALLERS <n>` argument in
+your menu CFG still overrides the row count). Real callers evicted from the
+old, shallower history are gone for good; the screen refills as calls arrive.
+No action needed.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,7 +8,7 @@ import (
 // Number is the global ViSiON/3 version.
 // Set this at build time with:
 // -ldflags "-X github.com/ViSiON-3/vision-3-bbs/internal/version.Number=1.0.0"
-var Number = "0.9.1"
+var Number = "0.9.2"
 
 // Display returns the version prefixed with "v", e.g. "v0.8.0". A Number that
 // already carries the prefix (a build stamped from a git tag) is left alone.


### PR DESCRIPTION
Release prep for v0.9.2 per the release process in `vision-3-release/docs/RELEASING.md`.

- `internal/version/version.go` → `0.9.2`
- The three `Current Version:` doc lines → `v0.9.2` (they were still at v0.9.0 — the v0.9.1 bump missed them)
- New **Worked example: upgrading to v0.9.2** section in `docs/sysop/getting-started/upgrading.md` covering the custom-`login.json` reorder (#324), the live config reload behavior change (#327–#333), lastread healing on pack (#326), the configurable stray-key limit (#339), and the last-callers display changes (#335/#336)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5cvD5xSUvefTYKLDdnAdE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated version references to v0.9.2 across the system operator documentation.
  - Added upgrade guidance covering login-sequence ordering, live configuration reloads, stale mail-pointer repair, bot challenge limits, and last-callers visibility and history.
  - Updated the Configuration link to use a site-root-relative path.
- **Release Information**
  - Updated the application version to v0.9.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->