### PR TITLE
chore(release): v0.9.3 — version bump, docs, and upgrade guide

### DIFF
--- a/docs/sysop/README.md
+++ b/docs/sysop/README.md
@@ -2,7 +2,7 @@
 
 Welcome, SysOp. This wiki covers everything you need to install, configure, and run a l33t ViSiON/3 BBS like it's 1992 all over again.
 
-> **Current Version: v0.9.2** | [GitHub Releases](https://github.com/ViSiON-3/vision-3-bbs/releases)
+> **Current Version: v0.9.3** | [GitHub Releases](https://github.com/ViSiON-3/vision-3-bbs/releases)
 >
 > ⚠️ **Early Development:** ViSiON/3 is under active development and not yet feature-complete. Expect rough edges and missing features. Use at your own risk.
 

--- a/docs/sysop/advanced/event-scheduler.md
+++ b/docs/sysop/advanced/event-scheduler.md
@@ -541,7 +541,8 @@ How it behaves:
   chains.
 - A `run_after` naming an event that does not exist is warned about at
   startup and never fires. An enabled event naming itself counts as a cycle
-  and disables chaining like any other loop; a disabled one is ignored.
+  and disables chaining like any other loop. A disabled event still gets
+  these warnings, but never takes part in chaining or in the cycle check.
 - A BBS shutdown cancels a chained event still waiting out its delay.
 
 ## Error Handling

--- a/docs/sysop/advanced/event-scheduler.md
+++ b/docs/sysop/advanced/event-scheduler.md
@@ -540,7 +540,8 @@ How it behaves:
   gives its slot back before the child asks for one, so a limit of 1 still
   chains.
 - A `run_after` naming an event that does not exist is warned about at
-  startup and never fires. An event naming itself is ignored.
+  startup and never fires. An enabled event naming itself counts as a cycle
+  and disables chaining like any other loop; a disabled one is ignored.
 - A BBS shutdown cancels a chained event still waiting out its delay.
 
 ## Error Handling

--- a/docs/sysop/advanced/event-scheduler.md
+++ b/docs/sysop/advanced/event-scheduler.md
@@ -518,7 +518,7 @@ schedule. Set `run_after` to the ID of the event it follows, and optionally
 }
 ```
 
-In the events editor these are the **Run After** and **Delay** fields.
+In the events editor these are the **Run After** and **Delay After** fields.
 
 How it behaves:
 

--- a/docs/sysop/advanced/event-scheduler.md
+++ b/docs/sysop/advanced/event-scheduler.md
@@ -57,15 +57,15 @@ Event scheduling is configured in `configs/events.json`.
 
 - **id** (string, required): Unique identifier for the event
 - **name** (string, required): Human-readable name for logging
-- **schedule** (string, required): Cron schedule expression (see below)
+- **schedule** (string): Cron schedule expression (see below). Required unless the event is `run_at_startup` or has a `run_after`
 - **command** (string, required): Path to the executable
 - **args** (array): Command-line arguments
 - **working_directory** (string): Directory to run the command in
 - **timeout_seconds** (integer): Maximum execution time (0 = no timeout)
 - **enabled** (boolean): Enable/disable this specific event
 - **environment_vars** (object): Environment variables to set
-- **run_after** (string): Event ID that must complete before this event runs (future feature)
-- **delay_after_seconds** (integer): Delay after run_after event completes (future feature)
+- **run_after** (string): Event ID this event follows; it runs when that event finishes (see [Event Chaining](#event-chaining-run_after))
+- **delay_after_seconds** (integer): Seconds to wait after the `run_after` event finishes before starting
 
 ## Cron Schedule Syntax
 
@@ -193,6 +193,10 @@ Networks did not control hub polling and has been removed; legacy
 > concurrently exporting the same bases (double-export). Scheduler events
 > remain useful for forced polls (`binkd -p`) of specific hubs. See
 > [ftn-echomail.md](messages/ftn-echomail.md#enabling-the-integrated-mailer-recommended).
+
+To poll several hubs one after another — over a single line, say, or to toss
+once after the last poll — chain the events with `run_after`; see
+[Event Chaining](#event-chaining-run_after).
 
 **Simple poll all nodes every 30 minutes:**
 
@@ -494,6 +498,51 @@ Time  Event A  Event B  Event C  Result
 0:03  Done     Running  Start    C runs (A freed slot)
 ```
 
+## Event Chaining (`run_after`)
+
+An event can follow another event instead of, or as well as, having a
+schedule. Set `run_after` to the ID of the event it follows, and optionally
+`delay_after_seconds` to wait before it starts:
+
+```json
+{
+  "id": "echomail_poll_tqwnet",
+  "name": "Poll tqwNet (after fsxNet)",
+  "run_after": "echomail_poll_fsxnet",
+  "delay_after_seconds": 30,
+  "command": "{BBS_ROOT}/bin/binkd",
+  "args": ["-p", "-P", "1337:3/123@tqwnet", "{BBS_ROOT}/data/ftn/binkd.conf"],
+  "working_directory": "{BBS_ROOT}",
+  "timeout_seconds": 300,
+  "enabled": true
+}
+```
+
+In the events editor these are the **Run After** and **Delay** fields.
+
+How it behaves:
+
+- **The chained event runs when its parent finishes, whatever the parent's
+  exit status.** "Run after" is about order, not success: a poll that failed
+  is exactly when the next network still wants its turn. An event that must
+  not run after a failure should be a different event.
+- **A chained event needs no schedule.** One with only `run_after` is fine; one
+  with both fires on its schedule *and* after its parent.
+- **Several events may follow one parent**, and chains may be several events
+  long (up to 16 deep, which is more than any real chain).
+- **A disabled event is never chained**, the same as it is never scheduled,
+  and it is ignored when the chain graph is checked.
+- **A cycle disables chaining for every event.** A after B after A would
+  re-trigger forever, so the scheduler refuses the whole graph at startup or
+  reload, logs an error naming the loop, and runs schedules only until the
+  loop is broken in the events editor.
+- **Chained events count toward `max_concurrent_events`**, but the parent
+  gives its slot back before the child asks for one, so a limit of 1 still
+  chains.
+- A `run_after` naming an event that does not exist is warned about at
+  startup and never fires. An event naming itself is ignored.
+- A BBS shutdown cancels a chained event still waiting out its delay.
+
 ## Error Handling
 
 ### Non-Fatal Errors (logged, scheduler continues)
@@ -632,8 +681,6 @@ The BBS will start normally but the scheduler will not run.
 
 Planned features for future releases:
 
-- **Event dependencies**: `run_after` and `delay_after_seconds` support
-- **Event chains**: Automatic sequential execution
 - **Manual triggers**: API/command to trigger events on-demand
 - **Event output capture**: Store full output for review
 - **Notification hooks**: Alert on event failures

--- a/docs/sysop/configuration/configuration.md
+++ b/docs/sysop/configuration/configuration.md
@@ -657,7 +657,7 @@ See [Message Areas Guide](messages/message-areas.md) for detailed configuration.
 
 > *Use the [Configuration Editor](#configuration-editor-tui) (key 3 → Echomail Networks / Echomail Links) to manage FTN settings interactively. The JSON structure below is for reference.*
 
-Located in the `configs/` directory. Configures the internal FTN tosser (v3mail) for echomail. Global fields include directory paths (`inbound_path`, `outbound_path`, `binkd_outbound_path`, `temp_path`) and routing tags (`bad_area_tag`, `dupe_area_tag`). Per-network fields include `own_address`, `internal_tosser_enabled`, and `origin`. Per-link fields include `address`, `packet_password`, `areafix_password`, `name`, and `flavour`.
+Located in the `configs/` directory. Configures the internal FTN tosser (v3mail) for echomail. Global fields include directory paths (`inbound_path`, `outbound_path`, `binkd_outbound_path`, `temp_path`) and routing tags (`bad_area_tag`, `dupe_area_tag`). Per-network fields include `own_address`, `internal_tosser_enabled`, `origin`, and an optional `binkd_outbound_path` (a BSO outbound of the network's own, needed when carrying more than one network). Per-link fields include `address`, `packet_password`, `areafix_password`, `name`, and `flavour`.
 
 Hub polling is configured under **Events** in `configs/events.json`; edit the
 `echomail_poll_<network>` event's cron schedule. The former per-network

--- a/docs/sysop/getting-started/README.md
+++ b/docs/sysop/getting-started/README.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-> **Current Version: v0.9.2** — [GitHub Releases](https://github.com/ViSiON-3/vision-3-bbs/releases)
+> **Current Version: v0.9.3** — [GitHub Releases](https://github.com/ViSiON-3/vision-3-bbs/releases)
 >
 > ⚠️ **Early Development:** ViSiON/3 is under active development and not yet feature-complete. Use at your own risk.
 

--- a/docs/sysop/getting-started/installation.md
+++ b/docs/sysop/getting-started/installation.md
@@ -1,6 +1,6 @@
 # ViSiON/3 Installation Guide
 
-> **Current Version: v0.9.2** — [GitHub Releases](https://github.com/ViSiON-3/vision-3-bbs/releases)
+> **Current Version: v0.9.3** — [GitHub Releases](https://github.com/ViSiON-3/vision-3-bbs/releases)
 >
 > ⚠️ **Early Development:** ViSiON/3 is under active development and not yet feature-complete. Expect rough edges and missing features. Use at your own risk. Check the [releases page](https://github.com/ViSiON-3/vision-3-bbs/releases) and the [README](https://github.com/ViSiON-3/vision-3-bbs) for the current status of features.
 

--- a/docs/sysop/getting-started/upgrading.md
+++ b/docs/sysop/getting-started/upgrading.md
@@ -494,7 +494,7 @@ No action needed.
 
 v0.9.3 is automatic for a board carrying **one** FTN network: deploy the new
 bundle and restart. A board carrying **two or more** networks has one thing to
-do by hand, and everyone should know about three behaviour changes.
+do by hand, and everyone should know about several behaviour changes.
 
 ### Two or more FTN networks: give each its own binkd outbound
 
@@ -534,9 +534,11 @@ Two things used to need a hand-edit and a restart:
   gap in the listener — whether the change came from the editor or from a
   hand edit.
 
-`ftn.json` is the source of truth for `node` lines and for each `domain`
-line's outbound path; every other line in `binkd.conf` is left exactly as you
-wrote it.
+Your configuration is the source of truth for the `node` lines, each `domain`
+line's outbound path, the listen port and log level (`iport`, `loglevel`), and
+the board identity (`sysname`, `sysop`, `location`); those are rewritten from
+`ftn.json` and `config.json` on every sync. Everything else in `binkd.conf`
+is left exactly as you wrote it.
 
 ### Poll events follow your networks
 
@@ -557,7 +559,7 @@ its exit status), after the delay. If you set **Run After** on an event in the
 past and shrugged when nothing happened, that event will start chaining after
 this upgrade — check `events.json` for stray values. A cycle (A after B after
 A) disables chaining for every event and logs an error naming the loop. See
-[Event Chaining](../advanced/event-scheduler.md#event-chaining-run_after).
+[Event Chaining](advanced/event-scheduler.md#event-chaining-run_after).
 
 ### Real names are validated everywhere
 
@@ -565,20 +567,23 @@ Sign-up has always required a real name of at least four characters with a
 space in it. The sysop user editors, the scripting API's
 `user.set('realName', ...)`, and the caller's own **Real Name** prompt in the
 config menu now apply the same rule instead of saving anything, including
-blank. Existing users are untouched; a blank real name is caught the next time
-someone edits that user. (An area flagged real-name-only still falls back to
+blank. Existing users are untouched, and editing another field leaves a blank
+real name alone; it is caught only when someone changes the Real Name field
+itself. (An area flagged real-name-only still falls back to
 the handle for a user with no real name — that is the behaviour the validation
 exists to stop happening silently.)
 
 ### Where the config editor's warnings went
 
 `./config` now writes a rolling `data/logs/config.log` instead of discarding
-its log. Warnings raised by a save — a link with no hostname, a rejected
-outbound path, a network declared in `binkd.conf` — land there. If the log
-cannot be opened, the editor says so in its status line at startup.
+its log. Warnings raised by a save — a link with no hostname, a network
+declared in `binkd.conf`, a `binkd.conf` sync that failed — land there. (A
+rejected outbound path is refused in the field itself and shown in the status
+line, not logged.) If the log cannot be opened, the editor says so in its
+status line at startup.
 
 ### 32-bit Windows and Docker
 
 Nothing to do. The 386 build no longer panics on every telnet connect, and the
 Docker image builds and starts again (see
-[Docker](docker.md)) — both were broken in v0.9.0 through v0.9.2.
+[Docker](getting-started/docker.md)) — both were broken in v0.9.0 through v0.9.2.

--- a/docs/sysop/getting-started/upgrading.md
+++ b/docs/sysop/getting-started/upgrading.md
@@ -489,3 +489,96 @@ shows up to 20 visible callers by default (a `RUN:LASTCALLERS <n>` argument in
 your menu CFG still overrides the row count). Real callers evicted from the
 old, shallower history are gone for good; the screen refills as calls arrive.
 No action needed.
+
+## Worked example: upgrading to v0.9.3
+
+v0.9.3 is automatic for a board carrying **one** FTN network: deploy the new
+bundle and restart. A board carrying **two or more** networks has one thing to
+do by hand, and everyone should know about three behaviour changes.
+
+### Two or more FTN networks: give each its own binkd outbound
+
+Until now every network's mail went into the single global
+`binkd_outbound_path`, and the mailer put it back there even if you had split
+the directories by hand. Sharing one BSO outbound between networks is unsafe:
+bundle and flow filenames are built from the destination net/node with no zone
+component, so two hubs in different networks that share a net/node pair
+collide on one filename, and one network's mail is handed to the other's hub.
+
+Each network can now have its own outbound. In `./config` → **Echomail
+Networks**, open each network beyond the first and set **Binkd Outbound** to a
+directory of its own — `data/ftn/out_tqw`, say. No dots in the directory name:
+binkd reserves `.<zone>` suffixes on the base outbound for zone directories and
+refuses to start on a dotted one, so the editor rejects it up front. Leave the
+field empty on a network to keep using the global directory.
+
+On save the mailer creates the directory, repoints that network's `domain`
+line in `binkd.conf`, and restarts binkd on the new configuration. Do this
+when the outbound is empty — right after a successful poll — or move that
+hub's bundle and flow files across by hand, since binkd only looks in the
+domain's current directory.
+
+### `binkd.conf` is kept in step, and binkd restarts itself
+
+Two things used to need a hand-edit and a restart:
+
+- A network added outside the FTN Setup Wizard (by hand in the editor, or with
+  `helper ftnsetup`) got a `node` line in `binkd.conf` and nothing else, so
+  binkd refused its sessions with `unknown domain`. The `domain` and
+  `address` lines are now added for any network missing them, on save and
+  before each mailer launch.
+- binkd reads `binkd.conf` once, at startup, and nothing asked it to re-read.
+  A new node, a changed hostname or password, or a different listen port sat
+  inert until binkd happened to exit. The integrated mailer now re-checks the
+  file every 15 seconds and recycles binkd when it has changed — a sub-second
+  gap in the listener — whether the change came from the editor or from a
+  hand edit.
+
+`ftn.json` is the source of truth for `node` lines and for each `domain`
+line's outbound path; every other line in `binkd.conf` is left exactly as you
+wrote it.
+
+### Poll events follow your networks
+
+The per-network `echomail_poll_<network>` event used to be created only by the
+wizard. It is now created on save for any network whose hub link has a
+**Hostname**, renamed along with its network, and **disabled** (never deleted,
+so a tuned schedule survives) when the network is removed or its hub loses its
+hostname. A link with no hostname is receive-only — binkd has nothing to dial —
+and the editor's log says so; set the hostname under **Echomail Links** to
+poll it.
+
+### Event chaining now works
+
+`run_after` and `delay_after_seconds` have been in `events.json` and the
+events editor since the scheduler shipped, but nothing read them. They do what
+they say now: the chained event runs when the named event finishes (whatever
+its exit status), after the delay. If you set **Run After** on an event in the
+past and shrugged when nothing happened, that event will start chaining after
+this upgrade — check `events.json` for stray values. A cycle (A after B after
+A) disables chaining for every event and logs an error naming the loop. See
+[Event Chaining](../advanced/event-scheduler.md#event-chaining-run_after).
+
+### Real names are validated everywhere
+
+Sign-up has always required a real name of at least four characters with a
+space in it. The sysop user editors, the scripting API's
+`user.set('realName', ...)`, and the caller's own **Real Name** prompt in the
+config menu now apply the same rule instead of saving anything, including
+blank. Existing users are untouched; a blank real name is caught the next time
+someone edits that user. (An area flagged real-name-only still falls back to
+the handle for a user with no real name — that is the behaviour the validation
+exists to stop happening silently.)
+
+### Where the config editor's warnings went
+
+`./config` now writes a rolling `data/logs/config.log` instead of discarding
+its log. Warnings raised by a save — a link with no hostname, a rejected
+outbound path, a network declared in `binkd.conf` — land there. If the log
+cannot be opened, the editor says so in its status line at startup.
+
+### 32-bit Windows and Docker
+
+Nothing to do. The 386 build no longer panics on every telnet connect, and the
+Docker image builds and starts again (see
+[Docker](docker.md)) — both were broken in v0.9.0 through v0.9.2.

--- a/docs/sysop/messages/ftn-echomail.md
+++ b/docs/sysop/messages/ftn-echomail.md
@@ -629,7 +629,7 @@ read by `v3mail toss`, `v3mail scan`, and `v3mail ftn-pack`.
 | `inbound_path`        | Unsecured inbound directory (binkd deposits bundles here)    |
 | `secure_inbound_path` | Secure inbound for password-authenticated mailer sessions    |
 | `outbound_path`       | Staging dir for outbound `.pkt` files (`v3mail scan` output) |
-| `binkd_outbound_path` | Outbound bundles dir (binkd picks up ZIP archives from here) |
+| `binkd_outbound_path` | Outbound bundles dir (binkd picks up ZIP archives from here); a network can override it with its own, see below |
 | `temp_path`           | Temp dir for bundle extraction during toss                   |
 | `bad_area_tag`        | Area tag for messages with unknown echo tags (e.g. `"BAD"`)  |
 | `dupe_area_tag`       | Area tag for duplicate MSGIDs (e.g. `"DUPE"`)                |
@@ -641,6 +641,7 @@ read by `v3mail toss`, `v3mail scan`, and `v3mail ftn-pack`.
 | `internal_tosser_enabled` | Set `true` to enable `v3mail` for this network      |
 | `own_address`             | Your FTN address (e.g., `21:4/158.1`)               |
 | `origin`                  | Origin line text (empty = board name)               |
+| `binkd_outbound_path`     | Optional: this network's own BSO outbound directory (**Binkd Outbound** in the editor). Empty = the global one. Set it on every network beyond the first — see [Adding a Second Network](#adding-a-second-network). No dots in the name. |
 
 Hub polling is controlled by the per-network `echomail_poll_<network>` event
 under **Events**. The wizard creates it with a 15-minute cron schedule; edit
@@ -758,7 +759,8 @@ Groups message areas for display in the BBS menu:
 To add another FTN network (e.g., AgoraNet alongside fsxNet):
 
 1. Get the network's `.na` file from your hub
-2. Run `helper ftnsetup` again with the new network details:
+2. Run `helper ftnsetup` again with the new network details (or add the
+   network by hand in `./config` → **Echomail Networks**):
 
 ```bash
 ./helper ftnsetup \
@@ -769,15 +771,30 @@ To add another FTN network (e.g., AgoraNet alongside fsxNet):
   --network agoranet
 ```
 
-3. Add the new domain, address, and node to `binkd.conf`:
+3. In `./config` → **Echomail Networks**, open the new network and set
+   **Binkd Outbound** to a directory of its own, e.g. `data/ftn/out_agora`
+   (no dots in the name — binkd reserves `.<zone>` suffixes on the base
+   outbound and refuses a dotted one). Every network needs its own BSO
+   outbound: bundle and flow filenames carry only the destination net/node,
+   so two networks sharing one directory can hand mail to the wrong hub when
+   two hubs share a net/node pair.
+4. Under **Echomail Links**, make sure the new hub link has a **Hostname**.
+   Without one binkd has nothing to dial, the network only ever receives mail
+   when the hub calls in, and no poll event is created.
+
+That is all with the integrated mailer. On save it adds the `domain`,
+`address` and `node` lines to `binkd.conf`, creates the outbound directory,
+creates an `echomail_poll_agoranet` event, and restarts binkd on the new
+configuration within 15 seconds.
+
+If you run an external binkd instead, add the lines to its config yourself and
+restart it:
 
 ```conf
-domain agoranet /home/bbs/vision3/data/ftn/out 46
+domain agoranet /home/bbs/vision3/data/ftn/out_agora 46
 address 46:1/100.1@agoranet
 node 46:1/100@agoranet hub-hostname:24554 HUBPASS -
 ```
-
-4. Restart binkd
 
 ## Troubleshooting
 

--- a/docs/sysop/messages/v3mail.md
+++ b/docs/sysop/messages/v3mail.md
@@ -108,6 +108,7 @@ Per-network fields (`networks.<key>`):
 | `own_address`               | This node's FTN address (zone:net/node.point)                   |
 | `internal_tosser_enabled`   | Set `true` to enable `v3mail` for this network                  |
 | `origin`                    | Origin line text (empty = board name)                           |
+| `binkd_outbound_path`       | Optional: this network's own BSO outbound (`ftn-pack` output); empty = the global one. Use one per network when carrying several. |
 
 Hub polling is scheduled through **Events**, using the per-network
 `echomail_poll_<network>` event created by the FTN wizard. See

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,7 +8,7 @@ import (
 // Number is the global ViSiON/3 version.
 // Set this at build time with:
 // -ldflags "-X github.com/ViSiON-3/vision-3-bbs/internal/version.Number=1.0.0"
-var Number = "0.9.2"
+var Number = "0.9.3"
 
 // Display returns the version prefixed with "v", e.g. "v0.8.0". A Number that
 // already carries the prefix (a build stamped from a git tag) is left alone.


### PR DESCRIPTION
Prepares v0.9.3. Same shape as the v0.9.2 bump (#340).

- `internal/version/version.go` → 0.9.3, and the three "Current Version" doc lines.
- **Upgrade guide:** a v0.9.3 worked example. The one manual step is for boards carrying two or more FTN networks (set a per-network Binkd Outbound); the rest describes behaviour changes: binkd.conf kept in step and binkd recycling itself, poll events following networks, `run_after` chaining now live, real-name validation everywhere, the editor log, and the 32-bit/Docker fixes.
- **Event scheduler docs:** `run_after` / `delay_after_seconds` documented as implemented, with a new Event Chaining section, and removed from Future Enhancements.
- **FTN docs:** per-network `binkd_outbound_path` in the field tables (ftn-echomail, v3mail, configuration), and "Adding a Second Network" rewritten for the integrated mailer, which now writes the binkd.conf lines, creates the poll event, and restarts binkd itself.

The release notes themselves live in the vision-3-release changelog; tagging follows the merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the documented release version to v0.9.3.
  * Added guidance for configuring separate outbound directories for multiple FTN networks.
  * Documented automatic binkd configuration synchronization, directory creation, polling, and restart behavior.
  * Added event scheduling and chaining guidance, including validation, concurrency, cycle handling, and shutdown behavior.
  * Added upgrade notes covering configuration changes, real-name validation, persistent warnings, and corrected Docker documentation links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->