### PR TITLE
fix(docker): repair the broken image build and first run

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,11 @@
 
 # Build artifacts
 bin/
+# ...but keep the optional third-party transfer/mailer binaries reachable, so a
+# derived image can COPY them with the repository root as its build context.
+# Everything else under bin/ stays excluded.
+!bin/sexyz
+!bin/binkd
 *.exe
 *.dll
 *.so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,12 @@ jobs:
       - name: Build image
         run: docker compose build
 
+      # Compose mounts ./menus over /vision3/menus, so the boot test below would
+      # still pass with the COPY menus/ layer dropped -- it would be reading the
+      # checkout. Check the image itself, where a plain `docker run` looks.
+      - name: Image ships the built-in menu set
+        run: docker run --rm --entrypoint test vision3:latest -d /vision3/menus/v3
+
       # A fresh clone has no configs/ or data/, so Compose creates them as root
       # while the BBS runs as uid 100 -- the exact state a new sysop starts from.
       - name: First run from a clean state
@@ -176,6 +182,14 @@ jobs:
             fi
           done
           exit $fail
+
+      # Taking ownership of the bind-mounted checkout would leave the host user
+      # unable to `git pull` or edit their own menu set.
+      - name: Bind-mounted menus/ kept its host ownership
+        run: |
+          owner=$(stat -c %u menus)
+          echo "menus/ owned by uid $owner (runner is $(id -u))"
+          [ "$owner" = "$(id -u)" ] || { echo "::error::the container chowned the host's menus/"; exit 1; }
 
       - name: Container logs
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,119 @@ jobs:
         run: go test ./...
       - name: go test -race
         run: go test -race ./...
+
+  # The Docker image went unbuildable for ~6 months: go.mod moved to go 1.25.0
+  # (a78bfce) while the Dockerfile stayed on golang:1.24-alpine, and the official
+  # golang images pin GOTOOLCHAIN=local, so `go mod download` failed outright
+  # instead of fetching a newer toolchain. Nothing in CI built the image, so two
+  # releases shipped with a broken container. This job builds it and boots it.
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # Cheapest possible guard on the drift above, and the one that fails with a
+      # message naming the fix rather than a toolchain error 6 layers deep.
+      - name: Dockerfile base image matches go.mod
+        run: |
+          gomod=$(awk '/^go /{print $2; exit}' go.mod | cut -d. -f1,2)
+          image=$(sed -n 's/^FROM golang:\([0-9]*\.[0-9]*\).*/\1/p' Dockerfile | head -1)
+          if [ -z "$gomod" ] || [ -z "$image" ]; then
+            echo "could not parse versions (go.mod='$gomod' Dockerfile='$image')"
+            exit 1
+          fi
+          if [ "$gomod" != "$image" ]; then
+            echo "Dockerfile uses golang:$image but go.mod requires go $gomod."
+            echo "The official golang images set GOTOOLCHAIN=local, so the build"
+            echo "will fail at 'go mod download'. Update the FROM line in Dockerfile."
+            exit 1
+          fi
+          echo "go.mod and Dockerfile agree on Go $gomod"
+
+      - name: Build image
+        run: docker compose build
+
+      # A fresh clone has no configs/ or data/, so Compose creates them as root
+      # while the BBS runs as uid 100 -- the exact state a new sysop starts from.
+      - name: First run from a clean state
+        run: docker compose up -d
+
+      - name: Wait for the BBS to come up
+        run: |
+          for _ in $(seq 1 90); do
+            if docker compose logs --no-color 2>&1 | grep -q "Vision/3 BBS running"; then
+              echo "BBS reported ready"
+              exit 0
+            fi
+            state=$(docker inspect -f '{{.State.Status}}' vision3-bbs 2>/dev/null || echo gone)
+            if [ "$state" = "restarting" ] || [ "$state" = "exited" ]; then
+              echo "container is $state -- first run failed"
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "timed out waiting for the BBS to start"
+          exit 1
+
+      # Each of these fired on a real fresh install before the entrypoint learned
+      # to fix volume ownership and drop privileges.
+      - name: First run needed no manual intervention
+        run: |
+          logs=$(docker compose logs --no-color 2>&1)
+          fail=0
+          for pattern in "Permission denied" "\[FAIL\]" "setup.sh"; do
+            if echo "$logs" | grep -q "$pattern"; then
+              echo "::error::first-run log contains '$pattern'"
+              fail=1
+            fi
+          done
+          for pattern in "SSH server ready" "telnet server ready" "created default sysop account"; do
+            if ! echo "$logs" | grep -q "$pattern"; then
+              echo "::error::first-run log is missing '$pattern'"
+              fail=1
+            fi
+          done
+          exit $fail
+
+      - name: Serves SSH and telnet
+        run: |
+          for port in 2222 2323; do
+            timeout 10 bash -c "until printf '' > /dev/tcp/127.0.0.1/$port 2>/dev/null; do sleep 1; done" \
+              || { echo "::error::nothing listening on $port"; exit 1; }
+            echo "port $port accepting connections"
+          done
+
+      # The entrypoint starts as root to chown the mounts, then su-execs to
+      # vision3. If that drop ever regresses, the BBS runs as root and silently
+      # scatters root-owned files through the operator's bind mounts.
+      - name: BBS dropped privileges to vision3
+        run: |
+          owner=$(docker compose exec -T -u vision3 vision3 sh -c "ps -o user,args | awk '/ViSiON3/ && !/awk/ {print \$1; exit}'")
+          echo "ViSiON3 runs as: $owner"
+          [ "$owner" = "vision3" ] || { echo "::error::expected vision3, got '$owner'"; exit 1; }
+
+      # build.sh builds eight binaries; the Dockerfile built seven and quietly
+      # omitted wfc, which has its own documented console.
+      - name: Image ships every binary build.sh builds
+        run: |
+          expected=$(sed -n 's/.*go build -o \([A-Za-z0-9_]*\) .*/\1/p' build.sh | sort -u)
+          fail=0
+          for bin in $expected; do
+            # build.sh writes lowercase 'vision3'; the image names it ViSiON3.
+            [ "$bin" = "vision3" ] && bin=ViSiON3
+            if ! docker compose exec -T -u vision3 vision3 test -x "/vision3/$bin"; then
+              echo "::error::/vision3/$bin missing from the image"
+              fail=1
+            fi
+          done
+          exit $fail
+
+      - name: Container logs
+        if: failure()
+        run: docker compose logs --no-color
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 # docker run -d -p 2222:2222 -p 2323:2323 \
 #   -v "$(pwd)/configs:/vision3/configs" \
 #   -v "$(pwd)/data:/vision3/data" \
