### PR TITLE
Menu overlay directory (menus.d) so customisations survive upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,12 @@ go.work.sum
 /data/*
 !/data/.gitkeep
 
+# Menu overlay: sysop overrides of menus/, read first, file by file. Never
+# tracked, so `git pull` cannot touch it. The README is kept so the directory
+# exists in every checkout (and Docker's bind mount does not create it as root).
+/menus.d/*
+!/menus.d/README.md
+
 # Compiled executable
 /vision3
 /cmd/vision3/vision3

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,11 +69,12 @@ COPY menus/ ./menus/
 # Create the mount points before declaring them so a named volume inherits
 # vision3 ownership. Bind mounts still arrive owned by the host uid, which the
 # entrypoint corrects at runtime.
-RUN mkdir -p /vision3/configs /vision3/data /vision3/temp /vision3/bin \
+RUN mkdir -p /vision3/configs /vision3/data /vision3/menus.d /vision3/temp /vision3/bin \
     && chown -R vision3:vision3 /vision3
 
 VOLUME /vision3/configs
 VOLUME /vision3/menus
+VOLUME /vision3/menus.d
 VOLUME /vision3/data
 
 EXPOSE 2222 2323

--- a/cmd/menuedit/main.go
+++ b/cmd/menuedit/main.go
@@ -16,6 +16,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/menuset"
+
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/menueditor"
@@ -23,6 +25,7 @@ import (
 
 func main() {
 	menusPath := flag.String("menus", "", "Path to menu set directory (default: menus/v3)")
+	noOverlay := flag.Bool("no-overlay", false, "Read and write the shipped menu set directly instead of its menus.d overlay")
 	flag.Parse()
 
 	// Resolve menus path
@@ -69,8 +72,16 @@ func main() {
 		}
 	}
 
+	// Menus are read through the overlay (menus.d/<set>) and saved into it,
+	// so edits survive a git pull of the shipped set. --no-overlay edits the
+	// shipped tree in place, as before the overlay existed.
+	set := menuset.FromPath(path)
+	if *noOverlay {
+		set = menuset.Bare(path)
+	}
+
 	// Create the editor model
-	model, err := menueditor.New(path)
+	model, err := menueditor.New(set)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error initializing editor: %v\n", err) //nolint:errcheck
 		os.Exit(1)

--- a/cmd/menuedit/main.go
+++ b/cmd/menuedit/main.go
@@ -4,7 +4,7 @@
 //
 // Usage:
 //
-//	./menuedit [--menus path/to/menus/set]
+//	./menuedit [--menus path/to/menus/set] [--no-overlay]
 //
 // If no --menus flag is provided, it looks for menus/v3 relative to the
 // current working directory.

--- a/cmd/vision3/config_watcher.go
+++ b/cmd/vision3/config_watcher.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/menuset"
+
 	"github.com/ViSiON-3/vision-3-bbs/internal/config"
 	"github.com/ViSiON-3/vision-3-bbs/internal/file"
 	"github.com/ViSiON-3/vision-3-bbs/internal/logging"
@@ -29,6 +31,12 @@ type reloadTarget struct {
 	name   string // basename, for logging
 	path   string
 	reload func()
+	// reloadOnRemove makes the target's removal count as a change. Set for
+	// files whose absence has a meaning of its own — an overlay theme.json
+	// going away means "back to the shipped one" — and left unset for
+	// required configs, where a vanished file is a broken install, not a
+	// request to reload nothing.
+	reloadOnRemove bool
 }
 
 // ConfigWatcher polls configuration files for modification and hot-reloads
@@ -122,11 +130,21 @@ func NewConfigWatcher(rootConfigPath, menuSetPath string, menuExecutor *menu.Men
 		{name: "login.json", path: filepath.Join(rootConfigPath, "login.json"), reload: cw.reloadLoginSequence},
 		{name: "strings.json", path: filepath.Join(rootConfigPath, "strings.json"), reload: cw.reloadStrings},
 		{name: "theme.json", path: filepath.Join(menuSetPath, "theme.json"), reload: cw.reloadTheme},
+	}
+	// theme.json can also live in the menu set's overlay, which shadows the
+	// shipped copy. Both are watched so that creating, editing or removing the
+	// overlay copy takes effect without a restart; reloadTheme resolves which
+	// one applies.
+	if overlay := menuset.OverlayFor(menuSetPath); overlay != "" {
+		cw.targets = append(cw.targets,
+			reloadTarget{name: "theme.json (overlay)", path: filepath.Join(overlay, "theme.json"), reload: cw.reloadTheme, reloadOnRemove: true})
+	}
+	cw.targets = append(cw.targets, []reloadTarget{
 		{name: "protocols.json", path: filepath.Join(rootConfigPath, "protocols.json"), reload: cw.reloadProtocols},
 		{name: "events.json", path: filepath.Join(rootConfigPath, "events.json"), reload: cw.reloadEvents},
 		{name: "conferences.json", path: filepath.Join(rootConfigPath, "conferences.json"), reload: cw.reloadConferences},
 		{name: "ftn.json", path: filepath.Join(rootConfigPath, "ftn.json"), reload: cw.reloadFTNOrigins},
-	}
+	}...)
 	cw.deferredTargets = []deferredTarget{
 		{
 			name:     "file_areas.json",
@@ -217,35 +235,35 @@ func (cw *ConfigWatcher) pollLoop() {
 // poll reloads every configuration file whose timestamp changed since the last
 // check. A touched sentinel reloads everything regardless of timestamps.
 func (cw *ConfigWatcher) poll() {
-	if cw.changed(cw.forceSentinelPath) {
+	if cw.changed(cw.forceSentinelPath, false) {
 		slog.Warn("force sentinel touched: applying all configuration now, including deferred structural changes",
 			"path", cw.forceSentinelPath, "active_sessions", cw.activeSessions())
 		for _, t := range cw.targets {
-			cw.changed(t.path)
+			cw.changed(t.path, t.reloadOnRemove)
 		}
 		cw.ReloadAll()
 		for _, t := range cw.deferredTargets {
-			cw.changed(t.path)
+			cw.changed(t.path, false)
 			cw.applyDeferred(t)
 		}
 		return
 	}
 
-	if cw.changed(cw.sentinelPath) {
+	if cw.changed(cw.sentinelPath, false) {
 		slog.Info("reload sentinel touched, reloading all configuration",
 			"path", cw.sentinelPath)
 		// Take the current timestamps first: the files being reloaded here are
 		// the same ones the sentinel is announcing, and without this each would
 		// reload a second time on the next poll.
 		for _, t := range cw.targets {
-			cw.changed(t.path)
+			cw.changed(t.path, t.reloadOnRemove)
 		}
 		cw.ReloadAll()
 		// Deferred targets covered by the save are queued, not applied: the
 		// sentinel is touched automatically by v3config on every save, and
 		// automatic saves must not bypass the idle gate.
 		for _, t := range cw.deferredTargets {
-			if cw.changed(t.path) {
+			if cw.changed(t.path, false) {
 				cw.queueDeferred(t)
 			}
 		}
@@ -254,13 +272,13 @@ func (cw *ConfigWatcher) poll() {
 	}
 
 	for _, t := range cw.targets {
-		if cw.changed(t.path) {
+		if cw.changed(t.path, t.reloadOnRemove) {
 			slog.Info("config file change detected", "file", t.name)
 			t.reload()
 		}
 	}
 	for _, t := range cw.deferredTargets {
-		if cw.changed(t.path) {
+		if cw.changed(t.path, false) {
 			cw.queueDeferred(t)
 		}
 	}
@@ -443,20 +461,22 @@ func (cw *ConfigWatcher) applyV3Net() error {
 }
 
 // changed reports whether path's modification time differs from the one last
-// recorded, updating the record. A file that does not exist is not a change;
-// its record is dropped so that re-creating it registers as one.
+// recorded, updating the record. A file that does not exist is not a change
+// unless reloadOnRemove is set and it was present on the previous poll; either
+// way its record is dropped so that re-creating it registers as one.
 //
 // Any difference counts, not just a newer timestamp, so that restoring a config
 // file from a backup — which can move the timestamp backwards — still reloads.
-func (cw *ConfigWatcher) changed(path string) bool {
+func (cw *ConfigWatcher) changed(path string, reloadOnRemove bool) bool {
 	info, err := os.Stat(path)
 
 	cw.mu.Lock()
 	defer cw.mu.Unlock()
 
 	if err != nil {
+		_, seen := cw.mtimes[path]
 		delete(cw.mtimes, path)
-		return false
+		return seen && reloadOnRemove
 	}
 
 	mt := info.ModTime()

--- a/cmd/vision3/config_watcher.go
+++ b/cmd/vision3/config_watcher.go
@@ -464,6 +464,7 @@ func (cw *ConfigWatcher) applyV3Net() error {
 // recorded, updating the record. A file that does not exist is not a change
 // unless reloadOnRemove is set and it was present on the previous poll; either
 // way its record is dropped so that re-creating it registers as one.
+// Other stat errors are logged without changing the saved timestamp.
 //
 // Any difference counts, not just a newer timestamp, so that restoring a config
 // file from a backup — which can move the timestamp backwards — still reloads.
@@ -474,6 +475,10 @@ func (cw *ConfigWatcher) changed(path string, reloadOnRemove bool) bool {
 	defer cw.mu.Unlock()
 
 	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn("could not stat watched configuration", "path", path, "error", err)
+			return false
+		}
 		_, seen := cw.mtimes[path]
 		delete(cw.mtimes, path)
 		return seen && reloadOnRemove

--- a/cmd/vision3/config_watcher_test.go
+++ b/cmd/vision3/config_watcher_test.go
@@ -432,3 +432,30 @@ func TestWatcherWatchesOverlayTheme(t *testing.T) {
 		t.Errorf("theme target not registered: %s", p)
 	}
 }
+
+func TestWatcherStatErrorDoesNotCountAsRemoval(t *testing.T) {
+	cw, dir, _ := newTestWatcher(t, "theme.json")
+	path := filepath.Join(dir, "theme.json")
+	before := cw.mtimes[path]
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("theme.json", path); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if _, err := os.Stat(path); err == nil || os.IsNotExist(err) {
+		t.Fatalf("expected non-missing stat error: %v", err)
+	}
+	if cw.changed(path, true) {
+		t.Error("stat failure triggered removal reload")
+	}
+	if got := cw.mtimes[path]; !got.Equal(before) {
+		t.Errorf("stat failure discarded mtime: %v, want %v", got, before)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if !cw.changed(path, true) {
+		t.Error("actual removal not reported after stat failure")
+	}
+}

--- a/cmd/vision3/config_watcher_test.go
+++ b/cmd/vision3/config_watcher_test.go
@@ -415,6 +415,7 @@ func TestWatcherWatchesOverlayTheme(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewConfigWatcher: %v", err)
 	}
+	defer cw.Stop()
 	want := map[string]bool{
 		filepath.Join(menuSet, "theme.json"):               false,
 		filepath.Join(root, "menus.d", "v3", "theme.json"): true,

--- a/cmd/vision3/config_watcher_test.go
+++ b/cmd/vision3/config_watcher_test.go
@@ -367,3 +367,67 @@ func TestReloadConferencesUpdatesManager(t *testing.T) {
 		t.Error("conference TECH missing after reload")
 	}
 }
+
+// TestPollReloadsOnRemovalWhenAsked covers the overlay theme.json: a file that
+// is absent at startup, appears, and is removed again must reload on both
+// transitions, because its absence means "use the shipped copy". Ordinary
+// targets keep ignoring removal (TestPollHandlesMissingAndRecreatedFile).
+func TestPollReloadsOnRemovalWhenAsked(t *testing.T) {
+	cw, dir, rec := newTestWatcher(t)
+	path := filepath.Join(dir, "theme.json")
+	cw.targets = append(cw.targets, reloadTarget{name: "theme.json", path: path, reload: rec.hit("theme.json"), reloadOnRemove: true})
+	cw.seed()
+
+	cw.poll() // still absent: nothing to do
+	if got := rec.count("theme.json"); got != 0 {
+		t.Fatalf("absent file reloaded %d times, want 0", got)
+	}
+
+	touch(t, path, time.Second)
+	cw.poll()
+	if got := rec.count("theme.json"); got != 1 {
+		t.Errorf("created file reloaded %d times, want 1", got)
+	}
+
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	cw.poll()
+	if got := rec.count("theme.json"); got != 2 {
+		t.Errorf("removed file reloaded %d times, want 2", got)
+	}
+	cw.poll() // still absent: no repeat
+	if got := rec.count("theme.json"); got != 2 {
+		t.Errorf("still-absent file reloaded %d times, want 2", got)
+	}
+}
+
+// TestWatcherWatchesOverlayTheme checks the constructor registers theme.json
+// in both the shipped set and its overlay.
+func TestWatcherWatchesOverlayTheme(t *testing.T) {
+	root := t.TempDir()
+	menuSet := filepath.Join(root, "menus", "v3")
+	configs := filepath.Join(root, "configs")
+	if err := os.MkdirAll(configs, 0755); err != nil {
+		t.Fatal(err)
+	}
+	cw, err := NewConfigWatcher(configs, menuSet, nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("NewConfigWatcher: %v", err)
+	}
+	want := map[string]bool{
+		filepath.Join(menuSet, "theme.json"):               false,
+		filepath.Join(root, "menus.d", "v3", "theme.json"): true,
+	}
+	for _, tg := range cw.targets {
+		if reloadOnRemove, ok := want[tg.path]; ok {
+			if tg.reloadOnRemove != reloadOnRemove {
+				t.Errorf("%s reloadOnRemove = %v, want %v", tg.path, tg.reloadOnRemove, reloadOnRemove)
+			}
+			delete(want, tg.path)
+		}
+	}
+	for p := range want {
+		t.Errorf("theme target not registered: %s", p)
+	}
+}

--- a/cmd/vision3/main.go
+++ b/cmd/vision3/main.go
@@ -1718,6 +1718,8 @@ func main() {
 		logging.Fatal("failed to load strings configuration", "error", err)
 	}
 
+	logMenuOverlay(menuSetPath)
+
 	// Load theme configuration from the menu set path
 	loadedTheme, err = config.LoadThemeConfig(menuSetPath)
 	if err != nil {

--- a/cmd/vision3/menu_overlay.go
+++ b/cmd/vision3/menu_overlay.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"log/slog"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/menuset"
+)
+
+// logMenuOverlay reports at startup whether the menu set's overlay directory
+// (menus.d/<set>) is in use and what it contributes. The single most common
+// question an overlay invites is "why isn't my change showing?", and the
+// answer is usually in this line: the directory is not where the BBS looks,
+// or a subdirectory name is misspelled.
+func logMenuOverlay(menuSetPath string) {
+	menus := menuset.FromPath(menuSetPath)
+	if !menus.HasOverlay() {
+		return
+	}
+	sum, ok, err := menus.Summarize()
+	if err != nil {
+		slog.Warn("menu overlay could not be read", "path", menus.Overlay, "error", err)
+		return
+	}
+	if !ok {
+		slog.Info("menu overlay not present; using the shipped menu set only",
+			"path", menus.Overlay, "menus", menus.Base)
+		return
+	}
+	slog.Info("menu overlay active", "path", menus.Overlay, "menus", menus.Base,
+		"overrides", sum.Overrides, "additions", sum.Additions)
+	for _, d := range sum.UnknownDirs {
+		slog.Warn("menu overlay subdirectory has no counterpart in the shipped set and will never be read",
+			"path", menus.Path(menuset.LayerOverlay, d))
+	}
+}

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -174,6 +174,9 @@ if [[ -d "$REPO_DIR/menus" ]] && [[ ! -d "$TARGET/menus" ]]; then
     elif [[ -d "$TARGET/menus" ]]; then
     info "Menus directory already exists, skipping."
 fi
+# The overlay is where menu customisations belong; menus/ can then track the
+# repo (see docs/sysop/getting-started/upgrading.md).
+mkdir -p "$TARGET/menus.d"
 
 # ── Copy scripts ─────────────────────────────────────────────────
 if [[ -d "$REPO_DIR/scripts/examples" ]] && [[ ! -d "$TARGET/scripts/examples" ]]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,12 @@ services:
       # Persistent data - these directories will be created on host
       - ./configs:/vision3/configs
       - ./data:/vision3/data
-      # Menus ship inside the image; this mount keeps a customised
-      # set on the host and lets `git pull` update them in place.
+      # Menus ship inside the image; this mount keeps the shipped set on
+      # the host and lets `git pull` update it in place.
       - ./menus:/vision3/menus
+      # Your menu overrides. Read before menus/, file by file; menuedit
+      # saves here. Writable by the container, never touched by git.
+      - ./menus.d:/vision3/menus.d
     environment:
       # Optional: Override default settings
       - TZ=America/Los_Angeles

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       # the host and lets `git pull` update it in place.
       - ./menus:/vision3/menus
       # Your menu overrides. Read before menus/, file by file; menuedit
-      # saves here. Writable by the container, never touched by git.
+      # saves here when run with the host uid:gid; ownership stays on the host.
       - ./menus.d:/vision3/menus.d
     environment:
       # Optional: Override default settings

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,13 +12,13 @@
 # chown; carry on and let the writes succeed or fail on their own merits.
 # ---------------------------------------------------------------------------
 if [ "$(id -u)" = "0" ]; then
-    mkdir -p /vision3/configs /vision3/data /vision3/menus /vision3/temp /vision3/bin
+    mkdir -p /vision3/configs /vision3/data /vision3/menus /vision3/menus.d /vision3/temp /vision3/bin
     # Walk the tree only when the mount root is not already ours. Docker creates
     # these owned by root on a fresh install, which is the case worth repairing;
     # on every restart afterwards a recursive pass would traverse the whole of
     # data/ -- every file area, every message base -- to change nothing.
     owner_uid=$(id -u vision3)
-    for d in /vision3/configs /vision3/data /vision3/temp /vision3/bin; do
+    for d in /vision3/configs /vision3/data /vision3/menus.d /vision3/temp /vision3/bin; do
         if [ "$(stat -c %u "$d" 2>/dev/null)" != "$owner_uid" ]; then
             chown -R vision3:vision3 "$d" 2>/dev/null
         fi
@@ -29,9 +29,9 @@ if [ "$(id -u)" = "0" ]; then
     # breaking the working tree it was started from. The BBS only reads menus,
     # and a normal checkout is already world-readable.
     #
-    # The trade-off: menuedit cannot save into a bind-mounted menus/ unless the
-    # host makes it writable by uid 100. Editing on the host, or dropping the
-    # mount to use the set baked into the image, both avoid that.
+    # menus.d/ IS chowned: it is the overlay menuedit saves into, so the
+    # container must be able to write it, and git never tracks its contents
+    # (only the README), so ownership there costs the host nothing.
     exec su-exec vision3 "$0" "$@"
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,7 +18,7 @@ if [ "$(id -u)" = "0" ]; then
     # on every restart afterwards a recursive pass would traverse the whole of
     # data/ -- every file area, every message base -- to change nothing.
     owner_uid=$(id -u vision3)
-    for d in /vision3/configs /vision3/data /vision3/menus.d /vision3/temp /vision3/bin; do
+    for d in /vision3/configs /vision3/data /vision3/temp /vision3/bin; do
         if [ "$(stat -c %u "$d" 2>/dev/null)" != "$owner_uid" ]; then
             chown -R vision3:vision3 "$d" 2>/dev/null
         fi
@@ -29,9 +29,8 @@ if [ "$(id -u)" = "0" ]; then
     # breaking the working tree it was started from. The BBS only reads menus,
     # and a normal checkout is already world-readable.
     #
-    # menus.d/ IS chowned: it is the overlay menuedit saves into, so the
-    # container must be able to write it, and git never tracks its contents
-    # (only the README), so ownership there costs the host nothing.
+    # menus.d/ also keeps its host ownership. Run menuedit with the host
+    # uid:gid so both host and container edits remain writable by the host.
     exec su-exec vision3 "$0" "$@"
 fi
 

--- a/docs/sysop/getting-started/docker.md
+++ b/docs/sysop/getting-started/docker.md
@@ -144,7 +144,7 @@ it when using `docker run` outside a checkout:
 
 ```bash
 mkdir -p menus.d
-docker compose exec -u "$(id -u):$(id -g)" vision3 ./menuedit
+docker exec -it -u "$(id -u):$(id -g)" vision3-bbs ./menuedit
 ```
 
 If an earlier container changed the overlay's ownership, restore it once with

--- a/docs/sysop/getting-started/docker.md
+++ b/docs/sysop/getting-started/docker.md
@@ -209,8 +209,8 @@ docker exec -u vision3 -it vision3-bbs ./strings
 # User editor
 docker exec -u vision3 -it vision3-bbs ./ue
 
-# Menu editor
-docker exec -u vision3 -it vision3-bbs ./menuedit
+# Menu editor (use the host UID/GID for the bind-mounted overlay)
+docker exec -it -u "$(id -u):$(id -g)" vision3-bbs ./menuedit
 
 # WFC sysop console
 docker exec -u vision3 -it vision3-bbs ./wfc

--- a/docs/sysop/getting-started/docker.md
+++ b/docs/sysop/getting-started/docker.md
@@ -78,7 +78,7 @@ If you prefer not to use Docker Compose:
    To customise menus, mount an overlay directory instead of the whole set:
    `-v "$(pwd)/menus.d:/vision3/menus.d"`. Files in it are read before the
    built-in ones, file by file, and `menuedit` inside the container saves there
-   (see [Customising menus without losing your changes](../menus/menu-system.md#customising-menus-without-losing-your-changes)).
+   (see [Customising menus without losing your changes](menus/menu-system.md#customising-menus-without-losing-your-changes)).
    Add `-v "$(pwd)/menus:/vision3/menus"` only if you keep a complete set of
    your own on the host — mounting an *empty* directory there hides the
    built-in menus and the pre-flight check will refuse to start.
@@ -130,26 +130,30 @@ drops privileges — so Docker-created bind mounts, which arrive owned by root,
 work without any manual preparation.
 
 Because of that privilege drop, `docker exec` lands you as **root**, not
-`vision3`. Always pass `-u vision3` when running the TUI tools, or they will
+`vision3`. Pass `-u vision3` when running the configuration TUI tools, or they will
 leave root-owned files in `configs/` that the BBS cannot rewrite.
 
 `menus/` is deliberately left alone. Compose bind-mounts your checkout there, and
 taking ownership of it would leave you unable to `git pull` or edit your own menu
 set on the host. The BBS only reads menus, so a normal checkout works as-is.
 
-`menus.d/` — the overlay your customisations go in — **is** chowned like
-`configs/` and `data/`, because `menuedit` in the container writes there. Git
-tracks nothing in it but a README, so the ownership change costs the host
-nothing. That is what makes editing menus from inside the container work:
+`menus.d/` also keeps its host ownership, including its tracked README. Run
+`menuedit` with your host UID and GID so files created inside the container
+remain editable on the host. Create the directory on the host before mounting
+it when using `docker run` outside a checkout:
 
 ```bash
-docker compose exec -u vision3 vision3 ./menuedit   # saves into /vision3/menus.d
+mkdir -p menus.d
+docker compose exec -u "$(id -u):$(id -g)" vision3 ./menuedit
 ```
+
+If an earlier container changed the overlay's ownership, restore it once with
+`sudo chown -R "$(id -u):$(id -g)" ./menus.d`.
 
 Edits made on the host land in the same directory (`./menus.d`) and are picked
 up on the next menu load. You never need to make `menus/` writable. If you
 customised `menus/` before the overlay existed, move those files across once —
-see [Moving existing customisations into menus.d](../menus/menu-system.md#moving-existing-customisations-into-menusd).
+see [Moving existing customisations into menus.d](menus/menu-system.md#moving-existing-customisations-into-menusd).
 
 ### Persistent Data
 

--- a/docs/sysop/getting-started/docker.md
+++ b/docs/sysop/getting-started/docker.md
@@ -147,7 +147,9 @@ docker compose exec -u vision3 vision3 ./menuedit   # saves into /vision3/menus.
 ```
 
 Edits made on the host land in the same directory (`./menus.d`) and are picked
-up on the next menu load. You never need to make `menus/` writable.
+up on the next menu load. You never need to make `menus/` writable. If you
+customised `menus/` before the overlay existed, move those files across once —
+see [Moving existing customisations into menus.d](../menus/menu-system.md#moving-existing-customisations-into-menusd).
 
 ### Persistent Data
 

--- a/docs/sysop/getting-started/docker.md
+++ b/docs/sysop/getting-started/docker.md
@@ -75,9 +75,13 @@ If you prefer not to use Docker Compose:
    ```
 
    The default menu set ships inside the image, so no `menus/` mount is needed.
-   Add `-v "$(pwd)/menus:/vision3/menus"` only if you keep a customised set on
-   the host — mounting an *empty* directory there hides the built-in menus and
-   the pre-flight check will refuse to start.
+   To customise menus, mount an overlay directory instead of the whole set:
+   `-v "$(pwd)/menus.d:/vision3/menus.d"`. Files in it are read before the
+   built-in ones, file by file, and `menuedit` inside the container saves there
+   (see [Customising menus without losing your changes](../menus/menu-system.md#customising-menus-without-losing-your-changes)).
+   Add `-v "$(pwd)/menus:/vision3/menus"` only if you keep a complete set of
+   your own on the host — mounting an *empty* directory there hides the
+   built-in menus and the pre-flight check will refuse to start.
 
 ## Important Notes
 
@@ -133,13 +137,17 @@ leave root-owned files in `configs/` that the BBS cannot rewrite.
 taking ownership of it would leave you unable to `git pull` or edit your own menu
 set on the host. The BBS only reads menus, so a normal checkout works as-is.
 
-The trade-off is that `menuedit` cannot save into a bind-mounted `menus/`, which
-the container user may read but not write. Pick whichever suits your setup:
+`menus.d/` — the overlay your customisations go in — **is** chowned like
+`configs/` and `data/`, because `menuedit` in the container writes there. Git
+tracks nothing in it but a README, so the ownership change costs the host
+nothing. That is what makes editing menus from inside the container work:
 
-- edit menus on the host (`./menuedit` from the checkout), or
-- drop the `menus/` mount and use the set baked into the image, or
-- make the mount writable by the container user: `sudo chown -R 100:101 ./menus`
-  — after which the host user needs `sudo` to edit those files.
+```bash
+docker compose exec -u vision3 vision3 ./menuedit   # saves into /vision3/menus.d
+```
+
+Edits made on the host land in the same directory (`./menus.d`) and are picked
+up on the next menu load. You never need to make `menus/` writable.
 
 ### Persistent Data
 
@@ -160,8 +168,11 @@ The following directories are mounted as volumes and persist across container re
   - `ftn/` - FidoNet/echomail data
   - `logs/` - Application logs (vision3.log, v3mail.log, binkd.log)
 
-- **`menus/`** - Menu files (ANSI screens, configs)
-  - Mount your custom menu set here
+- **`menus/`** - The shipped menu set (ANSI screens, configs)
+  - Mount your checkout here so `git pull` updates it, or leave it to the image
+
+- **`menus.d/`** - Your menu overrides
+  - Read before `menus/`, file by file; `menuedit` saves here
 
 ### First Run Initialization
 
@@ -296,7 +307,13 @@ services:
 
 ### Custom Menu Set
 
-Mount a custom menu directory:
+To override individual files, put them in `./menus.d` (mounted by default):
+
+```
+menus.d/v3/ansi/MAIN.ANS   # replaces the shipped MAIN.ANS; everything else is unchanged
+```
+
+To replace the whole set, mount a complete menu directory over the shipped one:
 
 ```yaml
 volumes:

--- a/docs/sysop/getting-started/upgrading.md
+++ b/docs/sysop/getting-started/upgrading.md
@@ -9,7 +9,9 @@ what makes upgrading safe, and also what makes two steps necessary:
 - Your menu set is a different story, and which story depends on how you
   installed. A repo-in-place upgrade **will** update `menus/`, and can
   overwrite menu edits you made in the repo. An instance or bundle install
-  never updates it, so artwork fixes do not reach you at all.
+  never updates it, so artwork fixes do not reach you at all. Keeping your
+  edits in `menus.d/` instead of `menus/` sidesteps both problems — see
+  [Customising menus without losing your changes](../menus/menu-system.md#customising-menus-without-losing-your-changes).
 - The binaries in `bin/` (`binkd`, `sexyz`) are prebuilt — a source build
   (`git pull` + `build.sh`) never touches them, so they stay at the version you
   first installed. Most releases don't change them; when one does, the release
@@ -69,8 +71,20 @@ git pull
 
 **`menus/` is tracked**, so a pull does update the shipped menu set — and will
 conflict, or overwrite, if you have edited a menu, `.ANS` or `.CFG` file in
-place. Commit your menu edits to a branch, or keep copies outside the repo,
-before pulling.
+place. Keep your edits in **`menus.d/`** instead: it is searched before `menus/`
+file by file, it is git-ignored, and `menuedit` saves there by default. If you
+already have edits inside `menus/`, move them across once:
+
+```bash
+# see which shipped files you have changed
+git status --short menus/
+# move each one into the overlay, then let git restore the shipped copy
+mkdir -p menus.d/v3/ansi
+mv menus/v3/ansi/MAIN.ANS menus.d/v3/ansi/
+git checkout -- menus/v3/ansi/MAIN.ANS
+```
+
+After that, `git pull` cannot conflict on menus again.
 
 Re-running `./setup.sh` is safe: it copies a config template only when the
 target does not already exist. It fills in genuinely new files and leaves
@@ -111,12 +125,20 @@ fixes never arrive on their own. Either copy the changed files by hand:
 cp ~/git/vision3/menus/v3/ansi/SOMEFILE.ANS /opt/vision3/menus/v3/ansi/
 ```
 
-…or, if you have not customised the menu set, replace the directory with a
-symlink once and it will track the repo from then on:
+…or replace the directory with a symlink once and it will track the repo from
+then on, with your own customisations kept in the instance's `menus.d/` where
+the symlinked set cannot overwrite them:
 
 ```bash
-cd /opt/vision3 && rm -rf menus && ln -s ~/git/vision3/menus menus
+cd /opt/vision3
+# first move anything you changed out of the way, e.g.
+#   mkdir -p menus.d/v3/ansi && mv menus/v3/ansi/MAIN.ANS menus.d/v3/ansi/
+rm -rf menus && ln -s ~/git/vision3/menus menus
 ```
+
+`menus.d/` is searched before `menus/`, file by file, so the shipped set can
+change underneath you without touching a file you have overridden — see
+[Customising menus without losing your changes](../menus/menu-system.md#customising-menus-without-losing-your-changes).
 
 The same is true of `configs/`: templates are copied only when the file is
 absent, so see [Settings added since your version](#settings-added-since-your-version).

--- a/docs/sysop/getting-started/upgrading.md
+++ b/docs/sysop/getting-started/upgrading.md
@@ -11,7 +11,7 @@ what makes upgrading safe, and also what makes two steps necessary:
   overwrite menu edits you made in the repo. An instance or bundle install
   never updates it, so artwork fixes do not reach you at all. Keeping your
   edits in `menus.d/` instead of `menus/` sidesteps both problems — see
-  [Customising menus without losing your changes](../menus/menu-system.md#customising-menus-without-losing-your-changes).
+  [Customising menus without losing your changes](menus/menu-system.md#customising-menus-without-losing-your-changes).
 - The binaries in `bin/` (`binkd`, `sexyz`) are prebuilt — a source build
   (`git pull` + `build.sh`) never touches them, so they stay at the version you
   first installed. Most releases don't change them; when one does, the release
@@ -86,7 +86,7 @@ git checkout -- menus/v3/ansi/MAIN.ANS
 
 After that, `git pull` cannot conflict on menus again. The full procedure,
 including edits committed on a branch, is in
-[Moving existing customisations into menus.d](../menus/menu-system.md#moving-existing-customisations-into-menusd).
+[Moving existing customisations into menus.d](menus/menu-system.md#moving-existing-customisations-into-menusd).
 
 Re-running `./setup.sh` is safe: it copies a config template only when the
 target does not already exist. It fills in genuinely new files and leaves
@@ -141,7 +141,7 @@ rm -rf menus && ln -s ~/git/vision3/menus menus
 `menus.d/` is searched before `menus/`, file by file, so the shipped set can
 change underneath you without touching a file you have overridden. Step by
 step, including how to tell your edits from fixes you have not copied yet:
-[Moving existing customisations into menus.d](../menus/menu-system.md#moving-existing-customisations-into-menusd).
+[Moving existing customisations into menus.d](menus/menu-system.md#moving-existing-customisations-into-menusd).
 
 The same is true of `configs/`: templates are copied only when the file is
 absent, so see [Settings added since your version](#settings-added-since-your-version).

--- a/docs/sysop/getting-started/upgrading.md
+++ b/docs/sysop/getting-started/upgrading.md
@@ -84,7 +84,9 @@ mv menus/v3/ansi/MAIN.ANS menus.d/v3/ansi/
 git checkout -- menus/v3/ansi/MAIN.ANS
 ```
 
-After that, `git pull` cannot conflict on menus again.
+After that, `git pull` cannot conflict on menus again. The full procedure,
+including edits committed on a branch, is in
+[Moving existing customisations into menus.d](../menus/menu-system.md#moving-existing-customisations-into-menusd).
 
 Re-running `./setup.sh` is safe: it copies a config template only when the
 target does not already exist. It fills in genuinely new files and leaves
@@ -131,14 +133,15 @@ the symlinked set cannot overwrite them:
 
 ```bash
 cd /opt/vision3
-# first move anything you changed out of the way, e.g.
-#   mkdir -p menus.d/v3/ansi && mv menus/v3/ansi/MAIN.ANS menus.d/v3/ansi/
+diff -rq menus/v3 ~/git/vision3/menus/v3      # find what you changed or added
+# move each of those files to the same path under menus.d/v3/, then:
 rm -rf menus && ln -s ~/git/vision3/menus menus
 ```
 
 `menus.d/` is searched before `menus/`, file by file, so the shipped set can
-change underneath you without touching a file you have overridden — see
-[Customising menus without losing your changes](../menus/menu-system.md#customising-menus-without-losing-your-changes).
+change underneath you without touching a file you have overridden. Step by
+step, including how to tell your edits from fixes you have not copied yet:
+[Moving existing customisations into menus.d](../menus/menu-system.md#moving-existing-customisations-into-menusd).
 
 The same is true of `configs/`: templates are copied only when the file is
 absent, so see [Settings added since your version](#settings-added-since-your-version).

--- a/docs/sysop/how-to-guides/keeping-binaries-updated.md
+++ b/docs/sysop/how-to-guides/keeping-binaries-updated.md
@@ -99,8 +99,11 @@ changed as a set; taking one file and not the others can leave you worse off
 than before. (For most menus the three must agree outright; menus that read
 their own keys in Go, like the Sponsor Menu, keep only a subset in their `.CFG`
 — see [the menu system guide](menus/menu-system.md#keeping-the-bar-file-and-the-art-in-step).)
-If you have customised a file, diff it against the repo's version rather than
-overwriting it.
+If you have customised a file, keep your version in `menus.d/` rather than in
+`menus/`: the BBS reads `menus.d/v3/ansi/SOMEMENU.ANS` in preference to the
+shipped copy, so you can overwrite `menus/` freely — or symlink it to the repo
+so it tracks every pull — and never lose an edit. See
+[Customising menus without losing your changes](../menus/menu-system.md#customising-menus-without-losing-your-changes).
 
 This does not apply if you run Vision/3 directly out of the git checkout, or if
 you bind-mount the repo's `menus/` as `docker-compose.yml` does — there `git pull`

--- a/docs/sysop/how-to-guides/keeping-binaries-updated.md
+++ b/docs/sysop/how-to-guides/keeping-binaries-updated.md
@@ -103,7 +103,7 @@ If you have customised a file, keep your version in `menus.d/` rather than in
 `menus/`: the BBS reads `menus.d/v3/ansi/SOMEMENU.ANS` in preference to the
 shipped copy, so you can overwrite `menus/` freely — or symlink it to the repo
 so it tracks every pull — and never lose an edit. See
-[Customising menus without losing your changes](../menus/menu-system.md#customising-menus-without-losing-your-changes).
+[Customising menus without losing your changes](menus/menu-system.md#customising-menus-without-losing-your-changes).
 
 This does not apply if you run Vision/3 directly out of the git checkout, or if
 you bind-mount the repo's `menus/` as `docker-compose.yml` does — there `git pull`

--- a/docs/sysop/menus/README.md
+++ b/docs/sysop/menus/README.md
@@ -3,3 +3,4 @@
 ViSiON/3's menu system is highly configurable via .MNU, .CFG, and .ANS files with ACS-based access control.
 
 - **[Menus & ACS](menus/menu-system.md)** — menu structure, ACS strings, key bindings, display files
+- **[Customising without losing changes](menus/menu-system.md#customising-menus-without-losing-your-changes)** — the `menus.d/` overlay that survives upgrades

--- a/docs/sysop/menus/menu-system.md
+++ b/docs/sysop/menus/menu-system.md
@@ -9,13 +9,19 @@ The ViSiON/3 menu system is the core of the BBS user interface. This guide expla
 ```bash
 ./menuedit                            # uses menus/v3 by default
 ./menuedit --menus /path/to/menus/v3  # explicit path
+./menuedit --no-overlay               # edit the shipped set in place
 ```
 
 The `--menus` path must contain `mnu/` and `cfg/` subdirectories. The BBS does not need to be stopped to run `menuedit`, but changes take effect on next menu load.
 
+`menuedit` reads menus through the [overlay directory](#customising-menus-without-losing-your-changes)
+and **saves into it** — `menus.d/v3/` for the default set — so your edits are
+never in the way of a `git pull`. A flash message on startup names the
+directory. Pass `--no-overlay` to read and write `menus/v3/` directly instead.
+
 ### Menu List
 
-The opening screen lists all menus in `menus/v3/mnu/`. Columns show the menu title and its filename pair (`.MNU` / `.CFG`).
+The opening screen lists all menus in `menus/v3/mnu/`, with any overrides from `menus.d/v3/mnu/` merged in. Columns show the menu title and its filename pair (`.MNU` / `.CFG`); a `*` after a filename means that file comes from the overlay.
 
 | Key | Action |
 |-----|--------|
@@ -96,7 +102,7 @@ Edits the 6 fields of a single command:
 
 **Creating a menu:** Press F5 from Menu List or Menu Edit. Enter a name (A-Z, 0-9, underscore, max 8 characters). The editor creates empty `.MNU` and `.CFG` files and opens Menu Edit for the new menu.
 
-**Deleting a menu:** F2 from Menu List or Menu Edit. This removes **both** `.MNU` and `.CFG` files permanently — there is no undo.
+**Deleting a menu:** F2 from Menu List or Menu Edit. This removes **both** `.MNU` and `.CFG` files permanently — there is no undo. With the overlay in use, only overlay copies are removed: deleting a menu you had overridden reverts it to the shipped version, and a menu that exists only in `menus/` cannot be deleted this way (use `--no-overlay`).
 
 **Saving:** Changes are written when you press Esc from an edit screen, navigate with PgUp/PgDn, or press F10 to jump to the Command List.
 
@@ -120,6 +126,60 @@ All menu files are located in `menus/v3/`:
 - `menus/v3/cfg/` - Command definition files
 - `menus/v3/ansi/` - ANSI art files
 - `menus/v3/bar/` - Lightbar menu files (optional)
+
+Any of them can be overridden from `menus.d/v3/` without editing `menus/v3/`
+itself — see the next section.
+
+## Customising menus without losing your changes
+
+`menus/v3/` is part of the repository, so every upgrade wants to update it, and
+every file you have edited there is a merge conflict waiting to happen. Put your
+changes in **`menus.d/`** instead. It mirrors the layout of `menus/` and is
+searched first, one file at a time:
+
+```
+menus.d/v3/ansi/MAIN.ANS     ← used if present
+menus/v3/ansi/MAIN.ANS       ← otherwise
+```
+
+Resolution is per file, not per directory. Overriding `MAIN.ANS` does not mean
+copying the rest of `ansi/`; every file you have not overridden still comes from
+the shipped set, so bug fixes to those files reach you on the next pull.
+
+`menus.d/` is git-ignored (only its README is tracked), so `git pull` never
+touches it, and there is nothing to re-copy after an upgrade.
+
+Everything that reads the menu set goes through the overlay: menu screens and
+prompts, `.MNU`/`.CFG`/`.BAR` definitions, templates (including the message
+header styles under `templates/message_headers/`), `PRELOGON` screens, the
+full-screen editor's own screens, `theme.json`, art displayed by scripts, and
+`menuedit`.
+
+**What to know:**
+
+- **Start with a copy.** To change a shipped file, copy it into the same place
+  under `menus.d/` and edit the copy: `cp menus/v3/ansi/MAIN.ANS menus.d/v3/ansi/`.
+  New files (a `PRELOGON.3`, a menu of your own) can be created there directly.
+- **Check the startup log.** The BBS logs `menu overlay active` with how many
+  files it overrides, and warns about any subdirectory in `menus.d/v3/` that
+  the shipped set does not have — the usual cause of "my change isn't showing"
+  is a misspelled directory name.
+- **Lightbar menus travel as a set.** A lightbar's `.ANS`, `.BAR` and `.CFG`
+  are drawn against each other (see [Keeping the BAR file and the art in step](#keeping-the-bar-file-and-the-art-in-step)).
+  If you override one and a release changes the others, they can drift apart.
+  The BBS logs a warning the first time a lightbar menu's files resolve from
+  different layers; when you see it, compare your copy with the shipped one.
+- **`theme.json` hot-reloads** from either place. Adding, editing or removing
+  `menus.d/v3/theme.json` takes effect without a restart.
+- **You cannot delete through the overlay.** A shipped file cannot be hidden by
+  the overlay; if you need a menu gone, remove it from `menus/` (and expect the
+  next pull to bring it back) or point its commands elsewhere.
+- **Reverting** a customisation is deleting the file from `menus.d/`; the
+  shipped one shows again on the next menu load.
+
+Docker users mount `./menus.d` alongside `./menus` — `docker-compose.yml`
+already does — and can leave the shipped set read-only; see
+[Docker](../getting-started/docker.md#container-user-and-file-ownership).
 
 ## Menu Configuration Files (.MNU)
 

--- a/docs/sysop/menus/menu-system.md
+++ b/docs/sysop/menus/menu-system.md
@@ -181,6 +181,77 @@ Docker users mount `./menus.d` alongside `./menus` — `docker-compose.yml`
 already does — and can leave the shipped set read-only; see
 [Docker](../getting-started/docker.md#container-user-and-file-ownership).
 
+### Moving existing customisations into `menus.d/`
+
+If you customised menus before the overlay existed, your edits are inside
+`menus/`. Moving them takes a few minutes and only has to be done once. How
+you find the changed files depends on [which install you have](../getting-started/upgrading.md#which-install-do-you-have).
+
+**Repo in place** — `menus/` is the git working tree, so git knows what you
+changed:
+
+```bash
+git status --short menus/       # M = a shipped file you edited, ?? = a file you added
+```
+
+Move each listed file to the same path under `menus.d/`, then let git put the
+shipped copy back:
+
+```bash
+mkdir -p menus.d/v3/ansi
+mv menus/v3/ansi/MAIN.ANS menus.d/v3/ansi/
+git checkout -- menus/v3/ansi/MAIN.ANS
+```
+
+Files you added (`??`) just move; there is nothing to restore. If you had
+committed your edits to a branch, use `git diff --name-only main -- menus/` to
+list them, move them the same way, and switch back to `main`.
+
+**Instance or bundle** — `menus/` is a copy that `dev-setup.sh` made or a
+bundle extracted, so compare it with the shipped set you got it from:
+
+```bash
+# instance: against the repo it was built from
+diff -rq menus/v3 ~/git/vision3/menus/v3
+# bundle: against a fresh extraction of the bundle you installed
+diff -rq menus/v3 /tmp/vision3-bundle/menus/v3
+```
+
+`Files ... differ` is a shipped file you edited, `Only in menus/v3/...` is one
+you added. Move each to the same path under `menus.d/v3/`. Then, on an
+instance, replace the copy with a symlink so the shipped set tracks the repo
+from now on:
+
+```bash
+rm -rf menus && ln -s ~/git/vision3/menus menus
+```
+
+The overlay stays in the instance directory (`/opt/vision3/menus.d/`), next to
+the symlink, not inside the repo.
+
+Be aware that a file can differ because a *release* changed it and you never
+copied the fix across, not because you edited it. Moving such a file into
+`menus.d/` would freeze it at the old version. If you are not sure whether a
+difference is yours, look at it (`diff menus/v3/ansi/X.ANS ~/git/vision3/menus/v3/ansi/X.ANS`)
+or check the repo's history for the file (`git log --oneline -- menus/v3/ansi/X.ANS`);
+leave anything you do not recognise to the shipped set.
+
+**Docker** — `menus/` is your checkout bind-mounted, so follow the repo-in-place
+steps on the host. If you had made `menus/` writable by the container
+(`chown -R 100:101`), you can take it back now: `sudo chown -R "$(id -u):$(id -g)" ./menus`.
+`menuedit` writes to `menus.d/`, which the entrypoint owns.
+
+**Check the result.** Start the BBS and look for the overlay line in the log:
+
+```
+menu overlay active path=.../menus.d/v3 overrides=3 additions=1
+```
+
+`overrides` should equal the number of shipped files you moved, `additions`
+the number of files you added. A `has no counterpart in the shipped set`
+warning means a subdirectory name is wrong. `git status menus/` (repo) or the
+`diff -rq` above (instance) should now report nothing.
+
 ## Menu Configuration Files (.MNU)
 
 Menu configuration files are JSON files that define menu behavior and prompts.

--- a/docs/sysop/menus/menu-system.md
+++ b/docs/sysop/menus/menu-system.md
@@ -179,13 +179,13 @@ full-screen editor's own screens, `theme.json`, art displayed by scripts, and
 
 Docker users mount `./menus.d` alongside `./menus` — `docker-compose.yml`
 already does — and can leave the shipped set read-only; see
-[Docker](../getting-started/docker.md#container-user-and-file-ownership).
+[Docker](getting-started/docker.md#container-user-and-file-ownership).
 
 ### Moving existing customisations into `menus.d/`
 
 If you customised menus before the overlay existed, your edits are inside
 `menus/`. Moving them takes a few minutes and only has to be done once. How
-you find the changed files depends on [which install you have](../getting-started/upgrading.md#which-install-do-you-have).
+you find the changed files depends on [which install you have](getting-started/upgrading.md#which-install-do-you-have).
 
 **Repo in place** — `menus/` is the git working tree, so git knows what you
 changed:
@@ -239,7 +239,8 @@ leave anything you do not recognise to the shipped set.
 **Docker** — `menus/` is your checkout bind-mounted, so follow the repo-in-place
 steps on the host. If you had made `menus/` writable by the container
 (`chown -R 100:101`), you can take it back now: `sudo chown -R "$(id -u):$(id -g)" ./menus`.
-`menuedit` writes to `menus.d/`, which the entrypoint owns.
+`menus.d/` keeps its host ownership too. Run container `menuedit` with your host
+UID and GID as described in [Docker](getting-started/docker.md#container-user-and-file-ownership).
 
 **Check the result.** Start the BBS and look for the overlay line in the log:
 

--- a/docs/sysop/reference/api-reference.md
+++ b/docs/sysop/reference/api-reference.md
@@ -1358,7 +1358,7 @@ Each script gets its own JSON file in `scripts/data/<script-name>.json`.
 
 ### v3.ansi — ANSI Art Display
 
-Resolves files from: script directory → `menus/v3/ansi/` → `menus/v3/templates/`.
+Resolves files from: script directory → `menus.d/v3/ansi/` → `menus/v3/ansi/` → `menus.d/v3/templates/` → `menus/v3/templates/`. Overlay files shadow shipped artwork.
 
 | Method                 | Parameters | Returns   | Description                                 |
 | ---------------------- | ---------- | --------- | ------------------------------------------- |

--- a/docs/sysop/reference/architecture.md
+++ b/docs/sysop/reference/architecture.md
@@ -197,11 +197,12 @@ vision3/
 │       ├── nal/        # Network Area List signing/verification
 │       ├── protocol/   # Wire format, message types, events
 │       └── registry/   # Network registry client
-└── menus/v3/           # Menu resources
-    ├── ansi/           # ANSI art files
-    ├── cfg/            # Menu display configurations
-    ├── mnu/            # Menu command definitions
-    └── templates/      # Display templates
+├── menus/v3/           # Shipped menu set (tracked)
+│   ├── ansi/           # ANSI art files
+│   ├── cfg/            # Menu display configurations
+│   ├── mnu/            # Menu command definitions
+│   └── templates/      # Display templates
+└── menus.d/v3/         # Sysop overrides, same layout, searched first (git-ignored)
 ```
 
 ## Module Boundaries
@@ -214,6 +215,7 @@ vision3/
 * `internal/conference`: Conference grouping for message and file areas
 * `internal/config`: Configuration file loading and parsing
 * `internal/menu`: Menu loading, display, command execution
+* `internal/menuset`: Menu set path resolution — the `menus.d/` overlay over the shipped set
 * `internal/jam`: JAM binary message base (read/write/index/lastread)
 * `internal/ftn`: FTN Type-2+ packet parsing and creation
 * `internal/message`: Message area management, JAM-backed storage
@@ -223,7 +225,7 @@ vision3/
 * `internal/file`: File area management and metadata
 * `internal/v3net`: V3Net message networking (hub, leaf, protocol, keystore, dedup, NAL, registry)
 * `internal/session`: Session state tracking (currently minimal)
-* `menus/v3`: Static menu resources (ANSI art, menu definitions)
+* `menus/v3`: Static menu resources (ANSI art, menu definitions); `menus.d/v3` holds per-file overrides
 * `data`: Persisted application data (users, JAM bases, FTN packets, logs)
 
 ## Key Design Decisions

--- a/docs/sysop/reference/architecture.md
+++ b/docs/sysop/reference/architecture.md
@@ -199,8 +199,8 @@ vision3/
 │       └── registry/   # Network registry client
 ├── menus/v3/           # Shipped menu set (tracked)
 │   ├── ansi/           # ANSI art files
-│   ├── cfg/            # Menu display configurations
-│   ├── mnu/            # Menu command definitions
+│   ├── cfg/            # Menu command definitions
+│   ├── mnu/            # Menu configurations
 │   └── templates/      # Display templates
 └── menus.d/v3/         # Sysop overrides, same layout, searched first (git-ignored)
 ```

--- a/docs/sysop/scripting/vpl-scripting.md
+++ b/docs/sysop/scripting/vpl-scripting.md
@@ -574,7 +574,7 @@ for (var i = 0; i < files.length; i++) {
 
 ### v3.ansi
 
-Display ANSI art files (.ANS) from scripts. Files are resolved by searching the script's working directory first, then `menus/v3/ansi/`, then `menus/v3/templates/`.
+Display ANSI art files (.ANS) from scripts. Files are resolved by searching the script's working directory first, then `menus.d/v3/ansi/`, `menus/v3/ansi/`, `menus.d/v3/templates/`, and `menus/v3/templates/` in that order. Overlay files shadow shipped artwork.
 
 | Function | Description |
 |----------|-------------|

--- a/internal/config/config_theme.go
+++ b/internal/config/config_theme.go
@@ -21,7 +21,7 @@ type ThemeConfig struct {
 // set path. A copy in the set's overlay (menus.d/<set>/theme.json) takes
 // precedence over the shipped one.
 func LoadThemeConfig(menuSetPath string) (ThemeConfig, error) {
-	filePath := menuset.FromPath(menuSetPath).Resolve("theme.json")
+	filePath, resolveErr := menuset.FromPath(menuSetPath).Resolve("theme.json")
 	slog.Info("loading theme configuration", "path", filePath)
 
 	// Default theme settings
@@ -30,6 +30,9 @@ func LoadThemeConfig(menuSetPath string) (ThemeConfig, error) {
 		YesNoRegularColor:   15,  // Bright White on Black
 	}
 
+	if resolveErr != nil {
+		return defaultTheme, resolveErr
+	}
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/config/config_theme.go
+++ b/internal/config/config_theme.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/menuset"
 )
 
 // ThemeConfig holds theme-related settings, loaded per menu set.
@@ -16,9 +17,11 @@ type ThemeConfig struct {
 	// Add other theme elements here as needed (e.g., default menu colors)
 }
 
-// LoadThemeConfig loads theme settings from theme.json within a specific menu set path.
+// LoadThemeConfig loads theme settings from theme.json within a specific menu
+// set path. A copy in the set's overlay (menus.d/<set>/theme.json) takes
+// precedence over the shipped one.
 func LoadThemeConfig(menuSetPath string) (ThemeConfig, error) {
-	filePath := filepath.Join(menuSetPath, "theme.json")
+	filePath := menuset.FromPath(menuSetPath).Resolve("theme.json")
 	slog.Info("loading theme configuration", "path", filePath)
 
 	// Default theme settings

--- a/internal/editor/commands.go
+++ b/internal/editor/commands.go
@@ -1,6 +1,7 @@
 package editor
 
 import (
+	"log/slog"
 	"strings"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/menuset"
@@ -284,8 +285,14 @@ func (ch *CommandHandler) processForBuffer(text string) string {
 // Displays the help screen
 func (ch *CommandHandler) HandleHelp(inputHandler *InputHandler) {
 	// Try to load EDITHELP.ANS file
-	helpPath := menuset.FromPath(ch.menuSetPath).Resolve("ansi", "EDITHELP.ANS")
-	helpContent, err := ansi.GetAnsiFileContent(helpPath)
+	helpPath, err := menuset.FromPath(ch.menuSetPath).Resolve("ansi", "EDITHELP.ANS")
+	var helpContent []byte
+	if err == nil {
+		helpContent, err = ansi.GetAnsiFileContent(helpPath)
+	}
+	if err != nil {
+		slog.Warn("failed to load editor help", "error", err)
+	}
 
 	ch.screen.ClearScreen()
 

--- a/internal/editor/commands.go
+++ b/internal/editor/commands.go
@@ -1,8 +1,9 @@
 package editor
 
 import (
-	"path/filepath"
 	"strings"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/menuset"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 )
@@ -283,7 +284,7 @@ func (ch *CommandHandler) processForBuffer(text string) string {
 // Displays the help screen
 func (ch *CommandHandler) HandleHelp(inputHandler *InputHandler) {
 	// Try to load EDITHELP.ANS file
-	helpPath := filepath.Join(ch.menuSetPath, "ansi", "EDITHELP.ANS")
+	helpPath := menuset.FromPath(ch.menuSetPath).Resolve("ansi", "EDITHELP.ANS")
 	helpContent, err := ansi.GetAnsiFileContent(helpPath)
 
 	ch.screen.ClearScreen()

--- a/internal/editor/screen.go
+++ b/internal/editor/screen.go
@@ -87,7 +87,10 @@ func (s *Screen) calculateGeometry() {
 // LoadHeaderTemplate loads and processes the FSEDITOR.ANS template.
 // fromName is the sender display name: handle, real name, or anonymous string.
 func (s *Screen) LoadHeaderTemplate(menuSetPath, subject, recipient, fromName string, isAnon bool) error {
-	templatePath := menuset.FromPath(menuSetPath).Resolve("ansi", "FSEDITOR.ANS")
+	templatePath, err := menuset.FromPath(menuSetPath).Resolve("ansi", "FSEDITOR.ANS")
+	if err != nil {
+		return err
+	}
 	content, err := ansi.GetAnsiFileContent(templatePath)
 	if err != nil {
 		// If template doesn't exist, create a minimal header
@@ -130,7 +133,10 @@ func (s *Screen) LoadHeaderTemplate(menuSetPath, subject, recipient, fromName st
 // Screen geometry (statusLineY) is adjusted to prevent the editing area from
 // overwriting footer rows.
 func (s *Screen) LoadFooterTemplate(menuSetPath string) error {
-	templatePath := menuset.FromPath(menuSetPath).Resolve("ansi", "FSEDITORF.ANS")
+	templatePath, err := menuset.FromPath(menuSetPath).Resolve("ansi", "FSEDITORF.ANS")
+	if err != nil {
+		return err
+	}
 	content, err := ansi.GetAnsiFileContent(templatePath)
 	if err != nil {
 		return nil // footer is optional

--- a/internal/editor/screen.go
+++ b/internal/editor/screen.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 	"unicode"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/menuset"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/config"
@@ -86,7 +87,7 @@ func (s *Screen) calculateGeometry() {
 // LoadHeaderTemplate loads and processes the FSEDITOR.ANS template.
 // fromName is the sender display name: handle, real name, or anonymous string.
 func (s *Screen) LoadHeaderTemplate(menuSetPath, subject, recipient, fromName string, isAnon bool) error {
-	templatePath := filepath.Join(menuSetPath, "ansi", "FSEDITOR.ANS")
+	templatePath := menuset.FromPath(menuSetPath).Resolve("ansi", "FSEDITOR.ANS")
 	content, err := ansi.GetAnsiFileContent(templatePath)
 	if err != nil {
 		// If template doesn't exist, create a minimal header
@@ -129,7 +130,7 @@ func (s *Screen) LoadHeaderTemplate(menuSetPath, subject, recipient, fromName st
 // Screen geometry (statusLineY) is adjusted to prevent the editing area from
 // overwriting footer rows.
 func (s *Screen) LoadFooterTemplate(menuSetPath string) error {
-	templatePath := filepath.Join(menuSetPath, "ansi", "FSEDITORF.ANS")
+	templatePath := menuset.FromPath(menuSetPath).Resolve("ansi", "FSEDITORF.ANS")
 	content, err := ansi.GetAnsiFileContent(templatePath)
 	if err != nil {
 		return nil // footer is optional

--- a/internal/menu/area_lightbar_conf.go
+++ b/internal/menu/area_lightbar_conf.go
@@ -2,7 +2,6 @@ package menu
 
 import (
 	"log/slog"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -46,9 +45,8 @@ func runChangeMsgConferenceLightbar(c *cmdCtx, args string) (*user.User, string,
 		return currentUser, "", nil
 	}
 
-	templateDir := filepath.Join(e.MenuSetPath, "templates")
-	topBytes, errTop := readTemplateFile(filepath.Join(templateDir, "MSGCONF.TOP"))
-	midBytes, errMid := readTemplateFile(filepath.Join(templateDir, "MSGCONF.MID"))
+	topBytes, errTop := readTemplateFile(e.templateFile("MSGCONF.TOP"))
+	midBytes, errMid := readTemplateFile(e.templateFile("MSGCONF.MID"))
 
 	if errTop != nil || errMid != nil {
 		slog.Warn("MSGCONF templates unavailable, using text mode", "node", nodeNumber, "topError", errTop, "midError", errMid)

--- a/internal/menu/area_lightbar_conf_file.go
+++ b/internal/menu/area_lightbar_conf_file.go
@@ -2,7 +2,6 @@ package menu
 
 import (
 	"log/slog"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -144,8 +143,7 @@ func runChangeFileConferenceLightbar(c *cmdCtx, args string) (*user.User, string
 		return currentUser, "", nil
 	}
 
-	templateDir := filepath.Join(e.MenuSetPath, "templates")
-	topBytes, midBytes := loadFileConfTemplates(templateDir)
+	topBytes, midBytes := loadFileConfTemplates(e)
 	if topBytes == nil || midBytes == nil {
 		// Conferences may well exist — the templates are what's missing — so
 		// report a template error rather than "no conferences".
@@ -231,14 +229,14 @@ func runChangeFileConferenceLightbar(c *cmdCtx, args string) (*user.User, string
 
 // loadFileConfTemplates returns the top/mid templates for the file conference
 // picker, preferring FILECONF.* and falling back to the shipped MSGCONF.*.
-func loadFileConfTemplates(templateDir string) (top, mid []byte) {
-	top, errTop := readTemplateFile(filepath.Join(templateDir, "FILECONF.TOP"))
-	mid, errMid := readTemplateFile(filepath.Join(templateDir, "FILECONF.MID"))
+func loadFileConfTemplates(e *MenuExecutor) (top, mid []byte) {
+	top, errTop := readTemplateFile(e.templateFile("FILECONF.TOP"))
+	mid, errMid := readTemplateFile(e.templateFile("FILECONF.MID"))
 	if errTop == nil && errMid == nil {
 		return top, mid
 	}
-	top, errTop = readTemplateFile(filepath.Join(templateDir, "MSGCONF.TOP"))
-	mid, errMid = readTemplateFile(filepath.Join(templateDir, "MSGCONF.MID"))
+	top, errTop = readTemplateFile(e.templateFile("MSGCONF.TOP"))
+	mid, errMid = readTemplateFile(e.templateFile("MSGCONF.MID"))
 	if errTop != nil || errMid != nil {
 		return nil, nil
 	}

--- a/internal/menu/area_lightbar_select.go
+++ b/internal/menu/area_lightbar_select.go
@@ -2,7 +2,6 @@ package menu
 
 import (
 	"log/slog"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -37,9 +36,8 @@ func runSelectMessageAreaLightbar(c *cmdCtx, args string) (*user.User, string, e
 		return nil, "", nil
 	}
 
-	templateDir := filepath.Join(e.MenuSetPath, "templates")
-	topBytes, errTop := readTemplateFile(filepath.Join(templateDir, "MSGAREA.TOP"))
-	midBytes, errMid := readTemplateFile(filepath.Join(templateDir, "MSGAREA.MID"))
+	topBytes, errTop := readTemplateFile(e.templateFile("MSGAREA.TOP"))
+	midBytes, errMid := readTemplateFile(e.templateFile("MSGAREA.MID"))
 
 	if errTop != nil || errMid != nil {
 		slog.Warn("MSGAREA templates unavailable, using text mode", "node", nodeNumber, "topError", errTop, "midError", errMid)

--- a/internal/menu/challenge_gate.go
+++ b/internal/menu/challenge_gate.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"path/filepath"
 	"time"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
@@ -26,7 +25,7 @@ const fallbackGatePrompt = "\x1b[0m\r\n Press {KEY} {PRESSES} {TIMES} if you're 
 // (and any "##" countdown field) unsubstituted; the caller is responsible for
 // running substituteGateTokens.
 func gatePromptOrFallback(e *MenuExecutor, fileName string, nodeNumber int) []byte {
-	path := filepath.Join(e.MenuSetPath, "ansi", fileName)
+	path := e.menuFile("ansi", fileName)
 	content, err := ansi.GetAnsiFileContent(path)
 	if err != nil {
 		slog.Warn("challenge gate art missing, using fallback", "node", nodeNumber, "file", path, "error", err)

--- a/internal/menu/chat.go
+++ b/internal/menu/chat.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -280,7 +279,7 @@ func runChat(c *cmdCtx, args string) (*user.User, string, error) {
 	// @MRCROOM@ and @MRCTOPIC@ placeholders with the current room and topic.
 	// Falls back to a simple text header if the art file is not found.
 	drawHeaderLocked := func() {
-		artPath := filepath.Join(e.MenuSetPath, "ansi", "CHATHEADER.ANS")
+		artPath := e.menuFile("ansi", "CHATHEADER.ANS")
 		artData, artErr := ansi.GetAnsiFileContent(artPath)
 		if artErr == nil {
 			// Convert CP437 high bytes to UTF-8 so box-drawing chars render

--- a/internal/menu/conference_menu.go
+++ b/internal/menu/conference_menu.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -240,11 +239,10 @@ func navigateMsgArea(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, us
 
 // displayConferenceList renders the conference list using templates.
 func displayConferenceList(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, currentUser *user.User, outputMode ansi.OutputMode, nodeNumber int, sessionStartTime time.Time) ([]*conference.Conference, error) {
-	templateDir := filepath.Join(e.MenuSetPath, "templates")
 
-	topBytes, errTop := readTemplateFile(filepath.Join(templateDir, "MSGCONF.TOP"))
-	midBytes, errMid := readTemplateFile(filepath.Join(templateDir, "MSGCONF.MID"))
-	botBytes, errBot := readTemplateFile(filepath.Join(templateDir, "MSGCONF.BOT"))
+	topBytes, errTop := readTemplateFile(e.templateFile("MSGCONF.TOP"))
+	midBytes, errMid := readTemplateFile(e.templateFile("MSGCONF.MID"))
+	botBytes, errBot := readTemplateFile(e.templateFile("MSGCONF.BOT"))
 
 	if errTop != nil || errMid != nil || errBot != nil {
 		slog.Error("failed to load MSGCONF templates", "node", nodeNumber, "topError", errTop, "midError", errMid, "botError", errBot)
@@ -298,10 +296,9 @@ func displayConferenceList(e *MenuExecutor, s ssh.Session, terminal *term.Termin
 func displayMessageAreaListFiltered(e *MenuExecutor, s ssh.Session, terminal *term.Terminal, currentUser *user.User, outputMode ansi.OutputMode, nodeNumber int, sessionStartTime time.Time, filterConfID int) ([]*message.MessageArea, error) {
 	slog.Debug("displaying message area list (filtered)", "node", nodeNumber, "confID", filterConfID)
 
-	templateDir := filepath.Join(e.MenuSetPath, "templates")
-	topTemplateBytes, errTop := readTemplateFile(filepath.Join(templateDir, "MSGAREA.TOP"))
-	midTemplateBytes, errMid := readTemplateFile(filepath.Join(templateDir, "MSGAREA.MID"))
-	botTemplateBytes, errBot := readTemplateFile(filepath.Join(templateDir, "MSGAREA.BOT"))
+	topTemplateBytes, errTop := readTemplateFile(e.templateFile("MSGAREA.TOP"))
+	midTemplateBytes, errMid := readTemplateFile(e.templateFile("MSGAREA.MID"))
+	botTemplateBytes, errBot := readTemplateFile(e.templateFile("MSGAREA.BOT"))
 
 	if errTop != nil || errMid != nil || errBot != nil {
 		slog.Error("failed to load MSGAREA template files", "node", nodeNumber, "topError", errTop, "midError", errMid, "botError", errBot)
@@ -310,7 +307,7 @@ func displayMessageAreaListFiltered(e *MenuExecutor, s ssh.Session, terminal *te
 		return nil, fmt.Errorf("failed loading MSGAREA templates")
 	}
 
-	confHdrBytes, errConf := readTemplateFile(filepath.Join(templateDir, "MSGCONF.HDR"))
+	confHdrBytes, errConf := readTemplateFile(e.templateFile("MSGCONF.HDR"))
 	confHdrTemplate := ""
 	if errConf == nil {
 		confHdrTemplate = string(ansi.ReplacePipeCodes(confHdrBytes))

--- a/internal/menu/door_handler.go
+++ b/internal/menu/door_handler.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -134,9 +133,9 @@ func runListDoors(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	// Load templates
-	topPath := filepath.Join(e.MenuSetPath, "templates", "DOORLIST.TOP")
-	midPath := filepath.Join(e.MenuSetPath, "templates", "DOORLIST.MID")
-	botPath := filepath.Join(e.MenuSetPath, "templates", "DOORLIST.BOT")
+	topPath := e.templateFile("DOORLIST.TOP")
+	midPath := e.templateFile("DOORLIST.MID")
+	botPath := e.templateFile("DOORLIST.BOT")
 
 	topBytes, errTop := readTemplateFile(topPath)
 	midBytes, errMid := readTemplateFile(midPath)

--- a/internal/menu/door_handler_windows.go
+++ b/internal/menu/door_handler_windows.go
@@ -298,9 +298,9 @@ func runListDoors(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	// Load templates (same as non-Windows)
-	topPath := filepath.Join(e.MenuSetPath, "templates", "DOORLIST.TOP")
-	midPath := filepath.Join(e.MenuSetPath, "templates", "DOORLIST.MID")
-	botPath := filepath.Join(e.MenuSetPath, "templates", "DOORLIST.BOT")
+	topPath := e.templateFile("DOORLIST.TOP")
+	midPath := e.templateFile("DOORLIST.MID")
+	botPath := e.templateFile("DOORLIST.BOT")
 
 	topBytes, errTop := readTemplateFile(topPath)
 	midBytes, errMid := readTemplateFile(midPath)

--- a/internal/menu/executor.go
+++ b/internal/menu/executor.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -291,7 +290,7 @@ func (e *MenuExecutor) isCoSysOpOrAbove(u *user.User) bool {
 // LOGOFF/DISCONNECT whenever ErrIdleTimeout is received from any input loop.
 func (e *MenuExecutor) handleIdleTimeout(terminal *term.Terminal, outputMode ansi.OutputMode, nodeNumber int, termHeight int) {
 	// Try to display TIMEOUT.ANS first.
-	ansPath := filepath.Join(e.MenuSetPath, "ansi", "TIMEOUT.ANS")
+	ansPath := e.menuFile("ansi", "TIMEOUT.ANS")
 	if rawContent, err := ansi.GetAnsiFileContent(ansPath); err == nil {
 		terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 		if outputMode == ansi.OutputModeCP437 {

--- a/internal/menu/executor_admin_users.go
+++ b/internal/menu/executor_admin_users.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -35,9 +34,9 @@ func runListUsers(c *cmdCtx, args string) (*user.User, string, error) {
 	slog.Debug("running LISTUSERS", "node", nodeNumber)
 
 	// 1. Load Templates (Corrected filenames)
-	topTemplatePath := filepath.Join(e.MenuSetPath, "templates", "USERLIST.TOP")
-	midTemplatePath := filepath.Join(e.MenuSetPath, "templates", "USERLIST.MID")
-	botTemplatePath := filepath.Join(e.MenuSetPath, "templates", "USERLIST.BOT")
+	topTemplatePath := e.templateFile("USERLIST.TOP")
+	midTemplatePath := e.templateFile("USERLIST.MID")
+	botTemplatePath := e.templateFile("USERLIST.BOT")
 
 	topTemplateBytes, errTop := readTemplateFile(topTemplatePath)
 	midTemplateBytes, errMid := readTemplateFile(midTemplatePath)

--- a/internal/menu/executor_display.go
+++ b/internal/menu/executor_display.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -185,7 +184,7 @@ func (e *MenuExecutor) applyCommonTemplateTokens(data []byte, currentUser *user.
 // with its status line showing.
 func (e *MenuExecutor) displayFile(terminal *term.Terminal, filename string, outputMode ansi.OutputMode, termHeight int, clearFirst ...bool) error {
 	// Construct full path using MenuSetPath
-	filePath := filepath.Join(e.MenuSetPath, "ansi", filename)
+	filePath := e.menuFile("ansi", filename)
 
 	// Read ANSI content via helper (strips SAUCE metadata)
 	data, err := ansi.GetAnsiFileContent(filePath)
@@ -507,7 +506,7 @@ func (e *MenuExecutor) processFileIncludes(prompt string, depth int) string {
 		// match is "%%name.ext%%"; strip the delimiters instead of re-matching.
 		fileName := strings.TrimSuffix(strings.TrimPrefix(match, "%%"), "%%")
 		// Look for included file in MenuSetPath/ansi
-		filePath := filepath.Join(e.MenuSetPath, "ansi", fileName)
+		filePath := e.menuFile("ansi", fileName)
 
 		slog.Debug("including file in prompt", "path", filePath, "depth", depth)
 		data, err := os.ReadFile(filePath)

--- a/internal/menu/executor_files_arealist.go
+++ b/internal/menu/executor_files_arealist.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -29,10 +28,9 @@ func displayFileAreaList(e *MenuExecutor, s ssh.Session, terminal *term.Terminal
 	topTemplateFilename := "FILEAREA.TOP"
 	midTemplateFilename := "FILEAREA.MID"
 	botTemplateFilename := "FILEAREA.BOT"
-	templateDir := filepath.Join(e.MenuSetPath, "templates")
-	topTemplatePath := filepath.Join(templateDir, topTemplateFilename)
-	midTemplatePath := filepath.Join(templateDir, midTemplateFilename)
-	botTemplatePath := filepath.Join(templateDir, botTemplateFilename)
+	topTemplatePath := e.templateFile(topTemplateFilename)
+	midTemplatePath := e.templateFile(midTemplateFilename)
+	botTemplatePath := e.templateFile(botTemplateFilename)
 
 	// 2. Load Template Files
 	topTemplateBytes, errTop := readTemplateFile(topTemplatePath)
@@ -54,7 +52,7 @@ func displayFileAreaList(e *MenuExecutor, s ssh.Session, terminal *term.Terminal
 	processedBotTemplate := ansi.ReplacePipeCodes(botTemplateBytes)
 
 	// Conference header template (optional)
-	confHdrBytes, errConf := readTemplateFile(filepath.Join(templateDir, "FILECONF.HDR"))
+	confHdrBytes, errConf := readTemplateFile(e.templateFile("FILECONF.HDR"))
 	confHdrTemplate := ""
 	if errConf == nil {
 		confHdrTemplate = string(ansi.ReplacePipeCodes(confHdrBytes))

--- a/internal/menu/executor_files_list_render.go
+++ b/internal/menu/executor_files_list_render.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -24,9 +23,9 @@ import (
 // since callers re-process them per page with processFileListPlaceholders.
 // mid is returned fully processed since it needs no further per-page work.
 func (e *MenuExecutor) loadFileListTemplates(currentUser *user.User, nodeNumber int, terminal *term.Terminal, outputMode ansi.OutputMode) (top []byte, mid string, bot []byte, err error) {
-	topTemplatePath := filepath.Join(e.MenuSetPath, "templates", "FILELIST.TOP")
-	midTemplatePath := filepath.Join(e.MenuSetPath, "templates", "FILELIST.MID")
-	botTemplatePath := filepath.Join(e.MenuSetPath, "templates", "FILELIST.BOT")
+	topTemplatePath := e.templateFile("FILELIST.TOP")
+	midTemplatePath := e.templateFile("FILELIST.MID")
+	botTemplatePath := e.templateFile("FILELIST.BOT")
 
 	topTemplateBytes, errTop := readTemplateFile(topTemplatePath)
 	midTemplateBytes, errMid := readTemplateFile(midTemplatePath)

--- a/internal/menu/executor_files_upload_register.go
+++ b/internal/menu/executor_files_upload_register.go
@@ -63,8 +63,8 @@ func (e *MenuExecutor) registerUploadedFiles(
 			proc := ziplab.NewProcessor(zlCfg, zlBaseDir)
 
 			// Load ZIPLAB.ANS and ZIPLAB.NFO for visual display
-			ansiPath := filepath.Join(e.MenuSetPath, "ansi", "ZIPLAB.ANS")
-			nfoPath := filepath.Join(e.MenuSetPath, "ansi", "ZIPLAB.NFO")
+			ansiPath := e.menuFile("ansi", "ZIPLAB.ANS")
+			nfoPath := e.menuFile("ansi", "ZIPLAB.NFO")
 
 			ansiContent, _ := ansi.GetAnsiFileContent(ansiPath)
 			nfo, _ := ziplab.ParseNFO(nfoPath)

--- a/internal/menu/executor_lastcallers.go
+++ b/internal/menu/executor_lastcallers.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -40,9 +39,9 @@ func runLastCallers(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	// 1. Load Template Files from MenuSetPath/templates
-	topTemplatePath := filepath.Join(e.MenuSetPath, "templates", "LASTCALL.TOP")
-	midTemplatePath := filepath.Join(e.MenuSetPath, "templates", "LASTCALL.MID")
-	botTemplatePath := filepath.Join(e.MenuSetPath, "templates", "LASTCALL.BOT")
+	topTemplatePath := e.templateFile("LASTCALL.TOP")
+	midTemplatePath := e.templateFile("LASTCALL.MID")
+	botTemplatePath := e.templateFile("LASTCALL.BOT")
 
 	topTemplateBytes, errTop := readTemplateFile(topTemplatePath)
 	midTemplateBytes, errMid := readTemplateFile(midTemplatePath)

--- a/internal/menu/executor_lastcallers_template.go
+++ b/internal/menu/executor_lastcallers_template.go
@@ -80,7 +80,9 @@ func readTemplateFile(path string) ([]byte, error) {
 		if err == nil {
 			return stripSauceMetadata(data), nil
 		}
-		if !os.IsNotExist(err) {
+		_, linkErr := os.Lstat(candidate)
+		if !os.IsNotExist(err) || !os.IsNotExist(linkErr) {
+			// A dangling link is an explicit template, not a missing candidate.
 			// Real I/O error (permissions, etc.) — stop trying.
 			return nil, err
 		}

--- a/internal/menu/executor_lightbar.go
+++ b/internal/menu/executor_lightbar.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -19,16 +18,15 @@ func loadLightbarOptions(menuName string, e *MenuExecutor) ([]LightbarOption, er
 	// Determine paths using MenuSetPath
 	cfgFilename := menuName + ".CFG"
 	barFilename := menuName + ".BAR"
-	cfgPath := filepath.Join(e.MenuSetPath, "cfg", cfgFilename)
-	barPath := filepath.Join(e.MenuSetPath, "bar", barFilename)
+	cfgPath := e.menuFile("cfg", cfgFilename)
+	barPath := e.menuFile("bar", barFilename)
 
 	slog.Debug("loading CFG", "path", cfgPath)
 	slog.Debug("loading BAR", "path", barPath)
 
 	// Load commands from CFG file using the proper JSON loader
 	commandsByHotkey := make(map[string]string)
-	configPath := filepath.Join(e.MenuSetPath, "cfg")
-	commands, err := LoadCommands(menuName, configPath)
+	commands, err := LoadCommands(menuName, e.Menus())
 	if err != nil {
 		slog.Warn("failed to load CFG file", "path", cfgPath, "error", err)
 	} else {
@@ -105,7 +103,7 @@ func loadLightbarOptions(menuName string, e *MenuExecutor) ([]LightbarOption, er
 // loadBarFile loads and parses a standalone BAR file (no matching CFG required).
 // Returns nil, nil if the file does not exist.
 func loadBarFile(barName string, e *MenuExecutor) ([]LightbarOption, error) {
-	barPath := filepath.Join(e.MenuSetPath, "bar", barName+".BAR")
+	barPath := e.menuFile("bar", barName+".BAR")
 
 	barFile, err := os.Open(barPath)
 	if err != nil {

--- a/internal/menu/executor_lightbar.go
+++ b/internal/menu/executor_lightbar.go
@@ -15,6 +15,11 @@ import (
 
 // loadLightbarOptions loads and parses lightbar options from configuration files
 func loadLightbarOptions(menuName string, e *MenuExecutor) ([]LightbarOption, error) {
+	// Every lightbar — matrix, fast login, ordinary menus — comes through
+	// here, so this is where a menu split across overlay and shipped layers
+	// gets reported.
+	e.warnLightbarLayerMismatch(menuName)
+
 	// Determine paths using MenuSetPath
 	cfgFilename := menuName + ".CFG"
 	barFilename := menuName + ".BAR"

--- a/internal/menu/executor_login_fastlogin.go
+++ b/internal/menu/executor_login_fastlogin.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
@@ -30,8 +29,7 @@ func runFastLogin(c *cmdCtx, args string) (*user.User, string, error) {
 
 	// Load FASTLOGN menu definition (.MNU) for CLR/CLS + prompt behavior
 	var fastlognMenu *MenuRecord
-	menuMnuPath := filepath.Join(e.MenuSetPath, "mnu")
-	loadedMenu, menuErr := LoadMenu("FASTLOGN", menuMnuPath)
+	loadedMenu, menuErr := LoadMenu("FASTLOGN", e.Menus())
 	if menuErr != nil {
 		slog.Warn("failed to load FASTLOGN.MNU", "node", nodeNumber, "error", menuErr)
 	} else {
@@ -60,8 +58,7 @@ func runFastLogin(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	// Load FASTLOGN commands
-	cfgPath := filepath.Join(e.MenuSetPath, "cfg")
-	commands, err := LoadCommands("FASTLOGN", cfgPath)
+	commands, err := LoadCommands("FASTLOGN", e.Menus())
 	if err != nil {
 		slog.Warn("failed to load FASTLOGN.CFG", "node", nodeNumber, "error", err)
 		return currentUser, "", nil
@@ -70,7 +67,7 @@ func runFastLogin(c *cmdCtx, args string) (*user.User, string, error) {
 	renderFastLoginScreen()
 
 	// Check for lightbar BAR file.
-	barPath := filepath.Join(e.MenuSetPath, "bar", "FASTLOGN.BAR")
+	barPath := e.menuFile("bar", "FASTLOGN.BAR")
 	lightbarOptions, barLoadErr := loadLightbarOptions("FASTLOGN", e)
 	isLightbar := barLoadErr == nil && len(lightbarOptions) > 0
 	if barLoadErr != nil {

--- a/internal/menu/executor_menuset.go
+++ b/internal/menu/executor_menuset.go
@@ -1,0 +1,76 @@
+package menu
+
+import (
+	"log/slog"
+	"sync"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/menuset"
+)
+
+// Menus returns the menu set the executor reads from: the shipped set at
+// MenuSetPath with its overlay (menus.d/<set>) searched first, file by file.
+// It is derived rather than stored so a MenuExecutor built as a struct
+// literal — every test does this — behaves the same as one from NewExecutor.
+func (e *MenuExecutor) Menus() menuset.Set {
+	return menuset.FromPath(e.MenuSetPath)
+}
+
+// menuFile resolves a file inside the menu set, overlay first. elem is the
+// path relative to the set root: menuFile("ansi", "MAIN.ANS").
+func (e *MenuExecutor) menuFile(elem ...string) string {
+	return e.Menus().Resolve(elem...)
+}
+
+// templateFile resolves a template by its bare name, accepting the .ANS/.ans
+// suffixed spellings the shipped set uses for some screens (FILEAREA.TOP.ANS).
+// Each spelling is tried in the overlay before the shipped set. readTemplateFile
+// probes the same suffixes itself, so passing its result on is safe either way.
+func (e *MenuExecutor) templateFile(name string) string {
+	return e.Menus().ResolveFirst("templates", name, name+".ANS", name+".ans")
+}
+
+// lightbarLayerWarned remembers which menus have already had their layer
+// mismatch reported, so a sysop sees the warning once per process rather
+// than once per menu display.
+var lightbarLayerWarned sync.Map
+
+// warnLightbarLayerMismatch logs once when a lightbar menu's .ANS, .BAR and
+// .CFG do not all come from the same layer. The three files are drawn against
+// each other — the BAR holds screen coordinates for the ANS, the CFG the keys
+// the BAR refers to — so overriding one without the others is the most likely
+// way for an overlay to produce a menu that looks right and behaves wrong.
+func (e *MenuExecutor) warnLightbarLayerMismatch(menuName string) {
+	m := e.Menus()
+	if !m.HasOverlay() {
+		return
+	}
+	type part struct {
+		sub, name string
+	}
+	parts := []part{
+		{"ansi", menuName + ".ANS"},
+		{"bar", menuName + ".BAR"},
+		{"cfg", menuName + ".CFG"},
+	}
+	var base, overlay []string
+	for _, p := range parts {
+		_, layer, ok := m.Locate(p.sub, p.name)
+		if !ok {
+			continue
+		}
+		if layer == menuset.LayerOverlay {
+			overlay = append(overlay, p.name)
+		} else {
+			base = append(base, p.name)
+		}
+	}
+	if len(base) == 0 || len(overlay) == 0 {
+		lightbarLayerWarned.Delete(menuName) // all one layer again: warn afresh if it drifts later
+		return
+	}
+	if _, already := lightbarLayerWarned.LoadOrStore(menuName, struct{}{}); already {
+		return
+	}
+	slog.Warn("lightbar menu files resolve from different layers; its .ANS, .BAR and .CFG must agree",
+		"menu", menuName, "overlay", overlay, "shipped", base, "overlay_dir", m.Overlay)
+}

--- a/internal/menu/executor_menuset.go
+++ b/internal/menu/executor_menuset.go
@@ -17,8 +17,14 @@ func (e *MenuExecutor) Menus() menuset.Set {
 
 // menuFile resolves a file inside the menu set, overlay first. elem is the
 // path relative to the set root: menuFile("ansi", "MAIN.ANS").
+// Resolution errors are logged; the failing path is retained for the reader
+// to report its open error rather than reading a different layer.
 func (e *MenuExecutor) menuFile(elem ...string) string {
-	return e.Menus().Resolve(elem...)
+	path, err := e.Menus().Resolve(elem...)
+	if err != nil {
+		slog.Error("resolving menu file", "path", path, "error", err)
+	}
+	return path
 }
 
 // templateFile resolves a template by its bare name, accepting the .ANS/.ans
@@ -26,7 +32,11 @@ func (e *MenuExecutor) menuFile(elem ...string) string {
 // Each spelling is tried in the overlay before the shipped set. readTemplateFile
 // probes the same suffixes itself, so passing its result on is safe either way.
 func (e *MenuExecutor) templateFile(name string) string {
-	return e.Menus().ResolveFirst("templates", name, name+".ANS", name+".ans")
+	path, err := e.Menus().ResolveFirst("templates", name, name+".ANS", name+".ans")
+	if err != nil {
+		slog.Error("resolving menu template", "path", path, "error", err)
+	}
+	return path
 }
 
 // lightbarLayerWarned remembers which menus have already had their layer
@@ -54,7 +64,11 @@ func (e *MenuExecutor) warnLightbarLayerMismatch(menuName string) {
 	}
 	var base, overlay []string
 	for _, p := range parts {
-		_, layer, ok := m.Locate(p.sub, p.name)
+		_, layer, ok, err := m.Locate(p.sub, p.name)
+		if err != nil {
+			slog.Warn("checking lightbar layers", "error", err)
+			return
+		}
 		if !ok {
 			continue
 		}

--- a/internal/menu/executor_messages_prompt.go
+++ b/internal/menu/executor_messages_prompt.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -49,10 +48,9 @@ func runPromptAndComposeMessage(c *cmdCtx, args string) (*user.User, string, err
 	topTemplateFilename := "MSGAREA.TOP"
 	midTemplateFilename := "MSGAREA.MID"
 	botTemplateFilename := "MSGAREA.BOT" // We'll use BOT template differently here
-	templateDir := filepath.Join(e.MenuSetPath, "templates")
-	topTemplatePath := filepath.Join(templateDir, topTemplateFilename)
-	midTemplatePath := filepath.Join(templateDir, midTemplateFilename)
-	botTemplatePath := filepath.Join(templateDir, botTemplateFilename) // Load BOT template
+	topTemplatePath := e.templateFile(topTemplateFilename)
+	midTemplatePath := e.templateFile(midTemplateFilename)
+	botTemplatePath := e.templateFile(botTemplateFilename) // Load BOT template
 
 	topTemplateBytes, errTop := readTemplateFile(topTemplatePath)
 	midTemplateBytes, errMid := readTemplateFile(midTemplatePath)

--- a/internal/menu/executor_messages_read.go
+++ b/internal/menu/executor_messages_read.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -53,9 +52,9 @@ func runReadMsgs(c *cmdCtx, args string) (*user.User, string, error) {
 	// template this menu set does not have. A fixed upper bound would reject
 	// styles the selector offers — MSGHDR.BAR ships fifteen and describes
 	// itself as supporting an unlimited number.
-	if !headerStyleAvailable(e.MenuSetPath, currentUser.MsgHdr) {
+	if !headerStyleAvailable(e.Menus(), currentUser.MsgHdr) {
 		// Check if MSGHDR.ANS exists for selection screen
-		selPath := filepath.Join(e.MenuSetPath, "templates", "message_headers", "MSGHDR.ANS")
+		selPath := e.menuFile("templates", "message_headers", "MSGHDR.ANS")
 		if _, statErr := os.Stat(selPath); statErr == nil {
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte("\r\n|07Please select a message header style.|07\r\n")), outputMode)
 			time.Sleep(500 * time.Millisecond)

--- a/internal/menu/executor_oneliners_ui.go
+++ b/internal/menu/executor_oneliners_ui.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -23,9 +22,9 @@ func displayOnelinerScreen(e *MenuExecutor, terminal *term.Terminal, outputMode 
 	numLiners := len(records)
 
 	// 1. Load template files (same flow as LASTCALLERS)
-	topTemplatePath := filepath.Join(e.MenuSetPath, "templates", "ONELINER.TOP")
-	midTemplatePath := filepath.Join(e.MenuSetPath, "templates", "ONELINER.MID")
-	botTemplatePath := filepath.Join(e.MenuSetPath, "templates", "ONELINER.BOT")
+	topTemplatePath := e.templateFile("ONELINER.TOP")
+	midTemplatePath := e.templateFile("ONELINER.MID")
+	botTemplatePath := e.templateFile("ONELINER.BOT")
 
 	topTemplateBytes, errTop := readTemplateFile(topTemplatePath)
 	midTemplateBytes, errMid := readTemplateFile(midTemplatePath)

--- a/internal/menu/executor_run.go
+++ b/internal/menu/executor_run.go
@@ -213,7 +213,11 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 
 		// --- Check for Lightbar Menu (.BAR) ---
 		// Check if a .BAR file exists for this menu in the MENU SET directory
-		st.isLightbarMenu = HasBarFile(st.currentMenuName, e.Menus())
+		isLightbar, err := HasBarFile(st.currentMenuName, e.Menus())
+		if err != nil {
+			return "", st.currentUser, err
+		}
+		st.isLightbarMenu = isLightbar
 
 		// Variable declarations for command handling
 		// var st.userInput string // REMOVE this redeclaration

--- a/internal/menu/executor_run.go
+++ b/internal/menu/executor_run.go
@@ -214,9 +214,6 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 		// --- Check for Lightbar Menu (.BAR) ---
 		// Check if a .BAR file exists for this menu in the MENU SET directory
 		st.isLightbarMenu = HasBarFile(st.currentMenuName, e.Menus())
-		if st.isLightbarMenu {
-			e.warnLightbarLayerMismatch(st.currentMenuName)
-		}
 
 		// Variable declarations for command handling
 		// var st.userInput string // REMOVE this redeclaration

--- a/internal/menu/executor_run.go
+++ b/internal/menu/executor_run.go
@@ -3,7 +3,6 @@ package menu
 import (
 	"fmt"
 	"log/slog"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -135,8 +134,7 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 
 		// --- REGULAR MENU PROCESSING (Common for ALL menus, including LOGIN after interaction) ---
 		// 1. Load Menu Definition (.MNU)
-		menuMnuPath := filepath.Join(e.MenuSetPath, "mnu") // Use correct path structure for MNU
-		menuRec, err := LoadMenu(st.currentMenuName, menuMnuPath)
+		menuRec, err := LoadMenu(st.currentMenuName, e.Menus())
 		if err != nil {
 			errMsg := fmt.Sprintf(e.Strings().ExecMenuLoadError, st.currentMenuName, err)
 			processedErrMsg := ansi.ReplacePipeCodes([]byte(errMsg))
@@ -150,8 +148,7 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 		}
 
 		// 2. Load Commands (.CFG) for the *current* menu (which might be LOGIN)
-		menuCfgPath := filepath.Join(e.MenuSetPath, "cfg") // Use correct path structure for CFG
-		commands, err := LoadCommands(st.currentMenuName, menuCfgPath)
+		commands, err := LoadCommands(st.currentMenuName, e.Menus())
 		if err != nil {
 			slog.Warn("failed to load commands for menu", "menu", st.currentMenuName, "error", err)
 			commands = []CommandRecord{} // Use empty slice
@@ -216,7 +213,10 @@ func (e *MenuExecutor) Run(s ssh.Session, terminal *term.Terminal, userManager *
 
 		// --- Check for Lightbar Menu (.BAR) ---
 		// Check if a .BAR file exists for this menu in the MENU SET directory
-		st.isLightbarMenu = HasBarFile(st.currentMenuName, e.MenuSetPath)
+		st.isLightbarMenu = HasBarFile(st.currentMenuName, e.Menus())
+		if st.isLightbarMenu {
+			e.warnLightbarLayerMismatch(st.currentMenuName)
+		}
 
 		// Variable declarations for command handling
 		// var st.userInput string // REMOVE this redeclaration

--- a/internal/menu/executor_run_login_menu.go
+++ b/internal/menu/executor_run_login_menu.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"path/filepath"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
@@ -244,10 +243,9 @@ func (st *runLoopState) resolvePostAuthAction() (action string, ok bool, err err
 	sessionStartTime := st.sessionStartTime
 
 	// Load LOGIN.CFG to find the default action
-	loginCfgPath := filepath.Join(e.MenuSetPath, "cfg") // Use correct path structure
-	loginCommands, loadCmdErr := LoadCommands("LOGIN", loginCfgPath)
+	loginCommands, loadCmdErr := LoadCommands("LOGIN", e.Menus())
 	if loadCmdErr != nil {
-		slog.Error("failed to load LOGIN.CFG after successful authentication", "path", filepath.Join(loginCfgPath, "LOGIN.CFG"), "error", loadCmdErr)
+		slog.Error("failed to load LOGIN.CFG after successful authentication", "path", e.menuFile("cfg", "LOGIN.CFG"), "error", loadCmdErr)
 		// Return an error? Or try to default to MAIN?
 		return "", false, fmt.Errorf("failed loading LOGIN.CFG post-auth") // Logoff user on critical error
 	}

--- a/internal/menu/executor_run_render.go
+++ b/internal/menu/executor_run_render.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"log/slog"
-	"path/filepath"
 	"strconv"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
@@ -26,7 +25,7 @@ func (st *runLoopState) renderMenuAnsi() (ansi.ProcessAnsiResult, error) {
 	// Determine ANSI filename using standard convention
 	ansFilename := st.currentMenuName + ".ANS"
 	// Use MenuSetPath for ANSI file
-	fullAnsPath := filepath.Join(e.MenuSetPath, "ansi", ansFilename)
+	fullAnsPath := e.menuFile("ansi", ansFilename)
 
 	// Process the associated ANSI file to get display bytes and coordinates
 	rawAnsiContent, readErr := ansi.GetAnsiFileContent(fullAnsPath)

--- a/internal/menu/executor_runnables.go
+++ b/internal/menu/executor_runnables.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -100,7 +99,7 @@ func runShowStats(c *cmdCtx, args string) (*user.User, string, error) {
 
 	ansFilename := "YOURSTAT.ANS"
 	// Use MenuSetPath for ANSI file
-	fullAnsPath := filepath.Join(e.MenuSetPath, "ansi", ansFilename)
+	fullAnsPath := e.menuFile("ansi", ansFilename)
 	rawAnsiContent, readErr := ansi.GetAnsiFileContent(fullAnsPath)
 	if readErr != nil {
 		slog.Error("failed to read file for showstats", "node", nodeNumber, "path", fullAnsPath, "error", readErr)

--- a/internal/menu/executor_whosonline.go
+++ b/internal/menu/executor_whosonline.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -114,9 +113,9 @@ func runWhoIsOnline(c *cmdCtx, args string) (*user.User, string, error) {
 
 	slog.Debug("running WHOISONLINE", "node", nodeNumber)
 
-	topPath := filepath.Join(e.MenuSetPath, "templates", "WHOONLN.TOP")
-	midPath := filepath.Join(e.MenuSetPath, "templates", "WHOONLN.MID")
-	botPath := filepath.Join(e.MenuSetPath, "templates", "WHOONLN.BOT")
+	topPath := e.templateFile("WHOONLN.TOP")
+	midPath := e.templateFile("WHOONLN.MID")
+	botPath := e.templateFile("WHOONLN.BOT")
 
 	topBytes, errTop := readTemplateFile(topPath)
 	midBytes, errMid := readTemplateFile(midPath)

--- a/internal/menu/file_area_lightbar_select.go
+++ b/internal/menu/file_area_lightbar_select.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"io"
 	"log/slog"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -54,9 +53,8 @@ func runSelectFileAreaLightbar(c *cmdCtx, args string) (*user.User, string, erro
 		return nil, "", nil
 	}
 
-	templateDir := filepath.Join(e.MenuSetPath, "templates")
-	topBytes, errTop := readTemplateFile(filepath.Join(templateDir, "FILEAREA.TOP"))
-	midBytes, errMid := readTemplateFile(filepath.Join(templateDir, "FILEAREA.MID"))
+	topBytes, errTop := readTemplateFile(e.templateFile("FILEAREA.TOP"))
+	midBytes, errMid := readTemplateFile(e.templateFile("FILEAREA.MID"))
 
 	if errTop != nil || errMid != nil {
 		slog.Warn("FILEAREA templates unavailable, using text mode", "node", nodeNumber, "errTop", errTop, "errMid", errMid)

--- a/internal/menu/file_newscan.go
+++ b/internal/menu/file_newscan.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -64,19 +63,19 @@ func runFileNewscan(c *cmdCtx, args string) (*user.User, string, error) {
 	defaultBot := []byte("|08" + scanLine + "|07\r\n")
 	defaultArea := []byte("\r\n|11@AREA@ |07(@COUNT@ new)\r\n")
 
-	topBytes, err := readTemplateFile(filepath.Join(e.MenuSetPath, "templates", "FILESCAN.TOP"))
+	topBytes, err := readTemplateFile(e.templateFile("FILESCAN.TOP"))
 	if err != nil {
 		topBytes = defaultTop
 	}
-	midBytes, err := readTemplateFile(filepath.Join(e.MenuSetPath, "templates", "FILESCAN.MID"))
+	midBytes, err := readTemplateFile(e.templateFile("FILESCAN.MID"))
 	if err != nil {
 		midBytes = defaultMid
 	}
-	botBytes, err := readTemplateFile(filepath.Join(e.MenuSetPath, "templates", "FILESCAN.BOT"))
+	botBytes, err := readTemplateFile(e.templateFile("FILESCAN.BOT"))
 	if err != nil {
 		botBytes = defaultBot
 	}
-	areaHdrBytes, err := readTemplateFile(filepath.Join(e.MenuSetPath, "templates", "FILESCAN.AREA"))
+	areaHdrBytes, err := readTemplateFile(e.templateFile("FILESCAN.AREA"))
 	if err != nil {
 		areaHdrBytes = defaultArea
 	}
@@ -426,7 +425,7 @@ func runFileNewscanConfig(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
-	ansPath := filepath.Join(e.MenuSetPath, "ansi", "FILESCAN.ANS")
+	ansPath := e.menuFile("ansi", "FILESCAN.ANS")
 	headerContent, ansErr := ansi.GetAnsiFileContent(ansPath)
 	if ansErr == nil {
 		if outputMode == ansi.OutputModeCP437 {

--- a/internal/menu/loader.go
+++ b/internal/menu/loader.go
@@ -12,7 +12,10 @@ import (
 // LoadMenu reads a .MNU file (assumed JSON) for the given menu name from the
 // menu set's mnu/ directory, overlay first.
 func LoadMenu(menuName string, menus menuset.Set) (*MenuRecord, error) {
-	filePath := menus.Resolve("mnu", menuName+".MNU")
+	filePath, err := menus.Resolve("mnu", menuName+".MNU")
+	if err != nil {
+		return nil, err
+	}
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -36,7 +39,10 @@ func LoadMenu(menuName string, menus menuset.Set) (*MenuRecord, error) {
 // LoadCommands reads a .CFG file (assumed JSON) for the given menu name from
 // the menu set's cfg/ directory, overlay first.
 func LoadCommands(menuName string, menus menuset.Set) ([]CommandRecord, error) {
-	filePath := menus.Resolve("cfg", menuName+".CFG")
+	filePath, err := menus.Resolve("cfg", menuName+".CFG")
+	if err != nil {
+		return nil, err
+	}
 	slog.Debug("attempting to load command file", "file", filePath, "menu", menuName)
 	data, err := os.ReadFile(filePath)
 	if err != nil {
@@ -71,6 +77,6 @@ func LoadCommands(menuName string, menus menuset.Set) ([]CommandRecord, error) {
 
 // HasBarFile returns true if a .BAR lightbar definition file exists for the
 // given menu name inside the menu set's bar/ directory, in either layer.
-func HasBarFile(menuName string, menus menuset.Set) bool {
+func HasBarFile(menuName string, menus menuset.Set) (bool, error) {
 	return menus.Exists("bar", menuName+".BAR")
 }

--- a/internal/menu/loader.go
+++ b/internal/menu/loader.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/menuset"
 )
 
-// LoadMenu reads a .MNU file (assumed JSON) for the given menu name.
-func LoadMenu(menuName string, configPath string) (*MenuRecord, error) {
-	filePath := filepath.Join(configPath, menuName+".MNU")
+// LoadMenu reads a .MNU file (assumed JSON) for the given menu name from the
+// menu set's mnu/ directory, overlay first.
+func LoadMenu(menuName string, menus menuset.Set) (*MenuRecord, error) {
+	filePath := menus.Resolve("mnu", menuName+".MNU")
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -31,10 +33,11 @@ func LoadMenu(menuName string, configPath string) (*MenuRecord, error) {
 	return &menuRec, nil
 }
 
-// LoadCommands reads a .CFG file (assumed JSON) for the given menu name.
-func LoadCommands(menuName string, configPath string) ([]CommandRecord, error) {
-	filePath := filepath.Join(configPath, menuName+".CFG")
-	slog.Debug("attempting to load command file", "file", filePath, "menu", menuName, "path", configPath)
+// LoadCommands reads a .CFG file (assumed JSON) for the given menu name from
+// the menu set's cfg/ directory, overlay first.
+func LoadCommands(menuName string, menus menuset.Set) ([]CommandRecord, error) {
+	filePath := menus.Resolve("cfg", menuName+".CFG")
+	slog.Debug("attempting to load command file", "file", filePath, "menu", menuName)
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -67,9 +70,7 @@ func LoadCommands(menuName string, configPath string) ([]CommandRecord, error) {
 }
 
 // HasBarFile returns true if a .BAR lightbar definition file exists for the
-// given menu name inside the menu set's bar/ directory.
-func HasBarFile(menuName string, menuSetPath string) bool {
-	barPath := filepath.Join(menuSetPath, "bar", menuName+".BAR")
-	_, err := os.Stat(barPath)
-	return err == nil
+// given menu name inside the menu set's bar/ directory, in either layer.
+func HasBarFile(menuName string, menus menuset.Set) bool {
+	return menus.Exists("bar", menuName+".BAR")
 }

--- a/internal/menu/loader_test.go
+++ b/internal/menu/loader_test.go
@@ -4,15 +4,28 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/menuset"
 )
 
-func TestLoadMenu(t *testing.T) {
+// setDir makes a menu set root with the given subdirectory and returns the root.
+func setDir(t *testing.T, sub string) string {
+	t.Helper()
 	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, sub), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	return dir
+}
+
+func TestLoadMenu(t *testing.T) {
+	root := setDir(t, "mnu")
+	dir := menuset.Bare(root)
 	mnu := `{"CLR": true, "PROMPT1": "Cmd: ", "FALLBACK": "MAIN"}`
-	if err := os.WriteFile(filepath.Join(dir, "MAIN.MNU"), []byte(mnu), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "mnu", "MAIN.MNU"), []byte(mnu), 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "BAD.MNU"), []byte("{nope"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "mnu", "BAD.MNU"), []byte("{nope"), 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
@@ -33,18 +46,19 @@ func TestLoadMenu(t *testing.T) {
 }
 
 func TestLoadCommandsFile(t *testing.T) {
-	dir := t.TempDir()
+	root := setDir(t, "cfg")
+	dir := menuset.Bare(root)
 	cfg := `[
 		{"KEYS": "M", "CMD": "GOTO:MSG", "ACS": "s10", "HIDDEN": false},
 		{"KEYS": "G", "CMD": "LOGOFF", "ACS": "", "HIDDEN": true}
 	]`
-	if err := os.WriteFile(filepath.Join(dir, "MAIN.CFG"), []byte(cfg), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "cfg", "MAIN.CFG"), []byte(cfg), 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "EMPTY.CFG"), nil, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "cfg", "EMPTY.CFG"), nil, 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "BAD.CFG"), []byte("nope"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "cfg", "BAD.CFG"), []byte("nope"), 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
@@ -86,10 +100,62 @@ func TestHasBarFile(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "bar", "MAIN.BAR"), []byte("x"), 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	if !HasBarFile("MAIN", dir) {
+	if !HasBarFile("MAIN", menuset.Bare(dir)) {
 		t.Error("MAIN.BAR should be detected")
 	}
-	if HasBarFile("OTHER", dir) {
+	if HasBarFile("OTHER", menuset.Bare(dir)) {
 		t.Error("OTHER.BAR should not be detected")
+	}
+}
+
+// TestLoaderReadsOverlayFirst covers the menus.d overlay end to end for the
+// three loaders: a file in the overlay shadows the shipped one, a file only in
+// the overlay is found, and everything else still comes from the shipped set.
+func TestLoaderReadsOverlayFirst(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, "menus", "v3")
+	overlay := filepath.Join(root, "menus.d", "v3")
+	write := func(path, content string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(base, "mnu", "MAIN.MNU"), `{"PROMPT1": "shipped"}`)
+	write(filepath.Join(base, "mnu", "MSG.MNU"), `{"PROMPT1": "shipped msg"}`)
+	write(filepath.Join(base, "cfg", "MAIN.CFG"), `[{"KEYS": "A", "CMD": "GOTO:A"}]`)
+	write(filepath.Join(base, "bar", "MAIN.BAR"), "x")
+	write(filepath.Join(overlay, "mnu", "MAIN.MNU"), `{"PROMPT1": "mine"}`)
+	write(filepath.Join(overlay, "cfg", "MAIN.CFG"), `[{"KEYS": "A", "CMD": "GOTO:A"}, {"KEYS": "B", "CMD": "GOTO:B"}]`)
+	write(filepath.Join(overlay, "bar", "EXTRA.BAR"), "x")
+
+	menus := menuset.FromPath(base)
+	if menus.Overlay != overlay {
+		t.Fatalf("overlay = %q, want %q", menus.Overlay, overlay)
+	}
+
+	rec, err := LoadMenu("MAIN", menus)
+	if err != nil || rec.Prompt1 != "mine" {
+		t.Errorf("MAIN.MNU: rec=%+v err=%v (want overlay copy)", rec, err)
+	}
+	rec, err = LoadMenu("MSG", menus)
+	if err != nil || rec.Prompt1 != "shipped msg" {
+		t.Errorf("MSG.MNU: rec=%+v err=%v (want shipped copy)", rec, err)
+	}
+	cmds, err := LoadCommands("MAIN", menus)
+	if err != nil || len(cmds) != 2 {
+		t.Errorf("MAIN.CFG: %d commands err=%v (want 2 from overlay)", len(cmds), err)
+	}
+	if !HasBarFile("MAIN", menus) || !HasBarFile("EXTRA", menus) || HasBarFile("NOPE", menus) {
+		t.Error("HasBarFile did not merge layers")
+	}
+
+	// The executor derives the same set from its MenuSetPath.
+	e := &MenuExecutor{MenuSetPath: base}
+	if got := e.menuFile("mnu", "MAIN.MNU"); got != filepath.Join(overlay, "mnu", "MAIN.MNU") {
+		t.Errorf("executor menuFile = %q", got)
 	}
 }

--- a/internal/menu/loader_test.go
+++ b/internal/menu/loader_test.go
@@ -100,10 +100,10 @@ func TestHasBarFile(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "bar", "MAIN.BAR"), []byte("x"), 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	if !HasBarFile("MAIN", menuset.Bare(dir)) {
+	if !hasBarFileOK(t, "MAIN", menuset.Bare(dir)) {
 		t.Error("MAIN.BAR should be detected")
 	}
-	if HasBarFile("OTHER", menuset.Bare(dir)) {
+	if hasBarFileOK(t, "OTHER", menuset.Bare(dir)) {
 		t.Error("OTHER.BAR should not be detected")
 	}
 }
@@ -149,7 +149,7 @@ func TestLoaderReadsOverlayFirst(t *testing.T) {
 	if err != nil || len(cmds) != 2 {
 		t.Errorf("MAIN.CFG: %d commands err=%v (want 2 from overlay)", len(cmds), err)
 	}
-	if !HasBarFile("MAIN", menus) || !HasBarFile("EXTRA", menus) || HasBarFile("NOPE", menus) {
+	if !hasBarFileOK(t, "MAIN", menus) || !hasBarFileOK(t, "EXTRA", menus) || hasBarFileOK(t, "NOPE", menus) {
 		t.Error("HasBarFile did not merge layers")
 	}
 
@@ -157,5 +157,41 @@ func TestLoaderReadsOverlayFirst(t *testing.T) {
 	e := &MenuExecutor{MenuSetPath: base}
 	if got := e.menuFile("mnu", "MAIN.MNU"); got != filepath.Join(overlay, "mnu", "MAIN.MNU") {
 		t.Errorf("executor menuFile = %q", got)
+	}
+}
+
+func hasBarFileOK(t *testing.T, name string, menus menuset.Set) bool {
+	t.Helper()
+	exists, err := HasBarFile(name, menus)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return exists
+}
+
+func TestLoadMenuReportsBrokenOverlay(t *testing.T) {
+	root := t.TempDir()
+	menus := menuset.FromPath(filepath.Join(root, "menus", "v3"))
+	for _, sub := range []string{"mnu", "cfg"} {
+		if err := os.MkdirAll(menus.Path(menuset.LayerBase, sub), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(menus.Path(menuset.LayerOverlay, sub), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, file := range []struct{ sub, name, content string }{{"mnu", "MAIN.MNU", "{}"}, {"cfg", "MAIN.CFG", "[]"}} {
+		if err := os.WriteFile(menus.Path(menuset.LayerBase, file.sub, file.name), []byte(file.content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(file.name, menus.Path(menuset.LayerOverlay, file.sub, file.name)); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+	}
+	if _, err := LoadMenu("MAIN", menus); err == nil {
+		t.Error("LoadMenu silently loaded shipped menu")
+	}
+	if _, err := LoadCommands("MAIN", menus); err == nil {
+		t.Error("LoadCommands silently loaded shipped commands")
 	}
 }

--- a/internal/menu/matrix.go
+++ b/internal/menu/matrix.go
@@ -338,7 +338,11 @@ func (e *MenuExecutor) showPrelogon(s ssh.Session, terminal *term.Terminal, node
 	// and leave PRELOGON.1 to the shipped set.
 	var candidates []string
 	for i := 1; i <= 20; i++ {
-		path, _, ok := menus.Locate("ansi", fmt.Sprintf("PRELOGON.%d", i))
+		path, _, ok, err := menus.Locate("ansi", fmt.Sprintf("PRELOGON.%d", i))
+		if err != nil {
+			slog.Warn("resolving prelogon file", "error", err)
+			return
+		}
 		if !ok {
 			break // Stop at first gap
 		}
@@ -347,7 +351,12 @@ func (e *MenuExecutor) showPrelogon(s ssh.Session, terminal *term.Terminal, node
 
 	// Fall back to single PRELOGON.ANS
 	if len(candidates) == 0 {
-		if path, _, ok := menus.Locate("ansi", "PRELOGON.ANS"); ok {
+		path, _, ok, err := menus.Locate("ansi", "PRELOGON.ANS")
+		if err != nil {
+			slog.Warn("resolving prelogon file", "error", err)
+			return
+		}
+		if ok {
 			candidates = append(candidates, path)
 		}
 	}

--- a/internal/menu/matrix.go
+++ b/internal/menu/matrix.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -45,8 +44,7 @@ func (e *MenuExecutor) RunMatrixScreen(
 	}
 
 	// Load commands from PDMATRIX.CFG to map hotkeys to actions
-	cfgPath := filepath.Join(e.MenuSetPath, "cfg")
-	commands, err := LoadCommands(menuName, cfgPath)
+	commands, err := LoadCommands(menuName, e.Menus())
 	if err != nil {
 		slog.Warn("failed to load CFG file, skipping matrix", "node", nodeNumber, "menu", menuName, "error", err)
 		return "LOGIN", nil, nil
@@ -60,7 +58,7 @@ func (e *MenuExecutor) RunMatrixScreen(
 
 	// Load the ANSI background (convention: PDMATRIX.ANS)
 	// Use GetAnsiFileContent to automatically strip SAUCE metadata
-	ansPath := filepath.Join(e.MenuSetPath, "ansi", menuName+".ANS")
+	ansPath := e.menuFile("ansi", menuName+".ANS")
 	ansBackground, err := ansi.GetAnsiFileContent(ansPath)
 	if err != nil {
 		slog.Warn("failed to load ANS file, skipping matrix", "node", nodeNumber, "menu", menuName, "error", err)
@@ -333,23 +331,23 @@ func (e *MenuExecutor) handleCheckAccess(
 // Matches Pascal: Printfile(PRELOGON.x) + HoldScreen where x is random 1..NumPrelogon.
 // Looks for numbered files (PRELOGON.1, PRELOGON.2, ...) first, falls back to PRELOGON.ANS.
 func (e *MenuExecutor) showPrelogon(s ssh.Session, terminal *term.Terminal, nodeNumber int, outputMode ansi.OutputMode, termWidth, termHeight int) {
-	ansiDir := filepath.Join(e.MenuSetPath, "ansi")
+	menus := e.Menus()
 
 	// Look for numbered PRELOGON files (Pascal pattern: PRELOGON.1, PRELOGON.2, ...)
+	// Each number resolves on its own, so an overlay can replace PRELOGON.2
+	// and leave PRELOGON.1 to the shipped set.
 	var candidates []string
 	for i := 1; i <= 20; i++ {
-		path := filepath.Join(ansiDir, fmt.Sprintf("PRELOGON.%d", i))
-		if _, err := os.Stat(path); err == nil {
-			candidates = append(candidates, path)
-		} else {
+		path, _, ok := menus.Locate("ansi", fmt.Sprintf("PRELOGON.%d", i))
+		if !ok {
 			break // Stop at first gap
 		}
+		candidates = append(candidates, path)
 	}
 
 	// Fall back to single PRELOGON.ANS
 	if len(candidates) == 0 {
-		path := filepath.Join(ansiDir, "PRELOGON.ANS")
-		if _, err := os.Stat(path); err == nil {
+		if path, _, ok := menus.Locate("ansi", "PRELOGON.ANS"); ok {
 			candidates = append(candidates, path)
 		}
 	}

--- a/internal/menu/menu_art_hotkeys_test.go
+++ b/internal/menu/menu_art_hotkeys_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/menuset"
+
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 )
 
@@ -61,7 +63,7 @@ func TestMenuArtHotkeysAreBound(t *testing.T) {
 			continue // art with no command set of its own
 		}
 
-		commands, err := LoadCommands(name, cfgDir)
+		commands, err := LoadCommands(name, menuset.Bare(menuSet))
 		if err != nil {
 			t.Errorf("%s.CFG: %v", name, err)
 			continue

--- a/internal/menu/message_header_reach_test.go
+++ b/internal/menu/message_header_reach_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/menuset"
 )
 
 // makeHeaderSet writes MSGHDR.<n>.ans for each n and returns the menu set root.
@@ -30,17 +32,17 @@ func TestHeaderStyleAvailableAcceptsEveryShippedTemplate(t *testing.T) {
 	root := makeHeaderSet(t, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 
 	for n := 1; n <= 15; n++ {
-		if !headerStyleAvailable(root, n) {
+		if !headerStyleAvailable(menuset.Bare(root), n) {
 			t.Errorf("style %d has a template but was rejected", n)
 		}
 	}
-	if headerStyleAvailable(root, 16) {
+	if headerStyleAvailable(menuset.Bare(root), 16) {
 		t.Error("style 16 has no template and should be rejected")
 	}
-	if headerStyleAvailable(root, 0) {
+	if headerStyleAvailable(menuset.Bare(root), 0) {
 		t.Error("0 means unset and must not count as available")
 	}
-	if headerStyleAvailable(root, -1) {
+	if headerStyleAvailable(menuset.Bare(root), -1) {
 		t.Error("negative styles must be rejected")
 	}
 }
@@ -50,12 +52,12 @@ func TestHeaderStyleAvailableHandlesGaps(t *testing.T) {
 	root := makeHeaderSet(t, 1, 2, 5)
 
 	for _, n := range []int{1, 2, 5} {
-		if !headerStyleAvailable(root, n) {
+		if !headerStyleAvailable(menuset.Bare(root), n) {
 			t.Errorf("style %d exists but was rejected", n)
 		}
 	}
 	for _, n := range []int{3, 4, 6} {
-		if headerStyleAvailable(root, n) {
+		if headerStyleAvailable(menuset.Bare(root), n) {
 			t.Errorf("style %d has no template but was accepted", n)
 		}
 	}
@@ -65,7 +67,7 @@ func TestHeaderStyleAvailableHandlesGaps(t *testing.T) {
 func TestHeaderStyleAvailableIsNotCappedAtFifteen(t *testing.T) {
 	root := makeHeaderSet(t, 1, 20, 42)
 	for _, n := range []int{20, 42} {
-		if !headerStyleAvailable(root, n) {
+		if !headerStyleAvailable(menuset.Bare(root), n) {
 			t.Errorf("style %d exists but was rejected; the bound is still fixed", n)
 		}
 	}
@@ -74,7 +76,7 @@ func TestHeaderStyleAvailableIsNotCappedAtFifteen(t *testing.T) {
 // If discovery fails there is no basis to reject a stored preference, and
 // forcing the selector open on every read would be worse than accepting it.
 func TestHeaderStyleAvailableAcceptsWhenDiscoveryFails(t *testing.T) {
-	if !headerStyleAvailable(filepath.Join(t.TempDir(), "nonexistent"), 7) {
+	if !headerStyleAvailable(menuset.Bare(filepath.Join(t.TempDir(), "nonexistent")), 7) {
 		t.Error("with no templates discoverable, a positive style should be accepted")
 	}
 }

--- a/internal/menu/message_header_test.go
+++ b/internal/menu/message_header_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/menuset"
 )
 
 func TestExtractHeaderNumber(t *testing.T) {
@@ -37,7 +39,7 @@ func TestExtractHeaderNumber(t *testing.T) {
 func TestDiscoverMessageHeaders(t *testing.T) {
 	// Create temporary test directory structure
 	tmpDir := t.TempDir()
-	msgHdrDir := filepath.Join(tmpDir, "message_headers")
+	msgHdrDir := filepath.Join(tmpDir, "templates", "message_headers")
 	if err := os.MkdirAll(msgHdrDir, 0755); err != nil {
 		t.Fatalf("Failed to create test directory: %v", err)
 	}
@@ -59,7 +61,7 @@ func TestDiscoverMessageHeaders(t *testing.T) {
 	}
 
 	// Run discovery
-	templates, err := discoverMessageHeaders(tmpDir)
+	templates, err := discoverMessageHeaders(menuset.Bare(tmpDir))
 	if err != nil {
 		t.Fatalf("discoverMessageHeaders() error = %v", err)
 	}
@@ -95,12 +97,12 @@ func TestDiscoverMessageHeaders(t *testing.T) {
 func TestDiscoverMessageHeadersEmpty(t *testing.T) {
 	// Create temporary test directory with no templates
 	tmpDir := t.TempDir()
-	msgHdrDir := filepath.Join(tmpDir, "message_headers")
+	msgHdrDir := filepath.Join(tmpDir, "templates", "message_headers")
 	if err := os.MkdirAll(msgHdrDir, 0755); err != nil {
 		t.Fatalf("Failed to create test directory: %v", err)
 	}
 
-	templates, err := discoverMessageHeaders(tmpDir)
+	templates, err := discoverMessageHeaders(menuset.Bare(tmpDir))
 	if err != nil {
 		t.Fatalf("discoverMessageHeaders() error = %v", err)
 	}

--- a/internal/menu/message_reader.go
+++ b/internal/menu/message_reader.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -88,13 +87,12 @@ func runMessageReader(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 	// load below already falls back.
 
 	// Load the MSGHDR template file
-	hdrTemplatePath := filepath.Join(e.MenuSetPath, "templates", "message_headers",
-		fmt.Sprintf("MSGHDR.%d.ans", hdrStyle))
+	hdrTemplatePath := e.menuFile("templates", "message_headers", fmt.Sprintf("MSGHDR.%d.ans", hdrStyle))
 	hdrTemplateBytes, hdrErr := ansi.GetAnsiFileContent(hdrTemplatePath)
 	if hdrErr != nil {
 		slog.Error("failed to load message header", "node", nodeNumber, "file", fmt.Sprintf("MSGHDR.%d.ans", hdrStyle), "error", hdrErr)
 		// Fallback to style 2 (simple text format)
-		hdrTemplatePath = filepath.Join(e.MenuSetPath, "templates", "message_headers", "MSGHDR.2.ans")
+		hdrTemplatePath = e.menuFile("templates", "message_headers", "MSGHDR.2.ans")
 		hdrTemplateBytes, hdrErr = ansi.GetAnsiFileContent(hdrTemplatePath)
 		if hdrErr != nil {
 			terminalio.WriteProcessedBytes(terminal, ansi.ReplacePipeCodes([]byte(e.Strings().MsgHdrLoadError)), outputMode)

--- a/internal/menu/message_reader_headers.go
+++ b/internal/menu/message_reader_headers.go
@@ -159,7 +159,11 @@ func runGetHeaderType(c *cmdCtx, args string) (*user.User, string, error) {
 		}
 
 		// Verify template file exists
-		if !e.Menus().Exists("templates", "message_headers", fmt.Sprintf("MSGHDR.%d.ans", templateNum)) {
+		exists, err := e.Menus().Exists("templates", "message_headers", fmt.Sprintf("MSGHDR.%d.ans", templateNum))
+		if err != nil {
+			return nil, "", err
+		}
+		if !exists {
 			slog.Warn("template file not found", "file", fmt.Sprintf("MSGHDR.%d.ans", templateNum))
 			continue
 		}

--- a/internal/menu/message_reader_headers.go
+++ b/internal/menu/message_reader_headers.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -16,6 +15,7 @@ import (
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/config"
 	"github.com/ViSiON-3/vision-3-bbs/internal/editor"
+	"github.com/ViSiON-3/vision-3-bbs/internal/menuset"
 	"github.com/ViSiON-3/vision-3-bbs/internal/message"
 	"github.com/ViSiON-3/vision-3-bbs/internal/terminalio"
 	"github.com/ViSiON-3/vision-3-bbs/internal/user"
@@ -49,11 +49,11 @@ func extractHeaderNumber(filename string) (int, error) {
 //
 // Membership rather than a maximum, so a menu set with a gap in its numbering
 // is handled too.
-func headerStyleAvailable(menuSetPath string, style int) bool {
+func headerStyleAvailable(menus menuset.Set, style int) bool {
 	if style < 1 {
 		return false
 	}
-	templates, err := discoverMessageHeaders(filepath.Join(menuSetPath, "templates"))
+	templates, err := discoverMessageHeaders(menus)
 	if err != nil || len(templates) == 0 {
 		// Discovery failed: fall back to accepting any positive style rather
 		// than forcing the selector open on every read.
@@ -67,18 +67,19 @@ func headerStyleAvailable(menuSetPath string, style int) bool {
 	return false
 }
 
-// discoverMessageHeaders finds all MSGHDR.*.ans template files in the templates/message_headers directory.
+// discoverMessageHeaders finds all MSGHDR.*.ans template files in the
+// templates/message_headers directory of either layer, an overlay copy
+// shadowing the shipped one of the same name.
 // Returns templates sorted by number (1, 2, ..., 14, 15, etc.).
-func discoverMessageHeaders(templatesPath string) ([]MessageHeaderTemplate, error) {
-	pattern := filepath.Join(templatesPath, "message_headers", "MSGHDR.*.ans")
-	files, err := filepath.Glob(pattern)
+func discoverMessageHeaders(menus menuset.Set) ([]MessageHeaderTemplate, error) {
+	files, err := menus.Glob(filepath.Join("templates", "message_headers"), "MSGHDR.*.ans")
 	if err != nil {
 		return nil, fmt.Errorf("failed to glob header templates: %w", err)
 	}
 
 	var templates []MessageHeaderTemplate
 	for _, file := range files {
-		base := filepath.Base(file)
+		base := file.Name
 
 		// Skip MSGHDR.ANS (selection screen, not a template)
 		if base == "MSGHDR.ANS" {
@@ -148,7 +149,6 @@ func runGetHeaderType(c *cmdCtx, args string) (*user.User, string, error) {
 	}
 
 	// Verify template files exist and extract template numbers
-	templatesPath := filepath.Join(e.MenuSetPath, "templates", "message_headers")
 	var validOptions []LightbarOption
 	for _, opt := range options {
 		// Parse template number from return value (not hotkey, since 10+ use letters)
@@ -159,8 +159,7 @@ func runGetHeaderType(c *cmdCtx, args string) (*user.User, string, error) {
 		}
 
 		// Verify template file exists
-		templateFile := filepath.Join(templatesPath, fmt.Sprintf("MSGHDR.%d.ans", templateNum))
-		if _, statErr := os.Stat(templateFile); statErr != nil {
+		if !e.Menus().Exists("templates", "message_headers", fmt.Sprintf("MSGHDR.%d.ans", templateNum)) {
 			slog.Warn("template file not found", "file", fmt.Sprintf("MSGHDR.%d.ans", templateNum))
 			continue
 		}
@@ -180,7 +179,7 @@ func runGetHeaderType(c *cmdCtx, args string) (*user.User, string, error) {
 	slog.Info("loaded message header options from BAR file", "node", nodeNumber, "count", len(options))
 
 	// Display the header selection ANSI screen
-	selectionPath := filepath.Join(e.MenuSetPath, "templates", "message_headers", "MSGHDR.ANS")
+	selectionPath := e.menuFile("templates", "message_headers", "MSGHDR.ANS")
 	selectionBytes, err := ansi.GetAnsiFileContent(selectionPath)
 	if err != nil {
 		slog.Error("failed to load MSGHDR.ANS", "node", nodeNumber, "error", err)
@@ -322,7 +321,7 @@ func runGetHeaderType(c *cmdCtx, args string) (*user.User, string, error) {
 		if key == editor.KeyEnter {
 			opt := options[selectedIndex]
 			templateNum, _ := strconv.Atoi(opt.ReturnValue)
-			hdrPath := filepath.Join(e.MenuSetPath, "templates", "message_headers", fmt.Sprintf("MSGHDR.%d.ans", templateNum))
+			hdrPath := e.menuFile("templates", "message_headers", fmt.Sprintf("MSGHDR.%d.ans", templateNum))
 
 			// Preview with sample data
 			hdrBytes, readErr := ansi.GetAnsiFileContent(hdrPath)

--- a/internal/menu/message_scan.go
+++ b/internal/menu/message_scan.go
@@ -195,7 +195,7 @@ func runGetScanType(ih *editor.InputHandler, e *MenuExecutor, terminal *term.Ter
 		terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 
 		// Display ANSI header (Vision/2 style - 4 rows tall)
-		ansPath := "menus/v3/ansi/NSCANHDR.ANS"
+		ansPath := e.menuFile("ansi", "NSCANHDR.ANS")
 		headerContent, ansErr := ansi.GetAnsiFileContent(ansPath)
 		if ansErr == nil {
 			// For CP437 mode, write raw bytes directly to avoid UTF-8 false positives

--- a/internal/menu/message_scan_config.go
+++ b/internal/menu/message_scan_config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -332,7 +331,7 @@ func runNewscanConfig(c *cmdCtx, args string) (*user.User, string, error) {
 	terminalio.WriteProcessedBytes(terminal, []byte(ansi.ClearScreen()), outputMode)
 
 	// Try to display ANSI header
-	ansPath := filepath.Join(e.MenuSetPath, "ansi", "NEWSCAN.ANS")
+	ansPath := e.menuFile("ansi", "NEWSCAN.ANS")
 	headerContent, ansErr := ansi.GetAnsiFileContent(ansPath)
 	if ansErr == nil {
 		// For CP437 mode, write raw bytes directly to avoid UTF-8 false positives

--- a/internal/menu/message_scan_header_test.go
+++ b/internal/menu/message_scan_header_test.go
@@ -1,0 +1,49 @@
+package menu
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestScanHeaderUsesSuffixedOverlay(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, "menus", "v3")
+	overlay := filepath.Join(root, "menus.d", "v3")
+	for _, layer := range []string{base, overlay} {
+		dir := filepath.Join(layer, "templates", "system_header")
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "HEADER.ANS"), []byte(layer), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	e := &MenuExecutor{MenuSetPath: base}
+	got, err := e.readScanHeaderTemplate()
+	if err != nil || string(got) != overlay {
+		t.Fatalf("header=%q err=%v, want overlay", got, err)
+	}
+	// Removing an override still allows the shipped suffixed header.
+	if err := os.Remove(filepath.Join(overlay, "templates", "system_header", "HEADER.ANS")); err != nil {
+		t.Fatal(err)
+	}
+	got, err = e.readScanHeaderTemplate()
+	if err != nil || string(got) != base {
+		t.Fatalf("header=%q err=%v, want base", got, err)
+	}
+}
+
+func TestTemplateDanglingLinkStopsSuffixFallback(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "HEADER")
+	if err := os.Symlink("missing", path); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if err := os.WriteFile(path+".ANS", []byte("must not be read"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := readTemplateFile(path); err == nil || got != nil {
+		t.Fatalf("template=%q err=%v", got, err)
+	}
+}

--- a/internal/menu/message_scan_run.go
+++ b/internal/menu/message_scan_run.go
@@ -127,7 +127,7 @@ func runNewScanAll(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 	}
 
 	// Load scan area header template (ANSI art) if available
-	scanHeaderTemplate, headerErr := readTemplateFile(e.menuFile("templates", "system_header", "HEADER"))
+	scanHeaderTemplate, headerErr := e.readScanHeaderTemplate()
 	if headerErr != nil && !os.IsNotExist(headerErr) {
 		slog.Warn("failed to load scan header template", "node", nodeNumber, "error", headerErr)
 	}
@@ -543,4 +543,13 @@ func scanBaseStart(e *MenuExecutor, cfg *ScanConfig, areaID int, username string
 		}
 	}
 	return totalCount + 1 // No messages on or after the target date; skip area
+}
+
+// readScanHeaderTemplate resolves suffixes in both layers before reading.
+func (e *MenuExecutor) readScanHeaderTemplate() ([]byte, error) {
+	path, err := e.Menus().ResolveFirst("templates/system_header", "HEADER", "HEADER.ANS", "HEADER.ans")
+	if err != nil {
+		return nil, err
+	}
+	return readTemplateFile(path)
 }

--- a/internal/menu/message_scan_run.go
+++ b/internal/menu/message_scan_run.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 	"unicode"
@@ -128,7 +127,7 @@ func runNewScanAll(e *MenuExecutor, s ssh.Session, terminal *term.Terminal,
 	}
 
 	// Load scan area header template (ANSI art) if available
-	scanHeaderTemplate, headerErr := readTemplateFile(filepath.Join(e.MenuSetPath, "templates", "system_header", "HEADER"))
+	scanHeaderTemplate, headerErr := readTemplateFile(e.menuFile("templates", "system_header", "HEADER"))
 	if headerErr != nil && !os.IsNotExist(headerErr) {
 		slog.Warn("failed to load scan header template", "node", nodeNumber, "error", headerErr)
 	}

--- a/internal/menu/news.go
+++ b/internal/menu/news.go
@@ -219,7 +219,7 @@ func displayNewsItem(e *MenuExecutor, terminal *term.Terminal, item *NewsItem, i
 	// menu set stays self-consistent instead of being hard-coded to 78.
 	headerWidth := newsFallbackHeaderWidth
 
-	ansiPath := filepath.Join(e.MenuSetPath, "ansi", "NEWSHDR.ANS")
+	ansiPath := e.menuFile("ansi", "NEWSHDR.ANS")
 	if raw, err := os.ReadFile(ansiPath); err == nil {
 		headerWidth = headerTemplateWidth(string(raw))
 		maxStr := strconv.Itoa(item.MaxLevel)

--- a/internal/menu/newuser.go
+++ b/internal/menu/newuser.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -318,7 +317,7 @@ func (e *MenuExecutor) handleNewUserApplication(
 
 // displayNewUserScreen loads and displays NEWUSER.ANS.
 func (e *MenuExecutor) displayNewUserScreen(terminal *term.Terminal, outputMode ansi.OutputMode, nodeNumber int) error {
-	fullAnsPath := filepath.Join(e.MenuSetPath, "ansi", "NEWUSER.ANS")
+	fullAnsPath := e.menuFile("ansi", "NEWUSER.ANS")
 	rawContent, err := ansi.GetAnsiFileContent(fullAnsPath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/menu/newuser_sysopmail.go
+++ b/internal/menu/newuser_sysopmail.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -224,7 +223,7 @@ func (e *MenuExecutor) requireNewUserSysopEmail(
 // require-email step. Like NEWUSER.ANS it lives in the active menu set's ansi
 // directory and is optional.
 func (e *MenuExecutor) newUserEmailArtPath() string {
-	return filepath.Join(e.MenuSetPath, "ansi", "NUEMAIL.ANS")
+	return e.menuFile("ansi", "NUEMAIL.ANS")
 }
 
 // displayNewUserEmailScreen loads and displays NUEMAIL.ANS. It returns

--- a/internal/menu/sponsor_menu.go
+++ b/internal/menu/sponsor_menu.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -80,8 +79,7 @@ func runSponsorMenu(c *cmdCtx, args string) (*user.User, string, error) {
 	slog.Info("user entering sponsor menu for area",
 		"node", nodeNumber, "handle", currentUser.Handle, "tag", area.Tag)
 
-	menuMnuPath := filepath.Join(e.MenuSetPath, "mnu")
-	menuRec, loadErr := LoadMenu("SPONSORM", menuMnuPath)
+	menuRec, loadErr := LoadMenu("SPONSORM", e.Menus())
 	if loadErr != nil {
 		slog.Warn("failed to load SPONSORM.MNU, using fallback prompt", "node", nodeNumber, "error", loadErr)
 		menuRec = nil

--- a/internal/menu/system_stats.go
+++ b/internal/menu/system_stats.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -31,8 +30,8 @@ func runSystemStats(c *cmdCtx, args string) (*user.User, string, error) {
 		return nil, "", nil
 	}
 
-	topPath := filepath.Join(e.MenuSetPath, "templates", "SYSSTATS.TOP")
-	botPath := filepath.Join(e.MenuSetPath, "templates", "SYSSTATS.BOT")
+	topPath := e.templateFile("SYSSTATS.TOP")
+	botPath := e.templateFile("SYSSTATS.BOT")
 
 	topBytes, err := readTemplateFile(topPath)
 	if err != nil && !os.IsNotExist(err) {

--- a/internal/menu/user_config_view.go
+++ b/internal/menu/user_config_view.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
@@ -29,8 +28,8 @@ func runCfgViewConfig(c *cmdCtx, args string) (*user.User, string, error) {
 		return nil, "", nil
 	}
 
-	topPath := filepath.Join(e.MenuSetPath, "templates", "USRCFGV.TOP")
-	botPath := filepath.Join(e.MenuSetPath, "templates", "USRCFGV.BOT")
+	topPath := e.templateFile("USRCFGV.TOP")
+	botPath := e.templateFile("USRCFGV.BOT")
 
 	topBytes, err := os.ReadFile(topPath)
 	if err != nil && !os.IsNotExist(err) {

--- a/internal/menueditor/fileio.go
+++ b/internal/menueditor/fileio.go
@@ -100,7 +100,10 @@ func LoadMenus(set menuset.Set) ([]menuEntry, error) {
 		if err != nil {
 			return nil, fmt.Errorf("loading %s: %w", name, err)
 		}
-		_, cfgLayer, _ := set.Locate("cfg", stem+".CFG")
+		_, cfgLayer, _, err := set.Locate("cfg", stem+".CFG")
+		if err != nil {
+			return nil, err
+		}
 		menus = append(menus, menuEntry{
 			Name:       stem,
 			Data:       data,
@@ -135,7 +138,10 @@ func LoadCommands(set menuset.Set, name string) ([]CmdData, error) {
 	if err != nil {
 		return nil, err
 	}
-	path := set.Resolve("cfg", n+".CFG")
+	path, err := set.Resolve("cfg", n+".CFG")
+	if err != nil {
+		return nil, err
+	}
 	raw, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return []CmdData{}, nil
@@ -286,10 +292,10 @@ func CreateMenu(set menuset.Set, name string) error {
 
 // MenuExists reports whether a .MNU file with the given name exists in
 // either layer.
-func MenuExists(set menuset.Set, name string) bool {
+func MenuExists(set menuset.Set, name string) (bool, error) {
 	n, err := normalizeMenuName(name)
 	if err != nil {
-		return false
+		return false, err
 	}
 	return set.Exists("mnu", n+".MNU")
 }

--- a/internal/menueditor/fileio.go
+++ b/internal/menueditor/fileio.go
@@ -3,12 +3,14 @@ package menueditor
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ViSiON-3/vision-3-bbs/internal/atomicfile"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/atomicfile"
+	"github.com/ViSiON-3/vision-3-bbs/internal/menuset"
 )
 
 // validMenuName matches a safe 1-8 character uppercase alphanumeric + underscore name.
@@ -54,43 +56,56 @@ type CmdData struct {
 type menuEntry struct {
 	Name string // basename without extension, e.g. "MAIN"
 	Data MenuData
+	// MnuOverlay and CfgOverlay report whether each file currently resolves
+	// from the menu set's overlay (menus.d) rather than the shipped tree.
+	MnuOverlay bool
+	CfgOverlay bool
 }
 
-// mnuDir returns the path to the .MNU files directory.
-func mnuDir(menuBase string) string {
-	return filepath.Join(menuBase, "mnu")
+// ShippedMenuError is returned by DeleteMenu when the menu remains in the
+// shipped tree, which the overlay cannot remove. Reverted reports whether an
+// overlay copy was removed in the process, i.e. the menu is back to shipped.
+type ShippedMenuError struct {
+	Name     string
+	Shipped  string // path of the shipped .MNU that remains
+	Reverted bool
 }
 
-// cfgDir returns the path to the .CFG files directory.
-func cfgDir(menuBase string) string {
-	return filepath.Join(menuBase, "cfg")
+func (e *ShippedMenuError) Error() string {
+	if e.Reverted {
+		return fmt.Sprintf("%s reverted to the shipped copy; %s cannot be removed through the overlay", e.Name, e.Shipped)
+	}
+	return fmt.Sprintf("%s is part of the shipped menu set (%s) and cannot be removed through the overlay; run menuedit --no-overlay to edit the shipped set", e.Name, e.Shipped)
 }
 
-// LoadMenus reads all .MNU files from {menuBase}/mnu/ and returns them
-// sorted alphabetically by name.
-func LoadMenus(menuBase string) ([]menuEntry, error) {
-	dir := mnuDir(menuBase)
-	entries, err := os.ReadDir(dir)
+// LoadMenus reads all .MNU files from the set's mnu/ directory — the overlay
+// merged over the shipped tree — and returns them sorted alphabetically by
+// name.
+func LoadMenus(set menuset.Set) ([]menuEntry, error) {
+	entries, err := set.ReadDir("mnu")
 	if err != nil {
-		return nil, fmt.Errorf("reading menu dir %s: %w", dir, err)
+		return nil, fmt.Errorf("reading menu dir %s: %w", set.Path(menuset.LayerBase, "mnu"), err)
 	}
 
 	var menus []menuEntry
 	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		name := e.Name()
+		name := e.Name
 		if !strings.HasSuffix(strings.ToUpper(name), ".MNU") {
 			continue
 		}
 		stem := strings.ToUpper(strings.TrimSuffix(name, filepath.Ext(name)))
 
-		data, err := loadMenuFile(filepath.Join(dir, name))
+		data, err := loadMenuFile(e.Path)
 		if err != nil {
 			return nil, fmt.Errorf("loading %s: %w", name, err)
 		}
-		menus = append(menus, menuEntry{Name: stem, Data: data})
+		_, cfgLayer, _ := set.Locate("cfg", stem+".CFG")
+		menus = append(menus, menuEntry{
+			Name:       stem,
+			Data:       data,
+			MnuOverlay: e.Layer == menuset.LayerOverlay,
+			CfgOverlay: cfgLayer == menuset.LayerOverlay,
+		})
 	}
 
 	sort.Slice(menus, func(i, j int) bool {
@@ -112,14 +127,14 @@ func loadMenuFile(path string) (MenuData, error) {
 	return d, nil
 }
 
-// LoadCommands reads the .CFG file for the given menu name from {menuBase}/cfg/.
-// Returns an empty slice if no .CFG exists.
-func LoadCommands(menuBase, name string) ([]CmdData, error) {
+// LoadCommands reads the .CFG file for the given menu name from the set's
+// cfg/ directory, overlay first. Returns an empty slice if no .CFG exists.
+func LoadCommands(set menuset.Set, name string) ([]CmdData, error) {
 	n, err := normalizeMenuName(name)
 	if err != nil {
 		return nil, err
 	}
-	path := filepath.Join(cfgDir(menuBase), n+".CFG")
+	path := set.Resolve("cfg", n+".CFG")
 	raw, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return []CmdData{}, nil
@@ -137,47 +152,60 @@ func LoadCommands(menuBase, name string) ([]CmdData, error) {
 	return cmds, nil
 }
 
-// SaveMenu writes a MenuData record atomically to {menuBase}/mnu/{name}.MNU.
-func SaveMenu(menuBase, name string, data MenuData) error {
+// SaveMenu writes a MenuData record atomically to mnu/{name}.MNU in the
+// set's write layer: the overlay when it has one, else the shipped tree.
+func SaveMenu(set menuset.Set, name string, data MenuData) error {
 	n, err := normalizeMenuName(name)
 	if err != nil {
 		return err
 	}
-	path := filepath.Join(mnuDir(menuBase), n+".MNU")
-	return atomicWriteJSON(path, data)
+	return atomicWriteJSON(set.WritePath("mnu", n+".MNU"), data)
 }
 
-// SaveCommands writes a command slice atomically to {menuBase}/cfg/{name}.CFG.
-func SaveCommands(menuBase, name string, cmds []CmdData) error {
+// SaveCommands writes a command slice atomically to cfg/{name}.CFG in the
+// set's write layer.
+func SaveCommands(set menuset.Set, name string, cmds []CmdData) error {
 	n, err := normalizeMenuName(name)
 	if err != nil {
 		return err
 	}
-	path := filepath.Join(cfgDir(menuBase), n+".CFG")
-	return atomicWriteJSON(path, cmds)
+	return atomicWriteJSON(set.WritePath("cfg", n+".CFG"), cmds)
 }
 
-// DeleteMenu removes the .MNU and .CFG files for the given menu name.
-func DeleteMenu(menuBase, name string) error {
+// DeleteMenu removes the .MNU and .CFG files for the given menu name from the
+// set's write layer. With an overlay, only overlay copies are removed: a menu
+// that also exists in the shipped tree is left there and a *ShippedMenuError
+// reports it, since there is no way to hide a shipped file from the overlay.
+func DeleteMenu(set menuset.Set, name string) error {
 	n, err := normalizeMenuName(name)
 	if err != nil {
 		return err
 	}
-	mnuPath := filepath.Join(mnuDir(menuBase), n+".MNU")
-	cfgPath := filepath.Join(cfgDir(menuBase), n+".CFG")
+	mnuPath := set.WritePath("mnu", n+".MNU")
+	cfgPath := set.WritePath("cfg", n+".CFG")
 
-	if err := os.Remove(mnuPath); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("removing %s: %w", mnuPath, err)
+	removed := false
+	for _, p := range []string{mnuPath, cfgPath} {
+		err := os.Remove(p)
+		switch {
+		case err == nil:
+			removed = true
+		case os.IsNotExist(err):
+		default:
+			return fmt.Errorf("removing %s: %w", p, err)
+		}
 	}
-	if err := os.Remove(cfgPath); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("removing %s: %w", cfgPath, err)
+	if set.HasOverlay() {
+		if shipped := set.Path(menuset.LayerBase, "mnu", n+".MNU"); fileExists(shipped) {
+			return &ShippedMenuError{Name: n, Shipped: shipped, Reverted: removed}
+		}
 	}
 	return nil
 }
 
 // CreateMenu writes a new empty .MNU and empty .CFG for the given name.
 // If writing the .CFG fails, the .MNU is removed so no half-created state is left on disk.
-func CreateMenu(menuBase, name string) error {
+func CreateMenu(set menuset.Set, name string) error {
 	n, err := normalizeMenuName(name)
 	if err != nil {
 		return err
@@ -188,36 +216,44 @@ func CreateMenu(menuBase, name string) error {
 		UsePrompt: true,
 		Fallback:  name,
 	}
-	if err := SaveMenu(menuBase, name, d); err != nil {
+	if err := SaveMenu(set, name, d); err != nil {
 		return err
 	}
-	if err := SaveCommands(menuBase, name, []CmdData{}); err != nil {
+	if err := SaveCommands(set, name, []CmdData{}); err != nil {
 		// Best-effort rollback: remove the .MNU we just wrote.
-		os.Remove(filepath.Join(mnuDir(menuBase), name+".MNU")) //nolint:errcheck
+		os.Remove(set.WritePath("mnu", name+".MNU")) //nolint:errcheck
 		return err
 	}
 	return nil
 }
 
-// MenuExists reports whether a .MNU file with the given name exists.
-func MenuExists(menuBase, name string) bool {
+// MenuExists reports whether a .MNU file with the given name exists in
+// either layer.
+func MenuExists(set menuset.Set, name string) bool {
 	n, err := normalizeMenuName(name)
 	if err != nil {
 		return false
 	}
-	path := filepath.Join(mnuDir(menuBase), n+".MNU")
-	_, err = os.Stat(path)
-	return err == nil
+	return set.Exists("mnu", n+".MNU")
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
 }
 
 // atomicWriteJSON marshals v to pretty-printed JSON and writes it to path
-// via a temp file + rename for atomicity.
+// via a temp file + rename for atomicity, creating the directory first: an
+// overlay's mnu/ and cfg/ do not exist until the first save.
 func atomicWriteJSON(path string, v any) error {
 	data, err := json.MarshalIndent(v, "", "    ")
 	if err != nil {
 		return fmt.Errorf("marshal: %w", err)
 	}
 	data = append(data, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(path), err)
+	}
 	if err := atomicfile.WriteFile(path, data, 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
 	}

--- a/internal/menueditor/fileio.go
+++ b/internal/menueditor/fileio.go
@@ -2,6 +2,7 @@ package menueditor
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -184,16 +185,9 @@ func DeleteMenu(set menuset.Set, name string) error {
 	mnuPath := set.WritePath("mnu", n+".MNU")
 	cfgPath := set.WritePath("cfg", n+".CFG")
 
-	removed := false
-	for _, p := range []string{mnuPath, cfgPath} {
-		err := os.Remove(p)
-		switch {
-		case err == nil:
-			removed = true
-		case os.IsNotExist(err):
-		default:
-			return fmt.Errorf("removing %s: %w", p, err)
-		}
+	removed, err := removeMenuFiles([]string{mnuPath, cfgPath}, os.Rename, os.Remove)
+	if err != nil {
+		return err
 	}
 	if set.HasOverlay() {
 		if shipped := set.Path(menuset.LayerBase, "mnu", n+".MNU"); fileExists(shipped) {
@@ -201,6 +195,69 @@ func DeleteMenu(set menuset.Set, name string) error {
 		}
 	}
 	return nil
+}
+
+// removeMenuFiles stages the pair beside the originals before deleting either
+// backup. Keep contents until cleanup succeeds so even a second cleanup failure
+// can restore the complete pair. Rollback errors are reported with the cause.
+func removeMenuFiles(paths []string, rename func(string, string) error, remove func(string) error) (bool, error) {
+	type stagedFile struct {
+		path, backup string
+		data         []byte
+		mode         os.FileMode
+		deleted      bool
+	}
+	var staged []stagedFile
+	rollback := func(cause error) (bool, error) {
+		for i := len(staged) - 1; i >= 0; i-- {
+			f := staged[i]
+			var err error
+			if f.deleted {
+				err = atomicfile.WriteFile(f.path, f.data, f.mode)
+			} else {
+				err = rename(f.backup, f.path)
+			}
+			if err != nil {
+				cause = errors.Join(cause, fmt.Errorf("restoring %s: %w", f.path, err))
+			}
+		}
+		return false, cause
+	}
+	for _, path := range paths {
+		info, err := os.Lstat(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return rollback(fmt.Errorf("removing %s: %w", path, err))
+		}
+		if !info.Mode().IsRegular() {
+			return rollback(fmt.Errorf("removing %s: not a regular file", path))
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return rollback(fmt.Errorf("removing %s: %w", path, err))
+		}
+		tmp, err := os.CreateTemp(filepath.Dir(path), ".menu-delete-*")
+		if err != nil {
+			return rollback(fmt.Errorf("removing %s: %w", path, err))
+		}
+		backup := tmp.Name()
+		if err := tmp.Close(); err != nil {
+			return rollback(errors.Join(err, os.Remove(backup)))
+		}
+		if err := rename(path, backup); err != nil {
+			return rollback(errors.Join(fmt.Errorf("removing %s: %w", path, err), os.Remove(backup)))
+		}
+		staged = append(staged, stagedFile{path: path, backup: backup, data: data, mode: info.Mode().Perm()})
+	}
+	for i := range staged {
+		if err := remove(staged[i].backup); err != nil {
+			return rollback(fmt.Errorf("removing %s: %w", staged[i].path, err))
+		}
+		staged[i].deleted = true
+	}
+	return len(staged) > 0, nil
 }
 
 // CreateMenu writes a new empty .MNU and empty .CFG for the given name.

--- a/internal/menueditor/fileio_overlay_test.go
+++ b/internal/menueditor/fileio_overlay_test.go
@@ -75,7 +75,7 @@ func TestOverlaySavesLandInOverlay(t *testing.T) {
 	if err := CreateMenu(set, "NEW"); err != nil {
 		t.Fatal(err)
 	}
-	if !MenuExists(set, "NEW") || MenuExists(menuset.Bare(set.Base), "NEW") {
+	if !menuExistsOK(t, set, "NEW") || menuExistsOK(t, menuset.Bare(set.Base), "NEW") {
 		t.Error("NEW should exist in the overlay only")
 	}
 }
@@ -89,7 +89,7 @@ func TestOverlayDeleteCannotRemoveShipped(t *testing.T) {
 	if !errors.As(err, &shipped) || shipped.Reverted {
 		t.Fatalf("DeleteMenu(shipped) = %v, want ShippedMenuError{Reverted:false}", err)
 	}
-	if !MenuExists(set, "MAIN") {
+	if !menuExistsOK(t, set, "MAIN") {
 		t.Error("shipped MAIN was removed")
 	}
 
@@ -116,7 +116,7 @@ func TestOverlayDeleteCannotRemoveShipped(t *testing.T) {
 	if err := DeleteMenu(set, "NEW"); err != nil {
 		t.Errorf("DeleteMenu(overlay-only) = %v", err)
 	}
-	if MenuExists(set, "NEW") {
+	if menuExistsOK(t, set, "NEW") {
 		t.Error("NEW still exists")
 	}
 }
@@ -191,5 +191,22 @@ func TestDeleteMenuRollsBackPair(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestOverlayReadReportsInaccessibleCommands(t *testing.T) {
+	set := newOverlaySet(t)
+	path := set.WritePath("cfg", "MAIN.CFG")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("MAIN.CFG", path); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if _, err := LoadCommands(set, "MAIN"); err == nil {
+		t.Error("LoadCommands silently loaded shipped commands")
+	}
+	if _, err := LoadMenus(set); err == nil {
+		t.Error("LoadMenus silently marked broken overlay commands as base")
 	}
 }

--- a/internal/menueditor/fileio_overlay_test.go
+++ b/internal/menueditor/fileio_overlay_test.go
@@ -1,0 +1,146 @@
+package menueditor
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/menuset"
+)
+
+// newOverlaySet builds menus/v3 with shipped menus MAIN and MSG and returns
+// the Set whose overlay is menus.d/v3 (not yet created).
+func newOverlaySet(t *testing.T) menuset.Set {
+	t.Helper()
+	root := t.TempDir()
+	base := filepath.Join(root, "menus", "v3")
+	bare := menuset.Bare(base)
+	for _, d := range []string{"mnu", "cfg"} {
+		if err := os.MkdirAll(filepath.Join(base, d), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range []string{"MAIN", "MSG"} {
+		if err := CreateMenu(bare, name); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+	return menuset.FromPath(base)
+}
+
+func TestOverlaySavesLandInOverlay(t *testing.T) {
+	set := newOverlaySet(t)
+
+	if err := SaveMenu(set, "MAIN", MenuData{Title: "Mine"}); err != nil {
+		t.Fatalf("SaveMenu: %v", err)
+	}
+	if err := SaveCommands(set, "MAIN", []CmdData{{Keys: "Q", Command: "LOGOFF"}}); err != nil {
+		t.Fatalf("SaveCommands: %v", err)
+	}
+
+	// The overlay has the new copies; the shipped ones are untouched.
+	for _, p := range []string{filepath.Join(set.Overlay, "mnu", "MAIN.MNU"), filepath.Join(set.Overlay, "cfg", "MAIN.CFG")} {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("expected %s to exist: %v", p, err)
+		}
+	}
+	shipped, err := loadMenuFile(filepath.Join(set.Base, "mnu", "MAIN.MNU"))
+	if err != nil || shipped.Title != "" {
+		t.Errorf("shipped MAIN.MNU changed: %+v err=%v", shipped, err)
+	}
+
+	// Reads go through the overlay and the listing marks it.
+	menus, err := LoadMenus(set)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(menus) != 2 {
+		t.Fatalf("got %d menus, want 2 (merged, not duplicated)", len(menus))
+	}
+	if menus[0].Name != "MAIN" || menus[0].Data.Title != "Mine" || !menus[0].MnuOverlay || !menus[0].CfgOverlay {
+		t.Errorf("MAIN = %+v", menus[0])
+	}
+	if menus[1].Name != "MSG" || menus[1].MnuOverlay || menus[1].CfgOverlay {
+		t.Errorf("MSG = %+v", menus[1])
+	}
+	cmds, err := LoadCommands(set, "MAIN")
+	if err != nil || len(cmds) != 1 || cmds[0].Keys != "Q" {
+		t.Errorf("LoadCommands = %+v err=%v", cmds, err)
+	}
+
+	// A brand-new menu goes to the overlay too and shows up in the list.
+	if err := CreateMenu(set, "NEW"); err != nil {
+		t.Fatal(err)
+	}
+	if !MenuExists(set, "NEW") || MenuExists(menuset.Bare(set.Base), "NEW") {
+		t.Error("NEW should exist in the overlay only")
+	}
+}
+
+func TestOverlayDeleteCannotRemoveShipped(t *testing.T) {
+	set := newOverlaySet(t)
+
+	// Shipped only: refused, nothing changes.
+	err := DeleteMenu(set, "MAIN")
+	var shipped *ShippedMenuError
+	if !errors.As(err, &shipped) || shipped.Reverted {
+		t.Fatalf("DeleteMenu(shipped) = %v, want ShippedMenuError{Reverted:false}", err)
+	}
+	if !MenuExists(set, "MAIN") {
+		t.Error("shipped MAIN was removed")
+	}
+
+	// Overridden: the overlay copy goes, the shipped one remains, reported as reverted.
+	if err := SaveMenu(set, "MAIN", MenuData{Title: "Mine"}); err != nil {
+		t.Fatal(err)
+	}
+	err = DeleteMenu(set, "MAIN")
+	if !errors.As(err, &shipped) || !shipped.Reverted {
+		t.Fatalf("DeleteMenu(overridden) = %v, want ShippedMenuError{Reverted:true}", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(set.Overlay, "mnu", "MAIN.MNU")); !os.IsNotExist(statErr) {
+		t.Error("overlay MAIN.MNU still present")
+	}
+	menus, _ := LoadMenus(set)
+	if len(menus) != 2 || menus[0].Data.Title != "" {
+		t.Errorf("after revert menus = %+v", menus)
+	}
+
+	// Overlay only: a plain delete.
+	if err := CreateMenu(set, "NEW"); err != nil {
+		t.Fatal(err)
+	}
+	if err := DeleteMenu(set, "NEW"); err != nil {
+		t.Errorf("DeleteMenu(overlay-only) = %v", err)
+	}
+	if MenuExists(set, "NEW") {
+		t.Error("NEW still exists")
+	}
+}
+
+func TestOverlayModelRevertsOnDeleteOfOverriddenMenu(t *testing.T) {
+	set := newOverlaySet(t)
+	if err := SaveMenu(set, "MAIN", MenuData{Title: "Mine"}); err != nil {
+		t.Fatal(err)
+	}
+	m, err := New(set)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.message == "" {
+		t.Error("expected a startup notice naming the overlay")
+	}
+	m.menuCursor = 0
+	m.pendingDeleteMenuIdx = 0
+	m.mode = modeDeleteMenuConfirm
+	m = asModel(t, mustUpdate(m.updateConfirm(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})))
+	if m.mode != modeMenuList {
+		t.Errorf("mode = %v, want menu list", m.mode)
+	}
+	if len(m.menus) != 2 || m.menus[0].Name != "MAIN" || m.menus[0].Data.Title != "" {
+		t.Errorf("menus after revert = %+v", m.menus)
+	}
+}

--- a/internal/menueditor/fileio_overlay_test.go
+++ b/internal/menueditor/fileio_overlay_test.go
@@ -144,3 +144,52 @@ func TestOverlayModelRevertsOnDeleteOfOverriddenMenu(t *testing.T) {
 		t.Errorf("menus after revert = %+v", m.menus)
 	}
 }
+
+func TestDeleteMenuRollsBackPair(t *testing.T) {
+	for _, failure := range []string{"stage", "cleanup"} {
+		t.Run(failure, func(t *testing.T) {
+			set := newOverlaySet(t)
+			if err := CreateMenu(set, "MAIN"); err != nil {
+				t.Fatal(err)
+			}
+			paths := []string{set.WritePath("mnu", "MAIN.MNU"), set.WritePath("cfg", "MAIN.CFG")}
+			before := make([][]byte, len(paths))
+			for i, path := range paths {
+				var err error
+				before[i], err = os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			injected := errors.New("second file failure")
+			rename := func(old, new string) error {
+				if failure == "stage" && old == paths[1] {
+					return injected
+				}
+				return os.Rename(old, new)
+			}
+			removes := 0
+			remove := func(path string) error {
+				removes++
+				if failure == "cleanup" && removes == 2 {
+					return injected
+				}
+				return os.Remove(path)
+			}
+			removed, err := removeMenuFiles(paths, rename, remove)
+			if removed || !errors.Is(err, injected) {
+				t.Fatalf("removed=%v err=%v", removed, err)
+			}
+			for i, path := range paths {
+				got, err := os.ReadFile(path)
+				if err != nil || string(got) != string(before[i]) {
+					t.Errorf("%s not restored: %q, %v", path, got, err)
+				}
+				entries, err := os.ReadDir(filepath.Dir(path))
+				if err != nil || len(entries) != 1 {
+					t.Errorf("backup left behind: %v, %v", entries, err)
+				}
+			}
+		})
+	}
+}

--- a/internal/menueditor/fileio_overlay_test.go
+++ b/internal/menueditor/fileio_overlay_test.go
@@ -210,3 +210,49 @@ func TestOverlayReadReportsInaccessibleCommands(t *testing.T) {
 		t.Error("LoadMenus silently marked broken overlay commands as base")
 	}
 }
+
+func TestSaveUpdatesOverlayMarkers(t *testing.T) {
+	for _, mode := range []string{"overlay", "bare", "failed"} {
+		for _, action := range []string{"menu", "commands", "all"} {
+			t.Run(mode+"/"+action, func(t *testing.T) {
+				set := newOverlaySet(t)
+				if mode == "bare" {
+					set = menuset.Bare(set.Base)
+				}
+				m, err := New(set)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if mode == "failed" {
+					if err := os.MkdirAll(filepath.Dir(set.Overlay), 0755); err != nil {
+						t.Fatal(err)
+					}
+					if err := os.WriteFile(set.Overlay, []byte("not a directory"), 0644); err != nil {
+						t.Fatal(err)
+					}
+				}
+				m.menuEditIdx, m.cmdsMenuIdx = 0, 0
+				name := m.menus[0].Name
+				m.menus[0].Data.Title = "saved title"
+				m.dirtyMenus[name] = true
+				m.dirtyCmds = true
+				switch action {
+				case "menu":
+					m.saveCurrentMenu()
+				case "commands":
+					_ = m.saveCurrentCommands()
+				case "all":
+					_ = m.saveAll()
+				}
+				wantMnu := mode == "overlay" && action != "commands"
+				wantCfg := mode == "overlay" && action != "menu"
+				if m.menus[0].MnuOverlay != wantMnu || m.menus[0].CfgOverlay != wantCfg {
+					t.Errorf("markers=(%v,%v) want (%v,%v)", m.menus[0].MnuOverlay, m.menus[0].CfgOverlay, wantMnu, wantCfg)
+				}
+				if mode == "failed" && (m.message == "" || !m.dirtyMenus[name] || !m.dirtyCmds) {
+					t.Errorf("failed save lost dirty state or error: %+v", m.message)
+				}
+			})
+		}
+	}
+}

--- a/internal/menueditor/fileio_test.go
+++ b/internal/menueditor/fileio_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ViSiON-3/vision-3-bbs/internal/menuset"
 )
 
 // newMenuBase creates a menu base directory with mnu/ and cfg/ subdirs.
@@ -61,11 +63,11 @@ func TestSaveAndLoadMenuRoundTrip(t *testing.T) {
 		ACS:      "s10",
 		MesConf:  2,
 	}
-	if err := SaveMenu(base, "main", want); err != nil {
+	if err := SaveMenu(menuset.Bare(base), "main", want); err != nil {
 		t.Fatalf("SaveMenu: %v", err)
 	}
 
-	menus, err := LoadMenus(base)
+	menus, err := LoadMenus(menuset.Bare(base))
 	if err != nil {
 		t.Fatalf("LoadMenus: %v", err)
 	}
@@ -93,10 +95,10 @@ func TestSaveAndLoadMenuRoundTrip(t *testing.T) {
 
 func TestLoadMenus_SkipsNonMenuFiles(t *testing.T) {
 	base := newMenuBase(t)
-	if err := SaveMenu(base, "B", MenuData{Title: "B"}); err != nil {
+	if err := SaveMenu(menuset.Bare(base), "B", MenuData{Title: "B"}); err != nil {
 		t.Fatalf("SaveMenu: %v", err)
 	}
-	if err := SaveMenu(base, "A", MenuData{Title: "A"}); err != nil {
+	if err := SaveMenu(menuset.Bare(base), "A", MenuData{Title: "A"}); err != nil {
 		t.Fatalf("SaveMenu: %v", err)
 	}
 	// Non-.MNU file and a subdirectory must be skipped.
@@ -107,7 +109,7 @@ func TestLoadMenus_SkipsNonMenuFiles(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 
-	menus, err := LoadMenus(base)
+	menus, err := LoadMenus(menuset.Bare(base))
 	if err != nil {
 		t.Fatalf("LoadMenus: %v", err)
 	}
@@ -121,7 +123,7 @@ func TestLoadMenus_SkipsNonMenuFiles(t *testing.T) {
 }
 
 func TestLoadMenus_MissingDir(t *testing.T) {
-	if _, err := LoadMenus(filepath.Join(t.TempDir(), "nope")); err == nil {
+	if _, err := LoadMenus(menuset.Bare(filepath.Join(t.TempDir(), "nope"))); err == nil {
 		t.Fatal("missing mnu dir should error")
 	}
 }
@@ -130,7 +132,7 @@ func TestSaveAndLoadCommands(t *testing.T) {
 	base := newMenuBase(t)
 
 	// Missing .CFG returns an empty slice, not an error.
-	cmds, err := LoadCommands(base, "MAIN")
+	cmds, err := LoadCommands(menuset.Bare(base), "MAIN")
 	if err != nil {
 		t.Fatalf("LoadCommands missing: %v", err)
 	}
@@ -142,10 +144,10 @@ func TestSaveAndLoadCommands(t *testing.T) {
 		{Keys: "M", Command: "GOTO:MSGMENU", ACS: "s10"},
 		{Keys: "G", Command: "LOGOFF", Hidden: true},
 	}
-	if err := SaveCommands(base, "main", want); err != nil {
+	if err := SaveCommands(menuset.Bare(base), "main", want); err != nil {
 		t.Fatalf("SaveCommands: %v", err)
 	}
-	got, err := LoadCommands(base, "MAIN")
+	got, err := LoadCommands(menuset.Bare(base), "MAIN")
 	if err != nil {
 		t.Fatalf("LoadCommands: %v", err)
 	}
@@ -162,7 +164,7 @@ func TestSaveAndLoadCommands(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(base, "cfg", "EMPTY.CFG"), nil, 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	cmds, err = LoadCommands(base, "EMPTY")
+	cmds, err = LoadCommands(menuset.Bare(base), "EMPTY")
 	if err != nil {
 		t.Fatalf("LoadCommands empty: %v", err)
 	}
@@ -171,13 +173,13 @@ func TestSaveAndLoadCommands(t *testing.T) {
 	}
 
 	// Invalid names are rejected.
-	if _, err := LoadCommands(base, "../etc"); err == nil {
+	if _, err := LoadCommands(menuset.Bare(base), "../etc"); err == nil {
 		t.Error("LoadCommands with traversal name should error")
 	}
-	if err := SaveCommands(base, "bad name", nil); err == nil {
+	if err := SaveCommands(menuset.Bare(base), "bad name", nil); err == nil {
 		t.Error("SaveCommands with invalid name should error")
 	}
-	if err := SaveMenu(base, "toolongname", MenuData{}); err == nil {
+	if err := SaveMenu(menuset.Bare(base), "toolongname", MenuData{}); err == nil {
 		t.Error("SaveMenu with invalid name should error")
 	}
 }
@@ -185,18 +187,18 @@ func TestSaveAndLoadCommands(t *testing.T) {
 func TestCreateDeleteExists(t *testing.T) {
 	base := newMenuBase(t)
 
-	if MenuExists(base, "NEW") {
+	if MenuExists(menuset.Bare(base), "NEW") {
 		t.Fatal("NEW should not exist yet")
 	}
-	if err := CreateMenu(base, "new"); err != nil {
+	if err := CreateMenu(menuset.Bare(base), "new"); err != nil {
 		t.Fatalf("CreateMenu: %v", err)
 	}
-	if !MenuExists(base, "new") {
+	if !MenuExists(menuset.Bare(base), "new") {
 		t.Error("MenuExists should be true after CreateMenu (case-insensitive)")
 	}
 
 	// CreateMenu seeds UsePrompt=true and Fallback=self.
-	menus, err := LoadMenus(base)
+	menus, err := LoadMenus(menuset.Bare(base))
 	if err != nil {
 		t.Fatalf("LoadMenus: %v", err)
 	}
@@ -208,10 +210,10 @@ func TestCreateDeleteExists(t *testing.T) {
 		t.Errorf("expected NEW.CFG to exist: %v", err)
 	}
 
-	if err := DeleteMenu(base, "NEW"); err != nil {
+	if err := DeleteMenu(menuset.Bare(base), "NEW"); err != nil {
 		t.Fatalf("DeleteMenu: %v", err)
 	}
-	if MenuExists(base, "NEW") {
+	if MenuExists(menuset.Bare(base), "NEW") {
 		t.Error("NEW should be gone after DeleteMenu")
 	}
 	if _, err := os.Stat(filepath.Join(base, "cfg", "NEW.CFG")); !os.IsNotExist(err) {
@@ -219,17 +221,17 @@ func TestCreateDeleteExists(t *testing.T) {
 	}
 
 	// Deleting a nonexistent menu is not an error.
-	if err := DeleteMenu(base, "GHOST"); err != nil {
+	if err := DeleteMenu(menuset.Bare(base), "GHOST"); err != nil {
 		t.Errorf("DeleteMenu(nonexistent) = %v, want nil", err)
 	}
 	// Invalid names.
-	if err := CreateMenu(base, "../X"); err == nil {
+	if err := CreateMenu(menuset.Bare(base), "../X"); err == nil {
 		t.Error("CreateMenu with traversal name should error")
 	}
-	if err := DeleteMenu(base, "../X"); err == nil {
+	if err := DeleteMenu(menuset.Bare(base), "../X"); err == nil {
 		t.Error("DeleteMenu with traversal name should error")
 	}
-	if MenuExists(base, "../X") {
+	if MenuExists(menuset.Bare(base), "../X") {
 		t.Error("MenuExists with invalid name should be false")
 	}
 }

--- a/internal/menueditor/fileio_test.go
+++ b/internal/menueditor/fileio_test.go
@@ -187,13 +187,13 @@ func TestSaveAndLoadCommands(t *testing.T) {
 func TestCreateDeleteExists(t *testing.T) {
 	base := newMenuBase(t)
 
-	if MenuExists(menuset.Bare(base), "NEW") {
+	if menuExistsOK(t, menuset.Bare(base), "NEW") {
 		t.Fatal("NEW should not exist yet")
 	}
 	if err := CreateMenu(menuset.Bare(base), "new"); err != nil {
 		t.Fatalf("CreateMenu: %v", err)
 	}
-	if !MenuExists(menuset.Bare(base), "new") {
+	if !menuExistsOK(t, menuset.Bare(base), "new") {
 		t.Error("MenuExists should be true after CreateMenu (case-insensitive)")
 	}
 
@@ -213,7 +213,7 @@ func TestCreateDeleteExists(t *testing.T) {
 	if err := DeleteMenu(menuset.Bare(base), "NEW"); err != nil {
 		t.Fatalf("DeleteMenu: %v", err)
 	}
-	if MenuExists(menuset.Bare(base), "NEW") {
+	if menuExistsOK(t, menuset.Bare(base), "NEW") {
 		t.Error("NEW should be gone after DeleteMenu")
 	}
 	if _, err := os.Stat(filepath.Join(base, "cfg", "NEW.CFG")); !os.IsNotExist(err) {
@@ -231,7 +231,16 @@ func TestCreateDeleteExists(t *testing.T) {
 	if err := DeleteMenu(menuset.Bare(base), "../X"); err == nil {
 		t.Error("DeleteMenu with traversal name should error")
 	}
-	if MenuExists(menuset.Bare(base), "../X") {
+	if exists, err := MenuExists(menuset.Bare(base), "../X"); err == nil || exists {
 		t.Error("MenuExists with invalid name should be false")
 	}
+}
+
+func menuExistsOK(t *testing.T, set menuset.Set, name string) bool {
+	t.Helper()
+	exists, err := MenuExists(set, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return exists
 }

--- a/internal/menueditor/harness_test.go
+++ b/internal/menueditor/harness_test.go
@@ -3,6 +3,8 @@ package menueditor
 import (
 	"testing"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/menuset"
+
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -11,11 +13,11 @@ func newTestEditor(t *testing.T) Model {
 	t.Helper()
 	base := newMenuBase(t)
 	for _, name := range []string{"ALPHA", "BETA"} {
-		if err := CreateMenu(base, name); err != nil {
+		if err := CreateMenu(menuset.Bare(base), name); err != nil {
 			t.Fatalf("CreateMenu(%s): %v", name, err)
 		}
 	}
-	m, err := New(base)
+	m, err := New(menuset.Bare(base))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}

--- a/internal/menueditor/model.go
+++ b/internal/menueditor/model.go
@@ -5,6 +5,8 @@ package menueditor
 import (
 	"fmt"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/menuset"
+
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -35,7 +37,7 @@ const (
 
 // Model is the BubbleTea model for the menu editor TUI.
 type Model struct {
-	menuBase string // path to menu set directory (parent of mnu/ and cfg/)
+	set menuset.Set // menu set: shipped tree plus the overlay saves go to
 
 	// Menu list state
 	menus      []menuEntry
@@ -86,9 +88,10 @@ type Model struct {
 	message string // flash message (cleared on next key)
 }
 
-// New creates a new menu editor model.
-func New(menuBase string) (Model, error) {
-	menus, err := LoadMenus(menuBase)
+// New creates a new menu editor model over a menu set. When the set has an
+// overlay, menus are read through it and every save lands in it.
+func New(set menuset.Set) (Model, error) {
+	menus, err := LoadMenus(set)
 	if err != nil {
 		return Model{}, fmt.Errorf("loading menus: %w", err)
 	}
@@ -103,8 +106,16 @@ func New(menuBase string) (Model, error) {
 	// is dragged.
 	art := pickBackdropArt()
 
+	// Tell the sysop where saves will land before the first one happens; the
+	// flash clears on the next key.
+	notice := ""
+	if set.HasOverlay() {
+		notice = fmt.Sprintf("Saving to overlay %s (* = overlay file)", set.Overlay)
+	}
+
 	return Model{
-		menuBase:             menuBase,
+		message:              notice,
+		set:                  set,
 		menus:                menus,
 		menuFields:           menuFields(),
 		cmdFields:            cmdFields(),

--- a/internal/menueditor/model_test.go
+++ b/internal/menueditor/model_test.go
@@ -129,7 +129,7 @@ func TestAddMenuDialog(t *testing.T) {
 	if m.mode != modeMenuEdit {
 		t.Fatalf("mode = %v, want menuEdit after create", m.mode)
 	}
-	if !MenuExists(m.set, "GAMMA") {
+	if !menuExistsOK(t, m.set, "GAMMA") {
 		t.Error("GAMMA should exist on disk")
 	}
 	if m.menus[m.menuEditIdx].Name != "GAMMA" {
@@ -172,7 +172,7 @@ func TestDeleteMenuConfirm(t *testing.T) {
 	if len(m.menus) != 1 || m.menus[0].Name != "BETA" {
 		t.Fatalf("after delete: menus = %+v, want just BETA", m.menus)
 	}
-	if MenuExists(m.set, "ALPHA") {
+	if menuExistsOK(t, m.set, "ALPHA") {
 		t.Error("ALPHA should be deleted from disk")
 	}
 }

--- a/internal/menueditor/model_test.go
+++ b/internal/menueditor/model_test.go
@@ -81,7 +81,7 @@ func TestMenuEditFieldFlow(t *testing.T) {
 	if m.dirtyMenus["ALPHA"] {
 		t.Error("ALPHA should be clean after save-on-escape")
 	}
-	menus, err := LoadMenus(m.menuBase)
+	menus, err := LoadMenus(m.set)
 	if err != nil {
 		t.Fatalf("LoadMenus: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestAddMenuDialog(t *testing.T) {
 	if m.mode != modeMenuEdit {
 		t.Fatalf("mode = %v, want menuEdit after create", m.mode)
 	}
-	if !MenuExists(m.menuBase, "GAMMA") {
+	if !MenuExists(m.set, "GAMMA") {
 		t.Error("GAMMA should exist on disk")
 	}
 	if m.menus[m.menuEditIdx].Name != "GAMMA" {
@@ -172,7 +172,7 @@ func TestDeleteMenuConfirm(t *testing.T) {
 	if len(m.menus) != 1 || m.menus[0].Name != "BETA" {
 		t.Fatalf("after delete: menus = %+v, want just BETA", m.menus)
 	}
-	if MenuExists(m.menuBase, "ALPHA") {
+	if MenuExists(m.set, "ALPHA") {
 		t.Error("ALPHA should be deleted from disk")
 	}
 }
@@ -222,7 +222,7 @@ func TestCommandListAndEditFlow(t *testing.T) {
 	if m.mode != modeMenuEdit {
 		t.Fatalf("mode = %v, want menuEdit", m.mode)
 	}
-	cmds, err := LoadCommands(m.menuBase, "ALPHA")
+	cmds, err := LoadCommands(m.set, "ALPHA")
 	if err != nil {
 		t.Fatalf("LoadCommands: %v", err)
 	}

--- a/internal/menueditor/save.go
+++ b/internal/menueditor/save.go
@@ -19,6 +19,7 @@ func (m *Model) saveCurrentMenu() {
 		m.message = fmt.Sprintf("Save error: %v", err)
 		return
 	}
+	m.menus[idx].MnuOverlay = m.set.HasOverlay()
 	delete(m.dirtyMenus, entry.Name)
 }
 
@@ -38,6 +39,7 @@ func (m *Model) saveCurrentCommands() error {
 		m.message = fmt.Sprintf("Save error: %v", err)
 		return err
 	}
+	m.menus[m.cmdsMenuIdx].CfgOverlay = m.set.HasOverlay()
 	m.dirtyCmds = false
 	return nil
 }
@@ -46,13 +48,14 @@ func (m *Model) saveCurrentCommands() error {
 // Returns true only if every save succeeded; failed entries remain dirty.
 func (m *Model) saveAll() bool {
 	ok := true
-	for _, entry := range m.menus {
+	for idx, entry := range m.menus {
 		if m.dirtyMenus[entry.Name] {
 			if err := SaveMenu(m.set, entry.Name, entry.Data); err != nil {
 				m.message = fmt.Sprintf("Save error: %v", err)
 				ok = false
 				continue
 			}
+			m.menus[idx].MnuOverlay = m.set.HasOverlay()
 			delete(m.dirtyMenus, entry.Name)
 		}
 	}

--- a/internal/menueditor/save.go
+++ b/internal/menueditor/save.go
@@ -15,7 +15,7 @@ func (m *Model) saveCurrentMenu() {
 	if !m.dirtyMenus[entry.Name] {
 		return
 	}
-	if err := SaveMenu(m.menuBase, entry.Name, entry.Data); err != nil {
+	if err := SaveMenu(m.set, entry.Name, entry.Data); err != nil {
 		m.message = fmt.Sprintf("Save error: %v", err)
 		return
 	}
@@ -34,7 +34,7 @@ func (m *Model) saveCurrentCommands() error {
 		return nil
 	}
 	name := m.menus[m.cmdsMenuIdx].Name
-	if err := SaveCommands(m.menuBase, name, m.cmds); err != nil {
+	if err := SaveCommands(m.set, name, m.cmds); err != nil {
 		m.message = fmt.Sprintf("Save error: %v", err)
 		return err
 	}
@@ -48,7 +48,7 @@ func (m *Model) saveAll() bool {
 	ok := true
 	for _, entry := range m.menus {
 		if m.dirtyMenus[entry.Name] {
-			if err := SaveMenu(m.menuBase, entry.Name, entry.Data); err != nil {
+			if err := SaveMenu(m.set, entry.Name, entry.Data); err != nil {
 				m.message = fmt.Sprintf("Save error: %v", err)
 				ok = false
 				continue
@@ -69,7 +69,7 @@ func (m Model) openCommandList(menuIdx int) (Model, tea.Cmd) {
 		return m, nil
 	}
 	name := m.menus[menuIdx].Name
-	cmds, err := LoadCommands(m.menuBase, name)
+	cmds, err := LoadCommands(m.set, name)
 	if err != nil {
 		m.message = fmt.Sprintf("Load commands error: %v", err)
 		return m, nil

--- a/internal/menueditor/update_confirm.go
+++ b/internal/menueditor/update_confirm.go
@@ -1,6 +1,7 @@
 package menueditor
 
 import (
+	"errors"
 	"fmt"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -41,9 +42,20 @@ func (m Model) executeConfirm() (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		name := m.menus[idx].Name
-		if err := DeleteMenu(m.menuBase, name); err != nil {
-			m.message = fmt.Sprintf("Delete error: %v", err)
+		if err := DeleteMenu(m.set, name); err != nil {
+			var shipped *ShippedMenuError
+			if errors.As(err, &shipped) && shipped.Reverted {
+				// The overlay copy is gone and the shipped one shows again.
+				delete(m.dirtyMenus, name)
+				if menus, loadErr := LoadMenus(m.set); loadErr == nil {
+					m.menus = menus
+				}
+				m.message = fmt.Sprintf("Reverted %s to the shipped copy (shipped menus cannot be deleted through the overlay)", name)
+			} else {
+				m.message = fmt.Sprintf("Delete error: %v", err)
+			}
 			m.mode = modeMenuList
+			m.clampMenuScroll()
 			return m, nil
 		}
 		delete(m.dirtyMenus, name)

--- a/internal/menueditor/update_menu.go
+++ b/internal/menueditor/update_menu.go
@@ -247,18 +247,18 @@ func (m Model) updateAddMenu(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 		}
-		if MenuExists(m.menuBase, name) {
+		if MenuExists(m.set, name) {
 			m.message = fmt.Sprintf("Menu %s already exists!", name)
 			m.mode = modeMenuList
 			return m, nil
 		}
-		if err := CreateMenu(m.menuBase, name); err != nil {
+		if err := CreateMenu(m.set, name); err != nil {
 			m.message = fmt.Sprintf("Create error: %v", err)
 			m.mode = modeMenuList
 			return m, nil
 		}
 		// Reload menus and jump to the new one
-		menus, err := LoadMenus(m.menuBase)
+		menus, err := LoadMenus(m.set)
 		if err != nil {
 			m.message = fmt.Sprintf("Reload error: %v", err)
 			m.mode = modeMenuList

--- a/internal/menueditor/update_menu.go
+++ b/internal/menueditor/update_menu.go
@@ -247,7 +247,13 @@ func (m Model) updateAddMenu(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 		}
-		if MenuExists(m.set, name) {
+		exists, err := MenuExists(m.set, name)
+		if err != nil {
+			m.message = fmt.Sprintf("Checking menu: %v", err)
+			m.mode = modeMenuList
+			return m, nil
+		}
+		if exists {
 			m.message = fmt.Sprintf("Menu %s already exists!", name)
 			m.mode = modeMenuList
 			return m, nil

--- a/internal/menueditor/view_menu_list.go
+++ b/internal/menueditor/view_menu_list.go
@@ -112,7 +112,8 @@ func (m Model) renderMenuRow(idx int, boxW int) string {
 		displayTitle = entry.Name
 	}
 	name := padRight(displayTitle, nameColW)
-	files := fmt.Sprintf("%s.MNU / %s.CFG", entry.Name, entry.Name)
+	// An asterisk marks a file that comes from the overlay (menus.d).
+	files := fmt.Sprintf("%s.MNU%s / %s.CFG%s", entry.Name, overlayMark(entry.MnuOverlay), entry.Name, overlayMark(entry.CfgOverlay))
 	files = padRight(files, boxW-nameColW-4) // 4 = 3 prefix + 1 separator
 	content := "   " + name + " " + files
 	if len(content) < boxW {
@@ -126,4 +127,11 @@ func (m Model) renderMenuRow(idx int, boxW int) string {
 		return listHighlightStyle.Render(content)
 	}
 	return listItemStyle.Render(content)
+}
+
+func overlayMark(fromOverlay bool) string {
+	if fromOverlay {
+		return "*"
+	}
+	return ""
 }

--- a/internal/menuset/menuset.go
+++ b/internal/menuset/menuset.go
@@ -96,46 +96,51 @@ func (s Set) Path(layer Layer, elem ...string) string {
 	return filepath.Join(append([]string{root}, elem...)...)
 }
 
-// Resolve returns the path to read for a file: the overlay copy if one exists,
-// otherwise the shipped path — whether or not that exists, so an error from
-// the subsequent open names the place the file was expected.
-func (s Set) Resolve(elem ...string) string {
-	path, _, _ := s.Locate(elem...)
-	return path
+// Resolve returns the overlay file if present, otherwise the shipped path.
+// Missing files return the shipped path without an error so readers can handle
+// absence as before. Other stat errors return the failing path and error;
+// an inaccessible overlay must never silently select the shipped file.
+func (s Set) Resolve(elem ...string) (string, error) {
+	path, _, _, err := s.Locate(elem...)
+	return path, err
 }
 
-// Locate is Resolve with the layer the file was found in. ok is false when
-// the file exists in neither layer, in which case path is the shipped path.
-func (s Set) Locate(elem ...string) (path string, layer Layer, ok bool) {
+// Locate reports the path and layer of a file, or ok=false if neither layer
+// contains it. A non-missing stat error stops lookup at the failing layer.
+func (s Set) Locate(elem ...string) (path string, layer Layer, ok bool, err error) {
 	if s.Overlay != "" {
 		p := s.Path(LayerOverlay, elem...)
-		if isFile(p) {
-			return p, LayerOverlay, true
+		exists, err := statFile(p)
+		if err != nil || exists {
+			return p, LayerOverlay, exists, err
 		}
 	}
 	p := s.Path(LayerBase, elem...)
-	return p, LayerBase, isFile(p)
+	exists, err := statFile(p)
+	return p, LayerBase, exists, err
 }
 
-// ResolveFirst tries several file names in order within one subdirectory
-// and returns the first that exists in either layer, overlay first. When none
-// exists it returns the shipped path of the first name.
-func (s Set) ResolveFirst(sub string, names ...string) string {
+// ResolveFirst tries names in order, overlay before base within each name.
+// A non-missing error stops lookup before trying another spelling. If no name
+// exists, it returns the shipped path of the first name without an error.
+func (s Set) ResolveFirst(sub string, names ...string) (string, error) {
 	for _, n := range names {
-		if p, _, ok := s.Locate(sub, n); ok {
-			return p
+		p, _, ok, err := s.Locate(sub, n)
+		if err != nil || ok {
+			return p, err
 		}
 	}
 	if len(names) == 0 {
-		return s.Path(LayerBase, sub)
+		return s.Path(LayerBase, sub), nil
 	}
-	return s.Path(LayerBase, sub, names[0])
+	return s.Path(LayerBase, sub, names[0]), nil
 }
 
-// Exists reports whether the file exists in either layer.
-func (s Set) Exists(elem ...string) bool {
-	_, _, ok := s.Locate(elem...)
-	return ok
+// Exists reports whether a file exists in either layer. Errors other than
+// absence are returned, not interpreted as a missing file.
+func (s Set) Exists(elem ...string) (bool, error) {
+	_, _, ok, err := s.Locate(elem...)
+	return ok, err
 }
 
 // WritePath returns where an editor should save a file: the overlay when one
@@ -278,7 +283,11 @@ func (s Set) Summarize() (sum Summary, ok bool, err error) {
 			}
 			return nil
 		}
-		if isFile(filepath.Join(s.Base, rel)) {
+		exists, err := statFile(filepath.Join(s.Base, rel))
+		if err != nil {
+			return err
+		}
+		if exists {
 			sum.Overrides++
 		} else {
 			sum.Additions++
@@ -292,9 +301,15 @@ func (s Set) Summarize() (sum Summary, ok bool, err error) {
 	return sum, true, nil
 }
 
-func isFile(p string) bool {
+func statFile(p string) (bool, error) {
 	info, err := os.Stat(p)
-	return err == nil && !info.IsDir()
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return !info.IsDir(), nil
 }
 
 func isDir(p string) bool {

--- a/internal/menuset/menuset.go
+++ b/internal/menuset/menuset.go
@@ -187,7 +187,7 @@ func (s Set) ReadDir(elem ...string) ([]Entry, error) {
 		}
 	}
 
-	if baseErr != nil && overlayMissing {
+	if baseErr != nil && (!errors.Is(baseErr, fs.ErrNotExist) || overlayMissing) {
 		return nil, baseErr
 	}
 

--- a/internal/menuset/menuset.go
+++ b/internal/menuset/menuset.go
@@ -1,0 +1,295 @@
+// Package menuset resolves files in a menu set through an optional overlay.
+//
+// A menu set is a directory tree such as menus/v3 holding ansi/, bar/, cfg/,
+// mnu/, templates/ and theme.json. The shipped set is tracked in git, so a
+// sysop who edits it in place fights every git pull. The overlay is a second
+// tree with the same layout — menus.d/v3 for menus/v3 — that is searched
+// first, file by file. A file present in the overlay shadows the shipped one;
+// everything else falls through to the shipped set. The overlay is not
+// tracked, so upgrades never touch it and it never has to be re-copied.
+//
+// Resolution is per file, not per directory. Overriding MAIN.ANS does not
+// require copying the rest of ansi/. There are no whiteouts: a file cannot be
+// removed from the shipped set by way of the overlay.
+package menuset
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// OverlaySuffix is appended to the menu root directory name to find the
+// overlay root: menus/v3 pairs with menus.d/v3.
+const OverlaySuffix = ".d"
+
+// Layer names which tree a file was resolved from.
+type Layer int
+
+const (
+	// LayerBase is the shipped menu set.
+	LayerBase Layer = iota
+	// LayerOverlay is the sysop's override tree.
+	LayerOverlay
+)
+
+func (l Layer) String() string {
+	if l == LayerOverlay {
+		return "overlay"
+	}
+	return "base"
+}
+
+// Set is a menu set with an optional overlay.
+type Set struct {
+	// Base is the shipped menu set directory, e.g. menus/v3.
+	Base string
+	// Overlay is the override directory, e.g. menus.d/v3. Empty disables
+	// the overlay entirely.
+	Overlay string
+}
+
+// FromPath returns the Set for a shipped menu set directory, pairing it with
+// the overlay derived from its location: <parent>.d/<name>. The pairing is
+// defined here and nowhere else so that every reader of a menu set — the
+// server, the editors, the scripting engine — agrees on where the overlay
+// lives, for relative and absolute paths alike.
+func FromPath(base string) Set {
+	return Set{Base: base, Overlay: OverlayFor(base)}
+}
+
+// Bare returns a Set that reads and writes the shipped tree only.
+func Bare(base string) Set {
+	return Set{Base: base}
+}
+
+// OverlayFor returns the overlay directory paired with a shipped menu set
+// directory: menus/v3 → menus.d/v3, /opt/bbs/menus/v3 → /opt/bbs/menus.d/v3.
+func OverlayFor(base string) string {
+	base = filepath.Clean(base)
+	parent, name := filepath.Split(base)
+	parent = filepath.Clean(parent)
+	if parent == "." || parent == string(filepath.Separator) || parent == "" {
+		// A set with no parent (e.g. "v3") has nowhere to hang a sibling.
+		return ""
+	}
+	return filepath.Join(parent+OverlaySuffix, name)
+}
+
+// HasOverlay reports whether an overlay directory is configured.
+func (s Set) HasOverlay() bool {
+	return s.Overlay != ""
+}
+
+// Path returns the path of a file in the given layer without checking that
+// it exists. elem is the path relative to the set root, e.g. "ansi",
+// "MAIN.ANS".
+func (s Set) Path(layer Layer, elem ...string) string {
+	root := s.Base
+	if layer == LayerOverlay {
+		root = s.Overlay
+	}
+	return filepath.Join(append([]string{root}, elem...)...)
+}
+
+// Resolve returns the path to read for a file: the overlay copy if one exists,
+// otherwise the shipped path — whether or not that exists, so an error from
+// the subsequent open names the place the file was expected.
+func (s Set) Resolve(elem ...string) string {
+	path, _, _ := s.Locate(elem...)
+	return path
+}
+
+// Locate is Resolve with the layer the file was found in. ok is false when
+// the file exists in neither layer, in which case path is the shipped path.
+func (s Set) Locate(elem ...string) (path string, layer Layer, ok bool) {
+	if s.Overlay != "" {
+		p := s.Path(LayerOverlay, elem...)
+		if isFile(p) {
+			return p, LayerOverlay, true
+		}
+	}
+	p := s.Path(LayerBase, elem...)
+	return p, LayerBase, isFile(p)
+}
+
+// ResolveFirst tries several file names in order within one subdirectory
+// and returns the first that exists in either layer, overlay first. When none
+// exists it returns the shipped path of the first name.
+func (s Set) ResolveFirst(sub string, names ...string) string {
+	for _, n := range names {
+		if p, _, ok := s.Locate(sub, n); ok {
+			return p
+		}
+	}
+	if len(names) == 0 {
+		return s.Path(LayerBase, sub)
+	}
+	return s.Path(LayerBase, sub, names[0])
+}
+
+// Exists reports whether the file exists in either layer.
+func (s Set) Exists(elem ...string) bool {
+	_, _, ok := s.Locate(elem...)
+	return ok
+}
+
+// WritePath returns where an editor should save a file: the overlay when one
+// is configured, otherwise the shipped tree. It does not create directories.
+func (s Set) WritePath(elem ...string) string {
+	if s.Overlay != "" {
+		return s.Path(LayerOverlay, elem...)
+	}
+	return s.Path(LayerBase, elem...)
+}
+
+// Entry is one file in a merged directory listing.
+type Entry struct {
+	Name  string // base name
+	Path  string // full path in the layer it resolved to
+	Layer Layer
+}
+
+// ReadDir lists the regular files of a subdirectory across both layers,
+// merged by name with the overlay winning, sorted by name. Directories are
+// omitted. The error is that of the shipped directory when neither layer has
+// the subdirectory; a subdirectory present in only one layer is not an error.
+func (s Set) ReadDir(elem ...string) ([]Entry, error) {
+	merged := map[string]Entry{}
+
+	baseDir := s.Path(LayerBase, elem...)
+	baseEntries, baseErr := os.ReadDir(baseDir)
+	for _, de := range baseEntries {
+		if de.IsDir() {
+			continue
+		}
+		merged[de.Name()] = Entry{Name: de.Name(), Path: filepath.Join(baseDir, de.Name()), Layer: LayerBase}
+	}
+
+	overlayMissing := true
+	if s.Overlay != "" {
+		overlayDir := s.Path(LayerOverlay, elem...)
+		overlayEntries, err := os.ReadDir(overlayDir)
+		if err == nil {
+			overlayMissing = false
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return nil, err
+		}
+		for _, de := range overlayEntries {
+			if de.IsDir() {
+				continue
+			}
+			merged[de.Name()] = Entry{Name: de.Name(), Path: filepath.Join(overlayDir, de.Name()), Layer: LayerOverlay}
+		}
+	}
+
+	if baseErr != nil && overlayMissing {
+		return nil, baseErr
+	}
+
+	out := make([]Entry, 0, len(merged))
+	for _, e := range merged {
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// Glob matches a shell pattern against the files of a subdirectory across
+// both layers, merged by name with the overlay winning. Results are sorted by
+// name. The pattern applies to the base name only.
+func (s Set) Glob(sub, pattern string) ([]Entry, error) {
+	if _, err := filepath.Match(pattern, ""); err != nil {
+		return nil, fmt.Errorf("bad pattern %q: %w", pattern, err)
+	}
+	entries, err := s.ReadDir(sub)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []Entry
+	for _, e := range entries {
+		if ok, _ := filepath.Match(pattern, e.Name); ok {
+			out = append(out, e)
+		}
+	}
+	return out, nil
+}
+
+// Summary describes what an overlay currently contributes. It exists for the
+// startup log so a sysop can see at a glance that their overrides are being
+// read, and catch a mistyped subdirectory.
+type Summary struct {
+	// Overrides counts overlay files that shadow a shipped file.
+	Overrides int
+	// Additions counts overlay files with no shipped counterpart.
+	Additions int
+	// UnknownDirs lists top-level overlay subdirectories that the shipped set
+	// does not have, e.g. "ANSI" typed for "ansi" on a case-sensitive filesystem.
+	UnknownDirs []string
+}
+
+// Summarize walks the overlay and classifies each file against the shipped
+// set. It returns ok=false with a zero Summary when the overlay does not exist.
+func (s Set) Summarize() (sum Summary, ok bool, err error) {
+	if s.Overlay == "" {
+		return Summary{}, false, nil
+	}
+	info, statErr := os.Stat(s.Overlay)
+	if statErr != nil {
+		if errors.Is(statErr, fs.ErrNotExist) {
+			return Summary{}, false, nil
+		}
+		return Summary{}, false, statErr
+	}
+	if !info.IsDir() {
+		return Summary{}, false, fmt.Errorf("%s is not a directory", s.Overlay)
+	}
+
+	walkErr := filepath.WalkDir(s.Overlay, func(path string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		rel, relErr := filepath.Rel(s.Overlay, path)
+		if relErr != nil || rel == "." {
+			return nil
+		}
+		if d.IsDir() {
+			// Only the first path component is checked: deeper layout is the
+			// shipped set's business.
+			if !strings.Contains(rel, string(filepath.Separator)) {
+				if !isDir(filepath.Join(s.Base, rel)) {
+					sum.UnknownDirs = append(sum.UnknownDirs, rel)
+				}
+			}
+			return nil
+		}
+		if isFile(filepath.Join(s.Base, rel)) {
+			sum.Overrides++
+		} else {
+			sum.Additions++
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return Summary{}, true, walkErr
+	}
+	sort.Strings(sum.UnknownDirs)
+	return sum, true, nil
+}
+
+func isFile(p string) bool {
+	info, err := os.Stat(p)
+	return err == nil && !info.IsDir()
+}
+
+func isDir(p string) bool {
+	info, err := os.Stat(p)
+	return err == nil && info.IsDir()
+}

--- a/internal/menuset/menuset.go
+++ b/internal/menuset/menuset.go
@@ -27,7 +27,7 @@ import (
 // overlay root: menus/v3 pairs with menus.d/v3.
 const OverlaySuffix = ".d"
 
-// Layer names which tree a file was resolved from.
+// Layer identifies the tree a file was resolved from.
 type Layer int
 
 const (
@@ -167,15 +167,7 @@ func (s Set) ReadDir(elem ...string) ([]Entry, error) {
 	merged := map[string]Entry{}
 
 	baseDir := s.Path(LayerBase, elem...)
-	baseEntries, baseErr := os.ReadDir(baseDir)
-	// Windows can report ErrNotExist when ReadDir targets a regular file.
-	// Confirm that the path is absent before treating that error as a missing
-	// layer, otherwise a malformed shipped tree is silently hidden.
-	if errors.Is(baseErr, fs.ErrNotExist) {
-		if info, err := os.Stat(baseDir); err == nil && !info.IsDir() {
-			return nil, fmt.Errorf("reading %s: not a directory", baseDir)
-		}
-	}
+	baseEntries, baseErr := readDir(baseDir)
 	for _, de := range baseEntries {
 		if de.IsDir() {
 			continue
@@ -186,15 +178,37 @@ func (s Set) ReadDir(elem ...string) ([]Entry, error) {
 	overlayMissing := true
 	if s.Overlay != "" {
 		overlayDir := s.Path(LayerOverlay, elem...)
-		overlayEntries, err := os.ReadDir(overlayDir)
+		overlayEntries, err := readDir(overlayDir)
 		if err == nil {
 			overlayMissing = false
 		} else if !errors.Is(err, fs.ErrNotExist) {
 			return nil, err
 		}
+		// Use the overlay filesystem's own case rules. A differently cased
+		// spelling shadows a base name only if that spelling resolves there.
+		// Preserve distinct names on case-sensitive filesystems.
+		overlayNames := make(map[string]bool, len(overlayEntries))
+		baseNames := make(map[string][]string, len(merged))
+		for name := range merged {
+			key := strings.ToUpper(name)
+			baseNames[key] = append(baseNames[key], name)
+		}
+		for _, de := range overlayEntries {
+			overlayNames[de.Name()] = true
+		}
 		for _, de := range overlayEntries {
 			if de.IsDir() {
 				continue
+			}
+			for _, baseName := range baseNames[strings.ToUpper(de.Name())] {
+				if overlayNames[baseName] {
+					continue
+				}
+				if _, err := os.Lstat(filepath.Join(overlayDir, baseName)); err == nil {
+					delete(merged, baseName)
+				} else if !errors.Is(err, fs.ErrNotExist) {
+					return nil, err
+				}
 			}
 			merged[de.Name()] = Entry{Name: de.Name(), Path: filepath.Join(overlayDir, de.Name()), Layer: LayerOverlay}
 		}
@@ -210,6 +224,22 @@ func (s Set) ReadDir(elem ...string) ([]Entry, error) {
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out, nil
+}
+
+// readDir distinguishes a missing layer from an invalid directory on Windows,
+// where reading a regular file can report ErrNotExist.
+func readDir(path string) ([]fs.DirEntry, error) {
+	entries, err := os.ReadDir(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		info, statErr := os.Stat(path)
+		if statErr == nil && !info.IsDir() {
+			return nil, fmt.Errorf("reading %s: not a directory", path)
+		}
+		if statErr != nil && !errors.Is(statErr, fs.ErrNotExist) {
+			return nil, statErr
+		}
+	}
+	return entries, err
 }
 
 // Glob matches a shell pattern against the files of a subdirectory across
@@ -304,6 +334,13 @@ func (s Set) Summarize() (sum Summary, ok bool, err error) {
 func statFile(p string) (bool, error) {
 	info, err := os.Stat(p)
 	if errors.Is(err, fs.ErrNotExist) {
+		// A dangling link is an explicit entry whose target cannot be read,
+		// not an absent override. Keep the target error instead of falling back.
+		if _, linkErr := os.Lstat(p); linkErr == nil {
+			return false, err
+		} else if !errors.Is(linkErr, fs.ErrNotExist) {
+			return false, linkErr
+		}
 		return false, nil
 	}
 	if err != nil {

--- a/internal/menuset/menuset.go
+++ b/internal/menuset/menuset.go
@@ -163,6 +163,14 @@ func (s Set) ReadDir(elem ...string) ([]Entry, error) {
 
 	baseDir := s.Path(LayerBase, elem...)
 	baseEntries, baseErr := os.ReadDir(baseDir)
+	// Windows can report ErrNotExist when ReadDir targets a regular file.
+	// Confirm that the path is absent before treating that error as a missing
+	// layer, otherwise a malformed shipped tree is silently hidden.
+	if errors.Is(baseErr, fs.ErrNotExist) {
+		if info, err := os.Stat(baseDir); err == nil && !info.IsDir() {
+			return nil, fmt.Errorf("reading %s: not a directory", baseDir)
+		}
+	}
 	for _, de := range baseEntries {
 		if de.IsDir() {
 			continue

--- a/internal/menuset/menuset_test.go
+++ b/internal/menuset/menuset_test.go
@@ -240,8 +240,8 @@ func TestSummarize(t *testing.T) {
 
 func TestReadDirDoesNotHideBrokenBase(t *testing.T) {
 	s := fixture(t)
-	// A file in place of the base directory produces a real error on every OS,
-	// including when tests run as root (unlike permission-based fixtures).
+	// A file in place of the base directory must not be treated as missing,
+	// even on Windows, where ReadDir can report ErrNotExist in this case.
 	write(t, filepath.Join(s.Base, "bar"), "not a directory")
 	write(t, filepath.Join(s.Overlay, "bar", "MAIN.BAR"), "overlay")
 	if entries, err := s.ReadDir("bar"); err == nil || entries != nil {

--- a/internal/menuset/menuset_test.go
+++ b/internal/menuset/menuset_test.go
@@ -39,8 +39,8 @@ func TestOverlayFor(t *testing.T) {
 		"menus/v3":              filepath.Join("menus.d", "v3"),
 		"menus/v3/":             filepath.Join("menus.d", "v3"),
 		"./menus/v3":            filepath.Join("menus.d", "v3"),
-		"/opt/vision3/menus/v3": "/opt/vision3/menus.d/v3",
-		"/vision3/menus/v3":     "/vision3/menus.d/v3",
+		"/opt/vision3/menus/v3": filepath.FromSlash("/opt/vision3/menus.d/v3"),
+		"/vision3/menus/v3":     filepath.FromSlash("/vision3/menus.d/v3"),
 		"custom/sets/mine":      filepath.Join("custom", "sets.d", "mine"),
 		"v3":                    "",
 		"/v3":                   "",
@@ -235,5 +235,16 @@ func TestSummarize(t *testing.T) {
 	want := Summary{Overrides: 2, Additions: 3, UnknownDirs: []string{"screens"}}
 	if !reflect.DeepEqual(sum, want) {
 		t.Errorf("Summary = %+v, want %+v", sum, want)
+	}
+}
+
+func TestReadDirDoesNotHideBrokenBase(t *testing.T) {
+	s := fixture(t)
+	// A file in place of the base directory produces a real error on every OS,
+	// including when tests run as root (unlike permission-based fixtures).
+	write(t, filepath.Join(s.Base, "bar"), "not a directory")
+	write(t, filepath.Join(s.Overlay, "bar", "MAIN.BAR"), "overlay")
+	if entries, err := s.ReadDir("bar"); err == nil || entries != nil {
+		t.Fatalf("broken base hidden: entries=%v err=%v", entries, err)
 	}
 }

--- a/internal/menuset/menuset_test.go
+++ b/internal/menuset/menuset_test.go
@@ -1,6 +1,7 @@
 package menuset
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -54,16 +55,22 @@ func TestOverlayFor(t *testing.T) {
 
 func TestResolveFallsBackToBase(t *testing.T) {
 	s := fixture(t)
-	got := s.Resolve("ansi", "MAIN.ANS")
+	got, err := s.Resolve("ansi", "MAIN.ANS")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if got != filepath.Join(s.Base, "ansi", "MAIN.ANS") {
 		t.Errorf("Resolve = %q", got)
 	}
 	// Missing everywhere: still the base path, so errors name the right place.
-	got = s.Resolve("ansi", "NOPE.ANS")
+	got, err = s.Resolve("ansi", "NOPE.ANS")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if got != filepath.Join(s.Base, "ansi", "NOPE.ANS") {
 		t.Errorf("Resolve(missing) = %q", got)
 	}
-	if s.Exists("ansi", "NOPE.ANS") {
+	if exists, err := s.Exists("ansi", "NOPE.ANS"); err != nil || exists {
 		t.Error("Exists(missing) = true")
 	}
 }
@@ -73,24 +80,24 @@ func TestResolvePrefersOverlay(t *testing.T) {
 	over := filepath.Join(s.Overlay, "ansi", "MAIN.ANS")
 	write(t, over, "mine")
 
-	path, layer, ok := s.Locate("ansi", "MAIN.ANS")
-	if !ok || layer != LayerOverlay || path != over {
+	path, layer, ok, err := s.Locate("ansi", "MAIN.ANS")
+	if err != nil || !ok || layer != LayerOverlay || path != over {
 		t.Errorf("Locate = %q %v %v", path, layer, ok)
 	}
 	// A sibling that is not overridden still comes from the base.
-	if _, layer, _ := s.Locate("ansi", "LOGIN.ANS"); layer != LayerBase {
+	if _, layer, _, err := s.Locate("ansi", "LOGIN.ANS"); err != nil || layer != LayerBase {
 		t.Errorf("LOGIN.ANS layer = %v", layer)
 	}
 	// A new file that only the overlay has resolves too.
 	write(t, filepath.Join(s.Overlay, "ansi", "EXTRA.ANS"), "x")
-	if !s.Exists("ansi", "EXTRA.ANS") {
+	if exists, err := s.Exists("ansi", "EXTRA.ANS"); err != nil || !exists {
 		t.Error("overlay-only file not found")
 	}
 	// A directory in the overlay is not a file match.
 	if err := os.MkdirAll(filepath.Join(s.Overlay, "ansi", "LOGIN.ANS"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if _, layer, _ := s.Locate("ansi", "LOGIN.ANS"); layer != LayerBase {
+	if _, layer, _, err := s.Locate("ansi", "LOGIN.ANS"); err != nil || layer != LayerBase {
 		t.Errorf("directory in overlay shadowed a base file")
 	}
 }
@@ -102,7 +109,7 @@ func TestBareHasNoOverlay(t *testing.T) {
 	if bare.HasOverlay() {
 		t.Error("Bare set reports an overlay")
 	}
-	if _, layer, _ := bare.Locate("ansi", "MAIN.ANS"); layer != LayerBase {
+	if _, layer, _, err := bare.Locate("ansi", "MAIN.ANS"); err != nil || layer != LayerBase {
 		t.Error("Bare set read the overlay")
 	}
 	if got := bare.WritePath("mnu", "X.MNU"); got != filepath.Join(s.Base, "mnu", "X.MNU") {
@@ -121,19 +128,28 @@ func TestResolveFirst(t *testing.T) {
 	s := fixture(t)
 	// Shipped set has FILEAREA.TOP.ANS only; the bare name is tried first and
 	// the .ANS candidate matches.
-	got := s.ResolveFirst("templates", "FILEAREA.TOP", "FILEAREA.TOP.ANS")
+	got, err := s.ResolveFirst("templates", "FILEAREA.TOP", "FILEAREA.TOP.ANS")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if got != filepath.Join(s.Base, "templates", "FILEAREA.TOP.ANS") {
 		t.Errorf("ResolveFirst = %q", got)
 	}
 	// An overlay copy under the *other* candidate name still wins — the
 	// candidate order is by name, the layer order within each name.
 	write(t, filepath.Join(s.Overlay, "templates", "FILEAREA.TOP"), "mine")
-	got = s.ResolveFirst("templates", "FILEAREA.TOP", "FILEAREA.TOP.ANS")
+	got, err = s.ResolveFirst("templates", "FILEAREA.TOP", "FILEAREA.TOP.ANS")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if got != filepath.Join(s.Overlay, "templates", "FILEAREA.TOP") {
 		t.Errorf("ResolveFirst with overlay = %q", got)
 	}
 	// Nothing matches: shipped path of the first name.
-	got = s.ResolveFirst("templates", "NOPE.TOP", "NOPE.TOP.ANS")
+	got, err = s.ResolveFirst("templates", "NOPE.TOP", "NOPE.TOP.ANS")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if got != filepath.Join(s.Base, "templates", "NOPE.TOP") {
 		t.Errorf("ResolveFirst(missing) = %q", got)
 	}
@@ -246,5 +262,60 @@ func TestReadDirDoesNotHideBrokenBase(t *testing.T) {
 	write(t, filepath.Join(s.Overlay, "bar", "MAIN.BAR"), "overlay")
 	if entries, err := s.ReadDir("bar"); err == nil || entries != nil {
 		t.Fatalf("broken base hidden: entries=%v err=%v", entries, err)
+	}
+}
+
+// A symlink loop produces a non-missing stat error without depending on Unix
+// permissions or whether the test runs as root.
+func TestResolutionPropagatesStatErrors(t *testing.T) {
+	for _, layer := range []Layer{LayerOverlay, LayerBase} {
+		t.Run(layer.String(), func(t *testing.T) {
+			s := fixture(t)
+			if layer == LayerBase {
+				s = Bare(s.Base)
+			}
+			path := s.Path(layer, "ansi", "BROKEN.ANS")
+			if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink("BROKEN.ANS", path); err != nil {
+				t.Skipf("symlink unavailable: %v", err)
+			}
+			_, statErr := os.Stat(path)
+			if statErr == nil || os.IsNotExist(statErr) {
+				t.Fatalf("expected non-missing stat error, got %v", statErr)
+			}
+			if layer == LayerOverlay {
+				write(t, s.Path(LayerBase, "ansi", "BROKEN.ANS"), "must not be read")
+			}
+			checkErr := func(err error) {
+				t.Helper()
+				var want, got *os.PathError
+				if !errors.As(statErr, &want) || !errors.As(err, &got) || got.Path != path || !errors.Is(err, want.Err) {
+					t.Errorf("error = %v, want original stat error %v", err, statErr)
+				}
+			}
+			got, gotLayer, ok, err := s.Locate("ansi", "BROKEN.ANS")
+			checkErr(err)
+			if got != path || gotLayer != layer || ok {
+				t.Errorf("Locate = %q %v %v", got, gotLayer, ok)
+			}
+			got, err = s.Resolve("ansi", "BROKEN.ANS")
+			checkErr(err)
+			if got != path {
+				t.Errorf("Resolve selected %s instead of failing path", got)
+			}
+			// A readable alternative must not mask the first candidate's error.
+			got, err = s.ResolveFirst("ansi", "BROKEN.ANS", "MAIN.ANS")
+			checkErr(err)
+			if got != path {
+				t.Errorf("ResolveFirst selected %s instead of failing path", got)
+			}
+			exists, err := s.Exists("ansi", "BROKEN.ANS")
+			checkErr(err)
+			if exists {
+				t.Error("Exists returned true on stat error")
+			}
+		})
 	}
 }

--- a/internal/menuset/menuset_test.go
+++ b/internal/menuset/menuset_test.go
@@ -1,0 +1,239 @@
+package menuset
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func write(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// fixture builds menus/v3 with a couple of shipped files and returns the Set
+// derived from it. The overlay directory is not created.
+func fixture(t *testing.T) Set {
+	t.Helper()
+	root := t.TempDir()
+	base := filepath.Join(root, "menus", "v3")
+	write(t, filepath.Join(base, "ansi", "MAIN.ANS"), "base main")
+	write(t, filepath.Join(base, "ansi", "LOGIN.ANS"), "base login")
+	write(t, filepath.Join(base, "templates", "FILEAREA.TOP.ANS"), "base top")
+	write(t, filepath.Join(base, "theme.json"), "{}")
+	s := FromPath(base)
+	if want := filepath.Join(root, "menus.d", "v3"); s.Overlay != want {
+		t.Fatalf("Overlay = %q, want %q", s.Overlay, want)
+	}
+	return s
+}
+
+func TestOverlayFor(t *testing.T) {
+	cases := map[string]string{
+		"menus/v3":              filepath.Join("menus.d", "v3"),
+		"menus/v3/":             filepath.Join("menus.d", "v3"),
+		"./menus/v3":            filepath.Join("menus.d", "v3"),
+		"/opt/vision3/menus/v3": "/opt/vision3/menus.d/v3",
+		"/vision3/menus/v3":     "/vision3/menus.d/v3",
+		"custom/sets/mine":      filepath.Join("custom", "sets.d", "mine"),
+		"v3":                    "",
+		"/v3":                   "",
+	}
+	for in, want := range cases {
+		if got := OverlayFor(in); got != want {
+			t.Errorf("OverlayFor(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestResolveFallsBackToBase(t *testing.T) {
+	s := fixture(t)
+	got := s.Resolve("ansi", "MAIN.ANS")
+	if got != filepath.Join(s.Base, "ansi", "MAIN.ANS") {
+		t.Errorf("Resolve = %q", got)
+	}
+	// Missing everywhere: still the base path, so errors name the right place.
+	got = s.Resolve("ansi", "NOPE.ANS")
+	if got != filepath.Join(s.Base, "ansi", "NOPE.ANS") {
+		t.Errorf("Resolve(missing) = %q", got)
+	}
+	if s.Exists("ansi", "NOPE.ANS") {
+		t.Error("Exists(missing) = true")
+	}
+}
+
+func TestResolvePrefersOverlay(t *testing.T) {
+	s := fixture(t)
+	over := filepath.Join(s.Overlay, "ansi", "MAIN.ANS")
+	write(t, over, "mine")
+
+	path, layer, ok := s.Locate("ansi", "MAIN.ANS")
+	if !ok || layer != LayerOverlay || path != over {
+		t.Errorf("Locate = %q %v %v", path, layer, ok)
+	}
+	// A sibling that is not overridden still comes from the base.
+	if _, layer, _ := s.Locate("ansi", "LOGIN.ANS"); layer != LayerBase {
+		t.Errorf("LOGIN.ANS layer = %v", layer)
+	}
+	// A new file that only the overlay has resolves too.
+	write(t, filepath.Join(s.Overlay, "ansi", "EXTRA.ANS"), "x")
+	if !s.Exists("ansi", "EXTRA.ANS") {
+		t.Error("overlay-only file not found")
+	}
+	// A directory in the overlay is not a file match.
+	if err := os.MkdirAll(filepath.Join(s.Overlay, "ansi", "LOGIN.ANS"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, layer, _ := s.Locate("ansi", "LOGIN.ANS"); layer != LayerBase {
+		t.Errorf("directory in overlay shadowed a base file")
+	}
+}
+
+func TestBareHasNoOverlay(t *testing.T) {
+	s := fixture(t)
+	bare := Bare(s.Base)
+	write(t, filepath.Join(s.Overlay, "ansi", "MAIN.ANS"), "mine")
+	if bare.HasOverlay() {
+		t.Error("Bare set reports an overlay")
+	}
+	if _, layer, _ := bare.Locate("ansi", "MAIN.ANS"); layer != LayerBase {
+		t.Error("Bare set read the overlay")
+	}
+	if got := bare.WritePath("mnu", "X.MNU"); got != filepath.Join(s.Base, "mnu", "X.MNU") {
+		t.Errorf("WritePath = %q", got)
+	}
+}
+
+func TestWritePathIsOverlay(t *testing.T) {
+	s := fixture(t)
+	if got := s.WritePath("cfg", "MAIN.CFG"); got != filepath.Join(s.Overlay, "cfg", "MAIN.CFG") {
+		t.Errorf("WritePath = %q", got)
+	}
+}
+
+func TestResolveFirst(t *testing.T) {
+	s := fixture(t)
+	// Shipped set has FILEAREA.TOP.ANS only; the bare name is tried first and
+	// the .ANS candidate matches.
+	got := s.ResolveFirst("templates", "FILEAREA.TOP", "FILEAREA.TOP.ANS")
+	if got != filepath.Join(s.Base, "templates", "FILEAREA.TOP.ANS") {
+		t.Errorf("ResolveFirst = %q", got)
+	}
+	// An overlay copy under the *other* candidate name still wins — the
+	// candidate order is by name, the layer order within each name.
+	write(t, filepath.Join(s.Overlay, "templates", "FILEAREA.TOP"), "mine")
+	got = s.ResolveFirst("templates", "FILEAREA.TOP", "FILEAREA.TOP.ANS")
+	if got != filepath.Join(s.Overlay, "templates", "FILEAREA.TOP") {
+		t.Errorf("ResolveFirst with overlay = %q", got)
+	}
+	// Nothing matches: shipped path of the first name.
+	got = s.ResolveFirst("templates", "NOPE.TOP", "NOPE.TOP.ANS")
+	if got != filepath.Join(s.Base, "templates", "NOPE.TOP") {
+		t.Errorf("ResolveFirst(missing) = %q", got)
+	}
+}
+
+func TestReadDirMerges(t *testing.T) {
+	s := fixture(t)
+	write(t, filepath.Join(s.Overlay, "ansi", "MAIN.ANS"), "mine")
+	write(t, filepath.Join(s.Overlay, "ansi", "EXTRA.ANS"), "new")
+	if err := os.MkdirAll(filepath.Join(s.Overlay, "ansi", "subdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := s.ReadDir("ansi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	layers := map[string]Layer{}
+	for _, e := range entries {
+		names = append(names, e.Name)
+		layers[e.Name] = e.Layer
+	}
+	if want := []string{"EXTRA.ANS", "LOGIN.ANS", "MAIN.ANS"}; !reflect.DeepEqual(names, want) {
+		t.Errorf("names = %v, want %v", names, want)
+	}
+	if layers["MAIN.ANS"] != LayerOverlay || layers["EXTRA.ANS"] != LayerOverlay || layers["LOGIN.ANS"] != LayerBase {
+		t.Errorf("layers = %v", layers)
+	}
+}
+
+func TestReadDirErrors(t *testing.T) {
+	s := fixture(t)
+	// Neither layer has the directory: error.
+	if _, err := s.ReadDir("bar"); err == nil {
+		t.Error("expected error for missing dir in both layers")
+	}
+	// Only the overlay has it: fine.
+	write(t, filepath.Join(s.Overlay, "bar", "MAIN.BAR"), "x")
+	entries, err := s.ReadDir("bar")
+	if err != nil || len(entries) != 1 {
+		t.Errorf("overlay-only dir: entries=%v err=%v", entries, err)
+	}
+	// Only the base has it: fine.
+	entries, err = s.ReadDir("templates")
+	if err != nil || len(entries) != 1 {
+		t.Errorf("base-only dir: entries=%v err=%v", entries, err)
+	}
+}
+
+func TestGlob(t *testing.T) {
+	s := fixture(t)
+	hdr := filepath.Join("templates", "message_headers")
+	write(t, filepath.Join(s.Base, hdr, "MSGHDR.1.ans"), "1")
+	write(t, filepath.Join(s.Base, hdr, "MSGHDR.2.ans"), "2")
+	write(t, filepath.Join(s.Base, hdr, "MSGHDR.ANS"), "sel")
+	write(t, filepath.Join(s.Overlay, hdr, "MSGHDR.2.ans"), "mine")
+	write(t, filepath.Join(s.Overlay, hdr, "MSGHDR.3.ans"), "3")
+
+	got, err := s.Glob(hdr, "MSGHDR.*.ans")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for _, e := range got {
+		names = append(names, e.Name)
+	}
+	if want := []string{"MSGHDR.1.ans", "MSGHDR.2.ans", "MSGHDR.3.ans"}; !reflect.DeepEqual(names, want) {
+		t.Errorf("names = %v, want %v", names, want)
+	}
+	if got[1].Layer != LayerOverlay {
+		t.Errorf("MSGHDR.2.ans should come from the overlay")
+	}
+
+	// A missing directory is an empty result, like filepath.Glob.
+	if got, err := s.Glob("nowhere", "*"); err != nil || len(got) != 0 {
+		t.Errorf("missing dir: got=%v err=%v", got, err)
+	}
+	if _, err := s.Glob(hdr, "["); err == nil {
+		t.Error("bad pattern should error")
+	}
+}
+
+func TestSummarize(t *testing.T) {
+	s := fixture(t)
+	if _, ok, err := s.Summarize(); ok || err != nil {
+		t.Errorf("absent overlay: ok=%v err=%v", ok, err)
+	}
+	write(t, filepath.Join(s.Overlay, "ansi", "MAIN.ANS"), "mine")
+	write(t, filepath.Join(s.Overlay, "ansi", "EXTRA.ANS"), "new")
+	write(t, filepath.Join(s.Overlay, "theme.json"), "{}")
+	write(t, filepath.Join(s.Overlay, "screens", "OOPS.ANS"), "typo") // not a shipped subdir
+	write(t, filepath.Join(s.Overlay, "templates", "message_headers", "MSGHDR.9.ans"), "deep")
+
+	sum, ok, err := s.Summarize()
+	if err != nil || !ok {
+		t.Fatalf("ok=%v err=%v", ok, err)
+	}
+	want := Summary{Overrides: 2, Additions: 3, UnknownDirs: []string{"screens"}}
+	if !reflect.DeepEqual(sum, want) {
+		t.Errorf("Summary = %+v, want %+v", sum, want)
+	}
+}

--- a/internal/menuset/menuset_test.go
+++ b/internal/menuset/menuset_test.go
@@ -2,6 +2,7 @@ package menuset
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -254,14 +255,92 @@ func TestSummarize(t *testing.T) {
 	}
 }
 
-func TestReadDirDoesNotHideBrokenBase(t *testing.T) {
+func TestReadDirDoesNotHideBrokenLayer(t *testing.T) {
+	for _, layer := range []Layer{LayerBase, LayerOverlay} {
+		t.Run(layer.String(), func(t *testing.T) {
+			s := fixture(t)
+			other := LayerBase
+			if layer == LayerBase {
+				other = LayerOverlay
+			}
+			write(t, s.Path(layer, "bar"), "not a directory")
+			write(t, s.Path(other, "bar", "MAIN.BAR"), "readable")
+			if entries, err := s.ReadDir("bar"); err == nil || errors.Is(err, fs.ErrNotExist) || entries != nil {
+				t.Fatalf("broken layer hidden: entries=%v err=%v", entries, err)
+			}
+			if entries, err := s.Glob("bar", "*"); err == nil || entries != nil {
+				t.Fatalf("Glob hid broken layer: entries=%v err=%v", entries, err)
+			}
+		})
+	}
+}
+
+func TestReadDirCaseVariantOverlay(t *testing.T) {
 	s := fixture(t)
-	// A file in place of the base directory must not be treated as missing,
-	// even on Windows, where ReadDir can report ErrNotExist in this case.
-	write(t, filepath.Join(s.Base, "bar"), "not a directory")
-	write(t, filepath.Join(s.Overlay, "bar", "MAIN.BAR"), "overlay")
-	if entries, err := s.ReadDir("bar"); err == nil || entries != nil {
-		t.Fatalf("broken base hidden: entries=%v err=%v", entries, err)
+	write(t, s.Path(LayerBase, "mnu", "MAIN.MNU"), "shipped")
+	write(t, s.Path(LayerOverlay, "mnu", "main.mnu"), "overlay")
+	// Detect semantics of the actual filesystem, including case-insensitive
+	// macOS volumes, rather than assuming them from the operating system.
+	_, aliasErr := os.Lstat(s.Path(LayerOverlay, "mnu", "MAIN.MNU"))
+	insensitive := aliasErr == nil
+	if aliasErr != nil && !os.IsNotExist(aliasErr) {
+		t.Fatal(aliasErr)
+	}
+	entries, err := s.ReadDir("mnu")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := 2
+	if insensitive {
+		want = 1
+	}
+	if len(entries) != want {
+		t.Fatalf("entries=%v want %d (case insensitive=%v)", entries, want, insensitive)
+	}
+	if insensitive && (entries[0].Layer != LayerOverlay || entries[0].Name != "main.mnu") {
+		t.Errorf("case variant did not shadow shipped menu: %v", entries)
+	}
+	glob, err := s.Glob("mnu", "*")
+	if err != nil || !reflect.DeepEqual(glob, entries) {
+		t.Errorf("Glob=%v err=%v, want %v", glob, err, entries)
+	}
+	// An exact overlay spelling on a case-sensitive volume must not hide
+	// another distinct file just because their names differ only in case.
+	if !insensitive {
+		write(t, s.Path(LayerOverlay, "mnu", "MAIN.MNU"), "another override")
+		entries, err = s.ReadDir("mnu")
+		if err != nil || len(entries) != 2 {
+			t.Fatalf("distinct names lost: %v, %v", entries, err)
+		}
+		for _, entry := range entries {
+			if entry.Layer != LayerOverlay {
+				t.Errorf("entry=%v", entry)
+			}
+		}
+	}
+}
+
+func TestDanglingOverlayDoesNotFallBack(t *testing.T) {
+	s := fixture(t)
+	path := s.Path(LayerOverlay, "ansi", "MAIN.ANS")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("missing-target", path); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	got, layer, ok, err := s.Locate("ansi", "MAIN.ANS")
+	if err == nil || got != path || layer != LayerOverlay || ok {
+		t.Fatalf("Locate=%q %v %v %v", got, layer, ok, err)
+	}
+	if got, err := s.Resolve("ansi", "MAIN.ANS"); err == nil || got != path {
+		t.Errorf("Resolve=%q %v", got, err)
+	}
+	if got, err := s.ResolveFirst("ansi", "MAIN.ANS", "LOGIN.ANS"); err == nil || got != path {
+		t.Errorf("ResolveFirst=%q %v", got, err)
+	}
+	if exists, err := s.Exists("ansi", "MAIN.ANS"); err == nil || exists {
+		t.Errorf("Exists=%v %v", exists, err)
 	}
 }
 

--- a/internal/scripting/ansi_display.go
+++ b/internal/scripting/ansi_display.go
@@ -108,7 +108,8 @@ func resolveAnsiPath(eng *Engine, filename string) string {
 			base := menus.Path(layer, sub)
 			path = filepath.Join(base, cleaned)
 			if _, err := os.Stat(path); err != nil {
-				if !os.IsNotExist(err) {
+				_, linkErr := os.Lstat(path)
+				if !os.IsNotExist(err) || !os.IsNotExist(linkErr) {
 					slog.Warn("resolving script art", "path", path, "error", err)
 					return ""
 				}

--- a/internal/scripting/ansi_display.go
+++ b/internal/scripting/ansi_display.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ViSiON-3/vision-3-bbs/internal/menuset"
+
 	"github.com/ViSiON-3/vision-3-bbs/internal/ansi"
 	"github.com/ViSiON-3/vision-3-bbs/internal/jsutil"
 	"github.com/dop251/goja"
@@ -69,6 +71,9 @@ func registerAnsi(v3 *goja.Object, eng *Engine) {
 //  2. menus/v3/ansi/
 //  3. menus/v3/templates/
 //
+// The menu set's overlay (menus.d/v3) is searched before the shipped tree
+// for the last two, as everywhere else in the BBS.
+//
 // Returns empty string if not found in any location.
 // Symlinks are resolved to prevent traversal outside the intended directories.
 func resolveAnsiPath(eng *Engine, filename string) string {
@@ -91,22 +96,22 @@ func resolveAnsiPath(eng *Engine, filename string) string {
 	if bbsRoot == "" {
 		return ""
 	}
+	menus := menuset.FromPath(filepath.Join(bbsRoot, "menus", "v3"))
 
-	// Try menus/v3/ansi/.
-	ansiBase := filepath.Join(bbsRoot, "menus", "v3", "ansi")
-	path = filepath.Join(ansiBase, cleaned)
-	if _, err := os.Stat(path); err == nil {
-		if real := pathUnderBase(ansiBase, path); real != "" {
-			return real
-		}
-	}
-
-	// Try menus/v3/templates/.
-	tmplBase := filepath.Join(bbsRoot, "menus", "v3", "templates")
-	path = filepath.Join(tmplBase, cleaned)
-	if _, err := os.Stat(path); err == nil {
-		if real := pathUnderBase(tmplBase, path); real != "" {
-			return real
+	// Try ansi/ then templates/, overlay before shipped set for each.
+	for _, sub := range []string{"ansi", "templates"} {
+		for _, layer := range []menuset.Layer{menuset.LayerOverlay, menuset.LayerBase} {
+			if layer == menuset.LayerOverlay && !menus.HasOverlay() {
+				continue
+			}
+			base := menus.Path(layer, sub)
+			path = filepath.Join(base, cleaned)
+			if _, err := os.Stat(path); err != nil {
+				continue
+			}
+			if real := pathUnderBase(base, path); real != "" {
+				return real
+			}
 		}
 	}
 

--- a/internal/scripting/ansi_display.go
+++ b/internal/scripting/ansi_display.go
@@ -1,6 +1,7 @@
 package scripting
 
 import (
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -107,6 +108,10 @@ func resolveAnsiPath(eng *Engine, filename string) string {
 			base := menus.Path(layer, sub)
 			path = filepath.Join(base, cleaned)
 			if _, err := os.Stat(path); err != nil {
+				if !os.IsNotExist(err) {
+					slog.Warn("resolving script art", "path", path, "error", err)
+					return ""
+				}
 				continue
 			}
 			if real := pathUnderBase(base, path); real != "" {

--- a/menus.d/README.md
+++ b/menus.d/README.md
@@ -1,8 +1,9 @@
 # menus.d — your menu overrides
 
 Anything you put in here is read **before** the shipped menu set in `menus/`,
-file by file. Nothing in this directory is tracked by git, so `git pull` never
-touches it and you never have to re-copy your customisations after an upgrade.
+file by file. Override files are git-ignored, so `git pull` never touches your
+customisations and you never have to re-copy them after an upgrade. Only this
+README is tracked.
 
 Mirror the layout of the set you are overriding. To replace the main menu art
 of the `v3` set, for example:
@@ -28,4 +29,4 @@ copying the rest of `ansi/`; every other file still comes from `menus/`.
   instance. Move each to the same path under `menus.d/`, then restore the
   shipped copy. Full steps in the guide linked below.
 
-See the sysop guide: `docs/sysop/menus/menu-system.md#customising-menus-without-losing-your-changes`.
+See the sysop guide: [Customising menus without losing your changes](../docs/sysop/menus/menu-system.md#customising-menus-without-losing-your-changes).

--- a/menus.d/README.md
+++ b/menus.d/README.md
@@ -1,0 +1,27 @@
+# menus.d — your menu overrides
+
+Anything you put in here is read **before** the shipped menu set in `menus/`,
+file by file. Nothing in this directory is tracked by git, so `git pull` never
+touches it and you never have to re-copy your customisations after an upgrade.
+
+Mirror the layout of the set you are overriding. To replace the main menu art
+of the `v3` set, for example:
+
+```
+menus.d/v3/ansi/MAIN.ANS      ← used if present
+menus/v3/ansi/MAIN.ANS        ← otherwise
+```
+
+Only the files you add here are affected. Overriding one `.ANS` does not mean
+copying the rest of `ansi/`; every other file still comes from `menus/`.
+
+- `menuedit` saves into this directory by default (files it wrote are marked
+  with `*` in its menu list). Run it with `--no-overlay` to edit `menus/`
+  directly.
+- `theme.json` can be overridden here too, and hot-reloads like the shipped one.
+- A lightbar menu's `.ANS`, `.BAR` and `.CFG` are drawn against each other.
+  If you override one, check the others still line up; the BBS logs a warning
+  when a lightbar menu's files come from different layers.
+- A file cannot be *removed* from the shipped set by way of this directory.
+
+See the sysop guide: `docs/sysop/menus/menu-system.md#customising-menus-without-losing-your-changes`.

--- a/menus.d/README.md
+++ b/menus.d/README.md
@@ -23,5 +23,9 @@ copying the rest of `ansi/`; every other file still comes from `menus/`.
   If you override one, check the others still line up; the BBS logs a warning
   when a lightbar menu's files come from different layers.
 - A file cannot be *removed* from the shipped set by way of this directory.
+- Already edited files inside `menus/`? Move them here once: `git status --short menus/`
+  lists them on a checkout, `diff -rq menus/v3 <repo>/menus/v3` on an
+  instance. Move each to the same path under `menus.d/`, then restore the
+  shipped copy. Full steps in the guide linked below.
 
 See the sysop guide: `docs/sysop/menus/menu-system.md#customising-menus-without-losing-your-changes`.


### PR DESCRIPTION
Closes #343

## What

A `menus.d/` overlay with the same layout as `menus/`, searched first, file by file:

```
menus.d/v3/ansi/MAIN.ANS     ← used if present
menus/v3/ansi/MAIN.ANS       ← otherwise
```

`menus.d/` is git-ignored (only its README is tracked), so `git pull` never touches it and there is nothing to re-copy after an upgrade. Overriding one file does not fork the directory; every file not overridden keeps receiving fixes.

## How

- **`internal/menuset`** is the single lookup point. A `Set` pairs a shipped directory with the overlay derived from its location (`<parent>.d/<name>`), so every reader agrees on where the overlay is without a second hardcode. It resolves single files, tries the suffixed template spellings (`FILEAREA.TOP.ANS`), merges directory listings and globs with the overlay winning, and summarises what an overlay contributes. Non-missing lookup errors stop resolution; case-variant directory entries merge according to the overlay filesystem’s case rules.
- **Every reader goes through it.** The issue counted 72 `MenuSetPath` joins on the executor; the sweep also covered the loader (which took directories, not files), the message-header glob, PRELOGON probing, `theme.json`, the full-screen editor's screens, script art lookup, the menu editor's listing, and the newscan header, which was read from a hardcoded relative path.
- **`menuedit`** reads through the overlay and saves into it by default, marking overlay files with `*`. `--no-overlay` edits the shipped set as before. Deleting an overridden menu reverts it to the shipped copy; deleting a shipped-only menu is refused with a message (no whiteouts).
- **Config watcher** watches `theme.json` in both layers, and removal of the overlay copy counts as a change so it falls back without a restart. Scoped to that target; required configs keep ignoring removal.
- **Startup log** reports whether the overlay is active, override/addition counts, and any subdirectory the shipped set lacks (the "why isn't my change showing" case).
- **Lightbar drift warning**, once per process, when a menu's `.ANS`, `.BAR` and `.CFG` resolve from different layers. Lives in `loadLightbarOptions`, which every lightbar goes through.
- **Docker** mounts `./menus.d` alongside `./menus`; both menu trees retain their host ownership. Run `docker exec -it -u "$(id -u):$(id -g)" vision3-bbs ./menuedit` to save into the bind-mounted overlay as the host user; the BBS continues to run as `vision3`.

## Docs

New section in the menu system guide: *Customising menus without losing your changes*, including step-by-step instructions for moving existing edits out of `menus/` for each install layout (checkout, instance, bundle, Docker) and how to tell your own edits from release fixes not yet copied. The upgrading, Docker, binary-update and architecture pages link to it.

## Testing

- Unit tests for the resolver, loader, menu editor file layer, and watcher, including malformed directories in both layers, dangling links, case-variant filenames, save markers, and suffixed scan-header overrides.
- Live test against a `dev-setup.sh` instance whose `menus/` is a symlink to the repo: overlay logged as active with the right counts, a typo'd subdirectory warned about, an overridden `PDMATRIX.ANS` served over telnet, the lightbar layer warning fired for it, and removing the overlay `theme.json` reloaded the shipped one within one poll.
- `gofmt`, `go vet`, `golangci-lint` clean; full `go test ./...` passes.

## Out of scope

Whiteouts (hiding a shipped file via the overlay) and configurable overlay locations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added upgrade-safe menu customization through the writable `menus.d/` overlay.
  * Customized menu files now take precedence over shipped files, with fallback to defaults.
  * Updated `menuedit` to use overlays by default; `--no-overlay` edits shipped menus directly.
  * Added overlay-aware theme, template, artwork, lightbar, and scripting asset resolution.
  * Added automatic theme reloads and clearer overlay status reporting.
  * Added safer menu deletion with rollback on partial failures.

* **Documentation**
  * Added setup, Docker, migration, ownership, and customization guidance for `menus.d/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
