### PR TITLE
fix(editor): align the idle/ESC timeout atomics for 32-bit builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,30 @@ jobs:
         with:
           only-new-issues: true
 
+      # The 386 builds run on 32-bit Windows, and there a 64-bit atomic on a
+      # struct field that is not 8-byte aligned panics at first use with
+      # "unaligned 64-bit atomic operation". 0.9.0 and 0.9.1 shipped with one
+      # in the editor's input handler, so every telnet connect on Windows 10
+      # 32-bit died at the matrix screen. No 64-bit build, vet, or test can see
+      # it: the field is aligned on amd64/arm64. staticcheck's SA1027 finds it,
+      # but only while analysing a 32-bit target, which the step above never
+      # does. Both OSes, since windows-tagged files are only analysed under
+      # GOOS=windows. Runs on main too: it has no baseline to hide behind.
+      - name: golangci-lint linux/386 (64-bit atomic alignment)
+        uses: golangci/golangci-lint-action@v8
+        with:
+          args: --config .golangci-32bit.yml
+        env:
+          GOOS: linux
+          GOARCH: "386"
+      - name: golangci-lint windows/386 (64-bit atomic alignment)
+        uses: golangci/golangci-lint-action@v8
+        with:
+          args: --config .golangci-32bit.yml
+        env:
+          GOOS: windows
+          GOARCH: "386"
+
   # Windows is a released platform (README: "Windows x86_64 Released") and now
   # gates like Linux does. It went untested for a long time, and turning it on
   # found four product bugs at once: FTN mail could not start there at all

--- a/.golangci-32bit.yml
+++ b/.golangci-32bit.yml
@@ -1,0 +1,18 @@
+# Used by the CI lint job with GOOS/GOARCH set to a 32-bit target. Only
+# staticcheck's SA1027 (64-bit atomic on a field that is not 8-byte aligned)
+# is enabled: it fires only while analysing a 32-bit target, so the main
+# .golangci.yml run never sees it. Everything else is covered there.
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - staticcheck
+  settings:
+    staticcheck:
+      checks:
+        - SA1027
+  exclusions:
+    generated: lax
+    paths:
+      - third_party

--- a/internal/editor/input.go
+++ b/internal/editor/input.go
@@ -74,14 +74,19 @@ type InputHandler struct {
 	unreadBuf []byte        // bytes pushed back for re-reading
 
 	// idleNs is the session-level idle timeout in nanoseconds (0 = disabled).
-	// Stored as int64 for lock-free atomic access. Any call to readByte()
-	// that blocks longer than this fires ErrIdleTimeout. Set via
-	// SetSessionIdleTimeout; read on every key-wait.
-	idleNs int64 // atomic
+	// Any call to readByte() that blocks longer than this fires
+	// ErrIdleTimeout. Set via SetSessionIdleTimeout; read on every key-wait.
+	//
+	// atomic.Int64 (not a bare int64 with atomic.LoadInt64/StoreInt64) is
+	// deliberate: the typed wrapper is guaranteed 8-byte aligned wherever it
+	// is placed, whereas a bare int64 after the pointer-sized fields above
+	// lands at a 4-byte offset on 32-bit targets (386, arm) and the first
+	// atomic access panics with "unaligned 64-bit atomic operation".
+	idleNs atomic.Int64
 
 	// escTimeoutNs overrides the inter-byte ESC disambiguation window
 	// (default 500 ms). 0 means use the default. Set via SetEscTimeout.
-	escTimeoutNs int64 // atomic
+	escTimeoutNs atomic.Int64
 
 	// Optional read interrupt integration for sessions that support it.
 	readInterrupt    chan struct{}
@@ -92,24 +97,24 @@ type InputHandler struct {
 // SetSessionIdleTimeout sets the session-level idle timeout applied to every
 // ReadKey call. Pass 0 to disable. Thread-safe.
 func (ih *InputHandler) SetSessionIdleTimeout(d time.Duration) {
-	atomic.StoreInt64(&ih.idleNs, d.Nanoseconds())
+	ih.idleNs.Store(d.Nanoseconds())
 }
 
 // SetEscTimeout overrides the ESC disambiguation window used in ReadKey.
 // Pass 0 to restore the default (500 ms). Thread-safe.
 func (ih *InputHandler) SetEscTimeout(d time.Duration) {
-	atomic.StoreInt64(&ih.escTimeoutNs, d.Nanoseconds())
+	ih.escTimeoutNs.Store(d.Nanoseconds())
 }
 
 func (ih *InputHandler) escTimeout() time.Duration {
-	if ns := atomic.LoadInt64(&ih.escTimeoutNs); ns > 0 {
+	if ns := ih.escTimeoutNs.Load(); ns > 0 {
 		return time.Duration(ns)
 	}
 	return 500 * time.Millisecond
 }
 
 func (ih *InputHandler) sessionIdleTimeout() time.Duration {
-	ns := atomic.LoadInt64(&ih.idleNs)
+	ns := ih.idleNs.Load()
 	if ns <= 0 {
 		return 0
 	}


### PR DESCRIPTION
Fixes the 386 build dying on every telnet connect with `telnet panic handling connection ... "unaligned 64-bit atomic operation"` (reported on Windows 10 32-bit 22H2, 0.9.0 and 0.9.1, stock config; Syncterm and Magiterm).

### Cause
`InputHandler` kept `idleNs` and `escTimeoutNs` as bare `int64` fields behind three pointer-sized fields and accessed them with `atomic.LoadInt64`/`StoreInt64`. On 32-bit targets the pointers are 4 bytes, so the int64s land at offset 20 and Go's 32-bit runtime panics on the first 64-bit atomic that touches them. That first touch is `SetSessionIdleTimeout`, called right after the matrix screen is drawn, which matches the reporter's log. amd64/arm64 pad the fields to 8 bytes and never see it.

### Fix
Both fields become `atomic.Int64`, whose alignment is guaranteed wherever the struct is placed.

### Verification (all from macOS)
- Editor tests cross-compiled for linux/386 and run under Docker (`--platform linux/386`): old code panics with the exact message, fixed code passes.
- `GOOS=linux GOARCH=386 go build ./...` and `GOOS=windows GOARCH=386 go build ./...` clean.
- Full native `go test ./...` passes.

### CI guard
Nothing in CI analysed a 32-bit target, and `go vet` has no alignment check. Adds `.golangci-32bit.yml` (staticcheck `SA1027` only) and runs it in the lint job against linux/386 and windows/386. It flags all four sites in the old code and is clean after the fix. It runs on `main` pushes too since it has no legacy baseline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved timeout value handling to support safer operation across 32-bit environments.

- **Tests**
  - Added automated static analysis for Linux and Windows 32-bit targets.
  - Added checks for potential 64-bit atomic alignment issues, including Windows-specific code paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->