### PR TITLE
chore(lint): clear the last two legacy issues and gate main on golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,11 @@ jobs:
           fi
       - name: go vet
         run: go vet ./...
-      # A ~131-issue legacy baseline exists (2026-07-15: 50 errcheck, 45
-      # staticcheck, 36 unused); block only new issues until it's burned
-      # down. only-new-issues requires a PR patch, so this step is
-      # PR-only by design — a full run on main would fail on the baseline.
+      # The legacy baseline (~131 issues on 2026-07-15) is gone as of #349, so
+      # this is a full run that gates pushes to main as well as PRs. Keep it
+      # that way: only-new-issues needs a PR patch and would silently skip main.
       - name: golangci-lint
-        if: github.event_name == 'pull_request'
         uses: golangci/golangci-lint-action@v8
-        with:
-          only-new-issues: true
 
       # The 386 builds run on 32-bit Windows, and there a 64-bit atomic on a
       # struct field that is not 8-byte aligned panics at first use with

--- a/internal/configeditor/update_records_reorder.go
+++ b/internal/configeditor/update_records_reorder.go
@@ -21,7 +21,7 @@ func (m Model) updateRecordReorder(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	lo := m.reorderMinIdx
 	hi := m.reorderMaxIdx
 
-	target := m.recordCursor
+	var target int
 	switch msg.Type {
 	case tea.KeyUp:
 		target = m.recordCursor - 1

--- a/internal/stringeditor/view.go
+++ b/internal/stringeditor/view.go
@@ -52,8 +52,7 @@ var (
 	fallbackStyle = tuiart.Color(dosBlack, dosDarkGray)
 
 	// State marker column, between the label and the value.
-	markerStyle          = tuiart.Color(dosBlack, dosLightCyan)
-	markerHighlightStyle = tuiart.Color(dosMagenta, dosLightCyan)
+	markerStyle = tuiart.Color(dosBlack, dosLightCyan)
 
 	// Description caption, drawn over the backdrop below the panel
 	descriptionStyle = tuiart.Color(dosBlack, dosLightMagenta)


### PR DESCRIPTION
Closes #348.

The lint job's ~131-issue legacy baseline is down to two, so this clears them and turns the golangci-lint step into a full run that gates pushes to `main` as well as PRs.

- `internal/configeditor/update_records_reorder.go`: `target := m.recordCursor` was dead, since every switch arm either assigns `target` or returns. Now `var target int`.
- `internal/stringeditor/view.go`: `markerHighlightStyle` had no callers. Removed.
- `.github/workflows/ci.yml`: drop `only-new-issues: true` and the `pull_request` guard; update the comment.

Local `golangci-lint run ./...` with the repo config reports 0 issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated code-quality checks to run consistently for main-branch updates and pull requests.

* **Refactor**
  * Streamlined internal editor state handling.
  * Removed unused internal styling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->