-#   -v "$(pwd)/menus:/vision3/menus" \
 #   vision3
 
 # ---------------------------------------------------------------------------
 # Stage 1: Build Go binaries
 # ---------------------------------------------------------------------------
-FROM golang:1.24-alpine AS builder
+# Keep this in step with the `go` directive in go.mod. The official images pin
+# GOTOOLCHAIN=local, so a base image older than go.mod fails outright at
+# `go mod download` rather than fetching a newer toolchain.
+FROM golang:1.25-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git
@@ -27,14 +29,16 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o /vision3/strings   ./c
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o /vision3/ue        ./cmd/ue
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o /vision3/config    ./cmd/config
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o /vision3/menuedit  ./cmd/menuedit
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o /vision3/wfc       ./cmd/wfc
 
 # ---------------------------------------------------------------------------
 # Stage 2: Runtime image
 # ---------------------------------------------------------------------------
 FROM alpine:latest
 
-# Install runtime dependencies
-RUN apk --no-cache add openssh-keygen ca-certificates
+# Install runtime dependencies. su-exec drops privileges in the entrypoint;
+# tzdata makes the TZ environment variable actually take effect.
+RUN apk --no-cache add openssh-keygen ca-certificates su-exec tzdata
 
 # Create non-root user for running the BBS
 RUN addgroup -S vision3 && adduser -S vision3 -G vision3
@@ -52,12 +56,21 @@ COPY --from=builder /vision3/strings   .
 COPY --from=builder /vision3/ue        .
 COPY --from=builder /vision3/config    .
 COPY --from=builder /vision3/menuedit  .
+COPY --from=builder /vision3/wfc       .
 
 # Copy template configs for initialization (includes sexyz.ini; entrypoint copies it to bin/)
 # Note: bin/sexyz and bin/binkd must be provided via a volume or added to a derived image
 COPY templates/ ./templates/
 
-RUN chown -R vision3:vision3 /vision3
+# Ship the default menu set so the image runs without a menus/ mount. Mount over
+# /vision3/menus only if you keep a customised set on the host.
+COPY menus/ ./menus/
+
+# Create the mount points before declaring them so a named volume inherits
+# vision3 ownership. Bind mounts still arrive owned by the host uid, which the
+# entrypoint corrects at runtime.
+RUN mkdir -p /vision3/configs /vision3/data /vision3/temp /vision3/bin \
+    && chown -R vision3:vision3 /vision3
 
 VOLUME /vision3/configs
 VOLUME /vision3/menus
@@ -65,8 +78,11 @@ VOLUME /vision3/data
 
 EXPOSE 2222 2323
 
-USER vision3
+# Marks the preflight check's guidance as containerised; see cmd/vision3/preflight.go.
+ENV VISION3_CONTAINER=1
 
