### PR TITLE
fix(scheduler): stop an event's orphaned child from holding the run open

### DIFF
--- a/internal/scheduler/executor.go
+++ b/internal/scheduler/executor.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -13,6 +14,19 @@ import (
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/config"
 )
+
+// outputWaitDelay is how long after an event's process has exited that
+// executeEvent keeps waiting for its stdout and stderr to close.
+//
+// Output is captured through pipes, and a pipe stays open for as long as any
+// process holds its write end. An event that leaves a background child
+// behind — a script that starts a daemon, or "sleep 30 &" — exits promptly
+// itself, but cmd.Run then blocked until that child also exited, and the same
+// held after a timeout kill, which reaches only the process we started. The
+// event's slot and running-event mark were held for the whole of it. After
+// this delay the pipes are closed and the run completes on the process's own
+// exit status.
+const outputWaitDelay = 5 * time.Second
 
 // executeEvent runs a scheduled event and returns the result
 func (s *Scheduler) executeEvent(ctx context.Context, event config.EventConfig) EventResult {
@@ -90,12 +104,22 @@ func (s *Scheduler) executeEvent(ctx context.Context, event config.EventConfig) 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
+	cmd.WaitDelay = outputWaitDelay
 
 	// Execute the command
 	err := cmd.Run()
 	result.EndTime = time.Now()
 	result.Output = stdout.String()
 	result.ErrorOutput = stderr.String()
+
+	// ErrWaitDelay means the process itself exited cleanly and only its
+	// orphaned output pipes had to be closed: the event succeeded, and what
+	// the orphan wrote afterwards is not part of its output.
+	if errors.Is(err, exec.ErrWaitDelay) {
+		slog.Warn("event left a child process holding its output open; output after the event's own exit was discarded",
+			"id", event.ID, "name", event.Name, "wait_delay", outputWaitDelay)
+		err = nil
+	}
 
 	// Determine result status
 	if err != nil {

--- a/internal/scheduler/executor_test.go
+++ b/internal/scheduler/executor_test.go
@@ -210,3 +210,34 @@ func TestPlaceholderSubstitutionInCommand(t *testing.T) {
 		t.Errorf("Expected output to contain 'placeholder_test_ok', got: %s", result2.Output)
 	}
 }
+
+// An event that leaves a background child behind exits promptly itself, but
+// the child inherits the output pipes. cmd.Run used to block until that child
+// exited too, holding the event's concurrency slot and running-event mark for
+// however long the orphan lived, and a timeout kill did not help because it
+// reaches only the process we started.
+func TestExecuteEvent_OrphanedChildDoesNotBlockCompletion(t *testing.T) {
+	s := &Scheduler{}
+
+	event := config.EventConfig{
+		ID:      "test_orphan",
+		Name:    "Test Orphaned Child",
+		Command: lookPath(t, "sh"),
+		// The shell exits at once; the sleep keeps stdout open for 30s.
+		Args: []string{"-c", "sleep 30 & echo started"},
+	}
+
+	start := time.Now()
+	result := s.executeEvent(context.Background(), event)
+	duration := time.Since(start)
+
+	if !result.Success {
+		t.Errorf("the shell exited 0, so the event should succeed: exit=%d err=%v", result.ExitCode, result.Error)
+	}
+	if !strings.Contains(result.Output, "started") {
+		t.Errorf("output written before exit must be kept, got %q", result.Output)
+	}
+	if duration > outputWaitDelay+5*time.Second {
+		t.Errorf("event took %v; the orphaned child must not hold it past the wait delay", duration)
+	}
+}

--- a/internal/scheduler/executor_test.go
+++ b/internal/scheduler/executor_test.go
@@ -2,7 +2,9 @@ package scheduler
 
 import (
 	"context"
+	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -219,12 +221,14 @@ func TestPlaceholderSubstitutionInCommand(t *testing.T) {
 func TestExecuteEvent_OrphanedChildDoesNotBlockCompletion(t *testing.T) {
 	s := &Scheduler{}
 
+	sleep := lookPath(t, "sleep") // resolved, so a missing sleep skips rather than passing vacuously
 	event := config.EventConfig{
 		ID:      "test_orphan",
 		Name:    "Test Orphaned Child",
 		Command: lookPath(t, "sh"),
-		// The shell exits at once; the sleep keeps stdout open for 30s.
-		Args: []string{"-c", "sleep 30 & echo started"},
+		// The shell exits at once; the sleep keeps stdout open for 30s. Its
+		// PID is printed so the test can kill it rather than leak it.
+		Args: []string{"-c", sleep + " 30 & echo started $!"},
 	}
 
 	start := time.Now()
@@ -234,8 +238,16 @@ func TestExecuteEvent_OrphanedChildDoesNotBlockCompletion(t *testing.T) {
 	if !result.Success {
 		t.Errorf("the shell exited 0, so the event should succeed: exit=%d err=%v", result.ExitCode, result.Error)
 	}
-	if !strings.Contains(result.Output, "started") {
-		t.Errorf("output written before exit must be kept, got %q", result.Output)
+	fields := strings.Fields(result.Output)
+	if len(fields) != 2 || fields[0] != "started" {
+		t.Fatalf("output written before exit must be kept, got %q", result.Output)
+	}
+	pid, err := strconv.Atoi(fields[1])
+	if err != nil {
+		t.Fatalf("shell did not print the sleep's pid: %q", result.Output)
+	}
+	if p, err := os.FindProcess(pid); err == nil {
+		_ = p.Kill() // do not leak the orphan past the test
 	}
 	if duration > outputWaitDelay+5*time.Second {
 		t.Errorf("event took %v; the orphaned child must not hold it past the wait delay", duration)


### PR DESCRIPTION
Found while working on #345: a scheduler test that ran `sh -c 'sleep 30'` hung on the Linux runner, because the cancellation killed the shell and the forked sleep kept the executor's output pipes open.

The underlying bug is in the executor. It captures stdout and stderr through pipes, so any event that leaves a background child behind (a script that starts a daemon, `sleep 30 &`) blocks `cmd.Run` until that child exits too, however long that is. A timeout kill does not help because it reaches only the process the executor started. The event holds its concurrency slot and running-event mark for the duration, and a BBS shutdown waits on it.

`cmd.WaitDelay` now closes the pipes five seconds after the process exits. The resulting `ErrWaitDelay` means the process itself exited cleanly, so it is logged as a warning and the event is counted on its own exit status; anything the orphan writes after that is discarded.

The new test hangs past a 20s timeout without the change and completes in about 5s with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event execution no longer hangs when orphaned child processes keep output streams open after the main process exits.
  * Events now complete successfully after the output wait period, preserving output produced before the main process exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->