### PR TITLE
fix(tosser): take echomail's origin address from the author, not the header

### DIFF
--- a/internal/tosser/addresses.go
+++ b/internal/tosser/addresses.go
@@ -40,15 +40,16 @@ func (t *Tosser) resolveOrigAddr(pktHdr *ftn.PacketHeader, msg *ftn.PackedMessag
 		Net:  int(msg.OrigNet),
 		Node: int(msg.OrigNode),
 	}
-	// On netmail gated between zones the packet header carries the gate's
-	// zone, not the author's; INTL carries the author's.
-	if a := intlAddr(parsed.Kludges, intlOrig); a != nil && a.Net == addr.Net && a.Node == addr.Node {
-		addr.Zone = a.Zone
-	}
 	if parsed.Area != "" {
 		if author, ok := echoAuthor(parsed, msgID); ok {
 			return author.String()
 		}
+	} else if a := intlAddr(parsed.Kludges, intlOrig); a != nil && a.Net == addr.Net && a.Node == addr.Node {
+		// On netmail gated between zones the packet header carries the
+		// gate's zone, not the author's; INTL carries the author's. INTL is
+		// netmail-only (FTS-4001), so on echomail it is a stray a transit
+		// system failed to strip and says nothing about the author.
+		addr.Zone = a.Zone
 	}
 	if origAddr, ok := origPoint(addr, pktHdr, parsed, msgID); ok {
 		addr = origAddr

--- a/internal/tosser/addresses.go
+++ b/internal/tosser/addresses.go
@@ -11,11 +11,19 @@ import (
 // resolveOrigAddr returns the author's FTN address for an inbound packed
 // message.
 //
-// The packed message header (FTS-0001) carries only net and node, so a point
-// author's ".N" has to be recovered from one of the places that does carry it:
-// the MSGID kludge, the origin line, an FMPT kludge, or the packet header.
-// Without this a point node arrives as a plain 3D address and the reader shows
-// (and replies quote) the boss node instead.
+// Echomail reaches us relayed, and the systems along the way rewrite the
+// packed message header's origin to suit themselves — a Mystic hub stamps the
+// receiving link into it, so every message it forwards appears to come from
+// us. The MSGID kludge and the origin line are written by the author and
+// travel untouched, so echomail takes its address from those and falls back
+// to the header only when neither names one.
+//
+// Netmail is point-to-point, so its packed header is trusted for net and node.
+// That header carries no point, so a point author's ".N" has to be recovered
+// from one of the places that does carry it: the MSGID kludge, the origin
+// line, an FMPT kludge, or the packet header. Without this a point node
+// arrives as a plain 3D address and the reader shows (and replies quote) the
+// boss node instead.
 func (t *Tosser) resolveOrigAddr(pktHdr *ftn.PacketHeader, msg *ftn.PackedMessage, parsed *ftn.ParsedBody, msgID string) string {
 	zone := pktHdr.OrigZone
 	if zone == 0 {
@@ -37,10 +45,38 @@ func (t *Tosser) resolveOrigAddr(pktHdr *ftn.PacketHeader, msg *ftn.PackedMessag
 	if a := intlAddr(parsed.Kludges, intlOrig); a != nil && a.Net == addr.Net && a.Node == addr.Node {
 		addr.Zone = a.Zone
 	}
+	if parsed.Area != "" {
+		if author, ok := echoAuthor(parsed, msgID); ok {
+			return author.String()
+		}
+	}
 	if origAddr, ok := origPoint(addr, pktHdr, parsed, msgID); ok {
 		addr = origAddr
 	}
 	return addr.String()
+}
+
+// echoAuthor returns the address an echomail message's author wrote into it,
+// or false when the message carries none we can parse.
+//
+// MSGID (FTS-0009) is "<address> <serial>" and names the author, making it the
+// most reliable source. The address half can be an @-style ID rather than an
+// FTN address, which simply fails to parse and falls through to the origin
+// line (FTS-0004), which carries the author's 4D address. An origin line
+// written without a zone fails to parse too, and the caller falls back to the
+// packed header.
+func echoAuthor(parsed *ftn.ParsedBody, msgID string) (jam.FidoAddress, bool) {
+	if fields := strings.Fields(msgID); len(fields) > 0 {
+		if a, err := jam.ParseAddress(fields[0]); err == nil {
+			return *a, true
+		}
+	}
+	if origin := jam.ExtractOriginAddress(parsed.Text); origin != "" {
+		if a, err := jam.ParseAddress(origin); err == nil {
+			return *a, true
+		}
+	}
+	return jam.FidoAddress{}, false
 }
 
 // resolveDestAddr returns the addressee's FTN address for an inbound packed
@@ -137,13 +173,15 @@ func kludgePoint(kludges []string, prefix string) (int, bool) {
 	return 0, false
 }
 
-// origPoint finds the author's complete address in an inbound message, or
-// returns false when no authoritative address is available.
+// origPoint finds the author's complete address in an inbound message whose
+// packed header is trusted for net and node, or returns false when no
+// authoritative address is available.
 //
 // Every candidate is checked against the packed header's net/node before it is
-// trusted: echomail reaches us relayed, so the packet was written by a link
-// rather than the author, and a point link's own packet header must not stamp
-// its point number onto everyone else's mail.
+// trusted, so a link's own packet header cannot stamp its point number onto
+// mail it merely relays. Echomail normally never reaches this: its author is
+// taken from the MSGID or origin line first (see echoAuthor), and only a
+// message naming neither ends up here with the header as its sole source.
 func origPoint(base jam.FidoAddress, pktHdr *ftn.PacketHeader, parsed *ftn.ParsedBody, msgID string) (jam.FidoAddress, bool) {
 	matches := func(a *jam.FidoAddress) bool {
 		return a.Net == base.Net && a.Node == base.Node

--- a/internal/tosser/addresses_test.go
+++ b/internal/tosser/addresses_test.go
@@ -190,6 +190,107 @@ func TestResolveOrigAddrRecoversPoint(t *testing.T) {
 	}
 }
 
+func TestResolveOrigAddrEchomailTrustsAuthor(t *testing.T) {
+	// A hub relaying another net's echomail: a Mystic hub stamps the
+	// receiving link (us, 21:4/158) into the packed message header's origin,
+	// so only the MSGID and origin line know who actually wrote it.
+	hubPkt := &ftn.PacketHeader{OrigZone: 21, OrigNet: 4, OrigNode: 100}
+	stamped := &ftn.PackedMessage{OrigNet: 4, OrigNode: 158}
+	const area = "FSX_TST"
+
+	tests := []struct {
+		name   string
+		msg    *ftn.PackedMessage
+		parsed *ftn.ParsedBody
+		msgID  string
+		want   string
+	}{
+		{
+			name:   "msgid names the author",
+			msg:    stamped,
+			parsed: &ftn.ParsedBody{Area: area, Text: "Hello\r * Origin: DEAD SOCKET (21:3/255)\r"},
+			msgID:  "21:3/255 1a2b3c4d",
+			want:   "21:3/255",
+		},
+		{
+			name:   "origin line names the author when the msgid is at-style",
+			msg:    stamped,
+			parsed: &ftn.ParsedBody{Area: area, Text: "Hello\r * Origin: DEAD SOCKET (21:3/255)\r"},
+			msgID:  "1a2b3c4d@deadsocket 1a2b3c4d",
+			want:   "21:3/255",
+		},
+		{
+			name:   "origin line names the author when there is no msgid",
+			msg:    stamped,
+			parsed: &ftn.ParsedBody{Area: area, Text: "Hello\r * Origin: DEAD SOCKET (21:3/255)\r"},
+			want:   "21:3/255",
+		},
+		{
+			name:   "msgid names a point author",
+			msg:    stamped,
+			parsed: &ftn.ParsedBody{Area: area},
+			msgID:  "21:3/255.1 1a2b3c4d",
+			want:   "21:3/255.1",
+		},
+		{
+			name:   "origin line names a point author",
+			msg:    stamped,
+			parsed: &ftn.ParsedBody{Area: area, Text: " * Origin: Point (21:3/255.1)\r"},
+			want:   "21:3/255.1",
+		},
+		{
+			name:   "three dimensional msgid wins over an origin point",
+			msg:    stamped,
+			parsed: &ftn.ParsedBody{Area: area, Text: " * Origin: Point (21:3/255.9)\r"},
+			msgID:  "21:3/255 1a2b3c4d",
+			want:   "21:3/255",
+		},
+		{
+			name:   "msgid from another zone keeps its zone",
+			msg:    stamped,
+			parsed: &ftn.ParsedBody{Area: area},
+			msgID:  "1:229/426 1a2b3c4d",
+			want:   "1:229/426",
+		},
+		{
+			name:   "header is the fallback when nothing names the author",
+			msg:    stamped,
+			parsed: &ftn.ParsedBody{Area: area, Text: "Hello\r"},
+			want:   "21:4/158",
+		},
+		{
+			name:   "header is the fallback when the origin line has no zone",
+			msg:    stamped,
+			parsed: &ftn.ParsedBody{Area: area, Text: " * Origin: Old BBS (3/255)\r"},
+			msgID:  "1a2b3c4d@deadsocket 1a2b3c4d",
+			want:   "21:4/158",
+		},
+		{
+			name:   "stray fmpt is still ignored on the header fallback",
+			msg:    stamped,
+			parsed: &ftn.ParsedBody{Area: area, Kludges: []string{"FMPT 3"}},
+			want:   "21:4/158",
+		},
+		{
+			name:   "author matching the header stays the same",
+			msg:    &ftn.PackedMessage{OrigNet: 3, OrigNode: 255},
+			parsed: &ftn.ParsedBody{Area: area, Text: " * Origin: DEAD SOCKET (21:3/255)\r"},
+			msgID:  "21:3/255 1a2b3c4d",
+			want:   "21:3/255",
+		},
+	}
+
+	tos := pointTosser(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tos.resolveOrigAddr(hubPkt, tt.msg, tt.parsed, tt.msgID)
+			if got != tt.want {
+				t.Errorf("resolveOrigAddr = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveOrigAddrTakesZoneFromINTL(t *testing.T) {
 	// Netmail gated between zones: the packet header carries the gate's zone,
 	// INTL carries the author's.

--- a/internal/tosser/addresses_test.go
+++ b/internal/tosser/addresses_test.go
@@ -272,6 +272,12 @@ func TestResolveOrigAddrEchomailTrustsAuthor(t *testing.T) {
 			want:   "21:4/158",
 		},
 		{
+			name:   "stray intl is still ignored on the header fallback",
+			msg:    stamped,
+			parsed: &ftn.ParsedBody{Area: area, Kludges: []string{"INTL 21:4/158 1:4/158"}},
+			want:   "21:4/158",
+		},
+		{
 			name:   "author matching the header stays the same",
 			msg:    &ftn.PackedMessage{OrigNet: 3, OrigNode: 255},
 			parsed: &ftn.ParsedBody{Area: area, Text: " * Origin: DEAD SOCKET (21:3/255)\r"},


### PR DESCRIPTION
## Problem

An echomail message from 21:3/255 (DEAD SOCKET, via the fsxNet hub) showed **21:4/158**, our own address, in the reader's From field. Its MSGID and origin line both said 21:3/255.

## Cause

`resolveOrigAddr` built the address from the packed message header's net/node, as FTS-0001 describes, and consulted the MSGID and origin line only to recover a point number. Both were gated on matching the header's net/node and were discarded otherwise. That guard is right for netmail, but relayed echomail has its header rewritten in transit: a Mystic hub stamps the receiving link into it, so every forwarded message looks like it came from us, and the guard then rejects the only two fields the author wrote.

This is not a regression; before #193 the tosser used the header alone and would have shown the same thing.

## Fix

For echomail (any message naming an AREA), the address now comes from the MSGID first, then the origin line, and falls back to the packed header only when neither parses (at-style MSGID, origin line without a zone, or no origin line). Netmail behavior is unchanged.

Replies quote the stored origin address, so those are fixed too. Messages already tossed keep the address stored at the time.

## Tests

New `TestResolveOrigAddrEchomailTrustsAuthor` covers MSGID, origin line, point authors, another zone, and each fallback. Existing netmail cases still pass. Full `go test ./...` and `go vet ./...` are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Echomail messages now correctly identify the original author’s address from MSGID or origin information, even when routing headers were stamped by a hub.
  - Improved handling of point addresses, zones, and FMPT information.
  - Added a reliable fallback to packet-header data when author information is unavailable.
  - `INTL` origin-zone overrides now apply only to netmail.
  - Netmail address resolution continues to use packet-header information for net, node, and point details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->