+# NOTE: deliberately no `USER vision3`. The entrypoint starts as root only long
+# enough to chown the mounted volumes, then drops to vision3 via su-exec.
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
 CMD ["./ViSiON3"]

--- a/cmd/vision3/preflight.go
+++ b/cmd/vision3/preflight.go
@@ -128,13 +128,25 @@ func runPreflight(basePath string) bool {
 		fmt.Fprintf(os.Stderr, "  %d critical issue(s), %d warning(s).\n", criticalFails, warnFails)
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "  It looks like the initial setup has not been completed.")
-		fmt.Fprintln(os.Stderr, "  Please run the setup script for your platform:")
-		fmt.Fprintln(os.Stderr, "")
-		if runtime.GOOS == "windows" {
-			fmt.Fprintln(os.Stderr, "    .\\setup.bat        (Command Prompt)")
-			fmt.Fprintln(os.Stderr, "    .\\setup.ps1        (PowerShell)")
+		if os.Getenv("VISION3_CONTAINER") != "" {
+			// setup.sh is not shipped in the container image -- the entrypoint
+			// does its job instead. Pointing a Docker operator at it sends them
+			// looking for a file that does not exist.
+			fmt.Fprintln(os.Stderr, "  The entrypoint could not prepare these paths, which almost always")
+			fmt.Fprintln(os.Stderr, "  means the mounted volumes are not writable by the container user.")
+			fmt.Fprintln(os.Stderr, "")
+			fmt.Fprintln(os.Stderr, "    docker compose down")
+			fmt.Fprintln(os.Stderr, "    sudo chown -R 100:101 ./configs ./data")
+			fmt.Fprintln(os.Stderr, "    docker compose up -d")
 		} else {
-			fmt.Fprintln(os.Stderr, "    ./setup.sh")
+			fmt.Fprintln(os.Stderr, "  Please run the setup script for your platform:")
+			fmt.Fprintln(os.Stderr, "")
+			if runtime.GOOS == "windows" {
+				fmt.Fprintln(os.Stderr, "    .\\setup.bat        (Command Prompt)")
+				fmt.Fprintln(os.Stderr, "    .\\setup.ps1        (PowerShell)")
+			} else {
+				fmt.Fprintln(os.Stderr, "    ./setup.sh")
+			}
 		}
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "  For detailed instructions see: https://vision3bbs.com/sysop/")

--- a/cmd/vision3/preflight.go
+++ b/cmd/vision3/preflight.go
@@ -8,6 +8,10 @@ import (
 	"runtime"
 )
 
+// menusCheckName labels the menu-set check so the failure report can tell an
+// empty menus/ bind mount apart from an unwritable volume.
+const menusCheckName = "menus/v3/"
+
 // preflightResult holds the outcome of a single preflight check.
 type preflightResult struct {
 	name     string
@@ -50,7 +54,7 @@ func runPreflight(basePath string) bool {
 	check("data/logs/", true, filepath.Join(dataPath, "logs"), true)
 	check("data/msgbases/", true, filepath.Join(dataPath, "msgbases"), true)
 	check("data/files/", true, filepath.Join(dataPath, "files"), true)
-	check("menus/v3/", true, filepath.Join(basePath, "menus", "v3"), true)
+	check(menusCheckName, true, filepath.Join(basePath, "menus", "v3"), true)
 
 	// --- Required config (critical) ---
 	check("configs/config.json", true, filepath.Join(configPath, "config.json"), false)
@@ -90,12 +94,22 @@ func runPreflight(basePath string) bool {
 	// --- Evaluate results ---
 	criticalFails := 0
 	warnFails := 0
+	// Tracked separately: an empty menus/ mount and an unwritable volume are
+	// both critical, but they need opposite advice, and chowning cannot fix the
+	// former.
+	menusMissing := false
+	otherCriticalFails := 0
 	for _, r := range results {
 		if r.ok {
 			continue
 		}
 		if r.critical {
 			criticalFails++
+			if r.name == menusCheckName {
+				menusMissing = true
+			} else {
+				otherCriticalFails++
+			}
 		} else {
 			warnFails++
 		}
@@ -132,12 +146,26 @@ func runPreflight(basePath string) bool {
 			// setup.sh is not shipped in the container image -- the entrypoint
 			// does its job instead. Pointing a Docker operator at it sends them
 			// looking for a file that does not exist.
-			fmt.Fprintln(os.Stderr, "  The entrypoint could not prepare these paths, which almost always")
-			fmt.Fprintln(os.Stderr, "  means the mounted volumes are not writable by the container user.")
-			fmt.Fprintln(os.Stderr, "")
-			fmt.Fprintln(os.Stderr, "    docker compose down")
-			fmt.Fprintln(os.Stderr, "    sudo chown -R 100:101 ./configs ./data")
-			fmt.Fprintln(os.Stderr, "    docker compose up -d")
+			if menusMissing {
+				fmt.Fprintln(os.Stderr, "  The image ships the default menu set, so an empty menus/v3 almost")
+				fmt.Fprintln(os.Stderr, "  always means an empty host directory is mounted over it. Either drop")
+				fmt.Fprintln(os.Stderr, "  the menus mount from docker-compose.yml, or populate it:")
+				fmt.Fprintln(os.Stderr, "")
+				fmt.Fprintln(os.Stderr, "    docker create --name v3tmp vision3:latest")
+				fmt.Fprintln(os.Stderr, "    docker cp v3tmp:/vision3/menus/v3 ./menus/")
+				fmt.Fprintln(os.Stderr, "    docker rm v3tmp")
+			}
+			if otherCriticalFails > 0 {
+				if menusMissing {
+					fmt.Fprintln(os.Stderr, "")
+				}
+				fmt.Fprintln(os.Stderr, "  The entrypoint could not prepare these paths, which almost always")
+				fmt.Fprintln(os.Stderr, "  means the mounted volumes are not writable by the container user.")
+				fmt.Fprintln(os.Stderr, "")
+				fmt.Fprintln(os.Stderr, "    docker compose down")
+				fmt.Fprintln(os.Stderr, "    sudo chown -R 100:101 ./configs ./data")
+				fmt.Fprintln(os.Stderr, "    docker compose up -d")
+			}
 		} else {
 			fmt.Fprintln(os.Stderr, "  Please run the setup script for your platform:")
 			fmt.Fprintln(os.Stderr, "")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   vision3:
     build:
@@ -15,6 +13,8 @@ services:
       # Persistent data - these directories will be created on host
       - ./configs:/vision3/configs
       - ./data:/vision3/data
+      # Menus ship inside the image; this mount keeps a customised
+      # set on the host and lets `git pull` update them in place.
       - ./menus:/vision3/menus
     environment:
       # Optional: Override default settings

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,11 +1,31 @@
 #!/bin/sh
 
+# ---------------------------------------------------------------------------
+# Privilege drop
+#
+# Bind-mounted volumes arrive owned by the host uid -- root, when Docker itself
+# created the directory. A build-time chown cannot reach them, so the container
+# starts as root, fixes ownership of the mounts, and re-execs this script as
+# vision3. Everything below therefore runs unprivileged.
+#
+# If the operator pinned a uid (docker run --user), we are not root and cannot
+# chown; carry on and let the writes succeed or fail on their own merits.
+# ---------------------------------------------------------------------------
+if [ "$(id -u)" = "0" ]; then
+    mkdir -p /vision3/configs /vision3/data /vision3/menus /vision3/temp /vision3/bin
+    chown -R vision3:vision3 \
+        /vision3/configs /vision3/data /vision3/temp /vision3/bin 2>/dev/null
+    # A curated menu set may be mounted read-only; never fail the boot over it.
+    chown -R vision3:vision3 /vision3/menus 2>/dev/null || true
+    exec su-exec vision3 "$0" "$@"
+fi
+
 # Create necessary directories
 mkdir -p /vision3/configs
 mkdir -p /vision3/data/users
 mkdir -p /vision3/data/logs
 mkdir -p /vision3/data/msgbases/privmail
-mkdir -p /vision3/data/files
+mkdir -p /vision3/data/files/general
 mkdir -p /vision3/data/infoforms/templates
 mkdir -p /vision3/data/infoforms/responses
 mkdir -p /vision3/temp
@@ -41,8 +61,12 @@ if [ ! -f "/vision3/configs/ssh_host_ed25519_key" ]; then
     ssh-keygen -t ed25519 -f /vision3/configs/ssh_host_ed25519_key -N "" -q
 fi
 
-# Copy any missing template configs (runs on every start to pick up newly added files)
-for template_file in /vision3/templates/configs/*.json; do
+# Copy any missing template configs (runs on every start to pick up newly added
+# files). The .txt pass covers the IP blocklist/allowlist that config.json's
+# ipBlocklistPath / ipAllowlistPath point at -- keep both globs in step with
+# setup.sh, which seeds the same files for a native install.
+for template_file in /vision3/templates/configs/*.json /vision3/templates/configs/*.txt; do
+    [ -f "$template_file" ] || continue
     target="/vision3/configs/$(basename "$template_file")"
     if [ ! -f "$target" ]; then
         echo "  Creating $(basename "$target") from template..."
@@ -65,11 +89,24 @@ for template_file in /vision3/templates/infoforms/form_*.txt; do
     fi
 done
 
+# Seed the initial data files setup.sh writes for a native install. users.json is
+# deliberately absent: the BBS creates the default sysop account itself on first
+# start (internal/user/manager.go), so writing it here would fork a second copy
+# of those defaults.
+[ -f /vision3/data/oneliners.json ]        || echo "[]" > /vision3/data/oneliners.json
+[ -f /vision3/data/users/callhistory.json ] || echo "[]" > /vision3/data/users/callhistory.json
+[ -f /vision3/data/users/callnumber.json ]  || echo "1"  > /vision3/data/users/callnumber.json
+
 # Ensure sexyz.ini is in bin/ (binary must be provided by user)
 mkdir -p /vision3/bin
 if [ ! -f "/vision3/bin/sexyz.ini" ] && [ -f "/vision3/templates/configs/sexyz.ini" ]; then
     echo "Copying sexyz.ini to bin/..."
     cp /vision3/templates/configs/sexyz.ini /vision3/bin/sexyz.ini
+fi
+
+# Initialise the JAM message bases, as setup.sh does. Harmless once they exist.
+if [ -x /vision3/v3mail ]; then
+    /vision3/v3mail stats --all --config /vision3/configs --data /vision3/data >/dev/null 2>&1 || true
 fi
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,10 +13,25 @@
 # ---------------------------------------------------------------------------
 if [ "$(id -u)" = "0" ]; then
     mkdir -p /vision3/configs /vision3/data /vision3/menus /vision3/temp /vision3/bin
-    chown -R vision3:vision3 \
-        /vision3/configs /vision3/data /vision3/temp /vision3/bin 2>/dev/null
-    # A curated menu set may be mounted read-only; never fail the boot over it.
-    chown -R vision3:vision3 /vision3/menus 2>/dev/null || true
+    # Walk the tree only when the mount root is not already ours. Docker creates
+    # these owned by root on a fresh install, which is the case worth repairing;
+    # on every restart afterwards a recursive pass would traverse the whole of
+    # data/ -- every file area, every message base -- to change nothing.
+    owner_uid=$(id -u vision3)
+    for d in /vision3/configs /vision3/data /vision3/temp /vision3/bin; do
+        if [ "$(stat -c %u "$d" 2>/dev/null)" != "$owner_uid" ]; then
+            chown -R vision3:vision3 "$d" 2>/dev/null
+        fi
+    done
+    # menus/ is deliberately NOT chowned. docker-compose.yml bind-mounts the
+    # repository checkout there, and taking ownership of it leaves the host user
+    # unable to `git pull` or edit their own menu set -- the container silently
+    # breaking the working tree it was started from. The BBS only reads menus,
+    # and a normal checkout is already world-readable.
+    #
+    # The trade-off: menuedit cannot save into a bind-mounted menus/ unless the
+    # host makes it writable by uid 100. Editing on the host, or dropping the
+    # mount to use the set baked into the image, both avoid that.
     exec su-exec vision3 "$0" "$@"
 fi
 
@@ -104,9 +119,13 @@ if [ ! -f "/vision3/bin/sexyz.ini" ] && [ -f "/vision3/templates/configs/sexyz.i
     cp /vision3/templates/configs/sexyz.ini /vision3/bin/sexyz.ini
 fi
 
-# Initialise the JAM message bases, as setup.sh does. Harmless once they exist.
+# Initialise the JAM message bases, as setup.sh does. Harmless once they exist,
+# and non-fatal if it fails -- the message manager opens bases on demand -- but
+# say so rather than swallowing it, or the first symptom is an empty message area.
 if [ -x /vision3/v3mail ]; then
-    /vision3/v3mail stats --all --config /vision3/configs --data /vision3/data >/dev/null 2>&1 || true
+    if ! /vision3/v3mail stats --all --config /vision3/configs --data /vision3/data >/dev/null; then
+        echo "WARNING: could not initialise JAM message bases; message areas may be unavailable" >&2
+    fi
 fi
 
 exec "$@"

--- a/docs/sysop/configuration/security.md
+++ b/docs/sysop/configuration/security.md
@@ -662,7 +662,7 @@ grep "authenticated successfully" data/logs/vision3.log
    git pull
    go build ./cmd/vision3
    # or
-   docker-compose up -d --build
+   docker compose up -d --build
    ```
 
 4. **Monitor Logs**

--- a/docs/sysop/files/file-areas.md
+++ b/docs/sysop/files/file-areas.md
@@ -331,7 +331,7 @@ Protocol configurations are defined in `configs/protocols.json`. ViSiON/3 uses *
 
 sexyz is included as a pre-built binary at `bin/sexyz`. If you need to build it for a different platform, see [File Transfer Protocols](files/file-transfer.md) for instructions.
 
-**Docker:** The sexyz binary is copied into the Docker image automatically if present at `bin/sexyz`.
+**Docker:** The sexyz binary is *not* bundled in the image — mount `./bin:/vision3/bin` or bake it into a derived image. See [Adding sexyz and binkd](getting-started/docker.md#adding-sexyz-and-binkd).
 
 **Currently Implemented:**
 

--- a/docs/sysop/files/file-transfer.md
+++ b/docs/sysop/files/file-transfer.md
@@ -143,15 +143,26 @@ ViSiON/3's telnet layer (`TelnetConn`) handles IAC stripping/escaping transparen
 
 ## Docker Deployment
 
-For Docker deployments, the sexyz binary must be included in the image. Place it at `bin/sexyz` before building:
+The stock image does **not** contain sexyz — `.dockerignore` excludes `bin/`, and
+the binary is a third-party build that has to match the container architecture
+(linux/amd64 for the Alpine base). Supply it one of two ways.
 
-```dockerfile
-# Copy sexyz binary
-COPY bin/sexyz ./bin/sexyz
-RUN chmod +x ./bin/sexyz
+Mount it at runtime:
+
+```yaml
+volumes:
+  - ./bin:/vision3/bin
 ```
 
-Ensure the binary matches the Docker container's architecture (typically linux/amd64 for Alpine-based images).
+Or bake it into a derived image:
+
+```dockerfile
+FROM vision3:latest
+COPY bin/sexyz /vision3/bin/sexyz
+```
+
+The entrypoint copies `sexyz.ini` into `bin/` on every start, so only the binary
+itself needs supplying. See [Docker Deployment](getting-started/docker.md#adding-sexyz-and-binkd).
 
 ## Troubleshooting
 

--- a/docs/sysop/files/file-transfer.md
+++ b/docs/sysop/files/file-transfer.md
@@ -161,6 +161,9 @@ FROM vision3:latest
 COPY bin/sexyz /vision3/bin/sexyz
 ```
 
+`.dockerignore` excludes `bin/` but re-includes `bin/sexyz` and `bin/binkd`, so
+this resolves with the repository root as the build context.
+
 The entrypoint copies `sexyz.ini` into `bin/` on every start, so only the binary
 itself needs supplying. See [Docker Deployment](getting-started/docker.md#adding-sexyz-and-binkd).
 

--- a/docs/sysop/getting-started/docker.md
+++ b/docs/sysop/getting-started/docker.md
@@ -24,12 +24,14 @@ This guide covers deploying ViSiON/3 using Docker and Docker Compose.
 
    This will:
    - Build the Docker image
-   - Compile all Go binaries (ViSiON3, v3mail, helper, strings)
-   - Bundle sexyz (Synchronet ZModem 8k) from `bin/sexyz`
-   - Create necessary directories (`configs/`, `data/`, `menus/`, `temp/`)
+   - Compile all Go binaries (ViSiON3, v3mail, helper, strings, ue, config, menuedit, wfc)
+   - Create necessary directories (`configs/`, `data/`, `temp/`)
    - Generate SSH host keys automatically
    - Initialize config files from templates
    - Start the BBS on ports 2222 (SSH) and 2323 (telnet)
+
+   > **sexyz and binkd are not bundled.** The image ships `sexyz.ini` but not the
+   > binaries themselves — see [Adding sexyz and binkd](#adding-sexyz-and-binkd).
 
 3. **Check logs:**
 
@@ -57,7 +59,7 @@ If you prefer not to use Docker Compose:
 2. **Create host directories:**
 
    ```bash
-   mkdir -p configs data menus
+   mkdir -p configs data
    ```
 
 3. **Run the container:**
@@ -69,9 +71,13 @@ If you prefer not to use Docker Compose:
      -p 2323:2323 \
      -v "$(pwd)/configs:/vision3/configs" \
      -v "$(pwd)/data:/vision3/data" \
-     -v "$(pwd)/menus:/vision3/menus" \
      vision3:latest
    ```
+
+   The default menu set ships inside the image, so no `menus/` mount is needed.
+   Add `-v "$(pwd)/menus:/vision3/menus"` only if you keep a customised set on
+   the host — mounting an *empty* directory there hides the built-in menus and
+   the pre-flight check will refuse to start.
 
 ## Important Notes
 
@@ -79,11 +85,46 @@ If you prefer not to use Docker Compose:
 
 ViSiON/3 uses a pure-Go SSH implementation (`gliderlabs/ssh`) — no CGO or native libraries required. The Dockerfile:
 
-- Builds all Go binaries: `vision3`, `v3mail`, `config`, `strings`, `ue`, `menuedit`, `helper`
-- Copies `bin/sexyz` for ZModem 8k file transfers (works on both SSH and telnet)
-- Copies the static `binkd` binary for FTN mailer support
+- Builds all Go binaries: `ViSiON3`, `v3mail`, `config`, `strings`, `ue`, `menuedit`, `helper`, `wfc`
+- Ships the default menu set at `/vision3/menus`
+- Ships `sexyz.ini`, which the entrypoint copies to `bin/`
 
-> **Note:** The sexyz binary at `bin/sexyz` must match the container's architecture (typically linux/amd64). See [File Transfer Protocols](files/file-transfer.md) for build instructions.
+The builder stage is pinned to the Go version in `go.mod`. The official `golang`
+images set `GOTOOLCHAIN=local`, so if `go.mod` is bumped past the base image the
+build fails at `go mod download` rather than fetching a newer toolchain — keep
+the two in step.
+
+### Adding sexyz and binkd
+
+The `sexyz` (ZModem 8k file transfers) and `binkd` (FTN mailer) binaries are
+**not** in the image: they are third-party builds that must match the
+container's architecture (linux/amd64 for the Alpine base). Supply them with a
+mount:
+
+```yaml
+volumes:
+  - ./bin:/vision3/bin
+```
+
+or add them in a derived image:
+
+```dockerfile
+FROM vision3:latest
+COPY bin/sexyz bin/binkd /vision3/bin/
+```
+
+See [File Transfer Protocols](files/file-transfer.md) for build instructions.
+
+### Container user and file ownership
+
+The BBS runs as the unprivileged `vision3` user (uid 100, gid 101). The
+entrypoint starts as root only long enough to `chown` the mounted volumes, then
+drops privileges — so Docker-created bind mounts, which arrive owned by root,
+work without any manual preparation.
+
+Because of that privilege drop, `docker exec` lands you as **root**, not
+`vision3`. Always pass `-u vision3` when running the TUI tools, or they will
+leave root-owned files in `configs/` that the BBS cannot rewrite.
 
 ### Persistent Data
 
@@ -111,10 +152,16 @@ The following directories are mounted as volumes and persist across container re
 
 On first run, the entrypoint script will:
 
-1. Create necessary directories
-2. Generate SSH host keys (RSA and ED25519)
-3. Copy template configs to `configs/` if missing
-4. Create default user (felonius/password)
+1. Fix ownership of the mounted volumes, then drop to the `vision3` user
+2. Create necessary directories
+3. Generate SSH host keys (RSA and ED25519)
+4. Copy template configs and IP list files to `configs/` if missing
+5. Seed `data/oneliners.json` and the call-history counters
+6. Initialize the JAM message bases
+
+The default sysop account (`felonius` / `password`, access level 255) is created
+by the BBS itself on first start, not by the entrypoint — watch for the
+`created default sysop account` warning in the logs.
 
 ### Configuration
 
@@ -122,17 +169,24 @@ After first run, use the TUI tools to configure your BBS. Run them via `docker e
 
 ```bash
 # Main config editor (BBS name, ports, access levels, networking, etc.)
-docker exec -it vision3-bbs ./config
+docker exec -u vision3 -it vision3-bbs ./config
 
 # String editor (display text and prompts)
-docker exec -it vision3-bbs ./strings
+docker exec -u vision3 -it vision3-bbs ./strings
 
 # User editor
-docker exec -it vision3-bbs ./ue
+docker exec -u vision3 -it vision3-bbs ./ue
 
 # Menu editor
-docker exec -it vision3-bbs ./menuedit
+docker exec -u vision3 -it vision3-bbs ./menuedit
+
+# WFC sysop console
+docker exec -u vision3 -it vision3-bbs ./wfc
 ```
+
+> Omitting `-u vision3` runs the tool as root and writes root-owned files into
+> the mounted volumes, which the BBS itself (running as `vision3`) then cannot
+> modify.
 
 The container's working directory is `/vision3`, which is where `configs/`, `data/`, and `menus/` are mounted — so the TUI tools find your files automatically without extra flags.
 

--- a/docs/sysop/getting-started/docker.md
+++ b/docs/sysop/getting-started/docker.md
@@ -113,6 +113,9 @@ FROM vision3:latest
 COPY bin/sexyz bin/binkd /vision3/bin/
 ```
 
+`.dockerignore` excludes `bin/` but re-includes those two paths specifically, so
+the `COPY` resolves with the repository root as the build context.
+
 See [File Transfer Protocols](files/file-transfer.md) for build instructions.
 
 ### Container user and file ownership
@@ -125,6 +128,18 @@ work without any manual preparation.
 Because of that privilege drop, `docker exec` lands you as **root**, not
 `vision3`. Always pass `-u vision3` when running the TUI tools, or they will
 leave root-owned files in `configs/` that the BBS cannot rewrite.
+
+`menus/` is deliberately left alone. Compose bind-mounts your checkout there, and
+taking ownership of it would leave you unable to `git pull` or edit your own menu
+set on the host. The BBS only reads menus, so a normal checkout works as-is.
+
+The trade-off is that `menuedit` cannot save into a bind-mounted `menus/`, which
+the container user may read but not write. Pick whichever suits your setup:
+
+- edit menus on the host (`./menuedit` from the checkout), or
+- drop the `menus/` mount and use the set baked into the image, or
+- make the mount writable by the container user: `sudo chown -R 100:101 ./menus`
+  — after which the host user needs `sudo` to edit those files.
 
 ### Persistent Data
 


### PR DESCRIPTION
## What a user hit

A sysop reported they couldn't get ViSiON/3 running under Docker. Reproduced from a clean checkout: the image has been **unbuildable since 2026-03-16** (`a78bfce`, which moved `go.mod` to `go 1.25.0`). The Dockerfile was last touched four days earlier and still pinned `golang:1.24-alpine`. The build died at step 6 of 14, before compiling anything:

```
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

The official `golang` images pin `GOTOOLCHAIN=local`, so there is no auto-download fallback — this fails on every platform, unconditionally. Nothing in CI built the image, so two releases shipped a container nobody could build.

## What was behind it

Bumping the base image got the build through, and the container then went into an infinite restart loop:

```
cp: can't create '/vision3/configs/config.json': Permission denied
  [FAIL] data/users/ — missing        ... 6 critical issue(s)
  Please run the setup script for your platform:
    ./setup.sh
```

`chown -R vision3:vision3 /vision3` ran at `Dockerfile:60`, but `configs/`, `data/` and `menus/` didn't exist yet — they are `VOLUME` mount points created at container start as `root:root`, and Compose creates the host side as root too. The entrypoint ran as uid 100 with no write access and, having no `set -e`, failed silently through every step. Preflight then pointed the operator at `./setup.sh`, which `.dockerignore:48` excludes from the image, while `restart: unless-stopped` looped it forever.

Four smaller defects surfaced alongside: `wfc` was never built (`build.sh` builds it, and it has its own docs page); `menus/` was never copied in, so the documented `docker run` path mounted an empty directory over nothing and tripped preflight's critical `menus/v3/` check; the entrypoint copied only `templates/configs/*.json`, so the blocklist/allowlist that `config.json:22-23` points at never existed in Docker; and `TZ` was silently ignored because Alpine has no tzdata.

## Changes

**Dockerfile** — base image tracks `go.mod`; builds `wfc`; ships `menus/`; adds `su-exec` and `tzdata`; creates and chowns the mount points before declaring them.

**docker-entrypoint.sh** — starts as root only to chown the mounts, then `su-exec`s to `vision3`. Closes the drift against `setup.sh`: copies `templates/configs/*.txt`, creates `data/files/general`, `oneliners.json`, `callhistory.json`, `callnumber.json`, and initializes the JAM bases.

**preflight** — containerised installs get volume-ownership guidance instead of a `setup.sh` that isn't shipped there.

**docs/sysop** — corrected the sexyz/binkd bundling claims in `docker.md`, `file-transfer.md` and `file-areas.md` (neither binary was ever copied), the binary list, the first-run sequence, and the manual `docker run` path. Documented the container user, since the privilege drop means `docker exec` lands as root — the TUI commands now use `-u vision3`.

**CI** — a `docker` job that builds the image, boots it from a clean state, and asserts the first run needs no intervention (no `Permission denied`, no `[FAIL]`, no `setup.sh`; SSH and telnet ready; sysop account created), that both ports accept connections, that `ViSiON3` runs as `vision3`, and that the image ships every binary `build.sh` builds. Plus a cheap guard that fails with a message naming the fix when the Dockerfile and `go.mod` drift apart again.

## Verification

Clean-room `git archive` of HEAD plus these changes, fresh `docker compose build && up`:

- container stays up; preflight passes with one expected first-boot warning (`users.json`, written by the BBS seconds later)
- sysop account created at level 255
- SSH handshakes and offers password auth; telnet renders the pre-login matrix ANSI
- `ps` confirms `./ViSiON3` running as `vision3`
- every CI step above executed locally and passed; the version guard was negative-tested in both directions (stale Dockerfile, and `go.mod` bumped past the image) and fails correctly
- `go build ./...`, `go vet`, `gofmt`, `go test ./cmd/... ./internal/user/...` clean




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker images now include built-in menus, the `wfc` console, required runtime tools, and expanded Go binaries.
  * Container startup initializes required data, repairs mounted-volume ownership, and runs services with non-root privileges.
  * Custom menu mounts remain supported, with improved handling for empty or unwritable mounts.

* **Bug Fixes**
  * Improved container startup diagnostics and initialization warnings.

* **Documentation**
  * Updated Docker, security, file-transfer, and file-area guidance, including current Compose commands and optional `sexyz` setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
